### PR TITLE
[account-address] Input and output with a 0x for hex output

### DIFF
--- a/language/tools/move-package/tests/test_sources/parsing/invalid_non_hex_address/Move.exp
+++ b/language/tools/move-package/tests/test_sources/parsing/invalid_non_hex_address/Move.exp
@@ -1,0 +1,1 @@
+Error parsing '[addresses]' section of manifest: Invalid address: Unable to parse AccountAddress

--- a/language/tools/move-package/tests/test_sources/parsing/invalid_non_hex_address/Move.toml
+++ b/language/tools/move-package/tests/test_sources/parsing/invalid_non_hex_address/Move.toml
@@ -1,0 +1,6 @@
+[package]
+name = "name"
+version = "0.1.2"
+
+[addresses]
+A = "1234"


### PR DESCRIPTION
### Summary

Accepts 0x as an input, and will print the output as a 0x for AccountAddress.
This removes confusion on whether it's in a different encoding, and keeps
it simple.

### Motivation

Addresses should start with a `0x` as I have been described by Todd how a hex literal must have `0x` in front of it.  Otherwise, we're being inconsistent and having `0x` in code, but no `0x` outside of it for the same representation.

Updated version from: https://github.com/diem/move/pull/199