### PR TITLE
[evm] Implements `isContract`, and more test cases for external calls

### DIFF
--- a/language/evm/hardhat-examples/contracts/ERC721ReceiverMock.sol
+++ b/language/evm/hardhat-examples/contracts/ERC721ReceiverMock.sol
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
+
+contract ERC721ReceiverMock is IERC721Receiver {
+    enum Error {
+        None,
+        RevertWithMessage,
+        RevertWithoutMessage,
+        Panic
+    }
+
+    bytes4 private immutable _retval;
+    Error private immutable _error;
+
+    event Received(address operator, address from, uint256 tokenId, bytes data, uint256 gas);
+
+    constructor(bytes4 retval, Error error) {
+        _retval = retval;
+        _error = error;
+    }
+
+    function onERC721Received(
+        address operator,
+        address from,
+        uint256 tokenId,
+        bytes memory data
+    ) public override returns (bytes4) {
+        if (_error == Error.RevertWithMessage) {
+            revert("ERC721ReceiverMock: reverting");
+        } else if (_error == Error.RevertWithoutMessage) {
+            revert();
+        } else if (_error == Error.Panic) {
+            uint256 a = uint256(0) / uint256(0);
+            a;
+        }
+        emit Received(operator, from, tokenId, data, gasleft());
+        return _retval;
+    }
+}

--- a/language/evm/hardhat-examples/contracts/ExternalCall/Move.toml
+++ b/language/evm/hardhat-examples/contracts/ExternalCall/Move.toml
@@ -2,5 +2,10 @@
 name = "ExternalCall"
 version = "0.0.0"
 
+[addresses]
+Std = "0x1"
+Evm = "0x2"
+
 [dependencies]
 EvmStdlib = { local = "../../../stdlib" }
+MoveStdlib = { local = "../../../../move-stdlib" }

--- a/language/evm/hardhat-examples/contracts/ExternalCall/sources/ExternalCall.move
+++ b/language/evm/hardhat-examples/contracts/ExternalCall/sources/ExternalCall.move
@@ -2,8 +2,9 @@
 module Evm::ExternalCall {
     use Evm::ExternalResult::{Self, ExternalResult};
     use Evm::Evm::Unit;
-    use Evm::Evm::abort_with;
-
+    use Evm::Evm::{abort_with, isContract, require, sender};
+    use Evm::U256::{U256};
+    use Std::Vector;
 
     #[external(sig=b"forty_two() returns (uint64)")]
     public native fun external_call_forty_two(contract: address): u64;
@@ -48,10 +49,50 @@ module Evm::ExternalCall {
         if (ExternalResult::is_ok(&v)) {
         } else if (ExternalResult::is_err_reason(&v)) {
             abort_with(b"error reason");
+        } else if (ExternalResult::is_err_data(&v)) {
+            abort_with(b"error data");
         } else if (ExternalResult::is_panic(&v)) {
             abort_with(b"panic");
         } else {
             abort_with(b"other");
         }
+    }
+
+    #[callable]
+    public fun test_for_move_to_yul(from: address, to: address, tokenId: U256, data: vector<u8>) {
+        // TODO: Uncomment the following line to see the error. The error occurs only when this function is set to be `callable`.
+        //       See https://github.com/move-language/move/issues/30 for more details.
+        //let _ = IERC721Receiver_try_call_onERC721Received(to, sender(), from, tokenId, data);
+    }
+
+    #[callable(sig=b"doSafeTransferAcceptanceCheck(address,address,uint256,bytes)"), pure]
+    public fun doSafeTransferAcceptanceCheck(from: address, to: address, tokenId: U256, data: vector<u8>) {
+       if (isContract(to)) {
+            let result = IERC721Receiver_try_call_onERC721Received(to, sender(), from, tokenId, data);
+            if (ExternalResult::is_ok(&result)) {
+                let retval = ExternalResult::unwrap(result);
+                let expected = IERC721Receiver_selector_onERC721Received();
+                require(retval == expected, b"Unexpected return value");
+            }
+            else {
+                if(ExternalResult::is_err_reason(&result)) {
+                    let reason = ExternalResult::unwrap_err_reason(result);
+                    if (Vector::length(&reason) == 0) {
+                        abort_with(b"ERC721: transfer to non ERC721Receiver implementer");
+                    }
+                    else {
+                        abort_with(reason);
+                    }
+                };
+                abort_with(b"Other");
+            }
+        }
+    }
+
+    #[external(sig=b"onERC721Received(address,address,uint256,bytes) returns (bytes4)")]
+    public native fun IERC721Receiver_try_call_onERC721Received(contract: address, operator: address, from: address, tokenId: U256, bytes: vector<u8>): ExternalResult<vector<u8>>;
+
+    public fun IERC721Receiver_selector_onERC721Received(): vector<u8> {
+        x"150b7a02"
     }
 }

--- a/language/evm/hardhat-examples/contracts/Native.sol
+++ b/language/evm/hardhat-examples/contracts/Native.sol
@@ -1,12 +1,20 @@
 //SPDX-License-Identifier: Unlicense
 pragma solidity ^0.8.0;
 
+import "@openzeppelin/contracts/utils/Address.sol";
+
 contract Native_Sol {
+    using Address for address;
+
     function getContractAddr() public view returns (address) {
         return address(this);
     }
 
     function getSenderAddr() public view returns (address) {
         return msg.sender;
+    }
+
+    function getIsContract(address addr) public view returns (bool) {
+        return addr.isContract();
     }
 }

--- a/language/evm/hardhat-examples/contracts/Native/sources/Native.move
+++ b/language/evm/hardhat-examples/contracts/Native/sources/Native.move
@@ -1,5 +1,5 @@
 module 0x1::Native {
-    use Evm::Evm::{self, sender};
+    use Evm::Evm::{self, sender, isContract};
 
     #[callable, view]
     public fun getContractAddr(): address {
@@ -9,5 +9,10 @@ module 0x1::Native {
     #[callable, view]
     public fun getSenderAddr(): address {
         sender()
+    }
+
+    #[callable, view]
+    public fun getIsContract(a: address): bool {
+        isContract(a)
     }
 }

--- a/language/evm/hardhat-examples/package-lock.json
+++ b/language/evm/hardhat-examples/package-lock.json
@@ -20,9 +20,27 @@
         "chai": "^4.3.6",
         "ethereum-waffle": "^3.4.4",
         "ethers": "^5.6.2",
-        "hardhat": "^2.9.2",
+        "hardhat": "^2.9.3",
         "hardhat-gas-reporter": "^1.0.8",
+        "hardhat-move": "file:../hardhat-move",
         "web3": "^1.7.1"
+      }
+    },
+    "../hardhat-move": {
+      "version": "0.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mocha": "^9.1.0",
+        "neverthrow": "^4.3.1",
+        "typescript": "^4.6.3"
+      },
+      "devDependencies": {
+        "hardhat": "^2.9.3",
+        "mocha": "^7.1.2"
+      },
+      "peerDependencies": {
+        "hardhat": "^2.0.0"
       }
     },
     "node_modules/@babel/runtime": {
@@ -16919,9 +16937,9 @@
       }
     },
     "node_modules/hardhat": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/hardhat/-/hardhat-2.9.2.tgz",
-      "integrity": "sha512-elTcUK1EdFverWinybQ+DoJzsM6sgiHUYs0ZYNNXMfESty6ESHiFSwkfJsC88/q09vmIz6YVaMh73BYnYd+feQ==",
+      "version": "2.9.3",
+      "resolved": "https://registry.npmjs.org/hardhat/-/hardhat-2.9.3.tgz",
+      "integrity": "sha512-7Vw99RbYbMZ15UzegOR/nqIYIqddZXvLwJGaX5sX4G5bydILnbjmDU6g3jMKJSiArEixS3vHAEaOs5CW1JQ3hg==",
       "dev": true,
       "dependencies": {
         "@ethereumjs/block": "^3.6.0",
@@ -16993,6 +17011,10 @@
       "peerDependencies": {
         "hardhat": "^2.0.2"
       }
+    },
+    "node_modules/hardhat-move": {
+      "resolved": "../hardhat-move",
+      "link": true
     },
     "node_modules/hardhat/node_modules/debug": {
       "version": "4.3.4",
@@ -36279,9 +36301,9 @@
       }
     },
     "hardhat": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/hardhat/-/hardhat-2.9.2.tgz",
-      "integrity": "sha512-elTcUK1EdFverWinybQ+DoJzsM6sgiHUYs0ZYNNXMfESty6ESHiFSwkfJsC88/q09vmIz6YVaMh73BYnYd+feQ==",
+      "version": "2.9.3",
+      "resolved": "https://registry.npmjs.org/hardhat/-/hardhat-2.9.3.tgz",
+      "integrity": "sha512-7Vw99RbYbMZ15UzegOR/nqIYIqddZXvLwJGaX5sX4G5bydILnbjmDU6g3jMKJSiArEixS3vHAEaOs5CW1JQ3hg==",
       "dev": true,
       "requires": {
         "@ethereumjs/block": "^3.6.0",
@@ -36407,6 +36429,16 @@
         "array-uniq": "1.0.3",
         "eth-gas-reporter": "^0.2.24",
         "sha1": "^1.1.1"
+      }
+    },
+    "hardhat-move": {
+      "version": "file:../hardhat-move",
+      "requires": {
+        "@types/mocha": "^9.1.0",
+        "hardhat": "^2.9.3",
+        "mocha": "^7.1.2",
+        "neverthrow": "^4.3.1",
+        "typescript": "^4.6.3"
       }
     },
     "has": {

--- a/language/evm/hardhat-examples/test/ExternalCall.test.js
+++ b/language/evm/hardhat-examples/test/ExternalCall.test.js
@@ -6,6 +6,11 @@ const { expect } = require('chai');
 const ExternalCall = artifacts.require('ExternalCall');
 const FortyTwo = artifacts.require('FortyTwo');
 const Revert = artifacts.require('Revert');
+const Receiver = artifacts.require('ERC721ReceiverMock');
+
+const Error = [ 'None', 'RevertWithMessage', 'RevertWithoutMessage', 'Panic' ]
+  .reduce((acc, entry, idx) => Object.assign({ [entry]: idx }, acc), {});
+const RECEIVER_MAGIC_VALUE = '0x150b7a02';
 
 contract('ExternalCall', function (accounts) {
     const [operator, tokenHolder, tokenBatchHolder, ...otherAccounts] = accounts;
@@ -45,19 +50,27 @@ contract('ExternalCall', function (accounts) {
     });
 
     describe('try_call_revertWithMessage', function () {
-        it('revert with error message', async function () {
+        it('callee reverts with error message', async function () {
             await expectRevert(
                 this.externalCall.try_call_revertWithMessage(this.revert.address),
                 'error reason',
             );
         });
 
-        // TODO: Fix this.
-        // it('revert with not implemented', async function () {
-        //     await expectRevert(
-        //         this.externalCall.try_call_revertWithMessage(ZERO_ADDRESS),
-        //         'non-contract',
-        //     );
-        // });
+        it('callee did not implement the function', async function () {
+            await expectRevert(
+                this.externalCall.try_call_revertWithMessage(this.fortyTwo.address),
+                'error data',
+            );
+        });
+    });
+
+    describe('Receiver', function () {
+        it('receiver test', async function () {
+            const receiver = await Receiver.new(RECEIVER_MAGIC_VALUE, Error.None);
+            // TODO: uncomment the following line to see the error "Transaction ran out of gas".
+            //       For more details, https://github.com/move-language/move/issues/31
+            //const receipt = await this.externalCall.doSafeTransferAcceptanceCheck(this.externalCall.address, receiver.address, 5042, '0x42');
+        });
     });
 });

--- a/language/evm/hardhat-examples/test/Native.test.js
+++ b/language/evm/hardhat-examples/test/Native.test.js
@@ -16,6 +16,14 @@ const make_test = function(contract_name) {
       const tx = this.native.getSenderAddr();
       expect(await tx).to.equal(this.native.signer.address);
     });
+    it("getIsContract(this.native.address) should return true", async function () {
+      const tx = this.native.getIsContract(this.native.address);
+      expect(await tx).to.equal(true);
+    });
+    it("getIsContract(this.native.signer.address) should return false", async function () {
+      const tx = this.native.getIsContract(this.native.signer.address);
+      expect(await tx).to.equal(false);
+    });
   }
 };
 

--- a/language/evm/move-to-yul/src/native_functions.rs
+++ b/language/evm/move-to-yul/src/native_functions.rs
@@ -363,6 +363,16 @@ impl NativeFunctions {
 }"
             );
         });
+
+        self.define(ctx, evm, "extcodesize", |_, ctx: &Context, _| {
+            emitln!(
+                ctx.writer,
+                "\
+                (addr) -> result {
+                  result := extcodesize(addr)
+                }"
+            );
+        });
     }
 
     fn define_move_functions(&mut self, ctx: &Context) {

--- a/language/evm/stdlib/sources/Evm.move
+++ b/language/evm/stdlib/sources/Evm.move
@@ -3,9 +3,7 @@
 /// This currently only represents a basic subset of what we may want to expose.
 module Evm::Evm {
     use Std::Vector;
-    use Std::ASCII::{String};
-    use Std::Errors;
-    use Evm::U256::{U256};
+    use Evm::U256::{Self, U256};
 
     /// Returns the address of the executing contract.
     public native fun self(): address;
@@ -39,7 +37,7 @@ module Evm::Evm {
     /// Returns the first four bytes of `data`.
     /// This is the equivalent to the type casting operation `bytes4` in Solidity.
     public fun bytes4(data: vector<u8>): vector<u8> {
-        assert!(Vector::length(&data) >= 4, Errors::invalid_argument(0));
+        assert!(Vector::length(&data) >= 4, 0);
         let res = Vector::empty<u8>();
         Vector::push_back(&mut res, *Vector::borrow(&data, 0));
         Vector::push_back(&mut res, *Vector::borrow(&data, 1));
@@ -61,7 +59,12 @@ module Evm::Evm {
     // }
     // return (size > 0);
     // ```
-    public native fun isContract(addr: address): bool;
+    public fun isContract(addr: address): bool {
+        U256::gt(extcodesize(addr), U256::zero())
+    }
+
+    /// Returns the size of the code at address `addr`.
+    public native fun extcodesize(addr: address): U256;
 
     /// Define the unit (null or void) type.
     struct Unit has drop {}
@@ -69,7 +72,10 @@ module Evm::Evm {
     /// Get tokenURI with base URI.
     // This is implemented in Solidity as follows:
     //   bytes(baseURI).length > 0 ? string(abi.encodePacked(baseURI, tokenId.toString())) : "";
-    public native fun tokenURI_with_baseURI(baseURI: String, tokenId: U256): String;
+    public fun tokenURI_with_baseURI(_baseURI: vector<u8>, _tokenId: U256): vector<u8> {
+        // TODO: implement this properly
+        b""
+    }
 
     /// Abort with an error message.
     public native fun abort_with(message: vector<u8>);


### PR DESCRIPTION
This commit:
- implements the `isContract` function by implementing the `Evm::extcodesize` native function.
- adds minimal test cases to reproduce the following two bugs in handling external calls
  - https://github.com/move-language/move/issues/30
  - https://github.com/move-language/move/issues/31


## Motivation

To implement `isContract`, and add test cases for external calls

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

npx hardhat test

