### PR TITLE
[ci] Run CI on merge commit instead of head commit

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -15,11 +15,6 @@ jobs:
       test-rust: ${{ steps.rust-changes.outputs.changes-found }}
     steps:
       - uses: actions/checkout@v2.4.0
-        with:
-          # This ensures that the tip of the PR is checked out instead of the merge between the base ref and the tip
-          # On `push` this value will be empty and will "do-the-right-thing"
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 0 #get all the history!!!
       - name: Git Hooks and Checks
         run: ./scripts/git-checks.sh
       - id: changes
@@ -50,8 +45,6 @@ jobs:
     # if: ${{ needs.prepare.outputs.any-changes-founds == 'true' }}
     steps:
       - uses: actions/checkout@v2.4.0
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
       - uses: ./.github/actions/build-setup
       - uses: Swatinem/rust-cache@c5ed9ba6b7e1bb8aff90d43acd2f0af4990fa57c
       - name: cargo lint
@@ -69,9 +62,6 @@ jobs:
     # if: ${{ needs.prepare.outputs.test-rust == 'true' }}
     steps:
       - uses: actions/checkout@v2.4.0
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 0 #get all the history!!!
       - uses: ./.github/actions/build-setup
       - uses: Swatinem/rust-cache@c5ed9ba6b7e1bb8aff90d43acd2f0af4990fa57c
       - name: Set Swap Space
@@ -89,8 +79,6 @@ jobs:
     # if: ${{ needs.prepare.outputs.test-rust == 'true' }}
     steps:
       - uses: actions/checkout@v2.4.0
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
       - uses: ./.github/actions/build-setup
       - uses: Swatinem/rust-cache@c5ed9ba6b7e1bb8aff90d43acd2f0af4990fa57c
       - name: compile and install move-cli
@@ -120,8 +108,6 @@ jobs:
   #   if: ${{ needs.prepare.outputs.test-rust == 'true' }}
   #   steps:
   #     - uses: actions/checkout@v2.4.0
-  #       with:
-  #         ref: ${{ github.event.pull_request.head.sha }}
   #     - uses: ./.github/actions/build-setup
   #     - uses: actions/cache@v2.1.6
   #       with:
@@ -143,8 +129,6 @@ jobs:
   #     CRITERION_HOME: /tmp/benches
   #   steps:
   #     - uses: actions/checkout@v2.4.0
-  #       with:
-  #         ref: ${{ github.event.pull_request.head.sha }}
   #     - uses: actions/cache@v2.1.6
   #       with:
   #         path: "/opt/cargo/git\n/opt/cargo/registry\n/opt/cargo/.package-cache"
@@ -174,8 +158,6 @@ jobs:
       - prepare
     steps:
       - uses: actions/checkout@v2.4.0
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
       - name: Use Node.js 14
         uses: actions/setup-node@v2.4.0
         with:

--- a/devtools/x/src/lint/license.rs
+++ b/devtools/x/src/lint/license.rs
@@ -3,9 +3,28 @@
 
 use x_lint::prelude::*;
 
-static LICENSE_HEADER: &str = "Copyright (c) The Diem Core Contributors\n\
-                               SPDX-License-Identifier: Apache-2.0\n\
-                               ";
+static ALLOWED_LICENSE_HEADERS: &[&str] = &[
+    "Copyright (c) The Move Contributors\n\
+    SPDX-License-Identifier: Apache-2.0\n\
+    ",
+    "Copyright (c) The Diem Core Contributors\n\
+    SPDX-License-Identifier: Apache-2.0\n\
+    ",
+    "Copyright (c) The Move Contributors\n\
+    Copyright (c) The Diem Core Contributors\n\
+    SPDX-License-Identifier: Apache-2.0\n\
+    ",
+];
+
+fn has_license<'a>(maybe_license: impl Iterator<Item = &'a str>) -> bool {
+    let maybe = maybe_license.collect::<Vec<_>>();
+    for allowed in ALLOWED_LICENSE_HEADERS {
+        if allowed.lines().eq(maybe.clone().into_iter()) {
+            return true;
+        }
+    }
+    false
+}
 
 #[derive(Copy, Clone, Debug)]
 pub(super) struct LicenseHeader;
@@ -50,7 +69,7 @@ impl ContentLinter for LicenseHeader {
                     .skip_while(|line| line.is_empty())
                     .take(2)
                     .map(|s| s.trim_start_matches("// "));
-                !LICENSE_HEADER.lines().eq(maybe_license)
+                !has_license(maybe_license)
             }
             FileType::Shell => {
                 let maybe_license = content
@@ -59,7 +78,7 @@ impl ContentLinter for LicenseHeader {
                     .skip_while(|line| line.is_empty())
                     .take(2)
                     .map(|s| s.trim_start_matches("# "));
-                !LICENSE_HEADER.lines().eq(maybe_license)
+                !has_license(maybe_license)
             }
         };
 

--- a/scripts/check_pr.sh
+++ b/scripts/check_pr.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+# Copyright (c) The Move Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# A script to check whether a local commit is ready for a PR.
+# This simulates CI checks locally
+
+set -e
+
+BUILD_FLAGS=
+
+BASE=$(git rev-parse --show-toplevel)
+echo "*************** [check-pr] Assuming move root at $BASE"
+
+# Run only tests which would also be run on CI
+export ENV_TEST_ON_CI=1
+
+while getopts "htcgdea" opt; do
+  case $opt in
+    h)
+      cat <<EOF
+Performs CI equivalent checks on a local client
+Usage:
+    check_pr <flags>
+Flags:
+    -h   Print this help
+    -t   Run tests
+    -c   Run xclippy, xlint, and xfmt
+    -g   Run the Move git checks script (whitespace check). This works
+         only for committed clients.
+    -d   Run documentation generation, abi generation, etc. for move-stdlib
+         and other Move libraries.
+    -e   Run hardhat EVM tests
+    -a   All of the above
+    With no options script behaves like -tcg is given.
+    If you want to run tests in release mode, call this script as 'BUILD_FLAGS=-release <script>'.
+
+
+EOF
+      exit 1
+      ;;
+    t)
+      TEST=1
+      ;;
+    c)
+      CHECK=1
+      ;;
+    d)
+      GEN_ARTIFACTS=1
+      ;;
+    g)
+      GIT_CHECKS=1
+      ;;
+    e)
+      HARDHAT_CHECKS=1
+      ;;
+    a)
+      TEST=1
+      CHECK=1
+      GEN_ARTIFACTS=1
+      GIT_CHECKS=1
+      HARDHAT_CHECKS=1
+  esac
+done
+
+if [ "$OPTIND" -eq 1 ]; then
+  TEST=1
+  CHECK=1
+  GIT_CHECKS=1
+fi
+
+ARTIFACT_CRATES="\
+  $BASE/language/move-stdlib\
+"
+
+if [ ! -z "$TEST" ]; then
+  echo "*************** [check-pr] Running tests"
+  (
+    cd $BASE
+    cargo test --workspace $BUILD_FLAGS
+  )
+fi
+
+if [ ! -z "$CHECK" ]; then
+  echo "*************** [check-pr] Running checks"
+  (
+    cd $BASE
+    cargo xlint
+    cargo xclippy --workspace --all-targets
+    cargo xfmt
+  )
+fi
+
+if [ ! -z "$GEN_ARTIFACTS" ]; then
+  for dir in $ARTIFACT_CRATES; do
+    echo "*************** [check-pr] Generating artifacts for crate $dir"
+    (
+      cd $dir
+      cargo run $BUILD_FLAGS
+    )
+  done
+fi
+
+if [ ! -z "$GIT_CHECKS" ]; then
+   echo "*************** [check-pr] Running git checks"
+   $BASE/scripts/git-checks.sh
+fi
+
+if [ ! -z "$HARDHAT_CHECKS" ]; then
+  echo "*************** [check-pr] Running hardhat tests (expecting hardhat configured)"
+  # (
+  #   cd $BASE/language/tools/move-cli
+  #   cargo install --path .
+  # )
+  # (
+  #   cd $BASE/language/evm/hardhat-move
+  #   npm install
+  #   npm run build
+  # )
+  (
+    cd $BASE/language/evm/hardhat-examples
+    # ./setup.sh
+    npx hardhat test
+  )
+fi


### PR DESCRIPTION
Running on head commit increases the chance that CI run passes standalone but fails once the changes are merged.

We had already the first case where head commit lead to a broken test state after merge (fixed in #21). 

Also removes checking out all branches because that seems to be not needed in the Move repo.


