### PR TITLE
[evm] fix the issue that move package build does not print out compiler errors

### DIFF
--- a/language/tools/move-cli/tests/build_tests/include_exclude_stdlib/args.evm.exp
+++ b/language/tools/move-cli/tests/build_tests/include_exclude_stdlib/args.evm.exp
@@ -1,6 +1,19 @@
 Command `package build -v --arch ethereum`:
 COMPILING build_include_exclude_stdlib to Yul
 ERROR Failed to compile Move into Yul
+[0m[1m[38;5;9merror[0m[1m: unbound module[0m
+  [0m[34m┌─[0m ./sources/UseSigner.move:2:7
+  [0m[34m│[0m
+[0m[34m2[0m [0m[34m│[0m   use [0m[31mStd::Signer[0m;
+  [0m[34m│[0m       [0m[31m^^^^^^^^^^^[0m [0m[31mInvalid 'use'. Unbound module: '(Std=1)::Signer'[0m
+
+[0m[1m[38;5;9merror[0m[1m: unbound module[0m
+  [0m[34m┌─[0m ./sources/UseSigner.move:5:5
+  [0m[34m│[0m
+[0m[34m5[0m [0m[34m│[0m     [0m[31mSigner[0m::address_of(account)
+  [0m[34m│[0m     [0m[31m^^^^^^[0m [0m[31mUnbound module alias 'Signer'[0m
+
+
 Error: exiting with Move build errors
 Command `-d -v package build --arch ethereum`:
 COMPILING MoveStdlib, build_include_exclude_stdlib to Yul

--- a/language/tools/move-package/src/compilation/build_plan.rs
+++ b/language/tools/move-package/src/compilation/build_plan.rs
@@ -178,7 +178,8 @@ impl BuildPlan {
             return Err(err.into());
         }
 
-        let mut error_buffer = Buffer::no_color();
+        // TODO: should inherit color settings from current shell
+        let mut error_buffer = Buffer::ansi();
         if let Err(err) = run_to_yul(
             &mut error_buffer,
             MoveToYulOptions {
@@ -195,6 +196,12 @@ impl BuildPlan {
                 writer,
                 "{} Failed to compile Move into Yul",
                 "ERROR".bold().red()
+            )?;
+
+            writeln!(
+                writer,
+                "{}",
+                std::str::from_utf8(error_buffer.as_slice()).unwrap()
             )?;
 
             let mut source = err.source();


### PR DESCRIPTION
This fixes the issue that `move package build` does not print out compiler errors (#29 ). This fix also includes the hardhat plugin.

Before
```
COMPILING EvmStdlib, ExternalCall, MoveStdlib to Yul
Error: exiting with Move build errors
```

After
```
COMPILING EvmStdlib, ExternalCall, MoveStdlib to Yul
ERROR Failed to compile Move into Yul
error: unexpected token
   ┌─ ./sources/ExternalCall.move:58:2
   │
58 │  xx
   │  ^^ Invalid code unit. Expected 'address', 'module', or 'script'. Got 'xx'


Error: exiting with Move build errors
```

resolves #29 