### PR TITLE
Macros

### DIFF
--- a/language/move-compiler/src/attr_derivation/mod.rs
+++ b/language/move-compiler/src/attr_derivation/mod.rs
@@ -107,6 +107,7 @@ pub fn new_native_fun(
         signature,
         acquires: vec![],
         name,
+        is_macro: false,
         body: sp(loc, FunctionBody_::Native),
     }
 }
@@ -129,6 +130,7 @@ pub fn new_fun(
         signature,
         acquires: vec![],
         name,
+        is_macro: false,
         body: sp(
             loc,
             FunctionBody_::Defined((vec![], vec![], None, Box::new(Some(def)))),

--- a/language/move-compiler/src/cfgir/constant_fold.rs
+++ b/language/move-compiler/src/cfgir/constant_fold.rs
@@ -199,7 +199,7 @@ fn is_valid_const_builtin_type(sp!(_, bt_): &BuiltinTypeName) -> bool {
         N::Address | N::U8 | N::U16 | N::U32 | N::U64 | N::U128 | N::U256 | N::Vector | N::Bool => {
             true
         }
-        N::Signer => false,
+        N::Signer | N::Fun => false,
     }
 }
 

--- a/language/move-compiler/src/diagnostics/codes.rs
+++ b/language/move-compiler/src/diagnostics/codes.rs
@@ -150,7 +150,6 @@ codes!(
         UnboundVariable: { msg: "unbound variable", severity: BlockingError },
         UnboundField: { msg: "unbound field", severity: BlockingError },
         ReservedName: { msg: "invalid use of reserved name", severity: BlockingError },
-        UnboundMacro: { msg: "unbound macro", severity: BlockingError },
     ],
     // errors for typing rules. mostly typing/translate
     TypeSafety: [
@@ -182,6 +181,8 @@ codes!(
                 (NOTE: this may become an error in the future)",
             severity: Warning
         },
+        InvalidCallTarget: { msg: "invalid call target", severity: BlockingError },
+        InvalidFunctionType: { msg: "invalid usage of function type", severity: BlockingError },
     ],
     // errors for ability rules. mostly typing/translate
     AbilitySafety: [
@@ -235,6 +236,7 @@ codes!(
     Bug: [
         BytecodeGeneration: { msg: "BYTECODE GENERATION FAILED", severity: Bug },
         BytecodeVerification: { msg: "BYTECODE VERIFICATION FAILED", severity: Bug },
+        Unimplemented: { msg: "Not yet implemented", severity: BlockingError },
     ],
     Derivation: [
         DeriveFailed: { msg: "attribute derivation failed", severity: BlockingError }

--- a/language/move-compiler/src/expansion/ast.rs
+++ b/language/move-compiler/src/expansion/ast.rs
@@ -199,6 +199,7 @@ pub struct SpecId(usize);
 pub struct Function {
     pub attributes: Attributes,
     pub loc: Loc,
+    pub is_macro: bool,
     pub visibility: Visibility,
     pub entry: Option<Loc>,
     pub signature: FunctionSignature,
@@ -416,7 +417,7 @@ pub enum Exp_ {
     While(Box<Exp>, Box<Exp>),
     Loop(Box<Exp>),
     Block(Sequence),
-    Lambda(LValueList, Box<Exp>), // spec only
+    Lambda(LValueList, Box<Exp>),
     Quant(
         QuantKind,
         LValueWithRangeList,
@@ -675,6 +676,10 @@ impl AbilitySet {
 
     pub fn collection(loc: Loc) -> Self {
         Self::from_abilities_(loc, Self::COLLECTION.to_vec()).unwrap()
+    }
+
+    pub fn functions() -> Self {
+        Self::empty()
     }
 }
 
@@ -1231,6 +1236,7 @@ impl AstDebug for (FunctionName, &Function) {
             Function {
                 attributes,
                 loc: _loc,
+                is_macro,
                 visibility,
                 entry,
                 signature,
@@ -1247,7 +1253,11 @@ impl AstDebug for (FunctionName, &Function) {
         if let FunctionBody_::Native = &body.value {
             w.write("native ");
         }
-        w.write(&format!("fun {}", name));
+        if *is_macro {
+            w.write(&format!("macro {}", name));
+        } else {
+            w.write(&format!("fun {}", name));
+        }
         signature.ast_debug(w);
         if !acquires.is_empty() {
             w.write(" acquires ");
@@ -1330,9 +1340,9 @@ impl AstDebug for Type_ {
                 s.ast_debug(w)
             }
             Type_::Fun(args, result) => {
-                w.write("(");
+                w.write("|");
                 w.comma(args, |w, ty| ty.ast_debug(w));
-                w.write("):");
+                w.write("|");
                 result.ast_debug(w);
             }
             Type_::UnresolvedError => w.write("_|_"),
@@ -1533,9 +1543,9 @@ impl AstDebug for Exp_ {
             }
             E::Block(seq) => w.block(|w| seq.ast_debug(w)),
             E::Lambda(sp!(_, bs), e) => {
-                w.write("fun ");
+                w.write("|");
                 bs.ast_debug(w);
-                w.write(" ");
+                w.write("|");
                 e.ast_debug(w);
             }
             E::Quant(kind, sp!(_, rs), trs, c_opt, e) => {

--- a/language/move-compiler/src/expansion/translate.rs
+++ b/language/move-compiler/src/expansion/translate.rs
@@ -1198,6 +1198,7 @@ fn function_(context: &mut Context, pfunction: P::Function) -> (FunctionName, E:
     let P::Function {
         attributes: pattributes,
         loc,
+        is_macro,
         name,
         visibility: pvisibility,
         entry,
@@ -1218,6 +1219,7 @@ fn function_(context: &mut Context, pfunction: P::Function) -> (FunctionName, E:
     let fdef = E::Function {
         attributes,
         loc,
+        is_macro,
         visibility,
         entry,
         signature,
@@ -1588,17 +1590,9 @@ fn type_(context: &mut Context, sp!(loc, pt_): P::Type) -> E::Type {
         }
         PT::Ref(mut_, inner) => ET::Ref(mut_, Box::new(type_(context, *inner))),
         PT::Fun(args, result) => {
-            if context.in_spec_context {
-                let args = types(context, args);
-                let result = type_(context, *result);
-                ET::Fun(args, Box::new(result))
-            } else {
-                context.env.add_diag(diag!(
-                    Syntax::SpecContextRestricted,
-                    (loc, "`|_|_` function type only allowed in specifications")
-                ));
-                ET::UnresolvedError
-            }
+            let args = types(context, args);
+            let result = type_(context, *result);
+            ET::Fun(args, Box::new(result))
         }
     };
     sp(loc, t_)
@@ -1882,21 +1876,13 @@ fn exp_(context: &mut Context, sp!(loc, pe_): P::Exp) -> E::Exp {
         PE::Loop(ploop) => EE::Loop(exp(context, *ploop)),
         PE::Block(seq) => EE::Block(sequence(context, loc, seq)),
         PE::Lambda(pbs, pe) => {
-            if !context.in_spec_context {
-                context.env.add_diag(diag!(
-                    Syntax::SpecContextRestricted,
-                    (loc, "lambda expression only allowed in specifications"),
-                ));
-                EE::UnresolvedError
-            } else {
-                let bs_opt = bind_list(context, pbs);
-                let e = exp_(context, *pe);
-                match bs_opt {
-                    Some(bs) => EE::Lambda(bs, Box::new(e)),
-                    None => {
-                        assert!(context.env.has_errors());
-                        EE::UnresolvedError
-                    }
+            let bs_opt = bind_list(context, pbs);
+            let e = exp_(context, *pe);
+            match bs_opt {
+                Some(bs) => EE::Lambda(bs, Box::new(e)),
+                None => {
+                    assert!(context.env.has_errors());
+                    EE::UnresolvedError
                 }
             }
         }

--- a/language/move-compiler/src/hlir/ast.rs
+++ b/language/move-compiler/src/hlir/ast.rs
@@ -452,6 +452,7 @@ impl BaseType_ {
                 )
                 .unwrap()
             }
+            Fun => panic!("ICE unexpected function type"),
         };
         let n = sp(loc, TypeName_::Builtin(sp(loc, b_)));
         sp(loc, BaseType_::Apply(kind, n, ty_args))

--- a/language/move-compiler/src/hlir/translate.rs
+++ b/language/move-compiler/src/hlir/translate.rs
@@ -281,6 +281,7 @@ fn function(context: &mut Context, _name: FunctionName, f: T::Function) -> H::Fu
     assert!(context.has_empty_locals());
     assert!(context.tmp_counter == 0);
     let T::Function {
+        is_macro: _,
         attributes,
         visibility,
         entry,

--- a/language/move-compiler/src/hlir/translate.rs
+++ b/language/move-compiler/src/hlir/translate.rs
@@ -277,6 +277,7 @@ fn script(context: &mut Context, tscript: T::Script) -> H::Script {
 //**************************************************************************************************
 
 fn function(context: &mut Context, _name: FunctionName, f: T::Function) -> H::Function {
+    assert!(!f.is_macro, "ICE unexpected macro definition");
     assert!(context.has_empty_locals());
     assert!(context.tmp_counter == 0);
     let T::Function {
@@ -1182,11 +1183,13 @@ fn exp_impl(
             let T::ModuleCall {
                 module,
                 name,
+                is_macro,
                 type_arguments,
                 arguments,
                 parameter_types,
                 acquires,
             } = *call;
+            assert!(!is_macro, "ICE unexpanded macro call");
             let expected_type = H::Type_::from_vec(eloc, single_types(context, parameter_types));
             let htys = base_types(context, type_arguments);
             let harg = exp(context, result, Some(&expected_type), *arguments);
@@ -1199,6 +1202,7 @@ fn exp_impl(
             };
             HE::ModuleCall(Box::new(call))
         }
+        TE::VarCall(..) => panic!("ICE unexpected local call"),
         TE::Builtin(bf, targ) => builtin(context, result, eloc, *bf, targ),
         TE::Vector(vec_loc, n, tty, targ) => {
             let ty = Box::new(base_type(context, *tty));
@@ -1365,6 +1369,7 @@ fn exp_impl(
                 .collect();
             HE::Spec(u, used_locals)
         }
+        TE::Lambda(..) => panic!("ICE unexpected lambda"),
         TE::UnresolvedError => {
             assert!(context.env.has_errors());
             HE::UnresolvedError
@@ -1705,7 +1710,7 @@ fn freeze_single(sp!(sloc, s): H::SingleType) -> H::SingleType {
 fn bind_for_short_circuit(e: &T::Exp) -> bool {
     use T::UnannotatedExp_ as TE;
     match &e.exp.value {
-        TE::Use(_) => panic!("ICE should have been expanded"),
+        TE::Use(_) | TE::VarCall(..) => panic!("ICE should have been expanded"),
         TE::Value(_)
         | TE::Constant(_, _)
         | TE::Move { .. }
@@ -1740,7 +1745,8 @@ fn bind_for_short_circuit(e: &T::Exp) -> bool {
         | TE::Vector(_, _, _, _)
         | TE::BorrowLocal(_, _)
         | TE::ExpList(_)
-        | TE::Cast(_, _) => panic!("ICE unexpected exp in short circuit check: {:?}", e),
+        | TE::Cast(_, _)
+        | TE::Lambda(..) => panic!("ICE unexpected exp in short circuit check: {:?}", e),
     }
 }
 

--- a/language/move-compiler/src/naming/ast.rs
+++ b/language/move-compiler/src/naming/ast.rs
@@ -109,6 +109,7 @@ pub type FunctionBody = Spanned<FunctionBody_>;
 #[derive(PartialEq, Debug, Clone)]
 pub struct Function {
     pub attributes: Attributes,
+    pub is_macro: bool,
     pub visibility: Visibility,
     pub entry: Option<Loc>,
     pub signature: FunctionSignature,
@@ -154,6 +155,8 @@ pub enum BuiltinTypeName_ {
     Vector,
     // bool
     Bool,
+    // Function (last type arg is result type)
+    Fun,
 }
 pub type BuiltinTypeName = Spanned<BuiltinTypeName_>;
 
@@ -166,6 +169,12 @@ pub enum TypeName_ {
     ModuleType(ModuleIdent, StructName),
 }
 pub type TypeName = Spanned<TypeName_>;
+
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
+pub enum Variance {
+    CoVariant,
+    ContraVariant,
+}
 
 #[derive(Debug, Hash, Eq, PartialEq, Ord, PartialOrd, Copy, Clone)]
 pub struct TParamID(pub u64);
@@ -239,9 +248,11 @@ pub enum Exp_ {
     ModuleCall(
         ModuleIdent,
         FunctionName,
+        bool,
         Option<Vec<Type>>,
         Spanned<Vec<Exp>>,
     ),
+    VarCall(Var, Spanned<Vec<Exp>>),
     Builtin(BuiltinFunction, Spanned<Vec<Exp>>),
     Vector(Loc, Option<Type>, Spanned<Vec<Exp>>),
 
@@ -249,6 +260,7 @@ pub enum Exp_ {
     While(Box<Exp>, Box<Exp>),
     Loop(Box<Exp>),
     Block(Sequence),
+    Lambda(LValueList, Box<Exp>),
 
     Assign(LValueList, Box<Exp>),
     FieldMutate(ExpDotted, Box<Exp>),
@@ -343,6 +355,7 @@ impl BuiltinTypeName_ {
     pub const U_256: &'static str = "u256";
     pub const BOOL: &'static str = "bool";
     pub const VECTOR: &'static str = "vector";
+    pub const FUN: &'static str = "|..|..";
 
     pub fn all_names() -> &'static BTreeSet<Symbol> {
         &BUILTIN_TYPE_ALL_NAMES
@@ -390,10 +403,11 @@ impl BuiltinTypeName_ {
             }
             B::Signer => AbilitySet::signer(loc),
             B::Vector => AbilitySet::collection(loc),
+            B::Fun => AbilitySet::functions(),
         }
     }
 
-    pub fn tparam_constraints(&self, _loc: Loc) -> Vec<AbilitySet> {
+    pub fn tparam_constraints(&self, _loc: Loc, arity: usize) -> Vec<AbilitySet> {
         use BuiltinTypeName_ as B;
         // Match here to make sure this function is fixed when collections are added
         match self {
@@ -407,6 +421,25 @@ impl BuiltinTypeName_ {
             | B::U256
             | B::Bool => vec![],
             B::Vector => vec![AbilitySet::empty()],
+            B::Fun => (0..arity).map(|_| AbilitySet::empty()).collect(),
+        }
+    }
+
+    pub fn variance(&self, pos: usize, arity: usize) -> Variance {
+        match self {
+            // Function variance: given g: T1 -> R1 and f: T2 -> R2, then
+            // f can substitute g if T2 >= T1 && R1 <= R2
+            BuiltinTypeName_::Fun if pos < arity - 1 => Variance::ContraVariant,
+            _ => Variance::CoVariant,
+        }
+    }
+}
+
+impl TypeName_ {
+    pub fn variance(&self, pos: usize, arity: usize) -> Variance {
+        match self {
+            TypeName_::Builtin(bn) => bn.value.variance(pos, arity),
+            _ => Variance::CoVariant,
         }
     }
 }
@@ -486,7 +519,7 @@ impl Type_ {
                 Some(AbilitySet::primitives(b.loc))
             }
             B::Signer => Some(AbilitySet::signer(b.loc)),
-            B::Vector => None,
+            B::Vector | B::Fun => None,
         };
         let n = sp(b.loc, TypeName_::Builtin(b));
         Type_::Apply(abilities, n, ty_args)
@@ -595,6 +628,7 @@ impl fmt::Display for BuiltinTypeName_ {
                 BT::U256 => BT::U_256,
                 BT::Bool => BT::BOOL,
                 BT::Vector => BT::VECTOR,
+                BT::Fun => BT::FUN,
             }
         )
     }
@@ -732,6 +766,7 @@ impl AstDebug for (FunctionName, &Function) {
             name,
             Function {
                 attributes,
+                is_macro,
                 visibility,
                 entry,
                 signature,
@@ -747,7 +782,11 @@ impl AstDebug for (FunctionName, &Function) {
         if let FunctionBody_::Native = &body.value {
             w.write("native ");
         }
-        w.write(&format!("fun {}", name));
+        if *is_macro {
+            w.write(&format!("macro {}", name));
+        } else {
+            w.write(&format!("fun {}", name));
+        }
         signature.ast_debug(w);
         if !acquires.is_empty() {
             w.write(" acquires ");
@@ -959,13 +998,22 @@ impl AstDebug for Exp_ {
             E::Use(v) => w.write(&format!("{}", v)),
             E::Constant(None, c) => w.write(&format!("{}", c)),
             E::Constant(Some(m), c) => w.write(&format!("{}::{}", m, c)),
-            E::ModuleCall(m, f, tys_opt, sp!(_, rhs)) => {
+            E::ModuleCall(m, f, is_macro, tys_opt, sp!(_, rhs)) => {
                 w.write(&format!("{}::{}", m, f));
+                if *is_macro {
+                    w.write("!");
+                }
                 if let Some(ss) = tys_opt {
                     w.write("<");
                     ss.ast_debug(w);
                     w.write(">");
                 }
+                w.write("(");
+                w.comma(rhs, |w, e| e.ast_debug(w));
+                w.write(")");
+            }
+            E::VarCall(var, sp!(_, rhs)) => {
+                w.write(&format!("{}", var));
                 w.write("(");
                 w.comma(rhs, |w, e| e.ast_debug(w));
                 w.write(")");
@@ -1021,6 +1069,12 @@ impl AstDebug for Exp_ {
                 e.ast_debug(w);
             }
             E::Block(seq) => w.block(|w| seq.ast_debug(w)),
+            E::Lambda(sp!(_, bs), e) => {
+                w.write("|");
+                bs.ast_debug(w);
+                w.write("|");
+                e.ast_debug(w);
+            }
             E::ExpList(es) => {
                 w.write("(");
                 w.comma(es, |w, e| e.ast_debug(w));

--- a/language/move-compiler/src/naming/ast.rs
+++ b/language/move-compiler/src/naming/ast.rs
@@ -172,7 +172,7 @@ pub type TypeName = Spanned<TypeName_>;
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
 pub enum Variance {
-    CoVariant,
+    Covariant,
     ContraVariant,
 }
 
@@ -430,7 +430,7 @@ impl BuiltinTypeName_ {
             // Function variance: given g: T1 -> R1 and f: T2 -> R2, then
             // f can substitute g if T2 >= T1 && R1 <= R2
             BuiltinTypeName_::Fun if pos < arity - 1 => Variance::ContraVariant,
-            _ => Variance::CoVariant,
+            _ => Variance::Covariant,
         }
     }
 }
@@ -439,7 +439,7 @@ impl TypeName_ {
     pub fn variance(&self, pos: usize, arity: usize) -> Variance {
         match self {
             TypeName_::Builtin(bn) => bn.value.variance(pos, arity),
-            _ => Variance::CoVariant,
+            _ => Variance::Covariant,
         }
     }
 }

--- a/language/move-compiler/src/naming/translate.rs
+++ b/language/move-compiler/src/naming/translate.rs
@@ -488,6 +488,7 @@ fn function(
     let E::Function {
         attributes,
         loc: _,
+        is_macro,
         visibility,
         entry,
         signature,
@@ -918,7 +919,7 @@ fn exp_(context: &mut Context, e: E::Exp) -> N::Exp {
             let bind_opt = bind_list(context, args);
             match bind_opt {
                 None => {
-                    assert!(context.env.has_diags());
+                    assert!(context.env.has_errors());
                     N::Exp_::UnresolvedError
                 }
                 Some(bind) => NE::Lambda(bind, Box::new(exp_(context, *body))),

--- a/language/move-compiler/src/parser/ast.rs
+++ b/language/move-compiler/src/parser/ast.rs
@@ -268,6 +268,7 @@ pub struct Function {
     pub signature: FunctionSignature,
     pub acquires: Vec<NameAccessChain>,
     pub name: FunctionName,
+    pub is_macro: bool,
     pub body: FunctionBody,
 }
 
@@ -1464,6 +1465,7 @@ impl AstDebug for Function {
             entry,
             signature,
             acquires,
+            is_macro,
             name,
             body,
         } = self;
@@ -1475,7 +1477,11 @@ impl AstDebug for Function {
         if let FunctionBody_::Native = &body.value {
             w.write("native ");
         }
-        w.write(&format!("fun {}", name));
+        if *is_macro {
+            w.write(&format!("macro {}", name));
+        } else {
+            w.write(&format!("fun {}", name));
+        }
         signature.ast_debug(w);
         if !acquires.is_empty() {
             w.write(" acquires ");
@@ -1763,9 +1769,9 @@ impl AstDebug for Exp_ {
             }
             E::Block(seq) => w.block(|w| seq.ast_debug(w)),
             E::Lambda(sp!(_, bs), e) => {
-                w.write("fun ");
+                w.write("|");
                 bs.ast_debug(w);
-                w.write(" ");
+                w.write("|");
                 e.ast_debug(w);
             }
             E::Quant(kind, sp!(_, rs), trs, c_opt, e) => {

--- a/language/move-compiler/src/parser/lexer.rs
+++ b/language/move-compiler/src/parser/lexer.rs
@@ -80,6 +80,7 @@ pub enum Tok {
     Friend,
     NumSign,
     AtSign,
+    Macro,
 }
 
 impl fmt::Display for Tok {
@@ -134,6 +135,7 @@ impl fmt::Display for Tok {
             Invariant => "invariant",
             Let => "let",
             Loop => "loop",
+            Macro => "macro",
             Module => "module",
             Move => "move",
             Native => "native",
@@ -627,6 +629,7 @@ fn get_name_token(name: &str) -> Tok {
         "invariant" => Tok::Invariant,
         "let" => Tok::Let,
         "loop" => Tok::Loop,
+        "macro" => Tok::Macro,
         "module" => Tok::Module,
         "move" => Tok::Move,
         "native" => Tok::Native,

--- a/language/move-compiler/src/parser/syntax.rs
+++ b/language/move-compiler/src/parser/syntax.rs
@@ -1882,7 +1882,7 @@ fn parse_struct_type_parameters(
 
 // Parse a function declaration:
 //      FunctionDecl =
-//          ( "macro" | "fun" )
+//          [ "macro" ] "fun"
 //          <FunctionDefName> "(" Comma<Parameter> ")"
 //          (":" <Type>)?
 //          ("acquires" <NameAccessChain> ("," <NameAccessChain>)*)?
@@ -1916,14 +1916,14 @@ fn parse_function_decl(
         }
     }
 
-    // "macro" | "fun" <FunctionDefName>
+    // [ "macro" ] "fun" <FunctionDefName>
     let is_macro = if context.tokens.peek() == Tok::Macro {
         context.tokens.advance()?;
         true
     } else {
-        consume_token(context.tokens, Tok::Fun)?;
         false
     };
+    consume_token(context.tokens, Tok::Fun)?;
     let name = FunctionName(parse_identifier(context)?);
     let type_parameters = parse_optional_type_parameters(context)?;
 

--- a/language/move-compiler/src/parser/syntax.rs
+++ b/language/move-compiler/src/parser/syntax.rs
@@ -1696,7 +1696,16 @@ fn parse_type(context: &mut Context) -> Result<Type, Box<Diagnostic>> {
         }
         Tok::Pipe => {
             let args = parse_comma_list(context, Tok::Pipe, Tok::Pipe, parse_type, "a type")?;
-            let result = parse_type(context)?;
+            let result = if is_start_of_type(context) {
+                parse_type(context)?
+            } else {
+                spanned(
+                    context.tokens.file_hash(),
+                    start_loc,
+                    context.tokens.start_loc(),
+                    Type_::Unit,
+                )
+            };
             return Ok(spanned(
                 context.tokens.file_hash(),
                 start_loc,
@@ -1716,6 +1725,15 @@ fn parse_type(context: &mut Context) -> Result<Type, Box<Diagnostic>> {
     };
     let end_loc = context.tokens.previous_end_loc();
     Ok(spanned(context.tokens.file_hash(), start_loc, end_loc, t))
+}
+
+/// Checks whether the next tokens looks like the start of a type. Must be aligned
+/// with `parse_type`.
+fn is_start_of_type(context: &mut Context) -> bool {
+    matches!(
+        context.tokens.peek(),
+        Tok::LParen | Tok::Amp | Tok::AmpMut | Tok::Pipe | Tok::Identifier
+    )
 }
 
 // Parse an optional list of type arguments.
@@ -1864,7 +1882,7 @@ fn parse_struct_type_parameters(
 
 // Parse a function declaration:
 //      FunctionDecl =
-//          "fun"
+//          ( "macro" | "fun" )
 //          <FunctionDefName> "(" Comma<Parameter> ")"
 //          (":" <Type>)?
 //          ("acquires" <NameAccessChain> ("," <NameAccessChain>)*)?
@@ -1898,8 +1916,14 @@ fn parse_function_decl(
         }
     }
 
-    // "fun" <FunctionDefName>
-    consume_token(context.tokens, Tok::Fun)?;
+    // "macro" | "fun" <FunctionDefName>
+    let is_macro = if context.tokens.peek() == Tok::Macro {
+        context.tokens.advance()?;
+        true
+    } else {
+        consume_token(context.tokens, Tok::Fun)?;
+        false
+    };
     let name = FunctionName(parse_identifier(context)?);
     let type_parameters = parse_optional_type_parameters(context)?;
 
@@ -1972,6 +1996,7 @@ fn parse_function_decl(
         entry,
         signature,
         acquires,
+        is_macro,
         name,
         body,
     })
@@ -2395,7 +2420,7 @@ fn parse_module(
                         Tok::Const => ModuleMember::Constant(parse_constant_decl(
                             attributes, start_loc, modifiers, context,
                         )?),
-                        Tok::Fun => ModuleMember::Function(parse_function_decl(
+                        Tok::Fun | Tok::Macro => ModuleMember::Function(parse_function_decl(
                             attributes, start_loc, modifiers, context,
                         )?),
                         Tok::Struct => ModuleMember::Struct(parse_struct_decl(
@@ -2405,12 +2430,13 @@ fn parse_module(
                             return Err(unexpected_token_error(
                                 context.tokens,
                                 &format!(
-                                    "a module member: '{}', '{}', '{}', '{}', '{}', or '{}'",
+                                    "a module member: '{}', '{}', '{}', '{}', '{}', '{}', or '{}'",
                                     Tok::Spec,
                                     Tok::Use,
                                     Tok::Friend,
                                     Tok::Const,
                                     Tok::Fun,
+                                    Tok::Macro,
                                     Tok::Struct
                                 ),
                             ))

--- a/language/move-compiler/src/to_bytecode/translate.rs
+++ b/language/move-compiler/src/to_bytecode/translate.rs
@@ -805,6 +805,9 @@ fn base_type(context: &mut Context, sp!(_, bt_): H::BaseType) -> IR::Type {
         B::Unreachable | B::UnresolvedError => {
             panic!("ICE should not have reached compilation if there are errors")
         }
+        B::Apply(_, sp!(_, TN::Builtin(sp!(_, BT::Fun))), _) => {
+            panic!("ICE should not have reached compilation if there are function types")
+        }
         B::Apply(_, sp!(_, TN::Builtin(sp!(_, BT::Address))), _) => IRT::Address,
         B::Apply(_, sp!(_, TN::Builtin(sp!(_, BT::Signer))), _) => IRT::Signer,
         B::Apply(_, sp!(_, TN::Builtin(sp!(_, BT::U8))), _) => IRT::U8,

--- a/language/move-compiler/src/to_bytecode/translate.rs
+++ b/language/move-compiler/src/to_bytecode/translate.rs
@@ -1096,7 +1096,7 @@ fn exp_(context: &mut Context, code: &mut IR::BytecodeBlock, e: H::Exp) {
                 BT::U64 => B::CastU64,
                 BT::U128 => B::CastU128,
                 BT::U256 => B::CastU256,
-                BT::Address | BT::Signer | BT::Vector | BT::Bool => {
+                BT::Address | BT::Signer | BT::Vector | BT::Bool | BT::Fun => {
                     panic!("ICE type checking failed. unexpected cast")
                 }
             };

--- a/language/move-compiler/src/typing/ast.rs
+++ b/language/move-compiler/src/typing/ast.rs
@@ -73,6 +73,7 @@ pub type FunctionBody = Spanned<FunctionBody_>;
 
 #[derive(PartialEq, Debug, Clone)]
 pub struct Function {
+    pub is_macro: bool,
     pub attributes: Attributes,
     pub visibility: Visibility,
     pub entry: Option<Loc>,
@@ -119,6 +120,7 @@ pub type LValueList = Spanned<LValueList_>;
 pub struct ModuleCall {
     pub module: ModuleIdent,
     pub name: FunctionName,
+    pub is_macro: bool,
     pub type_arguments: Vec<Type>,
     pub arguments: Box<Exp>,
     pub parameter_types: Vec<Type>,
@@ -147,6 +149,7 @@ pub enum UnannotatedExp_ {
     Constant(Option<ModuleIdent>, ConstantName),
 
     ModuleCall(Box<ModuleCall>),
+    VarCall(Var, Box<Exp>),
     Builtin(Box<BuiltinFunction>, Box<Exp>),
     Vector(Loc, usize, Box<Type>, Box<Exp>),
 
@@ -154,6 +157,7 @@ pub enum UnannotatedExp_ {
     While(Box<Exp>, Box<Exp>),
     Loop { has_break: bool, body: Box<Exp> },
     Block(Sequence),
+    Lambda(LValueList, Box<Exp>),
     Assign(LValueList, Vec<Option<Type>>, Box<Exp>),
     Mutate(Box<Exp>, Box<Exp>),
     Return(Box<Exp>),
@@ -338,6 +342,7 @@ impl AstDebug for (FunctionName, &Function) {
         let (
             name,
             Function {
+                is_macro,
                 attributes,
                 visibility,
                 entry,
@@ -355,6 +360,9 @@ impl AstDebug for (FunctionName, &Function) {
             w.write("native ");
         }
         w.write(&format!("fun {}", name));
+        if *is_macro {
+            w.write("!");
+        }
         signature.ast_debug(w);
         if !acquires.is_empty() {
             w.write(" acquires ");
@@ -447,6 +455,12 @@ impl AstDebug for UnannotatedExp_ {
             E::ModuleCall(mcall) => {
                 mcall.ast_debug(w);
             }
+            E::VarCall(var, rhs) => {
+                w.write(&format!("{}", var));
+                w.write("(");
+                rhs.ast_debug(w);
+                w.write(")");
+            }
             E::Builtin(bf, rhs) => {
                 bf.ast_debug(w);
                 w.write("(");
@@ -500,6 +514,12 @@ impl AstDebug for UnannotatedExp_ {
                 body.ast_debug(w);
             }
             E::Block(seq) => w.block(|w| seq.ast_debug(w)),
+            E::Lambda(sp!(_, bs), e) => {
+                w.write("|");
+                bs.ast_debug(w);
+                w.write("|");
+                e.ast_debug(w);
+            }
             E::ExpList(es) => {
                 w.write("(");
                 w.comma(es, |w, e| e.ast_debug(w));
@@ -612,12 +632,16 @@ impl AstDebug for ModuleCall {
         let ModuleCall {
             module,
             name,
+            is_macro,
             type_arguments,
             parameter_types,
             acquires,
             arguments,
         } = self;
         w.write(&format!("{}::{}", module, name));
+        if *is_macro {
+            w.write("!");
+        }
         if !acquires.is_empty() || !parameter_types.is_empty() {
             w.write("[");
             if !acquires.is_empty() {

--- a/language/move-compiler/src/typing/core.rs
+++ b/language/move-compiler/src/typing/core.rs
@@ -483,7 +483,7 @@ fn error_format_impl_(b_: &Type_, subst: &Subst, nested: bool) -> String {
             let k = tys.len() - 1;
             format!(
                 "|{}|{}",
-                format_comma((&tys[0..k]).iter().map(|t| error_format_nested(t, subst))),
+                format_comma(tys[0..k].iter().map(|t| error_format_nested(t, subst))),
                 error_format_nested(&tys[k], subst)
             )
         }

--- a/language/move-compiler/src/typing/core.rs
+++ b/language/move-compiler/src/typing/core.rs
@@ -1252,7 +1252,7 @@ fn instantiate_type_args(
             TVarCase::Single("Invalid expression list type argument".to_owned())
         }
         Some(TypeName_::Builtin(sp!(_, BuiltinTypeName_::Fun))) => {
-            TVarCase::SingleButLast("Invalid expression list type argument".to_owned())
+            TVarCase::Function("Invalid expression list type argument".to_owned())
         }
         None | Some(TypeName_::Builtin(_)) | Some(TypeName_::ModuleType(_, _)) => TVarCase::Base,
     };
@@ -1314,7 +1314,7 @@ fn check_type_argument_arity<F: FnOnce() -> String>(
 
 enum TVarCase {
     Single(String),
-    SingleButLast(String),
+    Function(String),
     Base,
 }
 
@@ -1332,10 +1332,10 @@ fn make_tparams(
             let tvar = make_tvar(context, vloc);
             context.add_ability_set_constraint(loc, None::<String>, tvar.clone(), constraint);
             match &case {
-                TVarCase::SingleButLast(_) if i + 1 == arity => {
+                TVarCase::Function(_) if i + 1 == arity => {
                     // Last arg (return type of a function): do not add any constraint
                 }
-                TVarCase::SingleButLast(msg) | TVarCase::Single(msg) => {
+                TVarCase::Function(msg) | TVarCase::Single(msg) => {
                     context.add_single_type_constraint(loc, msg, tvar.clone())
                 }
                 TVarCase::Base => {

--- a/language/move-compiler/src/typing/expand.rs
+++ b/language/move-compiler/src/typing/expand.rs
@@ -180,7 +180,7 @@ pub fn exp(context: &mut Context, e: &mut T::Exp) {
                 BT::U64 => u64_max,
                 BT::U128 => u128_max,
                 BT::U256 => u256_max,
-                BT::Address | BT::Signer | BT::Vector | BT::Bool => unreachable!(),
+                BT::Address | BT::Signer | BT::Vector | BT::Bool | BT::Fun => unreachable!(),
             };
             let new_exp = if v > max {
                 let msg = format!(
@@ -220,7 +220,7 @@ pub fn exp(context: &mut Context, e: &mut T::Exp) {
                     BT::U64 => Value_::U64(v.down_cast_lossy()),
                     BT::U128 => Value_::U128(v.down_cast_lossy()),
                     BT::U256 => Value_::U256(v),
-                    BT::Address | BT::Signer | BT::Vector | BT::Bool => unreachable!(),
+                    BT::Address | BT::Signer | BT::Vector | BT::Bool | BT::Fun => unreachable!(),
                 };
                 E::Value(sp(*vloc, value_))
             };

--- a/language/move-compiler/src/typing/globals.rs
+++ b/language/move-compiler/src/typing/globals.rs
@@ -277,13 +277,6 @@ where
             assert!(context.env.has_errors());
             return None;
         }
-        T::Apply(Some(abilities), sp!(_, TN::Multiple(_)), _)
-        | T::Apply(Some(abilities), sp!(_, TN::Builtin(_)), _) => {
-            // Key ability is checked by constraints
-            assert!(!abilities.has_ability_(Ability_::Key));
-            assert!(context.env.has_errors());
-            return None;
-        }
         T::Param(_) | T::Apply(_, sp!(_, TN::Builtin(sp!(_, BuiltinTypeName_::Fun))), _) => {
             let ty_debug = core::error_format(global_type, &Subst::empty());
             let tmsg = format!(
@@ -303,7 +296,7 @@ where
         | T::Apply(Some(abilities), sp!(_, TN::Builtin(_)), _) => {
             // Key ability is checked by constraints
             assert!(!abilities.has_ability_(Ability_::Key));
-            assert!(context.env.has_diags());
+            assert!(context.env.has_errors());
             return None;
         }
         T::Apply(Some(_), sp!(_, TN::ModuleType(m, s)), _args) => (*m, s),

--- a/language/move-compiler/src/typing/infinite_instantiations.rs
+++ b/language/move-compiler/src/typing/infinite_instantiations.rs
@@ -228,7 +228,7 @@ fn exp(context: &mut Context, e: &T::Exp) {
             context.add_usage(e.exp.loc, &call.module, &call.name, &call.type_arguments);
             exp(context, &call.arguments)
         }
-
+        E::VarCall(_, args) => exp(context, args),
         E::IfElse(eb, et, ef) => {
             exp(context, eb);
             exp(context, et);
@@ -240,6 +240,7 @@ fn exp(context: &mut Context, e: &T::Exp) {
         }
         E::Loop { body: eloop, .. } => exp(context, eloop),
         E::Block(seq) => sequence(context, seq),
+        E::Lambda(_, body) => exp(context, body),
         E::Assign(_, _, er) => exp(context, er),
 
         E::Builtin(_, er)

--- a/language/move-compiler/src/typing/translate.rs
+++ b/language/move-compiler/src/typing/translate.rs
@@ -10,7 +10,7 @@ use crate::{
     diag,
     diagnostics::{codes::*, Diagnostic},
     expansion::ast::{Fields, ModuleIdent, Value_},
-    naming::ast::{self as N, TParam, TParamID, Type, TypeName_, Type_},
+    naming::ast::{self as N, BuiltinTypeName_, TParam, TParamID, Type, TypeName_, Type_},
     parser::ast::{Ability_, BinOp_, ConstantName, Field, FunctionName, StructName, UnaryOp_, Var},
     shared::{unique_map::UniqueMap, *},
     typing::ast as T,
@@ -133,6 +133,7 @@ fn function(
     let loc = name.loc();
     let N::Function {
         attributes,
+        is_macro,
         visibility,
         entry,
         mut signature,
@@ -160,11 +161,24 @@ fn function(
             sp(loc, Type_::Unit),
         );
     }
-    expand::function_signature(context, &mut signature);
+    if is_macro {
+        expand::macro_signature(context, &mut signature);
+    } else {
+        expand::function_signature(context, &mut signature);
+    }
 
     let body = function_body(context, &acquires, n_body);
     context.current_function = None;
+
+    if is_macro && !context.env.has_blocking_diags() {
+        // TODO: remove once macro expansion is implemented
+        // flag as an error so we bail out after typing
+        context
+            .env
+            .add_diag(diag!(Bug::Unimplemented, (loc, "macro expansion")));
+    }
     T::Function {
+        is_macro,
         attributes,
         visibility,
         entry,
@@ -400,10 +414,18 @@ mod check_valid_constant {
                 exp(context, &call.arguments);
                 "Module calls are"
             }
+            E::VarCall(_, args) => {
+                exp(context, args);
+                "Local calls are"
+            }
             E::Builtin(b, args) => {
                 exp(context, args);
                 s = format!("'{}' is", b);
                 &s
+            }
+            E::Lambda(_, args) => {
+                exp(context, args);
+                "lambda expressions are"
             }
             E::IfElse(eb, et, ef) => {
                 exp(context, eb);
@@ -524,6 +546,7 @@ fn struct_def(context: &mut Context, s: &mut N::StructDefinition) {
         let loc = idx_ty.1.loc;
         let subst_ty = core::subst_tparams(tparam_subst, idx_ty.1.clone());
         let inst_ty = core::instantiate(context, subst_ty);
+        core::check_non_fun(context, &inst_ty);
         context.add_base_type_constraint(loc, "Invalid field type", inst_ty.clone());
         for declared_ability in declared_abilities {
             let required = declared_ability.value.requires();
@@ -938,6 +961,32 @@ enum SeqCase {
     },
 }
 
+fn lambda(
+    context: &mut Context,
+    loc: Loc,
+    args: N::LValueList,
+    body: N::Exp,
+) -> (N::Type, T::UnannotatedExp_) {
+    let old_locals = context.save_locals_scope();
+    let (declared, args) = bind_list(context, args, None);
+    let body = exp_(context, body);
+    context.close_locals_scope(old_locals, declared);
+    let fun_type_ctor = sp(loc, TypeName_::Builtin(sp(loc, BuiltinTypeName_::Fun)));
+    let fun_type_args = args
+        .value
+        .iter()
+        .filter_map(|lv| match &lv.value {
+            T::LValue_::Var(_, ty) => Some(ty.as_ref().clone()),
+            _ => None,
+        })
+        .chain(std::iter::once(body.ty.clone()))
+        .collect();
+    (
+        sp(loc, N::Type_::Apply(None, fun_type_ctor, fun_type_args)),
+        T::UnannotatedExp_::Lambda(args, Box::new(body)),
+    )
+}
+
 fn sequence(context: &mut Context, seq: N::Sequence) -> T::Sequence {
     use N::SequenceItem_ as NS;
     use T::SequenceItem_ as TS;
@@ -1225,9 +1274,13 @@ fn exp_inner(context: &mut Context, sp!(eloc, ne_): N::Exp) -> T::Exp {
             (ty, TE::Use(var))
         }
 
-        NE::ModuleCall(m, f, ty_args_opt, sp!(argloc, nargs_)) => {
+        NE::ModuleCall(m, f, is_macro, ty_args_opt, sp!(argloc, nargs_)) => {
             let args = exp_vec(context, nargs_);
-            module_call(context, eloc, m, f, ty_args_opt, argloc, args)
+            module_call(context, eloc, m, f, is_macro, ty_args_opt, argloc, args)
+        }
+        NE::VarCall(var, sp!(argloc, nargs_)) => {
+            let args = exp_vec(context, nargs_);
+            var_call(context, eloc, var, argloc, args)
         }
         NE::Builtin(b, sp!(argloc, nargs_)) => {
             let args = exp_vec(context, nargs_);
@@ -1281,7 +1334,7 @@ fn exp_inner(context: &mut Context, sp!(eloc, ne_): N::Exp) -> T::Exp {
             let seq = sequence(context, nseq);
             (sequence_type(&seq).clone(), TE::Block(seq))
         }
-
+        NE::Lambda(args, body) => lambda(context, eloc, args, *body),
         NE::Assign(na, nr) => {
             let er = exp(context, nr);
             let a = assign_list(context, na, er.ty.clone());
@@ -1643,9 +1696,9 @@ fn lvalue(
     ty: Type,
 ) -> T::LValue {
     use LValueCase as C;
-
     use N::LValue_ as NL;
     use T::LValue_ as TL;
+
     let tl_ = match nl_ {
         NL::Ignore => {
             context.add_ability_constraint(
@@ -1993,7 +2046,7 @@ fn exp_dotted_to_owned_value(
 ) -> T::Exp {
     use T::UnannotatedExp_ as TE;
     match edot {
-        // TODO investigate this nonsense
+        // sTODO investigate this nonsense
         sp!(_, ExpDotted_::Exp(lhs)) => *lhs,
         edot => {
             let name = match &edot {
@@ -2039,17 +2092,83 @@ impl crate::shared::ast_debug::AstDebug for ExpDotted_ {
 // Calls
 //**************************************************************************************************
 
+fn var_call(
+    context: &mut Context,
+    loc: Loc,
+    var: Var,
+    argloc: Loc,
+    args: Vec<T::Exp>,
+) -> (Type, T::UnannotatedExp_) {
+    let ty = context.get_local(var.0.loc, "function usage", &var);
+    match ty.value {
+        Type_::UnresolvedError => {
+            assert!(context.env.has_diags());
+            (ty, T::UnannotatedExp_::UnresolvedError)
+        }
+        Type_::Apply(_, sp!(_, TypeName_::Builtin(sp!(_, BuiltinTypeName_::Fun))), targs) => {
+            let (arguments, arg_tys) = call_args(
+                context,
+                loc,
+                || format!("Invalid call of '{}'", var),
+                targs.len() - 1,
+                argloc,
+                args,
+            );
+            assert!(arg_tys.len() == targs.len() - 1);
+            for (arg_ty, param_ty) in arg_tys
+                .into_iter()
+                .zip(targs[0..targs.len() - 1].iter().cloned())
+            {
+                let msg = || format!("Invalid call of '{}'. Invalid argument type", var);
+                subtype(context, loc, msg, arg_ty, param_ty);
+            }
+            (
+                targs[targs.len() - 1].clone(),
+                T::UnannotatedExp_::VarCall(var, arguments),
+            )
+        }
+        ty_ => {
+            let ty_str = core::error_format_(&ty_, &context.subst);
+            context.env.add_diag(diag!(
+                TypeSafety::JoinError,
+                (
+                    var.loc(),
+                    format!("Expected a function type but found {}", ty_str)
+                )
+            ));
+            (
+                context.error_type(ty.loc),
+                T::UnannotatedExp_::UnresolvedError,
+            )
+        }
+    }
+}
+
 fn module_call(
     context: &mut Context,
     loc: Loc,
     m: ModuleIdent,
     f: FunctionName,
+    is_macro: bool,
     ty_args_opt: Option<Vec<Type>>,
     argloc: Loc,
     args: Vec<T::Exp>,
 ) -> (Type, T::UnannotatedExp_) {
-    let (_, ty_args, parameters, acquires, ret_ty) =
+    let (_, ty_args, parameters, acquires, ret_ty, decl_is_macro) =
         core::make_function_type(context, loc, &m, &f, ty_args_opt);
+    if is_macro != decl_is_macro {
+        context.env.add_diag(diag!(
+            TypeSafety::InvalidCallTarget,
+            (
+                loc,
+                if is_macro {
+                    format!("'{}' is not a macro but a function", f)
+                } else {
+                    format!("'{}' is not a function but a macro", f)
+                }
+            )
+        ));
+    }
     let (arguments, arg_tys) = call_args(
         context,
         loc,
@@ -2072,11 +2191,19 @@ fn module_call(
     let call = T::ModuleCall {
         module: m,
         name: f,
+        is_macro,
         type_arguments: ty_args,
         arguments,
         parameter_types: params_ty_list,
         acquires,
     };
+    if is_macro && !context.env.has_blocking_diags() {
+        // TODO: remove once macro expansion is implemented
+        // flag as an error so we bail out after typing
+        context
+            .env
+            .add_diag(diag!(Bug::Unimplemented, (loc, "macro expansion")));
+    }
     (ret_ty, T::UnannotatedExp_::ModuleCall(Box::new(call)))
 }
 

--- a/language/move-compiler/src/typing/translate.rs
+++ b/language/move-compiler/src/typing/translate.rs
@@ -170,7 +170,7 @@ fn function(
     let body = function_body(context, &acquires, n_body);
     context.current_function = None;
 
-    if is_macro && !context.env.has_blocking_diags() {
+    if is_macro && !context.env.has_errors() {
         // TODO: remove once macro expansion is implemented
         // flag as an error so we bail out after typing
         context
@@ -2102,7 +2102,7 @@ fn var_call(
     let ty = context.get_local(var.0.loc, "function usage", &var);
     match ty.value {
         Type_::UnresolvedError => {
-            assert!(context.env.has_diags());
+            assert!(context.env.has_errors());
             (ty, T::UnannotatedExp_::UnresolvedError)
         }
         Type_::Apply(_, sp!(_, TypeName_::Builtin(sp!(_, BuiltinTypeName_::Fun))), targs) => {
@@ -2197,7 +2197,7 @@ fn module_call(
         parameter_types: params_ty_list,
         acquires,
     };
-    if is_macro && !context.env.has_blocking_diags() {
+    if is_macro && !context.env.has_errors() {
         // TODO: remove once macro expansion is implemented
         // flag as an error so we bail out after typing
         context

--- a/language/move-compiler/src/unit_test/filter_test_members.rs
+++ b/language/move-compiler/src/unit_test/filter_test_members.rs
@@ -201,6 +201,7 @@ fn create_test_poison(mloc: Loc) -> P::ModuleMember {
         entry: None,
         acquires: vec![],
         signature,
+        is_macro: false,
         name: P::FunctionName(sp(mloc, "unit_test_poison".into())),
         body: sp(
             mloc,

--- a/language/move-compiler/tests/move_check/expansion/use_function_tparam_shadows.exp
+++ b/language/move-compiler/tests/move_check/expansion/use_function_tparam_shadows.exp
@@ -4,9 +4,9 @@ warning[W09001]: unused alias
 7 │     use 0x2::X::foo;
   │                 ^^^ Unused 'use' of alias 'foo'. Consider removing it
 
-error[E03005]: unbound unscoped name
+error[E03009]: unbound variable
    ┌─ tests/move_check/expansion/use_function_tparam_shadows.move:10:9
    │
 10 │         foo()
-   │         ^^^ Unbound function 'foo' in current scope
+   │         ^^^ Invalid function usage. Unbound variable 'foo'
 

--- a/language/move-compiler/tests/move_check/expansion/use_function_unbound.exp
+++ b/language/move-compiler/tests/move_check/expansion/use_function_unbound.exp
@@ -7,9 +7,9 @@ error[E03003]: unbound module member
 6 │     use 0x2::X::u;
   │                 ^ Invalid 'use'. Unbound member 'u' in module '0x2::X'
 
-error[E03005]: unbound unscoped name
+error[E03009]: unbound variable
   ┌─ tests/move_check/expansion/use_function_unbound.move:9:9
   │
 9 │         u()
-  │         ^ Unbound function 'u' in current scope
+  │         ^ Invalid function usage. Unbound variable 'u'
 

--- a/language/move-compiler/tests/move_check/naming/unbound_builtin.exp
+++ b/language/move-compiler/tests/move_check/naming/unbound_builtin.exp
@@ -1,18 +1,18 @@
-error[E03005]: unbound unscoped name
+error[E03009]: unbound variable
   ┌─ tests/move_check/naming/unbound_builtin.move:3:9
   │
 3 │         global_borrow();
-  │         ^^^^^^^^^^^^^ Unbound function 'global_borrow' in current scope
+  │         ^^^^^^^^^^^^^ Invalid function usage. Unbound variable 'global_borrow'
 
-error[E03005]: unbound unscoped name
+error[E03009]: unbound variable
   ┌─ tests/move_check/naming/unbound_builtin.move:4:9
   │
 4 │         release<u64>();
-  │         ^^^^^^^ Unbound function 'release' in current scope
+  │         ^^^^^^^ Invalid function usage. Unbound variable 'release'
 
-error[E03005]: unbound unscoped name
+error[E03009]: unbound variable
   ┌─ tests/move_check/naming/unbound_builtin.move:5:9
   │
 5 │         sudo(false);
-  │         ^^^^ Unbound function 'sudo' in current scope
+  │         ^^^^ Invalid function usage. Unbound variable 'sudo'
 

--- a/language/move-compiler/tests/move_check/naming/unbound_unqualified_function.exp
+++ b/language/move-compiler/tests/move_check/naming/unbound_unqualified_function.exp
@@ -1,18 +1,18 @@
-error[E03005]: unbound unscoped name
+error[E03009]: unbound variable
   ┌─ tests/move_check/naming/unbound_unqualified_function.move:3:9
   │
 3 │         bar();
-  │         ^^^ Unbound function 'bar' in current scope
+  │         ^^^ Invalid function usage. Unbound variable 'bar'
 
-error[E03005]: unbound unscoped name
+error[E03009]: unbound variable
   ┌─ tests/move_check/naming/unbound_unqualified_function.move:4:17
   │
 4 │         let x = bar();
-  │                 ^^^ Unbound function 'bar' in current scope
+  │                 ^^^ Invalid function usage. Unbound variable 'bar'
 
-error[E03005]: unbound unscoped name
+error[E03009]: unbound variable
   ┌─ tests/move_check/naming/unbound_unqualified_function.move:5:10
   │
 5 │         *bar() = 0;
-  │          ^^^ Unbound function 'bar' in current scope
+  │          ^^^ Invalid function usage. Unbound variable 'bar'
 

--- a/language/move-compiler/tests/move_check/parser/module_missing_rbrace.exp
+++ b/language/move-compiler/tests/move_check/parser/module_missing_rbrace.exp
@@ -5,5 +5,5 @@ error[E01002]: unexpected token
   │ ^
   │ 
   │ Unexpected end-of-file
-  │ Expected a module member: 'spec', 'use', 'friend', 'const', 'fun', or 'struct'
+  │ Expected a module member: 'spec', 'use', 'friend', 'const', 'fun', 'macro', or 'struct'
 

--- a/language/move-compiler/tests/move_check/parser/spec_parsing_fun_type_fail.exp
+++ b/language/move-compiler/tests/move_check/parser/spec_parsing_fun_type_fail.exp
@@ -1,6 +1,6 @@
-error[E01010]: syntax item restricted to spec contexts
+error[E04024]: invalid usage of function type
   ┌─ tests/move_check/parser/spec_parsing_fun_type_fail.move:2:29
   │
 2 │     fun fun_type_in_prog(p: |u64|u64) {
-  │                             ^^^^^^^^ `|_|_` function type only allowed in specifications
+  │                             ^^^^^^^^ function type only allowed for macro arguments
 

--- a/language/move-compiler/tests/move_check/parser/spec_parsing_lambda_fail.exp
+++ b/language/move-compiler/tests/move_check/parser/spec_parsing_lambda_fail.exp
@@ -1,6 +1,0 @@
-error[E01010]: syntax item restricted to spec contexts
-  ┌─ tests/move_check/parser/spec_parsing_lambda_fail.move:3:15
-  │
-3 │       let _ = |y| x + y;
-  │               ^^^^^^^^^ lambda expression only allowed in specifications
-

--- a/language/move-compiler/tests/move_check/parser/spec_parsing_lambda_fail.move
+++ b/language/move-compiler/tests/move_check/parser/spec_parsing_lambda_fail.move
@@ -1,5 +1,0 @@
-module 0x8675309::M {
-    fun lambda_in_prog(x: u64) {
-      let _ = |y| x + y;
-    }
-}

--- a/language/move-compiler/tests/move_check/typing/constant_unsupported_exps.exp
+++ b/language/move-compiler/tests/move_check/typing/constant_unsupported_exps.exp
@@ -52,11 +52,11 @@ error[E04013]: invalid statement or expression in constant
 20 │         f_public();
    │         ^^^^^^^^^^ Module calls are not supported in constants
 
-error[E03005]: unbound unscoped name
+error[E03009]: unbound variable
    ┌─ tests/move_check/typing/constant_unsupported_exps.move:21:9
    │
 21 │         f_script();
-   │         ^^^^^^^^ Unbound function 'f_script' in current scope
+   │         ^^^^^^^^ Invalid function usage. Unbound variable 'f_script'
 
 error[E04013]: invalid statement or expression in constant
    ┌─ tests/move_check/typing/constant_unsupported_exps.move:22:9

--- a/language/move-compiler/tests/move_check/typing/lambda.exp
+++ b/language/move-compiler/tests/move_check/typing/lambda.exp
@@ -1,0 +1,93 @@
+error[E04017]: too many arguments
+   ┌─ tests/move_check/typing/lambda.move:40:13
+   │
+40 │             action(XVector::borrow(v, i), i); // expected to have wrong argument count
+   │             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │             │     │
+   │             │     Found 2 argument(s) here
+   │             Invalid call of 'action'. The call expected 1 argument(s) but got 2
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/lambda.move:48:13
+   │
+45 │     public macro wrong_local_call_arg_type<T>(v: &vector<T>, action: |&T|) {
+   │                                                                       -- Expected: '&T'
+   ·
+48 │             action(i); // expected to have wrong argument type
+   │             ^^^^^^^^^ Invalid call of 'action'. Invalid argument type
+   ·
+96 │     public fun length<T>(v: &vector<T>): u64 { abort(1) }
+   │                                          --- Given: 'u64'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/lambda.move:56:19
+   │
+53 │     public macro wrong_local_call_result_type<T>(v: &vector<T>, action: |&T|) {
+   │                                                                         ---- Found: '()'. It is not compatible with the other type.
+   ·
+56 │             i = i + action(XVector::borrow(v, i)); // expected to have wrong result type
+   │                   ^ Incompatible arguments to '+'
+   ·
+96 │     public fun length<T>(v: &vector<T>): u64 { abort(1) }
+   │                                          --- Found: 'u64'. It is not compatible with the other type.
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/lambda.move:61:9
+   │
+61 │         x(1)
+   │         ^ Expected a function type but found 'u64'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/lambda.move:67:9
+   │
+ 4 │     public macro foreach<T>(v: &vector<T>, action: |&T|) { // expected to be not implemented
+   │                                                     -- Given: '&{integer}'
+   ·
+67 │         foreach!(&v, |e| sum = sum + e) // expected to cannot infer type
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │         │             │
+   │         │             Expected: integer
+   │         Invalid call of '0x8675309::M::foreach'. Invalid argument for parameter 'action'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/lambda.move:73:9
+   │
+ 4 │     public macro foreach<T>(v: &vector<T>, action: |&T|) { // expected to be not implemented
+   │                                                    ---- Expected: '()'
+   ·
+73 │         foreach!(&v, |e| { sum = sum + *e; *e }) // expected to have wrong result type of lambda
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │         │                                  │
+   │         │                                  Given: integer
+   │         Invalid call of '0x8675309::M::foreach'. Invalid argument for parameter 'action'
+
+error[E04024]: invalid usage of function type
+   ┌─ tests/move_check/typing/lambda.move:77:18
+   │
+77 │         let _x = |i| i + 1; // expected lambda not allowed
+   │                  ^^^^^^^^^ function type only allowed for macro arguments
+
+error[E04024]: invalid usage of function type
+   ┌─ tests/move_check/typing/lambda.move:81:12
+   │
+81 │         f: |u64|u64, // expected lambda not allowed
+   │            ^^^^^^^^ function type only allowed for macro arguments
+
+error[E04024]: invalid usage of function type
+   ┌─ tests/move_check/typing/lambda.move:84:46
+   │
+84 │     public fun fun_arg_lambda_not_allowed(x: |u64|) {} // expected lambda not allowed
+   │                                              ^^^^^ function type only allowed for macro arguments
+
+error[E04024]: invalid usage of function type
+   ┌─ tests/move_check/typing/lambda.move:86:53
+   │
+86 │     public macro macro_result_lambda_not_allowed(): |u64| {  // expected lambda not allowed
+   │                                                     ^^^^^ function type only allowed for macro arguments
+
+error[E04024]: invalid usage of function type
+   ┌─ tests/move_check/typing/lambda.move:89:49
+   │
+89 │     public fun fun_result_lambda_not_allowed(): |u64| {  // expected lambda not allowed
+   │                                                 ^^^^^ function type only allowed for macro arguments
+

--- a/language/move-compiler/tests/move_check/typing/lambda.exp
+++ b/language/move-compiler/tests/move_check/typing/lambda.exp
@@ -10,8 +10,8 @@ error[E04017]: too many arguments
 error[E04007]: incompatible types
    ┌─ tests/move_check/typing/lambda.move:48:13
    │
-45 │     public macro wrong_local_call_arg_type<T>(v: &vector<T>, action: |&T|) {
-   │                                                                       -- Expected: '&T'
+45 │     public macro fun wrong_local_call_arg_type<T>(v: &vector<T>, action: |&T|) {
+   │                                                                           -- Expected: '&T'
    ·
 48 │             action(i); // expected to have wrong argument type
    │             ^^^^^^^^^ Invalid call of 'action'. Invalid argument type
@@ -22,8 +22,8 @@ error[E04007]: incompatible types
 error[E04007]: incompatible types
    ┌─ tests/move_check/typing/lambda.move:56:19
    │
-53 │     public macro wrong_local_call_result_type<T>(v: &vector<T>, action: |&T|) {
-   │                                                                         ---- Found: '()'. It is not compatible with the other type.
+53 │     public macro fun wrong_local_call_result_type<T>(v: &vector<T>, action: |&T|) {
+   │                                                                             ---- Found: '()'. It is not compatible with the other type.
    ·
 56 │             i = i + action(XVector::borrow(v, i)); // expected to have wrong result type
    │                   ^ Incompatible arguments to '+'
@@ -40,8 +40,8 @@ error[E04007]: incompatible types
 error[E04007]: incompatible types
    ┌─ tests/move_check/typing/lambda.move:67:9
    │
- 4 │     public macro foreach<T>(v: &vector<T>, action: |&T|) { // expected to be not implemented
-   │                                                     -- Given: '&{integer}'
+ 4 │     public macro fun foreach<T>(v: &vector<T>, action: |&T|) { // expected to be not implemented
+   │                                                         -- Given: '&{integer}'
    ·
 67 │         foreach!(&v, |e| sum = sum + e) // expected to cannot infer type
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -52,8 +52,8 @@ error[E04007]: incompatible types
 error[E04007]: incompatible types
    ┌─ tests/move_check/typing/lambda.move:73:9
    │
- 4 │     public macro foreach<T>(v: &vector<T>, action: |&T|) { // expected to be not implemented
-   │                                                    ---- Expected: '()'
+ 4 │     public macro fun foreach<T>(v: &vector<T>, action: |&T|) { // expected to be not implemented
+   │                                                        ---- Expected: '()'
    ·
 73 │         foreach!(&v, |e| { sum = sum + *e; *e }) // expected to have wrong result type of lambda
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -80,10 +80,10 @@ error[E04024]: invalid usage of function type
    │                                              ^^^^^ function type only allowed for macro arguments
 
 error[E04024]: invalid usage of function type
-   ┌─ tests/move_check/typing/lambda.move:86:53
+   ┌─ tests/move_check/typing/lambda.move:86:57
    │
-86 │     public macro macro_result_lambda_not_allowed(): |u64| {  // expected lambda not allowed
-   │                                                     ^^^^^ function type only allowed for macro arguments
+86 │     public macro fun macro_result_lambda_not_allowed(): |u64| {  // expected lambda not allowed
+   │                                                         ^^^^^ function type only allowed for macro arguments
 
 error[E04024]: invalid usage of function type
    ┌─ tests/move_check/typing/lambda.move:89:49

--- a/language/move-compiler/tests/move_check/typing/lambda.move
+++ b/language/move-compiler/tests/move_check/typing/lambda.move
@@ -1,0 +1,100 @@
+module 0x8675309::M {
+    use 0x1::XVector;
+
+    public macro foreach<T>(v: &vector<T>, action: |&T|) { // expected to be not implemented
+        let i = 0;
+        while (i < XVector::length(v)) {
+            action(XVector::borrow(v, i));
+            i = i + 1;
+        }
+    }
+
+    public macro reduce<R, T>(v: vector<T>, accu: R, reducer: |T, R|R): R {
+        while (!XVector::is_empty(&v)) {
+            accu = reducer(XVector::pop_back(&mut v), accu);
+        };
+        accu
+    }
+
+
+    public fun correct_foreach() {
+        let v = vector[1, 2, 3];
+        let sum = 0;
+        foreach!(&v, |e| sum = sum + *e) // expected to be not implemented
+    }
+
+    public fun correct_reduce(): u64 {
+        let v = vector[1, 2, 3];
+        reduce!(v, 0, |t, r| t + r)
+    }
+
+    public fun corrected_nested() {
+        let v = vector[vector[1,2], vector[3]];
+        let sum = 0;
+        foreach!(&v, |e| sum = sum + reduce!(*e, 0, |t, r| t + r));
+    }
+
+    public macro wrong_local_call_arg_count<T>(v: &vector<T>, action: |&T|) {
+        let i = 0;
+        while (i < XVector::length(v)) {
+            action(XVector::borrow(v, i), i); // expected to have wrong argument count
+            i = i + 1;
+        }
+    }
+
+    public macro wrong_local_call_arg_type<T>(v: &vector<T>, action: |&T|) {
+        let i = 0;
+        while (i < XVector::length(v)) {
+            action(i); // expected to have wrong argument type
+            i = i + 1;
+        }
+    }
+
+    public macro wrong_local_call_result_type<T>(v: &vector<T>, action: |&T|) {
+        let i = 0;
+        while (i < XVector::length(v)) {
+            i = i + action(XVector::borrow(v, i)); // expected to have wrong result type
+        }
+    }
+
+    public fun wrong_local_call_no_fun(x: u64) {
+        x(1)
+    }
+
+    public fun wrong_lambda_inferred_type() {
+        let v = vector[1, 2, 3];
+        let sum = 0;
+        foreach!(&v, |e| sum = sum + e) // expected to cannot infer type
+    }
+
+    public fun wrong_lambda_result_type() {
+        let v = vector[1, 2, 3];
+        let sum = 0;
+        foreach!(&v, |e| { sum = sum + *e; *e }) // expected to have wrong result type of lambda
+    }
+
+    public fun lambda_not_allowed() {
+        let _x = |i| i + 1; // expected lambda not allowed
+    }
+
+    struct FieldFunNotAllowed {
+        f: |u64|u64, // expected lambda not allowed
+    }
+
+    public fun fun_arg_lambda_not_allowed(x: |u64|) {} // expected lambda not allowed
+
+    public macro macro_result_lambda_not_allowed(): |u64| {  // expected lambda not allowed
+        abort (1)
+    }
+    public fun fun_result_lambda_not_allowed(): |u64| {  // expected lambda not allowed
+        abort (1)
+    }
+
+}
+
+module 0x1::XVector {
+    public fun length<T>(v: &vector<T>): u64 { abort(1) }
+    public fun is_empty<T>(v: &vector<T>): bool { abort(1) }
+    public fun borrow<T>(v: &vector<T>, i: u64): &T { abort(1) }
+    public fun pop_back<T>(v: &mut vector<T>): T { abort(1) }
+}

--- a/language/move-compiler/tests/move_check/typing/lambda.move
+++ b/language/move-compiler/tests/move_check/typing/lambda.move
@@ -1,7 +1,7 @@
 module 0x8675309::M {
     use 0x1::XVector;
 
-    public macro foreach<T>(v: &vector<T>, action: |&T|) { // expected to be not implemented
+    public macro fun foreach<T>(v: &vector<T>, action: |&T|) { // expected to be not implemented
         let i = 0;
         while (i < XVector::length(v)) {
             action(XVector::borrow(v, i));
@@ -9,7 +9,7 @@ module 0x8675309::M {
         }
     }
 
-    public macro reduce<R, T>(v: vector<T>, accu: R, reducer: |T, R|R): R {
+    public macro fun reduce<R, T>(v: vector<T>, accu: R, reducer: |T, R|R): R {
         while (!XVector::is_empty(&v)) {
             accu = reducer(XVector::pop_back(&mut v), accu);
         };
@@ -34,7 +34,7 @@ module 0x8675309::M {
         foreach!(&v, |e| sum = sum + reduce!(*e, 0, |t, r| t + r));
     }
 
-    public macro wrong_local_call_arg_count<T>(v: &vector<T>, action: |&T|) {
+    public macro fun wrong_local_call_arg_count<T>(v: &vector<T>, action: |&T|) {
         let i = 0;
         while (i < XVector::length(v)) {
             action(XVector::borrow(v, i), i); // expected to have wrong argument count
@@ -42,7 +42,7 @@ module 0x8675309::M {
         }
     }
 
-    public macro wrong_local_call_arg_type<T>(v: &vector<T>, action: |&T|) {
+    public macro fun wrong_local_call_arg_type<T>(v: &vector<T>, action: |&T|) {
         let i = 0;
         while (i < XVector::length(v)) {
             action(i); // expected to have wrong argument type
@@ -50,7 +50,7 @@ module 0x8675309::M {
         }
     }
 
-    public macro wrong_local_call_result_type<T>(v: &vector<T>, action: |&T|) {
+    public macro fun wrong_local_call_result_type<T>(v: &vector<T>, action: |&T|) {
         let i = 0;
         while (i < XVector::length(v)) {
             i = i + action(XVector::borrow(v, i)); // expected to have wrong result type
@@ -83,7 +83,7 @@ module 0x8675309::M {
 
     public fun fun_arg_lambda_not_allowed(x: |u64|) {} // expected lambda not allowed
 
-    public macro macro_result_lambda_not_allowed(): |u64| {  // expected lambda not allowed
+    public macro fun macro_result_lambda_not_allowed(): |u64| {  // expected lambda not allowed
         abort (1)
     }
     public fun fun_result_lambda_not_allowed(): |u64| {  // expected lambda not allowed

--- a/language/move-compiler/tests/move_check/typing/module_call_missing_function.exp
+++ b/language/move-compiler/tests/move_check/typing/module_call_missing_function.exp
@@ -4,11 +4,11 @@ error[E03003]: unbound module member
 13 │         Self::fooo();
    │         ^^^^^^^^^^ Invalid module access. Unbound function 'fooo' in module '0x2::M'
 
-error[E03005]: unbound unscoped name
+error[E03009]: unbound variable
    ┌─ tests/move_check/typing/module_call_missing_function.move:14:9
    │
 14 │         foooo();
-   │         ^^^^^ Unbound function 'foooo' in current scope
+   │         ^^^^^ Invalid function usage. Unbound variable 'foooo'
 
 error[E03003]: unbound module member
    ┌─ tests/move_check/typing/module_call_missing_function.move:15:9

--- a/language/move-compiler/tests/move_check/unit_test/test_filter_function.exp
+++ b/language/move-compiler/tests/move_check/unit_test/test_filter_function.exp
@@ -1,6 +1,6 @@
-error[E03005]: unbound unscoped name
+error[E03009]: unbound variable
   ┌─ tests/move_check/unit_test/test_filter_function.move:6:24
   │
 6 │     public fun foo() { bar() }
-  │                        ^^^ Unbound function 'bar' in current scope
+  │                        ^^^ Invalid function usage. Unbound variable 'bar'
 

--- a/language/move-compiler/tests/move_check/verification/single_module_invalid.exp
+++ b/language/move-compiler/tests/move_check/verification/single_module_invalid.exp
@@ -10,9 +10,9 @@ error[E03004]: unbound type
 9 │         Foo {}
   │         ^^^ Unbound type 'Foo' in current scope
 
-error[E03005]: unbound unscoped name
+error[E03009]: unbound variable
    ┌─ tests/move_check/verification/single_module_invalid.move:17:24
    │
 17 │     public fun baz() { bar() }
-   │                        ^^^ Unbound function 'bar' in current scope
+   │                        ^^^ Invalid function usage. Unbound variable 'bar'
 

--- a/language/move-model/src/builder/exp_translator.rs
+++ b/language/move-model/src/builder/exp_translator.rs
@@ -563,6 +563,10 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
                         U256 => Type::new_prim(PrimitiveType::U256),
                         Vector => Type::Vector(Box::new(self.translate_hlir_base_type(&args[0]))),
                         Bool => Type::new_prim(PrimitiveType::Bool),
+                        Fun => Type::Fun(
+                            self.translate_hlir_base_types(&args[0..args.len() - 1]),
+                            Box::new(self.translate_hlir_base_type(&args[args.len() - 1])),
+                        ),
                     },
                     ModuleType(m, n) => {
                         let addr_bytes = self.parent.parent.resolve_address(&loc, &m.value.address);


### PR DESCRIPTION
This PR realizes the 1st step towards a high fidelity implementation of _macros_. Macros are expanded at compile time and do not appear in the Move bytecode. Most importantly,  macros can take lambda expressions as parameters, which allows to define collection operations like contains, filter, foreach, etc. 

A macro is declared similar to a function; below is an example:

```
    public macro fun foreach<T>(v: &vector<T>, action: |&T|) {
        let i = 0;
        while (i < Vector::length(v)) {
            action(Vector::borrow(v, i));
            i = i + 1;
        }
    }

   // Using the macro
   fun use_foreach() {
        let v = vector[1, 2, 3];
        let sum = 0;
        foreach!(&v, |e| sum = sum + *e);
    }

```

This PR implements parsing and type checking of this style of macros up to the typing AST. Macro expansion is not yet implemented and intended to be added in a followup.

The biggest change is enabling function types, lambda expressions, and calls of function values for naming and typing. Those had been supported before for the spec language, but weren't supported in move-lang beyond expansion. In the design, we represent function types by a new `BuiltinTypeName_::Fun` which allows to minimize changes to the code, as no new type variant needs to be introduced, and existing functionality for inference et. al can be adopted with minimal changes. This consistent e.g. with the treatment of function types in Rust, where they are just type constructors with some syntactic sugar.

A new test case has been added at [lambda.move](language/move-compiler/tests/move_check/typing/lambda.move) which shows usage and intends to cover all type check failure scenarios.

After this PR, to complete this style of macros, we still need to:

- Implement actual expansion of macros. This is intended to happen in a new phase after typing.
- Implement representation of macros in compiled, persisted modules. We need to be able to fetch the macro definition from an imported, precompiled module.
- Implement techniques (in the prover) to refer to specifications of passed lambda arguments to macros. (See https://github.com/diem/move/blob/main/language/move-prover/tests/sources/functional/macro_verification.move for what we want to do here.)


## Motivation

Macros

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Added new tests


