### PR TITLE
[move-compiler][move-stdlib] Switch to vector bytecode instructions     

### DIFF
--- a/language/extensions/async/move-async-vm/src/natives.rs
+++ b/language/extensions/async/move-async-vm/src/natives.rs
@@ -38,22 +38,20 @@ pub struct AsyncExtension {
 pub fn actor_natives(
     async_addr: AccountAddress,
 ) -> Vec<(AccountAddress, Identifier, Identifier, NativeFunction)> {
-    native_functions::make_table(
-        async_addr,
-        &[
-            ("Actor", "self", native_self),
-            ("Actor", "virtual_time", native_virtual_time),
-            ("Runtime", "send__0", native_send),
-            ("Runtime", "send__1", native_send),
-            ("Runtime", "send__2", native_send),
-            ("Runtime", "send__3", native_send),
-            ("Runtime", "send__4", native_send),
-            ("Runtime", "send__5", native_send),
-            ("Runtime", "send__6", native_send),
-            ("Runtime", "send__7", native_send),
-            ("Runtime", "send__8", native_send),
-        ],
-    )
+    const NATIVES: &[(&str, &str, NativeFunction)] = &[
+        ("Actor", "self", native_self),
+        ("Actor", "virtual_time", native_virtual_time),
+        ("Runtime", "send__0", native_send),
+        ("Runtime", "send__1", native_send),
+        ("Runtime", "send__2", native_send),
+        ("Runtime", "send__3", native_send),
+        ("Runtime", "send__4", native_send),
+        ("Runtime", "send__5", native_send),
+        ("Runtime", "send__6", native_send),
+        ("Runtime", "send__7", native_send),
+        ("Runtime", "send__8", native_send),
+    ];
+    native_functions::make_table(async_addr, NATIVES)
 }
 
 fn native_self(

--- a/language/move-compiler/src/diagnostics/codes.rs
+++ b/language/move-compiler/src/diagnostics/codes.rs
@@ -223,6 +223,8 @@ codes!(
         InvalidValue: { msg: "invalid attribute value", severity: NonblockingError },
         InvalidUsage: { msg: "invalid usage of known attribute", severity: NonblockingError },
         InvalidTest: { msg: "unable to generate test", severity: NonblockingError },
+        InvalidBytecodeInst:
+            { msg: "unknown bytecode instruction function", severity: NonblockingError },
     ],
     Tests: [
         TestFailed: { msg: "test failure", severity: BlockingError },

--- a/language/move-compiler/src/naming/fake_natives.rs
+++ b/language/move-compiler/src/naming/fake_natives.rs
@@ -1,0 +1,120 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use std::convert::TryInto;
+
+use crate::{
+    diag,
+    expansion::ast::{Address, AttributeName_, ModuleIdent, ModuleIdent_},
+    naming::ast as N,
+    parser::ast::FunctionName,
+    shared::{
+        known_attributes::{KnownAttribute, NativeAttribute},
+        CompilationEnv, Identifier,
+    },
+};
+use move_ir_types::ast as IR;
+
+pub const FAKE_NATIVE_ATTR: AttributeName_ =
+    AttributeName_::Known(KnownAttribute::Native(NativeAttribute::BytecodeInstruction));
+
+pub fn function(
+    env: &mut CompilationEnv,
+    module_opt: Option<ModuleIdent>,
+    function_name: FunctionName,
+    function: &N::Function,
+) {
+    let loc = match function.attributes.get_loc_(&FAKE_NATIVE_ATTR) {
+        None => return,
+        Some(loc) => *loc,
+    };
+    let module = match module_opt {
+        Some(module) => module,
+        None => {
+            let msg = format!(
+                "Invalid usage of '{}' attribute to map function to bytecode instruction.",
+                NativeAttribute::BYTECODE_INSTRUCTION
+            );
+            let smsg = "Script functions are never mapped to bytecode instructions";
+            let diag = diag!(
+                Attributes::InvalidBytecodeInst,
+                (loc, msg),
+                (function_name.loc(), smsg),
+            );
+            env.add_diag(diag);
+            return;
+        }
+    };
+    if resolve_builtin(&module, &function_name).is_none() {
+        let attr_msg = format!(
+            "Invalid usage of '{}' attribute to map function to bytecode instruction.",
+            NativeAttribute::BYTECODE_INSTRUCTION
+        );
+        let name_msg = format!(
+            "No known mapping of '{}::{}' to bytecode instruction",
+            module, function_name
+        );
+        let diag = diag!(
+            Attributes::InvalidBytecodeInst,
+            (loc, attr_msg),
+            (function_name.loc(), name_msg),
+        );
+        env.add_diag(diag);
+    }
+    match &function.body.value {
+        N::FunctionBody_::Native => (),
+        N::FunctionBody_::Defined(_) => {
+            let attr_msg = format!(
+                "Invalid usage of '{}' attribute on non-native function",
+                NativeAttribute::BYTECODE_INSTRUCTION
+            );
+            let diag = diag!(Attributes::InvalidBytecodeInst, (loc, attr_msg));
+            env.add_diag(diag);
+        }
+    }
+}
+
+pub fn resolve_builtin(
+    module: &ModuleIdent,
+    function: &FunctionName,
+) -> Option<fn(Vec<IR::Type>) -> IR::Bytecode_> {
+    let sp!(_, ModuleIdent_ { address, module }) = module;
+    let addr_name = match address {
+        Address::Numerical(Some(sp!(_, n_)), _) | Address::NamedUnassigned(sp!(_, n_)) => n_,
+        _ => return None,
+    };
+    Some(
+        match (
+            addr_name.as_str(),
+            module.value().as_str(),
+            function.value().as_str(),
+        ) {
+            ("Std", "Vector", "empty") => |tys| IR::Bytecode_::VecPack(expect_one_ty_arg(tys), 0),
+            ("Std", "Vector", "length") => |tys| IR::Bytecode_::VecLen(expect_one_ty_arg(tys)),
+            ("Std", "Vector", "borrow") => {
+                |tys| IR::Bytecode_::VecImmBorrow(expect_one_ty_arg(tys))
+            }
+            ("Std", "Vector", "push_back") => {
+                |tys| IR::Bytecode_::VecPushBack(expect_one_ty_arg(tys))
+            }
+            ("Std", "Vector", "borrow_mut") => {
+                |tys| IR::Bytecode_::VecMutBorrow(expect_one_ty_arg(tys))
+            }
+            ("Std", "Vector", "pop_back") => {
+                |tys| IR::Bytecode_::VecPopBack(expect_one_ty_arg(tys))
+            }
+            ("Std", "Vector", "destroy_empty") => {
+                |tys| IR::Bytecode_::VecUnpack(expect_one_ty_arg(tys), 0)
+            }
+            ("Std", "Vector", "swap") => |tys| IR::Bytecode_::VecSwap(expect_one_ty_arg(tys)),
+            _ => return None,
+        },
+    )
+}
+
+fn expect_one_ty_arg(ty_args: Vec<IR::Type>) -> IR::Type {
+    let [ty]: [IR::Type; 1] = ty_args
+        .try_into()
+        .expect("ICE native bytecode function expected a single type argument");
+    ty
+}

--- a/language/move-compiler/src/naming/fake_natives.rs
+++ b/language/move-compiler/src/naming/fake_natives.rs
@@ -1,5 +1,9 @@
-// Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
+
+//! This module verifies the usage of the "fake native" functions. These functions are declared
+//! as 'native`, but do not appear in the compiled module. For developer sanity, they must be marked
+//! with the `FAKE_NATIVE_ATTR`
 
 use std::convert::TryInto;
 
@@ -18,6 +22,7 @@ use move_ir_types::ast as IR;
 pub const FAKE_NATIVE_ATTR: AttributeName_ =
     AttributeName_::Known(KnownAttribute::Native(NativeAttribute::BytecodeInstruction));
 
+/// verify `FAKE_NATIVE_ATTR` usage
 pub fn function(
     env: &mut CompilationEnv,
     module_opt: Option<ModuleIdent>,
@@ -74,6 +79,8 @@ pub fn function(
     }
 }
 
+/// Resolve the mapping for a module + function name to a bytecode instruction.
+/// The function should already be verified by `function` above
 pub fn resolve_builtin(
     module: &ModuleIdent,
     function: &FunctionName,

--- a/language/move-compiler/src/naming/mod.rs
+++ b/language/move-compiler/src/naming/mod.rs
@@ -2,4 +2,5 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod ast;
+pub(crate) mod fake_natives;
 pub(crate) mod translate;

--- a/language/move-compiler/src/naming/translate.rs
+++ b/language/move-compiler/src/naming/translate.rs
@@ -17,6 +17,8 @@ use move_ir_types::location::*;
 use move_symbol_pool::Symbol;
 use std::collections::BTreeMap;
 
+use super::fake_natives;
+
 //**************************************************************************************************
 // Context
 //**************************************************************************************************
@@ -377,7 +379,7 @@ fn module(
     });
     let functions = efunctions.map(|name, f| {
         context.restore_unscoped(unscoped.clone());
-        function(context, name, f)
+        function(context, Some(ident), name, f)
     });
     let constants = econstants.map(|name, c| {
         context.restore_unscoped(unscoped.clone());
@@ -428,7 +430,7 @@ fn script(context: &mut Context, escript: E::Script) -> N::Script {
         constant(context, name, c)
     });
     context.restore_unscoped(inner_unscoped);
-    let function = function(context, function_name, efunction);
+    let function = function(context, None, function_name, efunction);
     context.restore_unscoped(outer_unscoped);
     N::Script {
         package_name,
@@ -476,19 +478,33 @@ fn friend(context: &mut Context, mident: ModuleIdent, friend: E::Friend) -> Opti
 // Functions
 //**************************************************************************************************
 
-fn function(context: &mut Context, _name: FunctionName, f: E::Function) -> N::Function {
-    let attributes = f.attributes;
-    let visibility = f.visibility;
-    let signature = function_signature(context, f.signature);
-    let acquires = function_acquires(context, f.acquires);
-    let body = function_body(context, f.body);
-    N::Function {
+fn function(
+    context: &mut Context,
+    module_opt: Option<ModuleIdent>,
+    name: FunctionName,
+    ef: E::Function,
+) -> N::Function {
+    let E::Function {
+        attributes,
+        loc: _,
+        visibility,
+        signature,
+        acquires,
+        body,
+        specs: _,
+    } = ef;
+    let signature = function_signature(context, signature);
+    let acquires = function_acquires(context, acquires);
+    let body = function_body(context, body);
+    let f = N::Function {
         attributes,
         visibility,
         signature,
         acquires,
         body,
-    }
+    };
+    fake_natives::function(&mut context.env, module_opt, name, &f);
+    f
 }
 
 fn function_signature(context: &mut Context, sig: E::FunctionSignature) -> N::FunctionSignature {

--- a/language/move-compiler/src/shared/mod.rs
+++ b/language/move-compiler/src/shared/mod.rs
@@ -543,6 +543,7 @@ pub mod known_attributes {
     #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
     pub enum KnownAttribute {
         Testing(TestingAttribute),
+        Native(NativeAttribute),
     }
 
     #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -553,6 +554,12 @@ pub mod known_attributes {
         Test,
         // This test is expected to fail
         ExpectedFailure,
+    }
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+    pub enum NativeAttribute {
+        // It is a fake native function that actually compiles to a bytecode instruction
+        BytecodeInstruction,
     }
 
     impl fmt::Display for AttributePosition {
@@ -579,6 +586,9 @@ pub mod known_attributes {
                 TestingAttribute::EXPECTED_FAILURE => {
                     Self::Testing(TestingAttribute::ExpectedFailure)
                 }
+                NativeAttribute::BYTECODE_INSTRUCTION => {
+                    Self::Native(NativeAttribute::BytecodeInstruction)
+                }
                 _ => return None,
             })
         }
@@ -586,12 +596,14 @@ pub mod known_attributes {
         pub const fn name(&self) -> &str {
             match self {
                 Self::Testing(a) => a.name(),
+                Self::Native(a) => a.name(),
             }
         }
 
         pub fn expected_positions(&self) -> &'static BTreeSet<AttributePosition> {
             match self {
                 Self::Testing(a) => a.expected_positions(),
+                Self::Native(a) => a.expected_positions(),
             }
         }
     }
@@ -631,6 +643,24 @@ pub mod known_attributes {
                 TestingAttribute::TestOnly => &*TEST_ONLY_POSITIONS,
                 TestingAttribute::Test => &*TEST_POSITIONS,
                 TestingAttribute::ExpectedFailure => &*EXPECTED_FAILURE_POSITIONS,
+            }
+        }
+    }
+
+    impl NativeAttribute {
+        pub const BYTECODE_INSTRUCTION: &'static str = "bytecode_instruction";
+
+        pub const fn name(&self) -> &str {
+            match self {
+                NativeAttribute::BytecodeInstruction => Self::BYTECODE_INSTRUCTION,
+            }
+        }
+
+        pub fn expected_positions(&self) -> &'static BTreeSet<AttributePosition> {
+            static BYTECODE_INSTRUCTION_POSITIONS: Lazy<BTreeSet<AttributePosition>> =
+                Lazy::new(|| IntoIterator::into_iter([AttributePosition::Function]).collect());
+            match self {
+                NativeAttribute::BytecodeInstruction => &*BYTECODE_INSTRUCTION_POSITIONS,
             }
         }
     }

--- a/language/move-compiler/src/to_bytecode/translate.rs
+++ b/language/move-compiler/src/to_bytecode/translate.rs
@@ -11,7 +11,10 @@ use crate::{
         ast::{self as H, Value_},
         translate::{display_var, DisplayVar},
     },
-    naming::ast::{BuiltinTypeName_, StructTypeParameter, TParam},
+    naming::{
+        ast::{BuiltinTypeName_, StructTypeParameter, TParam},
+        fake_natives,
+    },
     parser::ast::{
         Ability, Ability_, BinOp, BinOp_, ConstantName, Field, FunctionName, StructName, UnaryOp,
         UnaryOp_, Var, Visibility,
@@ -82,12 +85,19 @@ fn extract_decls(
     let context = &mut Context::new(compilation_env, None);
     let fdecls = all_modules()
         .flat_map(|(m, mdef)| {
-            mdef.functions.key_cloned_iter().map(move |(f, fdef)| {
-                let key = (m, f);
-                let seen = seen_structs(&fdef.signature);
-                let gsig = fdef.signature.clone();
-                (key, (seen, gsig))
-            })
+            mdef.functions
+                .key_cloned_iter()
+                .filter(|(_, fdef)| {
+                    !fdef
+                        .attributes
+                        .contains_key_(&fake_natives::FAKE_NATIVE_ATTR)
+                })
+                .map(move |(f, fdef)| {
+                    let key = (m, f);
+                    let seen = seen_structs(&fdef.signature);
+                    let gsig = fdef.signature.clone();
+                    (key, (seen, gsig))
+                })
         })
         .map(|(key, (seen, gsig))| (key, (seen, function_signature(context, gsig))))
         .collect();
@@ -177,6 +187,11 @@ fn module(
     let functions = mdef
         .functions
         .into_iter()
+        .filter(|(_, fdef)| {
+            !fdef
+                .attributes
+                .contains_key_(&fake_natives::FAKE_NATIVE_ATTR)
+        })
         .map(|(f, fdef)| {
             let (res, info) = function(&mut context, Some(&ident), f, fdef);
             collected_function_infos.add(f, info).unwrap();
@@ -1073,8 +1088,13 @@ fn module_call(
     tys: Vec<H::BaseType>,
 ) {
     use IR::Bytecode_ as B;
-    let (m, n) = context.qualified_function_name(&mident, fname);
-    code.push(sp(loc, B::Call(m, n, base_types(context, tys))))
+    match fake_natives::resolve_builtin(&mident, &fname) {
+        Some(mk_bytecode) => code.push(sp(loc, mk_bytecode(base_types(context, tys)))),
+        None => {
+            let (m, n) = context.qualified_function_name(&mident, fname);
+            code.push(sp(loc, B::Call(m, n, base_types(context, tys))))
+        }
+    }
 }
 
 fn builtin(context: &mut Context, code: &mut IR::BytecodeBlock, sp!(loc, b_): H::BuiltinFunction) {

--- a/language/move-compiler/src/to_bytecode/translate.rs
+++ b/language/move-compiler/src/to_bytecode/translate.rs
@@ -91,6 +91,7 @@ fn extract_decls(
                 // TODO filter out fake natives
                 // These cannot be filtered out due to lacking prover support for the operations
                 // .filter(|(_, fdef)| {
+                //     // TODO full evm support for vector bytecode instructions
                 //     cfg!(feature = "evm-backend")
                 //         || !fdef
                 //             .attributes
@@ -195,6 +196,7 @@ fn module(
         // TODO filter out fake natives
         // These cannot be filtered out due to lacking prover support for the operations
         // .filter(|(_, fdef)| {
+        //     // TODO full evm support for vector bytecode instructions
         //     cfg!(feature = "evm-backend")
         //         || !fdef
         //             .attributes
@@ -1097,6 +1099,7 @@ fn module_call(
 ) {
     use IR::Bytecode_ as B;
     match fake_natives::resolve_builtin(&mident, &fname) {
+        // TODO full evm support for vector bytecode instructions
         Some(mk_bytecode) if !cfg!(feature = "evm-backend") => {
             code.push(sp(loc, mk_bytecode(base_types(context, tys))))
         }

--- a/language/move-compiler/src/unit_test/filter_test_members.rs
+++ b/language/move-compiler/src/unit_test/filter_test_members.rs
@@ -344,6 +344,7 @@ fn test_attributes(attrs: &P::Attributes) -> Vec<(Loc, known_attributes::Testing
         .filter_map(
             |attr| match KnownAttribute::resolve(&attr.value.attribute_name().value)? {
                 KnownAttribute::Testing(test_attr) => Some((attr.loc, test_attr)),
+                KnownAttribute::Native(_) => None,
             },
         )
         .collect()

--- a/language/move-model/src/model.rs
+++ b/language/move-model/src/model.rs
@@ -1387,7 +1387,7 @@ impl GlobalEnv {
     }
 
     /// Converts a storage module id into an AST module name.
-    fn to_module_name(&self, storage_id: &language_storage::ModuleId) -> ModuleName {
+    pub fn to_module_name(&self, storage_id: &language_storage::ModuleId) -> ModuleName {
         ModuleName::from_str(
             &storage_id.address().to_string(),
             self.symbol_pool.make(storage_id.name().as_str()),

--- a/language/move-prover/bytecode/src/borrow_analysis.rs
+++ b/language/move-prover/bytecode/src/borrow_analysis.rs
@@ -590,9 +590,14 @@ impl<'a> TransferFunctions for BorrowAnalysis<'a> {
                         let callee_target = &self
                             .targets
                             .get_target(callee_env, &FunctionVariant::Baseline);
-                        if let Some(callee_an) =
+                        let native_an;
+                        let callee_an_opt = if callee_env.is_native() {
+                            native_an = native_annotation(callee_env);
+                            Some(&native_an)
+                        } else {
                             callee_target.get_annotations().get::<BorrowAnnotation>()
-                        {
+                        };
+                        if let Some(callee_an) = callee_an_opt {
                             state.instantiate(
                                 callee_target,
                                 targs,

--- a/language/move-stdlib/docs/ASCII.md
+++ b/language/move-stdlib/docs/ASCII.md
@@ -26,7 +26,6 @@ that characters are valid ASCII, and that strings consist of only valid ASCII ch
 
 <pre><code><b>use</b> <a href="Errors.md#0x1_Errors">0x1::Errors</a>;
 <b>use</b> <a href="Option.md#0x1_Option">0x1::Option</a>;
-<b>use</b> <a href="Vector.md#0x1_Vector">0x1::Vector</a>;
 </code></pre>
 
 

--- a/language/move-stdlib/docs/BitVector.md
+++ b/language/move-stdlib/docs/BitVector.md
@@ -17,7 +17,6 @@
 
 
 <pre><code><b>use</b> <a href="Errors.md#0x1_Errors">0x1::Errors</a>;
-<b>use</b> <a href="Vector.md#0x1_Vector">0x1::Vector</a>;
 </code></pre>
 
 

--- a/language/move-stdlib/nursery/docs/Compare.md
+++ b/language/move-stdlib/nursery/docs/Compare.md
@@ -12,8 +12,7 @@ Utilities for comparing Move values based on their representation in BCS.
 -  [Function `cmp_u64`](#0x1_Compare_cmp_u64)
 
 
-<pre><code><b>use</b> <a href="">0x1::Vector</a>;
-</code></pre>
+<pre><code></code></pre>
 
 
 

--- a/language/move-stdlib/sources/Vector.move
+++ b/language/move-stdlib/sources/Vector.move
@@ -13,31 +13,39 @@ module Std::Vector {
     /// The index into the vector is out of bounds
     const EINDEX_OUT_OF_BOUNDS: u64 = 0;
 
+    #[bytecode_instruction]
     /// Create an empty vector.
     native public fun empty<Element>(): vector<Element>;
 
+    #[bytecode_instruction]
     /// Return the length of the vector.
     native public fun length<Element>(v: &vector<Element>): u64;
 
+    #[bytecode_instruction]
     /// Acquire an immutable reference to the `i`th element of the vector `v`.
     /// Aborts if `i` is out of bounds.
     native public fun borrow<Element>(v: &vector<Element>, i: u64): &Element;
 
+    #[bytecode_instruction]
     /// Add element `e` to the end of the vector `v`.
     native public fun push_back<Element>(v: &mut vector<Element>, e: Element);
 
+    #[bytecode_instruction]
     /// Return a mutable reference to the `i`th element in the vector `v`.
     /// Aborts if `i` is out of bounds.
     native public fun borrow_mut<Element>(v: &mut vector<Element>, i: u64): &mut Element;
 
+    #[bytecode_instruction]
     /// Pop an element from the end of vector `v`.
     /// Aborts if `v` is empty.
     native public fun pop_back<Element>(v: &mut vector<Element>): Element;
 
+    #[bytecode_instruction]
     /// Destroy the vector `v`.
     /// Aborts if `v` is not empty.
     native public fun destroy_empty<Element>(v: vector<Element>);
 
+    #[bytecode_instruction]
     /// Swaps the elements at the `i`th and `j`th indices in the vector `v`.
     /// Aborts if `i`or `j` is out of bounds.
     native public fun swap<Element>(v: &mut vector<Element>, i: u64, j: u64);

--- a/language/move-stdlib/src/natives/mod.rs
+++ b/language/move-stdlib/src/natives/mod.rs
@@ -19,13 +19,36 @@ use move_vm_runtime::{
     native_functions::{NativeFunction, NativeFunctionTable},
 };
 
+const NATIVES: &[(&str, &str, NativeFunction)] = &[
+    ("BCS", "to_bytes", bcs::native_to_bytes),
+    ("Event", "write_to_event_store", event::write_to_event_store),
+    ("Hash", "sha2_256", hash::native_sha2_256),
+    ("Hash", "sha3_256", hash::native_sha3_256),
+    ("Signer", "borrow_address", signer::native_borrow_address),
+    #[cfg(feature = "testing")]
+    ("Debug", "print", debug::native_print),
+    #[cfg(feature = "testing")]
+    (
+        "Debug",
+        "print_stack_trace",
+        debug::native_print_stack_trace,
+    ),
+    #[cfg(feature = "testing")]
+    (
+        "UnitTest",
+        "create_signers_for_testing",
+        unit_test::native_create_signers_for_testing,
+    ),
+];
+
 pub fn all_natives(move_std_addr: AccountAddress) -> NativeFunctionTable {
-    const NATIVES: &[(&str, &str, NativeFunction)] = &[
-        ("BCS", "to_bytes", bcs::native_to_bytes),
-        ("Event", "write_to_event_store", event::write_to_event_store),
-        ("Hash", "sha2_256", hash::native_sha2_256),
-        ("Hash", "sha3_256", hash::native_sha3_256),
-        ("Signer", "borrow_address", signer::native_borrow_address),
+    native_functions::make_table(move_std_addr, NATIVES)
+}
+
+pub fn all_natives_with_deprecated_vector_natives(
+    move_std_addr: AccountAddress,
+) -> NativeFunctionTable {
+    const VEC_NATIVES: &[(&str, &str, NativeFunction)] = &[
         ("Vector", "length", vector::native_length),
         ("Vector", "empty", vector::native_empty),
         ("Vector", "borrow", vector::native_borrow),
@@ -34,20 +57,9 @@ pub fn all_natives(move_std_addr: AccountAddress) -> NativeFunctionTable {
         ("Vector", "pop_back", vector::native_pop),
         ("Vector", "destroy_empty", vector::native_destroy_empty),
         ("Vector", "swap", vector::native_swap),
-        #[cfg(feature = "testing")]
-        ("Debug", "print", debug::native_print),
-        #[cfg(feature = "testing")]
-        (
-            "Debug",
-            "print_stack_trace",
-            debug::native_print_stack_trace,
-        ),
-        #[cfg(feature = "testing")]
-        (
-            "UnitTest",
-            "create_signers_for_testing",
-            unit_test::native_create_signers_for_testing,
-        ),
     ];
-    native_functions::make_table(move_std_addr, NATIVES)
+    native_functions::make_table_from_iter(
+        move_std_addr,
+        NATIVES.iter().chain(VEC_NATIVES).cloned(),
+    )
 }

--- a/language/move-stdlib/src/natives/mod.rs
+++ b/language/move-stdlib/src/natives/mod.rs
@@ -19,36 +19,13 @@ use move_vm_runtime::{
     native_functions::{NativeFunction, NativeFunctionTable},
 };
 
-const NATIVES: &[(&str, &str, NativeFunction)] = &[
-    ("BCS", "to_bytes", bcs::native_to_bytes),
-    ("Event", "write_to_event_store", event::write_to_event_store),
-    ("Hash", "sha2_256", hash::native_sha2_256),
-    ("Hash", "sha3_256", hash::native_sha3_256),
-    ("Signer", "borrow_address", signer::native_borrow_address),
-    #[cfg(feature = "testing")]
-    ("Debug", "print", debug::native_print),
-    #[cfg(feature = "testing")]
-    (
-        "Debug",
-        "print_stack_trace",
-        debug::native_print_stack_trace,
-    ),
-    #[cfg(feature = "testing")]
-    (
-        "UnitTest",
-        "create_signers_for_testing",
-        unit_test::native_create_signers_for_testing,
-    ),
-];
-
 pub fn all_natives(move_std_addr: AccountAddress) -> NativeFunctionTable {
-    native_functions::make_table(move_std_addr, NATIVES)
-}
-
-pub fn all_natives_with_deprecated_vector_natives(
-    move_std_addr: AccountAddress,
-) -> NativeFunctionTable {
-    const VEC_NATIVES: &[(&str, &str, NativeFunction)] = &[
+    const NATIVES: &[(&str, &str, NativeFunction)] = &[
+        ("BCS", "to_bytes", bcs::native_to_bytes),
+        ("Event", "write_to_event_store", event::write_to_event_store),
+        ("Hash", "sha2_256", hash::native_sha2_256),
+        ("Hash", "sha3_256", hash::native_sha3_256),
+        ("Signer", "borrow_address", signer::native_borrow_address),
         ("Vector", "length", vector::native_length),
         ("Vector", "empty", vector::native_empty),
         ("Vector", "borrow", vector::native_borrow),
@@ -57,9 +34,20 @@ pub fn all_natives_with_deprecated_vector_natives(
         ("Vector", "pop_back", vector::native_pop),
         ("Vector", "destroy_empty", vector::native_destroy_empty),
         ("Vector", "swap", vector::native_swap),
+        #[cfg(feature = "testing")]
+        ("Debug", "print", debug::native_print),
+        #[cfg(feature = "testing")]
+        (
+            "Debug",
+            "print_stack_trace",
+            debug::native_print_stack_trace,
+        ),
+        #[cfg(feature = "testing")]
+        (
+            "UnitTest",
+            "create_signers_for_testing",
+            unit_test::native_create_signers_for_testing,
+        ),
     ];
-    native_functions::make_table_from_iter(
-        move_std_addr,
-        NATIVES.iter().chain(VEC_NATIVES).cloned(),
-    )
+    native_functions::make_table(move_std_addr, NATIVES)
 }

--- a/language/move-vm/runtime/src/native_functions.rs
+++ b/language/move-vm/runtime/src/native_functions.rs
@@ -31,9 +31,15 @@ pub fn make_table(
     addr: AccountAddress,
     elems: &[(&str, &str, NativeFunction)],
 ) -> NativeFunctionTable {
+    make_table_from_iter(addr, elems.iter().cloned())
+}
+
+pub fn make_table_from_iter<S: Into<Box<str>>>(
+    addr: AccountAddress,
+    elems: impl IntoIterator<Item = (S, S, NativeFunction)>,
+) -> NativeFunctionTable {
     elems
-        .iter()
-        .cloned()
+        .into_iter()
         .map(|(module_name, func_name, func)| {
             (
                 addr,

--- a/language/tools/move-cli/tests/sandbox_tests/explain_stdlib_abort/args.exp
+++ b/language/tools/move-cli/tests/sandbox_tests/explain_stdlib_abort/args.exp
@@ -1,9 +1,2 @@
 Command `sandbox run sources/bad_borrow.move`:
-Execution aborted with code 1 in module 00000000000000000000000000000001::Vector. Abort code details:
-Reason:
-  Name: EINDEX_OUT_OF_BOUNDS
-  Description: The index into the vector is out of bounds
-Category:
-  Name: INVALID_STATE
-  Description: The system is in a state where the performed operation is not allowed. Example: call to a function only allowed
- in genesis.
+Execution failed because of an error originated from vector operations (i.e., index out of bound, pop an empty vector, or unpack a vector with a wrong parity) in script at code offset 4

--- a/language/tools/move-cli/tests/sandbox_tests/print_stack_trace/args.exp
+++ b/language/tools/move-cli/tests/sandbox_tests/print_stack_trace/args.exp
@@ -5,12 +5,12 @@ Call Stack:
 
         Code:
             [12] LdU64(1)
-            [13] CallGeneric(2)
+            [13] VecImmBorrow(2)
             [14] StLoc(2)
-          > [15] CallGeneric(3)
+          > [15] CallGeneric(0)
             [16] StLoc(4)
             [17] ImmBorrowLoc(4)
-            [18] CallGeneric(4)
+            [18] CallGeneric(1)
 
         Locals:
             [0] -
@@ -95,10 +95,10 @@ Call Stack:
     [0] main
 
         Code:
-            [18] CallGeneric(4)
+            [18] CallGeneric(1)
             [19] MoveLoc(2)
             [20] Pop
-          > [21] CallGeneric(5)
+          > [21] CallGeneric(2)
             [22] Pop
             [23] Ret
 

--- a/language/tools/move-unit-test/tests/test_sources/native_abort.exp
+++ b/language/tools/move-unit-test/tests/test_sources/native_abort.exp
@@ -1,5 +1,5 @@
 Running Move unit tests
-[ PASS    ] 0x1::A::native_abort_good_right_code
+[ FAIL    ] 0x1::A::native_abort_good_right_code
 [ FAIL    ] 0x1::A::native_abort_good_wrong_code
 [ FAIL    ] 0x1::A::native_abort_unexpected_abort
 
@@ -7,15 +7,27 @@ Test failures:
 
 Failures in 0x1::A:
 
+┌── native_abort_good_right_code ──────
+│ error[E11001]: test failure
+│    ┌─ native_abort.move:18:9
+│    │
+│ 17 │     fun native_abort_good_right_code() {
+│    │         ---------------------------- In this function in 0x1::A
+│ 18 │         Vector::borrow(&Vector::empty<u64>(), 1);
+│    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Test did not abort with expected code. Expected test to abort with 1 but instead it aborted with 1 here
+│ 
+│ 
+└──────────────────
+
+
 ┌── native_abort_good_wrong_code ──────
 │ error[E11001]: test failure
-│    ┌─ Vector.move:24:23
+│    ┌─ native_abort.move:12:9
 │    │
-│ 24 │     native public fun borrow<Element>(v: &vector<Element>, i: u64): &Element;
-│    │                       ^^^^^^
-│    │                       │
-│    │                       Test did not abort with expected code. Expected test to abort with 0 but instead it aborted with 1 here
-│    │                       In this function in 0x1::Vector
+│ 11 │     fun native_abort_good_wrong_code() {
+│    │         ---------------------------- In this function in 0x1::A
+│ 12 │         Vector::borrow(&Vector::empty<u64>(), 1);
+│    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Test did not abort with expected code. Expected test to abort with 0 but instead it aborted with 1 here
 │ 
 │ 
 └──────────────────
@@ -23,15 +35,14 @@ Failures in 0x1::A:
 
 ┌── native_abort_unexpected_abort ──────
 │ error[E11001]: test failure
-│    ┌─ Vector.move:24:23
-│    │
-│ 24 │     native public fun borrow<Element>(v: &vector<Element>, i: u64): &Element;
-│    │                       ^^^^^^
-│    │                       │
-│    │                       Test was not expected to abort but it aborted with 1 here
-│    │                       In this function in 0x1::Vector
+│   ┌─ native_abort.move:6:9
+│   │
+│ 5 │     fun native_abort_unexpected_abort() {
+│   │         ----------------------------- In this function in 0x1::A
+│ 6 │         Vector::borrow(&Vector::empty<u64>(), 1);
+│   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Test was not expected to abort but it aborted with 1 here
 │ 
 │ 
 └──────────────────
 
-Test result: FAILED. Total tests: 3; passed: 1; failed: 2
+Test result: FAILED. Total tests: 3; passed: 0; failed: 3


### PR DESCRIPTION
- Add annotation for native functions that are bytecode instructions
- Add compiler support for swapping those annotated functions to known bytecode instructions
- Used source files instead of interface files for source language tests
- Stopped interface files from shadowing fully compiled deps

## Motivation

- The native bytecode operations have been there for a while, but have been unused 

## Test Plan

- Existing tests, just swapping out behavior 
