### PR TITLE
[move-vm] Removed most RCs from runtime

### DIFF
--- a/language/extensions/async/move-async-vm/src/async_vm.rs
+++ b/language/extensions/async/move-async-vm/src/async_vm.rs
@@ -15,6 +15,7 @@ use move_core_types::{
     identifier::Identifier,
     language_storage::{ModuleId, StructTag, TypeTag},
     resolver::MoveResolver,
+    value::MoveTypeLayout,
     vm_status::StatusCode,
 };
 use move_vm_runtime::{
@@ -23,10 +24,7 @@ use move_vm_runtime::{
     native_functions::NativeFunction,
     session::{SerializedReturnValues, Session},
 };
-use move_vm_types::{
-    gas_schedule::GasStatus,
-    values::{Reference, Value},
-};
+use move_vm_types::{gas_schedule::GasStatus, values::GlobalValue};
 
 use crate::{actor_metadata, actor_metadata::ActorMetadata, natives, natives::AsyncExtension};
 
@@ -254,23 +252,18 @@ impl<'r, 'l, S: MoveResolver> AsyncSession<'r, 'l, S> {
             .load_type(&state_type_tag)
             .map_err(vm_error_to_async)?;
 
-        let actor_state_global = self
+        let layout = self
+            .get_type_layout(&state_type_tag)
+            .map_err(partial_vm_error_to_async)?;
+        let actor_state_global: &GlobalValue = self
             .vm_session
             .get_data_store()
             .load_resource(actor_addr, &state_type)
             .map_err(partial_vm_error_to_async)?;
-        let actor_state = unsafe {
-            actor_state_global
-                .borrow_global()
-                .and_then(|v| v.value_as::<Reference>())
-                .map_err(partial_vm_error_to_async)?
-                .read_ref()
-        };
-        args.insert(
-            0,
-            self.to_bcs(actor_state, &state_type_tag)
-                .map_err(partial_vm_error_to_async)?,
-        );
+        let bcs = actor_state_global
+            .simple_serialize(&layout)
+            .ok_or_else(|| async_extension_error("serialization failed"))?;
+        args.insert(0, bcs);
 
         // Execute the handler.
         let gas_before = gas_status.remaining_gas().get();
@@ -319,14 +312,10 @@ impl<'r, 'l, S: MoveResolver> AsyncSession<'r, 'l, S> {
         }
     }
 
-    fn to_bcs(&self, value: Value, tag: &TypeTag) -> PartialVMResult<Vec<u8>> {
-        let type_layout = self
-            .vm_session
+    fn get_type_layout(&self, tag: &TypeTag) -> PartialVMResult<MoveTypeLayout> {
+        self.vm_session
             .get_type_layout(tag)
-            .map_err(|e| e.to_partial())?;
-        value
-            .simple_serialize(&type_layout)
-            .ok_or_else(|| partial_extension_error("serialization failed"))
+            .map_err(|e| e.to_partial())
     }
 }
 

--- a/language/extensions/async/move-async-vm/src/async_vm.rs
+++ b/language/extensions/async/move-async-vm/src/async_vm.rs
@@ -259,11 +259,13 @@ impl<'r, 'l, S: MoveResolver> AsyncSession<'r, 'l, S> {
             .get_data_store()
             .load_resource(actor_addr, &state_type)
             .map_err(partial_vm_error_to_async)?;
-        let actor_state = actor_state_global
-            .borrow_global()
-            .and_then(|v| v.value_as::<Reference>())
-            .and_then(|r| r.read_ref())
-            .map_err(partial_vm_error_to_async)?;
+        let actor_state = unsafe {
+            actor_state_global
+                .borrow_global()
+                .and_then(|v| v.value_as::<Reference>())
+                .map_err(partial_vm_error_to_async)?
+                .read_ref()
+        };
         args.insert(
             0,
             self.to_bcs(actor_state, &state_type_tag)

--- a/language/extensions/async/move-async-vm/src/natives.rs
+++ b/language/extensions/async/move-async-vm/src/natives.rs
@@ -14,7 +14,7 @@ use move_vm_types::{
     loaded_data::runtime_types::Type,
     natives::function::{native_gas, NativeResult},
     pop_arg,
-    values::{Value, Vector},
+    values::Value,
 };
 use smallvec::smallvec;
 use std::collections::VecDeque;
@@ -77,7 +77,7 @@ fn native_send(
     let ext = context.extensions_mut().get_mut::<AsyncExtension>();
     let mut bcs_args = vec![];
     while args.len() > 2 {
-        bcs_args.push(pop_arg!(args, Vector).to_vec_u8()?);
+        bcs_args.push(pop_arg!(args, Vec<u8>));
     }
     bcs_args.reverse();
     let message_hash = pop_arg!(args, u64);

--- a/language/extensions/move-table-extension/src/lib.rs
+++ b/language/extensions/move-table-extension/src/lib.rs
@@ -372,12 +372,9 @@ fn native_add_box(
     let table_context = context.extensions().get::<NativeTableContext>();
     let mut table_data = table_context.table_data.borrow_mut();
 
+    // see REFERENCE SAFETY EXPLANATION in values
     let val = args.pop_back().unwrap();
-    let key = args
-        .pop_back()
-        .unwrap()
-        .value_as::<Reference>()?
-        .read_ref()?;
+    let key = unsafe { args.pop_back().unwrap().value_as::<Reference>()?.read_ref() };
     let handle = get_table_handle(&pop_arg!(args, StructRef))?;
 
     let table = table_data.get_or_create_table(context, handle, &ty_args[0], &ty_args[2])?;
@@ -403,11 +400,8 @@ fn native_borrow_box(
     let table_context = context.extensions().get::<NativeTableContext>();
     let mut table_data = table_context.table_data.borrow_mut();
 
-    let key = args
-        .pop_back()
-        .unwrap()
-        .value_as::<Reference>()?
-        .read_ref()?;
+    // see REFERENCE SAFETY EXPLANATION in values
+    let key = unsafe { args.pop_back().unwrap().value_as::<Reference>()?.read_ref() };
     let handle = get_table_handle(&pop_arg!(args, StructRef))?;
 
     let table = table_data.get_or_create_table(context, handle, &ty_args[0], &ty_args[2])?;
@@ -432,11 +426,8 @@ fn native_contains_box(
     let table_context = context.extensions().get::<NativeTableContext>();
     let mut table_data = table_context.table_data.borrow_mut();
 
-    let key = args
-        .pop_back()
-        .unwrap()
-        .value_as::<Reference>()?
-        .read_ref()?;
+    // see REFERENCE SAFETY EXPLANATION in values
+    let key = unsafe { args.pop_back().unwrap().value_as::<Reference>()?.read_ref() };
     let handle = get_table_handle(&pop_arg!(args, StructRef))?;
 
     let table = table_data.get_or_create_table(context, handle, &ty_args[0], &ty_args[2])?;
@@ -461,11 +452,8 @@ fn native_remove_box(
     let table_context = context.extensions().get::<NativeTableContext>();
     let mut table_data = table_context.table_data.borrow_mut();
 
-    let key = args
-        .pop_back()
-        .unwrap()
-        .value_as::<Reference>()?
-        .read_ref()?;
+    // see REFERENCE SAFETY EXPLANATION in values
+    let key = unsafe { args.pop_back().unwrap().value_as::<Reference>()?.read_ref() };
     let handle = get_table_handle(&pop_arg!(args, StructRef))?;
     let table = table_data.get_or_create_table(context, handle, &ty_args[0], &ty_args[2])?;
     let (val, key_size, val_size) = table.remove(table_context, &key)?;
@@ -521,7 +509,8 @@ fn get_table_handle(table: &StructRef) -> PartialVMResult<TableHandle> {
     let field_ref = table
         .borrow_field(HANDLE_FIELD_INDEX)?
         .value_as::<Reference>()?;
-    field_ref.read_ref()?.value_as::<u128>().map(TableHandle)
+    // see REFERENCE SAFETY EXPLANATION in values
+    unsafe { field_ref.read_ref().value_as::<u128>().map(TableHandle) }
 }
 
 fn serialize(layout: &MoveTypeLayout, val: &Value) -> PartialVMResult<Vec<u8>> {

--- a/language/move-core/types/src/value.rs
+++ b/language/move-core/types/src/value.rs
@@ -523,3 +523,61 @@ impl TryInto<StructTag> for &MoveStructLayout {
         }
     }
 }
+
+impl fmt::Display for MoveValue {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            MoveValue::U8(u) => write!(f, "{}u8", u),
+            MoveValue::U64(u) => write!(f, "{}u64", u),
+            MoveValue::U128(u) => write!(f, "{}u128", u),
+            MoveValue::Bool(false) => write!(f, "false"),
+            MoveValue::Bool(true) => write!(f, "true"),
+            MoveValue::Address(a) => write!(f, "{}", a.to_hex_literal()),
+            MoveValue::Signer(a) => write!(f, "signer({})", a.to_hex_literal()),
+            MoveValue::Vector(v) => fmt_list(f, "vector[", v, "]"),
+            MoveValue::Struct(s) => fmt::Display::fmt(s, f),
+        }
+    }
+}
+
+impl fmt::Display for MoveStruct {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            MoveStruct::Runtime(v) => fmt_list(f, "struct[", v, "]"),
+            MoveStruct::WithFields(fields) => {
+                fmt_list(f, "{", fields.iter().map(DisplayFieldBinding), "}")
+            }
+            MoveStruct::WithTypes { type_, fields } => {
+                fmt::Display::fmt(type_, f)?;
+                fmt_list(f, " {", fields.iter().map(DisplayFieldBinding), "}")
+            }
+        }
+    }
+}
+
+struct DisplayFieldBinding<'a>(&'a (Identifier, MoveValue));
+
+impl fmt::Display for DisplayFieldBinding<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let DisplayFieldBinding((field, value)) = self;
+        write!(f, "{}: {}", field, value)
+    }
+}
+
+fn fmt_list<T: fmt::Display>(
+    f: &mut fmt::Formatter<'_>,
+    begin: &str,
+    items: impl IntoIterator<Item = T>,
+    end: &str,
+) -> fmt::Result {
+    write!(f, "{}", begin)?;
+    let mut items = items.into_iter();
+    if let Some(x) = items.next() {
+        write!(f, "{}", x)?;
+        for x in items {
+            write!(f, ", {}", x)?;
+        }
+    }
+    write!(f, "{}", end)?;
+    Ok(())
+}

--- a/language/move-stdlib/src/natives/bcs.rs
+++ b/language/move-stdlib/src/natives/bcs.rs
@@ -29,7 +29,7 @@ pub fn native_to_bytes(
     // delegate to the BCS serialization for `Value`
     let serialized_value_opt = match context.type_to_type_layout(&arg_type)? {
         None => None,
-        Some(layout) => ref_to_val.read_ref().simple_serialize(&layout),
+        Some(layout) => unsafe { ref_to_val.read_ref() }.simple_serialize(&layout),
     };
     let serialized_value = match serialized_value_opt {
         None => {

--- a/language/move-stdlib/src/natives/bcs.rs
+++ b/language/move-stdlib/src/natives/bcs.rs
@@ -29,7 +29,7 @@ pub fn native_to_bytes(
     // delegate to the BCS serialization for `Value`
     let serialized_value_opt = match context.type_to_type_layout(&arg_type)? {
         None => None,
-        Some(layout) => ref_to_val.read_ref()?.simple_serialize(&layout),
+        Some(layout) => ref_to_val.read_ref().simple_serialize(&layout),
     };
     let serialized_value = match serialized_value_opt {
         None => {

--- a/language/move-stdlib/src/natives/debug.rs
+++ b/language/move-stdlib/src/natives/debug.rs
@@ -30,7 +30,7 @@ pub fn native_print(
         let r = pop_arg!(args, Reference);
 
         let mut buf = String::new();
-        print_reference(&mut buf, &r)?;
+        unsafe { print_reference(&mut buf, &r)? };
         println!("[debug] {}", buf);
     }
 

--- a/language/move-stdlib/src/natives/vector.rs
+++ b/language/move-stdlib/src/natives/vector.rs
@@ -36,7 +36,7 @@ pub fn native_length(
 
     let r = pop_arg!(args, VectorRef);
     let cost = native_gas(context.cost_table(), NativeCostIndex::LENGTH, 1);
-    NativeResult::map_partial_vm_result_one(cost, r.len(&ty_args[0]))
+    NativeResult::map_partial_vm_result_one(cost, unsafe { r.len(&ty_args[0]) })
 }
 
 pub fn native_push_back(
@@ -54,7 +54,7 @@ pub fn native_push_back(
         NativeCostIndex::PUSH_BACK,
         e.size().get() as usize,
     );
-    NativeResult::map_partial_vm_result_empty(cost, r.push_back(e, &ty_args[0]))
+    NativeResult::map_partial_vm_result_empty(cost, unsafe { r.push_back(e, &ty_args[0]) })
 }
 
 pub fn native_borrow(
@@ -70,8 +70,7 @@ pub fn native_borrow(
     let cost = native_gas(context.cost_table(), NativeCostIndex::BORROW, 1);
     NativeResult::map_partial_vm_result_one(
         cost,
-        r.borrow_elem(idx, &ty_args[0])
-            .map_err(native_error_to_abort),
+        unsafe { r.borrow_elem(idx, &ty_args[0]) }.map_err(native_error_to_abort),
     )
 }
 
@@ -85,7 +84,10 @@ pub fn native_pop(
 
     let r = pop_arg!(args, VectorRef);
     let cost = native_gas(context.cost_table(), NativeCostIndex::POP_BACK, 1);
-    NativeResult::map_partial_vm_result_one(cost, r.pop(&ty_args[0]).map_err(native_error_to_abort))
+    NativeResult::map_partial_vm_result_one(
+        cost,
+        unsafe { r.pop(&ty_args[0]) }.map_err(native_error_to_abort),
+    )
 }
 
 pub fn native_destroy_empty(
@@ -118,8 +120,7 @@ pub fn native_swap(
     let cost = native_gas(context.cost_table(), NativeCostIndex::SWAP, 1);
     NativeResult::map_partial_vm_result_empty(
         cost,
-        r.swap(idx1, idx2, &ty_args[0])
-            .map_err(native_error_to_abort),
+        unsafe { r.swap(idx1, idx2, &ty_args[0]) }.map_err(native_error_to_abort),
     )
 }
 

--- a/language/move-vm/runtime/src/debug.rs
+++ b/language/move-vm/runtime/src/debug.rs
@@ -175,7 +175,9 @@ impl DebugContext {
                                 println!("        Locals:");
                                 if function_desc.local_count() > 0 {
                                     let mut s = String::new();
-                                    values::debug::print_locals(&mut s, locals).unwrap();
+                                    unsafe {
+                                        values::debug::print_locals(&mut s, locals).unwrap();
+                                    }
                                     println!("{}", s);
                                 } else {
                                     println!("            (none)");

--- a/language/move-vm/runtime/src/interpreter.rs
+++ b/language/move-vm/runtime/src/interpreter.rs
@@ -491,7 +491,8 @@ impl Interpreter {
         debug_writeln!(buf)?;
         debug_writeln!(buf, "        Locals:")?;
         if func.local_count() > 0 {
-            values::debug::print_locals(buf, &frame.locals)?;
+            // see REFERENCE SAFETY EXPLANATION in values
+            unsafe { values::debug::print_locals(buf, &frame.locals)? };
             debug_writeln!(buf)?;
         } else {
             debug_writeln!(buf, "            (none)")?;
@@ -516,7 +517,8 @@ impl Interpreter {
             // TODO: Currently we do not know the types of the values on the operand stack.
             // Revisit.
             debug_write!(buf, "    [{}] ", idx)?;
-            values::debug::print_value(buf, val)?;
+            // see REFERENCE SAFETY EXPLANATION in values
+            unsafe { values::debug::print_value(buf, val)? };
             debug_writeln!(buf)?;
         }
         Ok(())
@@ -560,10 +562,28 @@ impl Interpreter {
             }
             internal_state.push_str(format!("{}* {:?}\n", i, code[pc]).as_str());
         }
-        internal_state.push_str(format!("Locals:\n{}\n", current_frame.locals).as_str());
+        let locals_str = {
+            let mut buf = String::new();
+            // see REFERENCE SAFETY EXPLANATION in values
+            let res = unsafe { values::debug::print_locals(&mut buf, &current_frame.locals) };
+            match res {
+                Ok(()) => buf,
+                Err(err) => format!("!!!ERRROR COULD NOT PRINT LOCALS {:?}!!!", err),
+            }
+        };
+        internal_state.push_str(format!("Locals:\n{}\n", locals_str).as_str());
         internal_state.push_str("Operand Stack:\n");
         for value in &self.operand_stack.0 {
-            internal_state.push_str(format!("{}\n", value).as_str());
+            let value_str = {
+                let mut buf = String::new();
+                // see REFERENCE SAFETY EXPLANATION in values
+                let res = unsafe { values::debug::print_value(&mut buf, value) };
+                match res {
+                    Ok(()) => buf,
+                    Err(err) => format!("!!!ERRROR COULD NOT PRINT VALUE {:?}!!!", err),
+                }
+            };
+            internal_state.push_str(format!("{}\n", value_str).as_str());
         }
         internal_state
     }
@@ -928,7 +948,8 @@ impl Frame {
                     }
                     Bytecode::ReadRef => {
                         let reference = interpreter.operand_stack.pop_as::<Reference>()?;
-                        let value = reference.read_ref();
+                        // see REFERENCE SAFETY EXPLANATION in values
+                        let value = unsafe { reference.read_ref() };
                         gas_status.charge_instr_with_size(Opcodes::READ_REF, value.size())?;
                         interpreter.operand_stack.push(value)?;
                     }
@@ -936,8 +957,7 @@ impl Frame {
                         let reference = interpreter.operand_stack.pop_as::<Reference>()?;
                         let value = interpreter.operand_stack.pop()?;
                         gas_status.charge_instr_with_size(Opcodes::WRITE_REF, value.size())?;
-                        // safe due as long as the code being executed passed the reference
-                        // safety checks
+                        // see REFERENCE SAFETY EXPLANATION in values
                         unsafe {
                             reference.write_ref(value)?;
                         }
@@ -1057,18 +1077,20 @@ impl Frame {
                         let rhs = interpreter.operand_stack.pop()?;
                         gas_status
                             .charge_instr_with_size(Opcodes::EQ, lhs.size().add(rhs.size()))?;
+                        // see REFERENCE SAFETY EXPLANATION in values
                         interpreter
                             .operand_stack
-                            .push(Value::bool(lhs.equals(&rhs)?))?;
+                            .push(Value::bool(unsafe { lhs.equals(&rhs)? }))?;
                     }
                     Bytecode::Neq => {
                         let lhs = interpreter.operand_stack.pop()?;
                         let rhs = interpreter.operand_stack.pop()?;
                         gas_status
                             .charge_instr_with_size(Opcodes::NEQ, lhs.size().add(rhs.size()))?;
+                        // see REFERENCE SAFETY EXPLANATION in values
                         interpreter
                             .operand_stack
-                            .push(Value::bool(!lhs.equals(&rhs)?))?;
+                            .push(Value::bool(unsafe { !lhs.equals(&rhs)? }))?;
                     }
                     Bytecode::MutBorrowGlobal(sd_idx) | Bytecode::ImmBorrowGlobal(sd_idx) => {
                         let addr = interpreter.operand_stack.pop_as::<AccountAddress>()?;
@@ -1115,11 +1137,14 @@ impl Frame {
                     Bytecode::MoveTo(sd_idx) => {
                         let resource = interpreter.operand_stack.pop()?;
                         let signer_reference = interpreter.operand_stack.pop_as::<StructRef>()?;
-                        let addr = signer_reference
-                            .borrow_field(0)?
-                            .value_as::<Reference>()?
-                            .read_ref()
-                            .value_as::<AccountAddress>()?;
+                        // see REFERENCE SAFETY EXPLANATION in values
+                        let addr = unsafe {
+                            signer_reference
+                                .borrow_field(0)?
+                                .value_as::<Reference>()?
+                                .read_ref()
+                                .value_as::<AccountAddress>()?
+                        };
                         let ty = resolver.get_struct_type(*sd_idx);
                         // REVIEW: Can we simplify Interpreter::move_to?
                         let size = interpreter.move_to(data_store, addr, &ty, resource)?;
@@ -1128,11 +1153,14 @@ impl Frame {
                     Bytecode::MoveToGeneric(si_idx) => {
                         let resource = interpreter.operand_stack.pop()?;
                         let signer_reference = interpreter.operand_stack.pop_as::<StructRef>()?;
-                        let addr = signer_reference
-                            .borrow_field(0)?
-                            .value_as::<Reference>()?
-                            .read_ref()
-                            .value_as::<AccountAddress>()?;
+                        // see REFERENCE SAFETY EXPLANATION in values
+                        let addr = unsafe {
+                            signer_reference
+                                .borrow_field(0)?
+                                .value_as::<Reference>()?
+                                .read_ref()
+                                .value_as::<AccountAddress>()?
+                        };
                         let ty = resolver.instantiate_generic_type(*si_idx, self.ty_args())?;
                         let size = interpreter.move_to(data_store, addr, &ty, resource)?;
                         gas_status.charge_instr_with_size(Opcodes::MOVE_TO_GENERIC, size)?;
@@ -1164,7 +1192,7 @@ impl Frame {
                         let vec_ref = interpreter.operand_stack.pop_as::<VectorRef>()?;
                         gas_status.charge_instr(Opcodes::VEC_LEN)?;
                         let vec_ty_arg = &resolver.instantiate_single_type(*si, self.ty_args())?;
-                        let value = vec_ref.len(vec_ty_arg)?;
+                        let value = unsafe { vec_ref.len(vec_ty_arg)? };
                         interpreter.operand_stack.push(value)?;
                     }
                     Bytecode::VecImmBorrow(si) => {
@@ -1172,7 +1200,7 @@ impl Frame {
                         let vec_ref = interpreter.operand_stack.pop_as::<VectorRef>()?;
                         gas_status.charge_instr(Opcodes::VEC_IMM_BORROW)?;
                         let vec_ty_arg = &resolver.instantiate_single_type(*si, self.ty_args())?;
-                        let value = vec_ref.borrow_elem(idx, vec_ty_arg)?;
+                        let value = unsafe { vec_ref.borrow_elem(idx, vec_ty_arg)? };
                         interpreter.operand_stack.push(value)?;
                     }
                     Bytecode::VecMutBorrow(si) => {
@@ -1180,7 +1208,7 @@ impl Frame {
                         let vec_ref = interpreter.operand_stack.pop_as::<VectorRef>()?;
                         gas_status.charge_instr(Opcodes::VEC_MUT_BORROW)?;
                         let vec_ty_arg = &resolver.instantiate_single_type(*si, self.ty_args())?;
-                        let value = vec_ref.borrow_elem(idx, vec_ty_arg)?;
+                        let value = unsafe { vec_ref.borrow_elem(idx, vec_ty_arg)? };
                         interpreter.operand_stack.push(value)?;
                     }
                     Bytecode::VecPushBack(si) => {
@@ -1188,13 +1216,13 @@ impl Frame {
                         let vec_ref = interpreter.operand_stack.pop_as::<VectorRef>()?;
                         gas_status.charge_instr_with_size(Opcodes::VEC_PUSH_BACK, elem.size())?;
                         let vec_ty_arg = &resolver.instantiate_single_type(*si, self.ty_args())?;
-                        vec_ref.push_back(elem, vec_ty_arg)?;
+                        unsafe { vec_ref.push_back(elem, vec_ty_arg)? };
                     }
                     Bytecode::VecPopBack(si) => {
                         let vec_ref = interpreter.operand_stack.pop_as::<VectorRef>()?;
                         gas_status.charge_instr(Opcodes::VEC_POP_BACK)?;
                         let vec_ty_arg = &resolver.instantiate_single_type(*si, self.ty_args())?;
-                        let value = vec_ref.pop(vec_ty_arg)?;
+                        let value = unsafe { vec_ref.pop(vec_ty_arg)? };
                         interpreter.operand_stack.push(value)?;
                     }
                     Bytecode::VecUnpack(si, num) => {
@@ -1213,7 +1241,7 @@ impl Frame {
                         let vec_ref = interpreter.operand_stack.pop_as::<VectorRef>()?;
                         gas_status.charge_instr(Opcodes::VEC_SWAP)?;
                         let vec_ty_arg = &resolver.instantiate_single_type(*si, self.ty_args())?;
-                        vec_ref.swap(idx1, idx2, vec_ty_arg)?;
+                        unsafe { vec_ref.swap(idx1, idx2, vec_ty_arg)? };
                     }
                 }
                 // invariant: advance to pc +1 is iff instruction at pc executed without aborting

--- a/language/move-vm/runtime/src/interpreter.rs
+++ b/language/move-vm/runtime/src/interpreter.rs
@@ -928,7 +928,7 @@ impl Frame {
                     }
                     Bytecode::ReadRef => {
                         let reference = interpreter.operand_stack.pop_as::<Reference>()?;
-                        let value = reference.read_ref()?;
+                        let value = reference.read_ref();
                         gas_status.charge_instr_with_size(Opcodes::READ_REF, value.size())?;
                         interpreter.operand_stack.push(value)?;
                     }
@@ -936,7 +936,11 @@ impl Frame {
                         let reference = interpreter.operand_stack.pop_as::<Reference>()?;
                         let value = interpreter.operand_stack.pop()?;
                         gas_status.charge_instr_with_size(Opcodes::WRITE_REF, value.size())?;
-                        reference.write_ref(value)?;
+                        // safe due as long as the code being executed passed the reference
+                        // safety checks
+                        unsafe {
+                            reference.write_ref(value)?;
+                        }
                     }
                     Bytecode::CastU8 => {
                         gas_status.charge_instr(Opcodes::CAST_U8)?;
@@ -1114,7 +1118,7 @@ impl Frame {
                         let addr = signer_reference
                             .borrow_field(0)?
                             .value_as::<Reference>()?
-                            .read_ref()?
+                            .read_ref()
                             .value_as::<AccountAddress>()?;
                         let ty = resolver.get_struct_type(*sd_idx);
                         // REVIEW: Can we simplify Interpreter::move_to?
@@ -1127,7 +1131,7 @@ impl Frame {
                         let addr = signer_reference
                             .borrow_field(0)?
                             .value_as::<Reference>()?
-                            .read_ref()?
+                            .read_ref()
                             .value_as::<AccountAddress>()?;
                         let ty = resolver.instantiate_generic_type(*si_idx, self.ty_args())?;
                         let size = interpreter.move_to(data_store, addr, &ty, resource)?;

--- a/language/move-vm/runtime/src/interpreter.rs
+++ b/language/move-vm/runtime/src/interpreter.rs
@@ -1192,6 +1192,7 @@ impl Frame {
                         let vec_ref = interpreter.operand_stack.pop_as::<VectorRef>()?;
                         gas_status.charge_instr(Opcodes::VEC_LEN)?;
                         let vec_ty_arg = &resolver.instantiate_single_type(*si, self.ty_args())?;
+                        // see REFERENCE SAFETY EXPLANATION in values
                         let value = unsafe { vec_ref.len(vec_ty_arg)? };
                         interpreter.operand_stack.push(value)?;
                     }
@@ -1200,6 +1201,7 @@ impl Frame {
                         let vec_ref = interpreter.operand_stack.pop_as::<VectorRef>()?;
                         gas_status.charge_instr(Opcodes::VEC_IMM_BORROW)?;
                         let vec_ty_arg = &resolver.instantiate_single_type(*si, self.ty_args())?;
+                        // see REFERENCE SAFETY EXPLANATION in values
                         let value = unsafe { vec_ref.borrow_elem(idx, vec_ty_arg)? };
                         interpreter.operand_stack.push(value)?;
                     }
@@ -1208,6 +1210,7 @@ impl Frame {
                         let vec_ref = interpreter.operand_stack.pop_as::<VectorRef>()?;
                         gas_status.charge_instr(Opcodes::VEC_MUT_BORROW)?;
                         let vec_ty_arg = &resolver.instantiate_single_type(*si, self.ty_args())?;
+                        // see REFERENCE SAFETY EXPLANATION in values
                         let value = unsafe { vec_ref.borrow_elem(idx, vec_ty_arg)? };
                         interpreter.operand_stack.push(value)?;
                     }
@@ -1216,12 +1219,14 @@ impl Frame {
                         let vec_ref = interpreter.operand_stack.pop_as::<VectorRef>()?;
                         gas_status.charge_instr_with_size(Opcodes::VEC_PUSH_BACK, elem.size())?;
                         let vec_ty_arg = &resolver.instantiate_single_type(*si, self.ty_args())?;
+                        // see REFERENCE SAFETY EXPLANATION in values
                         unsafe { vec_ref.push_back(elem, vec_ty_arg)? };
                     }
                     Bytecode::VecPopBack(si) => {
                         let vec_ref = interpreter.operand_stack.pop_as::<VectorRef>()?;
                         gas_status.charge_instr(Opcodes::VEC_POP_BACK)?;
                         let vec_ty_arg = &resolver.instantiate_single_type(*si, self.ty_args())?;
+                        // see REFERENCE SAFETY EXPLANATION in values
                         let value = unsafe { vec_ref.pop(vec_ty_arg)? };
                         interpreter.operand_stack.push(value)?;
                     }
@@ -1241,6 +1246,7 @@ impl Frame {
                         let vec_ref = interpreter.operand_stack.pop_as::<VectorRef>()?;
                         gas_status.charge_instr(Opcodes::VEC_SWAP)?;
                         let vec_ty_arg = &resolver.instantiate_single_type(*si, self.ty_args())?;
+                        // see REFERENCE SAFETY EXPLANATION in values
                         unsafe { vec_ref.swap(idx1, idx2, vec_ty_arg)? };
                     }
                 }

--- a/language/move-vm/runtime/src/lib.rs
+++ b/language/move-vm/runtime/src/lib.rs
@@ -1,8 +1,6 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#![forbid(unsafe_code)]
-
 //! The core Move VM logic.
 //!
 //! It is a design goal for the Move VM to be independent of the Diem blockchain, so that

--- a/language/move-vm/runtime/src/runtime.rs
+++ b/language/move-vm/runtime/src/runtime.rs
@@ -266,7 +266,8 @@ impl VMRuntime {
                         "non reference value given for a reference typed return value".to_string(),
                     )
                 })?;
-                let inner_value = ref_value.read_ref()?;
+                // safe as long as the dummy locals are not dropped
+                let inner_value = unsafe { ref_value.read_ref() };
                 (&**inner, inner_value)
             }
             _ => (ty, value),

--- a/language/move-vm/types/src/lib.rs
+++ b/language/move-vm/types/src/lib.rs
@@ -1,8 +1,6 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#![forbid(unsafe_code)]
-
 macro_rules! debug_write {
     ($($toks: tt)*) => {
         write!($($toks)*).map_err(|_|

--- a/language/move-vm/types/src/values/mod.rs
+++ b/language/move-vm/types/src/values/mod.rs
@@ -1,6 +1,18 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+//! Implementation for Move values
+//!
+//! REFERENCE SAFETY EXPLANATION
+//! References in Move are proved safe statically in the reference safety check
+//! (bytecode_verifier/reference_safety). This check guarantees that there are no dangling
+//! references and no memory leaks. But the access pattern for reading/writing to Values must
+//! abide by these safety rules (which the VM interpreter does. You should refrain from writing to
+//! reference values outside of the VM or native functions (with special care))
+//! However, it is **very important** that any instance of `Locals` is not dropped until after
+//! all Values are consumed. If this is not followed, reading/writing to Values *will* read from
+//! invalid pointers.
+
 pub mod values_impl;
 
 #[cfg(test)]

--- a/language/move-vm/types/src/values/value_tests.rs
+++ b/language/move-vm/types/src/values/value_tests.rs
@@ -15,10 +15,12 @@ fn locals() -> PartialVMResult<()> {
     }
     locals.store_loc(1, Value::u64(42))?;
 
-    assert!(locals.copy_loc(1)?.equals(&Value::u64(42))?);
-    let r = locals.borrow_loc(1)?.value_as::<Reference>()?;
-    assert!(r.read_ref().equals(&Value::u64(42))?);
-    assert!(locals.move_loc(1)?.equals(&Value::u64(42))?);
+    unsafe {
+        assert!(locals.copy_loc(1)?.equals(&Value::u64(42))?);
+        let r = locals.borrow_loc(1)?.value_as::<Reference>()?;
+        assert!(r.read_ref().equals(&Value::u64(42))?);
+        assert!(locals.move_loc(1)?.equals(&Value::u64(42))?);
+    }
 
     assert!(locals.copy_loc(1).is_err());
     assert!(locals.move_loc(1).is_err());
@@ -39,7 +41,9 @@ fn struct_pack_and_unpack() -> PartialVMResult<()> {
 
     assert!(vals.len() == unpacked.len());
     for (v1, v2) in vals.iter().zip(unpacked.iter()) {
-        assert!(v1.equals(v2)?);
+        unsafe {
+            assert!(v1.equals(v2)?);
+        }
     }
 
     Ok(())
@@ -54,7 +58,7 @@ fn struct_borrow_field() -> PartialVMResult<()> {
     )?;
     let r: StructRef = locals.borrow_loc(0)?.value_as()?;
 
-    {
+    unsafe {
         let f: Reference = r.borrow_field(1)?.value_as()?;
         assert!(f.read_ref().equals(&Value::bool(false))?);
     }
@@ -64,7 +68,7 @@ fn struct_borrow_field() -> PartialVMResult<()> {
         f.write_ref(Value::bool(true))?;
     }
 
-    {
+    unsafe {
         let f: Reference = r.borrow_field(1)?.value_as()?;
         assert!(f.read_ref().equals(&Value::bool(true))?);
     }
@@ -87,7 +91,7 @@ fn struct_borrow_nested() -> PartialVMResult<()> {
     let r1: StructRef = locals.borrow_loc(0)?.value_as()?;
     let r2: StructRef = r1.borrow_field(1)?.value_as()?;
 
-    {
+    unsafe {
         let r3: Reference = r2.borrow_field(0)?.value_as()?;
         assert!(r3.read_ref().equals(&Value::u64(20))?);
     }
@@ -97,13 +101,15 @@ fn struct_borrow_nested() -> PartialVMResult<()> {
         r3.write_ref(Value::u64(30))?;
     }
 
-    {
+    unsafe {
         let r3: Reference = r2.borrow_field(0)?.value_as()?;
         assert!(r3.read_ref().equals(&Value::u64(30))?);
     }
 
-    assert!(r2.into_ref().read_ref().equals(&inner(30))?);
-    assert!(r1.into_ref().read_ref().equals(&outer(30))?);
+    unsafe {
+        assert!(r2.into_ref().read_ref().equals(&inner(30))?);
+        assert!(r1.into_ref().read_ref().equals(&outer(30))?);
+    }
 
     Ok(())
 }

--- a/language/move-vm/types/src/values/value_tests.rs
+++ b/language/move-vm/types/src/values/value_tests.rs
@@ -17,7 +17,7 @@ fn locals() -> PartialVMResult<()> {
 
     assert!(locals.copy_loc(1)?.equals(&Value::u64(42))?);
     let r = locals.borrow_loc(1)?.value_as::<Reference>()?;
-    assert!(r.read_ref()?.equals(&Value::u64(42))?);
+    assert!(r.read_ref().equals(&Value::u64(42))?);
     assert!(locals.move_loc(1)?.equals(&Value::u64(42))?);
 
     assert!(locals.copy_loc(1).is_err());
@@ -56,17 +56,17 @@ fn struct_borrow_field() -> PartialVMResult<()> {
 
     {
         let f: Reference = r.borrow_field(1)?.value_as()?;
-        assert!(f.read_ref()?.equals(&Value::bool(false))?);
+        assert!(f.read_ref().equals(&Value::bool(false))?);
     }
 
-    {
+    unsafe {
         let f: Reference = r.borrow_field(1)?.value_as()?;
         f.write_ref(Value::bool(true))?;
     }
 
     {
         let f: Reference = r.borrow_field(1)?.value_as()?;
-        assert!(f.read_ref()?.equals(&Value::bool(true))?);
+        assert!(f.read_ref().equals(&Value::bool(true))?);
     }
 
     Ok(())
@@ -89,21 +89,21 @@ fn struct_borrow_nested() -> PartialVMResult<()> {
 
     {
         let r3: Reference = r2.borrow_field(0)?.value_as()?;
-        assert!(r3.read_ref()?.equals(&Value::u64(20))?);
+        assert!(r3.read_ref().equals(&Value::u64(20))?);
     }
 
-    {
+    unsafe {
         let r3: Reference = r2.borrow_field(0)?.value_as()?;
         r3.write_ref(Value::u64(30))?;
     }
 
     {
         let r3: Reference = r2.borrow_field(0)?.value_as()?;
-        assert!(r3.read_ref()?.equals(&Value::u64(30))?);
+        assert!(r3.read_ref().equals(&Value::u64(30))?);
     }
 
-    assert!(r2.read_ref()?.equals(&inner(30))?);
-    assert!(r1.read_ref()?.equals(&outer(30))?);
+    assert!(r2.into_ref().read_ref().equals(&inner(30))?);
+    assert!(r1.into_ref().read_ref().equals(&outer(30))?);
 
     Ok(())
 }

--- a/language/move-vm/types/src/values/values_impl.rs
+++ b/language/move-vm/types/src/values/values_impl.rs
@@ -1734,6 +1734,11 @@ impl GlobalValue {
         self.0.move_to(val.0)
     }
 
+    pub fn simple_serialize(&self, layout: &MoveTypeLayout) -> Option<Vec<u8>> {
+        let value = self.borrow_global().ok()?;
+        value.simple_serialize(layout)
+    }
+
     pub fn borrow_global(&self) -> PartialVMResult<Value> {
         Ok(Value(self.0.borrow_global()?))
     }

--- a/language/move-vm/types/src/values/values_impl.rs
+++ b/language/move-vm/types/src/values/values_impl.rs
@@ -1480,18 +1480,6 @@ impl Vector {
         self.unpack(type_param, 0)?;
         Ok(())
     }
-
-    pub fn to_vec_u8(self) -> PartialVMResult<Vec<u8>> {
-        check_elem_layout(&Type::U8, &self.0)?;
-        if let Container::VecU8(r) = self.0 {
-            Ok(take_unique_ownership(r)?.into_iter().collect())
-        } else {
-            Err(
-                PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
-                    .with_message("expected vector<u8>".to_string()),
-            )
-        }
-    }
 }
 
 /***************************************************************************************

--- a/language/move-vm/types/src/values/values_impl.rs
+++ b/language/move-vm/types/src/values/values_impl.rs
@@ -16,9 +16,9 @@ use move_core_types::{
     vm_status::{sub_status::NFE_VECTOR_ERROR_BASE, StatusCode},
 };
 use std::{
+    borrow::Borrow,
     cell::RefCell,
     fmt::{self, Debug, Display},
-    iter,
     mem::size_of,
     ops::Add,
     rc::Rc,
@@ -35,7 +35,7 @@ use std::{
  **************************************************************************************/
 
 /// Runtime representation of a Move value.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 enum ValueImpl {
     Invalid,
 
@@ -47,8 +47,7 @@ enum ValueImpl {
 
     Container(Container),
 
-    ContainerRef(ContainerRef),
-    IndexedRef(IndexedRef),
+    Reference(ReferenceImpl),
 }
 
 /// A container is a collection of values. It is used to represent data structures like a
@@ -62,70 +61,46 @@ enum ValueImpl {
 /// making it possible to be shared by references.
 #[derive(Debug, Clone)]
 enum Container {
-    Locals(Rc<RefCell<Vec<ValueImpl>>>),
-    Vec(Rc<RefCell<Vec<ValueImpl>>>),
-    Struct(Rc<RefCell<Vec<ValueImpl>>>),
-    VecU8(Rc<RefCell<Vec<u8>>>),
-    VecU64(Rc<RefCell<Vec<u64>>>),
-    VecU128(Rc<RefCell<Vec<u128>>>),
-    VecBool(Rc<RefCell<Vec<bool>>>),
-    VecAddress(Rc<RefCell<Vec<AccountAddress>>>),
+    Vec(Vec<ValueImpl>),
+    Struct(Vec<ValueImpl>),
+    VecU8(Vec<u8>),
+    VecU64(Vec<u64>),
+    VecU128(Vec<u128>),
+    VecBool(Vec<bool>),
+    VecAddress(Vec<AccountAddress>),
 }
 
-/// A ContainerRef is a direct reference to a container, which could live either in the frame
-/// or in global storage. In the latter case, it also keeps a status flag indicating whether
-/// the container has been possibly modified.
-#[derive(Debug)]
-enum ContainerRef {
-    Local(Container),
-    Global {
-        status: Rc<RefCell<GlobalDataStatus>>,
-        container: Container,
-    },
-}
-
-/// Status for global (on-chain) data:
+/// Status for external data, usually from global storage
 /// Clean - the data was only read.
 /// Dirty - the data was possibly modified.
 #[derive(Debug, Clone, Copy)]
-enum GlobalDataStatus {
+enum ExternalDataStatus {
     Clean,
     Dirty,
 }
 
-/// A Move reference pointing to an element in a container.
-#[derive(Debug)]
-struct IndexedRef {
-    idx: usize,
-    container_ref: ContainerRef,
+#[derive(Debug, Clone, Copy)]
+/// A simple reference to data, represented as a pointer
+/// Pointer access is safe due to Move's static reference safety rules
+enum CheckedRef {
+    U8(*mut u8),
+    U64(*mut u64),
+    U128(*mut u128),
+    Bool(*mut bool),
+    Address(*mut AccountAddress),
+    Container(*mut Container),
 }
 
-/// An umbrella enum for references. It is used to hide the internals of the public type
-/// Reference.
-#[derive(Debug)]
-enum ReferenceImpl {
-    IndexedRef(IndexedRef),
-    ContainerRef(ContainerRef),
+#[derive(Debug, Clone)]
+struct ExternalRef {
+    /// Maintains dirt/clean status of the source, if it is from Move's global storage
+    data_status: Option<Rc<RefCell<ExternalDataStatus>>>,
+    /// ref counted source of the value. not actually accessed but kept so the value isn't dropped
+    /// TODO this could likely just be an Rc once get_mut_unchecked is stabilized
+    source: Rc<RefCell<ValueImpl>>,
+    /// pointer into the source
+    checked_ref: CheckedRef,
 }
-
-// A reference to a signer. Clients can attempt a cast to this struct if they are
-// expecting a Signer on the stack or as an argument.
-#[derive(Debug)]
-pub struct SignerRef(ContainerRef);
-
-// A reference to a vector. This is an alias for a ContainerRef for now but we may change
-// it once Containers are restructured.
-// It's used from vector native functions to get a reference to a vector and operate on that.
-// There is an impl for VectorRef which implements the API private to this module.
-#[derive(Debug)]
-pub struct VectorRef(ContainerRef);
-
-// A vector. This is an alias for a Container for now but we may change
-// it once Containers are restructured.
-// It's used from vector native functions to get a vector and operate on that.
-// There is an impl for Vector which implements the API private to this module.
-#[derive(Debug)]
-pub struct Vector(Container);
 
 /***************************************************************************************
  *
@@ -143,23 +118,50 @@ pub struct Vector(Container);
  *
  **************************************************************************************/
 
-/// A reference to a Move struct that allows you to take a reference to one of its fields.
-#[derive(Debug)]
-pub struct StructRef(ContainerRef);
-
-/// A generic Move reference that offers two functionalities: read_ref & write_ref.
-#[derive(Debug)]
-pub struct Reference(ReferenceImpl);
-
 /// A Move value -- a wrapper around `ValueImpl` which can be created only through valid
 /// means.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Value(ValueImpl);
 
 /// The locals for a function frame. It allows values to be read, written or taken
 /// reference from.
 #[derive(Debug)]
-pub struct Locals(Rc<RefCell<Vec<ValueImpl>>>);
+pub struct Locals(Vec<ValueImpl>);
+
+/// A generic Move reference that offers two functionalities: read_ref & write_ref.
+#[derive(Debug)]
+pub struct Reference(ReferenceImpl);
+
+/// An umbrella enum for references. It is used to hide the internals of the public type
+/// Reference.
+#[derive(Debug, Clone)]
+enum ReferenceImpl {
+    CheckedRef(CheckedRef),
+    ExternalRef(ExternalRef),
+}
+
+/// A reference to a Move struct that allows you to take a reference to one of its fields.
+#[derive(Debug)]
+pub struct StructRef(ReferenceImpl);
+
+// A reference to a signer. Clients can attempt a cast to this struct if they are
+// expecting a Signer on the stack or as an argument.
+#[derive(Debug)]
+pub struct SignerRef(ReferenceImpl);
+
+// A reference to a vector. This is an alias for a ContainerRef for now but we may change
+// it once Containers are restructured.
+// It's used from vector native functions to get a reference to a vector and operate on that.
+// There is an impl for VectorRef which implements the API private to this module.
+#[derive(Debug)]
+pub struct VectorRef(ReferenceImpl);
+
+// A vector. This is an alias for a Container for now but we may change
+// it once Containers are restructured.
+// It's used from vector native functions to get a vector and operate on that.
+// There is an impl for Vector which implements the API private to this module.
+#[derive(Debug)]
+pub struct Vector(Container);
 
 /// An integer value in Move.
 #[derive(Debug)]
@@ -183,12 +185,12 @@ enum GlobalValueImpl {
     /// No resource resides in this slot or in storage.
     None,
     /// A resource has been published to this slot and it did not previously exist in storage.
-    Fresh { fields: Rc<RefCell<Vec<ValueImpl>>> },
+    Fresh { value: Rc<RefCell<ValueImpl>> },
     /// A resource resides in this slot and also in storage. The status flag indicates whether
     /// it has potentially been altered.
     Cached {
-        fields: Rc<RefCell<Vec<ValueImpl>>>,
-        status: Rc<RefCell<GlobalDataStatus>>,
+        value: Rc<RefCell<ValueImpl>>,
+        status: Rc<RefCell<ExternalDataStatus>>,
     },
     /// A resource used to exist in storage but has been deleted by the current transaction.
     Deleted,
@@ -220,28 +222,17 @@ pub enum GlobalValueEffect<T> {
 impl Container {
     fn len(&self) -> usize {
         match self {
-            Self::Locals(r) | Self::Struct(r) | Self::Vec(r) => r.borrow().len(),
-            Self::VecU8(r) => r.borrow().len(),
-            Self::VecU64(r) => r.borrow().len(),
-            Self::VecU128(r) => r.borrow().len(),
-            Self::VecBool(r) => r.borrow().len(),
-            Self::VecAddress(r) => r.borrow().len(),
-        }
-    }
-
-    fn rc_count(&self) -> usize {
-        match self {
-            Self::Locals(r) | Self::Struct(r) | Self::Vec(r) => Rc::strong_count(r),
-            Self::VecU8(r) => Rc::strong_count(r),
-            Self::VecU64(r) => Rc::strong_count(r),
-            Self::VecU128(r) => Rc::strong_count(r),
-            Self::VecBool(r) => Rc::strong_count(r),
-            Self::VecAddress(r) => Rc::strong_count(r),
+            Self::Struct(r) | Self::Vec(r) => r.len(),
+            Self::VecU8(r) => r.len(),
+            Self::VecU64(r) => r.len(),
+            Self::VecU128(r) => r.len(),
+            Self::VecBool(r) => r.len(),
+            Self::VecAddress(r) => r.len(),
         }
     }
 
     fn signer(x: AccountAddress) -> Self {
-        Container::Struct(Rc::new(RefCell::new(vec![ValueImpl::Address(x)])))
+        Container::Struct(vec![ValueImpl::Address(x)])
     }
 }
 
@@ -254,27 +245,97 @@ impl Container {
  *
  **************************************************************************************/
 
-fn take_unique_ownership<T: Debug>(r: Rc<RefCell<T>>) -> PartialVMResult<T> {
-    match Rc::try_unwrap(r) {
-        Ok(cell) => Ok(cell.into_inner()),
-        Err(r) => Err(
-            PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
-                .with_message(format!("moving value {:?} with dangling references", r)),
-        ),
+impl CheckedRef {
+    fn new(value: &mut ValueImpl) -> PartialVMResult<Self> {
+        Ok(match value {
+            ValueImpl::U8(u) => Self::U8(u),
+            ValueImpl::U64(u) => Self::U64(u),
+            ValueImpl::U128(u) => Self::U128(u),
+            ValueImpl::Bool(b) => Self::Bool(b),
+            ValueImpl::Address(a) => Self::Address(a),
+            ValueImpl::Container(c) => Self::Container(c),
+            v @ ValueImpl::Invalid | v @ ValueImpl::Reference(_) => {
+                return Err(PartialVMError::new(StatusCode::INTERNAL_TYPE_ERROR)
+                    .with_message(format!("cannot borrow loc: {:?}", v)))
+            }
+        })
     }
 }
 
-impl ContainerRef {
-    fn container(&self) -> &Container {
+impl ExternalRef {
+    fn new_source(
+        global_status: Option<Rc<RefCell<ExternalDataStatus>>>,
+        source: Rc<RefCell<ValueImpl>>,
+    ) -> PartialVMResult<Self> {
+        let checked_ref = CheckedRef::new(&mut *source.borrow_mut())?;
+        Ok(Self {
+            data_status: global_status,
+            source,
+            checked_ref,
+        })
+    }
+
+    fn mark_dirty(&self) {
+        if let Some(status) = &self.data_status {
+            *status.borrow_mut() = ExternalDataStatus::Dirty;
+        }
+    }
+}
+
+impl ReferenceImpl {
+    fn checked_ref(&self) -> CheckedRef {
         match self {
-            Self::Local(container) | Self::Global { container, .. } => container,
+            Self::CheckedRef(checked_ref) | Self::ExternalRef(ExternalRef { checked_ref, .. }) => {
+                *checked_ref
+            }
+        }
+    }
+
+    fn container(&self) -> PartialVMResult<*mut Container> {
+        match self.checked_ref() {
+            CheckedRef::Container(c) => Ok(c),
+            _ => {
+                return Err(
+                    PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
+                        .with_message(
+                            "tried to borrow a container on a non-container ref".to_string(),
+                        ),
+                )
+            }
         }
     }
 
     fn mark_dirty(&self) {
-        if let Self::Global { status, .. } = self {
-            *status.borrow_mut() = GlobalDataStatus::Dirty
+        if let Self::ExternalRef(ext) = self {
+            ext.mark_dirty()
         }
+    }
+
+    fn extend_ref(&self, extension: CheckedRef) -> Self {
+        match self {
+            Self::CheckedRef(_) => Self::CheckedRef(extension),
+            Self::ExternalRef(ExternalRef {
+                data_status: global_status,
+                source,
+                checked_ref: _,
+            }) => Self::ExternalRef(ExternalRef {
+                data_status: global_status.clone(),
+                source: source.clone(),
+                checked_ref: extension,
+            }),
+        }
+    }
+
+    fn borrow_elem(&self, idx: usize) -> PartialVMResult<ReferenceImpl> {
+        let extension = match unsafe { &mut *self.container()? } {
+            Container::Vec(v) | Container::Struct(v) => CheckedRef::new(&mut v[idx])?,
+            Container::VecU8(v) => CheckedRef::U8(&mut v[idx]),
+            Container::VecU64(v) => CheckedRef::U64(&mut v[idx]),
+            Container::VecU128(v) => CheckedRef::U128(&mut v[idx]),
+            Container::VecBool(v) => CheckedRef::Bool(&mut v[idx]),
+            Container::VecAddress(v) => CheckedRef::Address(&mut v[idx]),
+        };
+        Ok(self.extend_ref(extension))
     }
 }
 
@@ -310,15 +371,6 @@ impl_vm_value_ref!(u128, U128);
 impl_vm_value_ref!(bool, Bool);
 impl_vm_value_ref!(AccountAddress, Address);
 
-impl ValueImpl {
-    fn as_value_ref<T>(&self) -> PartialVMResult<&T>
-    where
-        Self: VMValueRef<T>,
-    {
-        VMValueRef::value_ref(self)
-    }
-}
-
 /***************************************************************************************
  *
  * Copy Value
@@ -328,99 +380,78 @@ impl ValueImpl {
  *   surprising behaviors from happening.
  *
  **************************************************************************************/
-impl ValueImpl {
-    fn copy_value(&self) -> PartialVMResult<Self> {
-        use ValueImpl::*;
+// impl ValueImpl {
+//     fn copy_value(&self) -> PartialVMResult<Self> {
+//         use ValueImpl::*;
 
-        Ok(match self {
-            Invalid => Invalid,
+//         Ok(match self {
+//             Invalid => Invalid,
 
-            U8(x) => U8(*x),
-            U64(x) => U64(*x),
-            U128(x) => U128(*x),
-            Bool(x) => Bool(*x),
-            Address(x) => Address(*x),
+//             U8(x) => U8(*x),
+//             U64(x) => U64(*x),
+//             U128(x) => U128(*x),
+//             Bool(x) => Bool(*x),
+//             Address(x) => Address(*x),
 
-            ContainerRef(r) => ContainerRef(r.copy_value()),
-            IndexedRef(r) => IndexedRef(r.copy_value()),
+//             Reference(r) => Reference(r.copy_value()),
 
-            // When cloning a container, we need to make sure we make a deep
-            // copy of the data instead of a shallow copy of the Rc.
-            Container(c) => Container(c.copy_value()?),
-        })
-    }
-}
+//             // When cloning a container, we need to make sure we make a deep
+//             // copy of the data instead of a shallow copy of the Rc.
+//             Container(c) => Container(c.copy_value()?),
+//         })
+//     }
+// }
 
-impl Container {
-    fn copy_value(&self) -> PartialVMResult<Self> {
-        let copy_rc_ref_vec_val = |r: &Rc<RefCell<Vec<ValueImpl>>>| {
-            Ok(Rc::new(RefCell::new(
-                r.borrow()
-                    .iter()
-                    .map(|v| v.copy_value())
-                    .collect::<PartialVMResult<_>>()?,
-            )))
-        };
+// impl Container {
+//     fn copy_value(&self) -> PartialVMResult<Self> {
+//         let copy_vec_val = |r: &Vec<ValueImpl>| -> PartialVMResult<Vec<ValueImpl>> {
+//             Ok(r.iter()
+//                 .map(|v| v.copy_value())
+//                 .collect::<PartialVMResult<_>>()?)
+//         };
 
-        Ok(match self {
-            Self::Vec(r) => Self::Vec(copy_rc_ref_vec_val(r)?),
-            Self::Struct(r) => Self::Struct(copy_rc_ref_vec_val(r)?),
+//         Ok(match self {
+//             Self::Vec(v) => Self::Vec(copy_vec_val(v)?),
+//             Self::Struct(v) => Self::Struct(copy_vec_val(v)?),
 
-            Self::VecU8(r) => Self::VecU8(Rc::new(RefCell::new(r.borrow().clone()))),
-            Self::VecU64(r) => Self::VecU64(Rc::new(RefCell::new(r.borrow().clone()))),
-            Self::VecU128(r) => Self::VecU128(Rc::new(RefCell::new(r.borrow().clone()))),
-            Self::VecBool(r) => Self::VecBool(Rc::new(RefCell::new(r.borrow().clone()))),
-            Self::VecAddress(r) => Self::VecAddress(Rc::new(RefCell::new(r.borrow().clone()))),
+//             Self::VecU8(v) => Self::VecU8(v.clone()),
+//             Self::VecU64(v) => Self::VecU64(v.clone()),
+//             Self::VecU128(v) => Self::VecU128(v.clone()),
+//             Self::VecBool(v) => Self::VecBool(v.clone()),
+//             Self::VecAddress(v) => Self::VecAddress(v.clone()),
+//         })
+//     }
+// }
 
-            Self::Locals(_) => {
-                return Err(
-                    PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
-                        .with_message("cannot copy a Locals container".to_string()),
-                )
-            }
-        })
-    }
+// impl ReferenceImpl {
+//     fn copy_value(&self) -> Self {
+//         match self {
+//             ReferenceImpl::CheckedRef(r) => ReferenceImpl::CheckedRef(*r),
+//             ReferenceImpl::ExternalRef(r) => ReferenceImpl::ExternalRef(r.copy_value()),
+//         }
+//     }
+// }
 
-    fn copy_by_ref(&self) -> Self {
-        match self {
-            Self::Vec(r) => Self::Vec(Rc::clone(r)),
-            Self::Struct(r) => Self::Struct(Rc::clone(r)),
-            Self::VecU8(r) => Self::VecU8(Rc::clone(r)),
-            Self::VecU64(r) => Self::VecU64(Rc::clone(r)),
-            Self::VecU128(r) => Self::VecU128(Rc::clone(r)),
-            Self::VecBool(r) => Self::VecBool(Rc::clone(r)),
-            Self::VecAddress(r) => Self::VecAddress(Rc::clone(r)),
-            Self::Locals(r) => Self::Locals(Rc::clone(r)),
-        }
-    }
-}
+// impl ExternalRef {
+//     fn copy_value(&self) -> Self {
+//         let ExternalRef {
+//             global_status,
+//             source,
+//             checked_ref,
+//         } = self;
+//         ExternalRef {
+//             global_status: global_status.clone(),
+//             source: source.clone(),
+//             checked_ref: *checked_ref,
+//         }
+//     }
+// }
 
-impl IndexedRef {
-    fn copy_value(&self) -> Self {
-        Self {
-            idx: self.idx,
-            container_ref: self.container_ref.copy_value(),
-        }
-    }
-}
-
-impl ContainerRef {
-    fn copy_value(&self) -> Self {
-        match self {
-            Self::Local(container) => Self::Local(container.copy_by_ref()),
-            Self::Global { status, container } => Self::Global {
-                status: Rc::clone(status),
-                container: container.copy_by_ref(),
-            },
-        }
-    }
-}
-
-impl Value {
-    pub fn copy_value(&self) -> PartialVMResult<Self> {
-        Ok(Self(self.0.copy_value()?))
-    }
-}
+// impl Value {
+//     pub fn copy_value(&self) -> PartialVMResult<Self> {
+//         Ok(Self(self.0.copy_value()?))
+//     }
+// }
 
 /***************************************************************************************
  *
@@ -452,8 +483,7 @@ impl ValueImpl {
 
             (Container(l), Container(r)) => l.equals(r)?,
 
-            (ContainerRef(l), ContainerRef(r)) => l.equals(r)?,
-            (IndexedRef(l), IndexedRef(r)) => l.equals(r)?,
+            (Reference(l), Reference(r)) => l.equals(r)?,
 
             _ => {
                 return Err(PartialVMError::new(StatusCode::INTERNAL_TYPE_ERROR)
@@ -471,9 +501,6 @@ impl Container {
 
         let res = match (self, other) {
             (Vec(l), Vec(r)) | (Struct(l), Struct(r)) => {
-                let l = &*l.borrow();
-                let r = &*r.borrow();
-
                 if l.len() != r.len() {
                     return Ok(false);
                 }
@@ -484,14 +511,13 @@ impl Container {
                 }
                 true
             }
-            (VecU8(l), VecU8(r)) => l.borrow().eq(&*r.borrow()),
-            (VecU64(l), VecU64(r)) => l.borrow().eq(&*r.borrow()),
-            (VecU128(l), VecU128(r)) => l.borrow().eq(&*r.borrow()),
-            (VecBool(l), VecBool(r)) => l.borrow().eq(&*r.borrow()),
-            (VecAddress(l), VecAddress(r)) => l.borrow().eq(&*r.borrow()),
+            (VecU8(l), VecU8(r)) => l == r,
+            (VecU64(l), VecU64(r)) => l == r,
+            (VecU128(l), VecU128(r)) => l == r,
+            (VecBool(l), VecBool(r)) => l == r,
+            (VecAddress(l), VecAddress(r)) => l == r,
 
-            (Locals(_), _)
-            | (Vec(_), _)
+            (Vec(_), _)
             | (Struct(_), _)
             | (VecU8(_), _)
             | (VecU64(_), _)
@@ -511,85 +537,20 @@ impl Container {
     }
 }
 
-impl ContainerRef {
-    fn equals(&self, other: &Self) -> PartialVMResult<bool> {
-        self.container().equals(other.container())
-    }
-}
-
-impl IndexedRef {
-    fn equals(&self, other: &Self) -> PartialVMResult<bool> {
-        use Container::*;
-
-        let res = match (
-            self.container_ref.container(),
-            other.container_ref.container(),
-        ) {
-            // VecC <=> VecR impossible
-            (Vec(r1), Vec(r2))
-            | (Vec(r1), Struct(r2))
-            | (Vec(r1), Locals(r2))
-            | (Struct(r1), Vec(r2))
-            | (Struct(r1), Struct(r2))
-            | (Struct(r1), Locals(r2))
-            | (Locals(r1), Vec(r2))
-            | (Locals(r1), Struct(r2))
-            | (Locals(r1), Locals(r2)) => r1.borrow()[self.idx].equals(&r2.borrow()[other.idx])?,
-
-            (VecU8(r1), VecU8(r2)) => r1.borrow()[self.idx] == r2.borrow()[other.idx],
-            (VecU64(r1), VecU64(r2)) => r1.borrow()[self.idx] == r2.borrow()[other.idx],
-            (VecU128(r1), VecU128(r2)) => r1.borrow()[self.idx] == r2.borrow()[other.idx],
-            (VecBool(r1), VecBool(r2)) => r1.borrow()[self.idx] == r2.borrow()[other.idx],
-            (VecAddress(r1), VecAddress(r2)) => r1.borrow()[self.idx] == r2.borrow()[other.idx],
-
-            // Equality between a generic and a specialized container.
-            (Locals(r1), VecU8(r2)) | (Struct(r1), VecU8(r2)) => {
-                *r1.borrow()[self.idx].as_value_ref::<u8>()? == r2.borrow()[other.idx]
+impl ReferenceImpl {
+    pub(crate) fn equals(&self, other: &ReferenceImpl) -> PartialVMResult<bool> {
+        unsafe {
+            match (self.checked_ref(), other.checked_ref()) {
+                (CheckedRef::U8(l), CheckedRef::U8(r)) => Ok(*l == *r),
+                (CheckedRef::U64(l), CheckedRef::U64(r)) => Ok(*l == *r),
+                (CheckedRef::U128(l), CheckedRef::U128(r)) => Ok(&*l == &*r),
+                (CheckedRef::Bool(l), CheckedRef::Bool(r)) => Ok(*l == *r),
+                (CheckedRef::Address(l), CheckedRef::Address(r)) => Ok(&*l == &*r),
+                (CheckedRef::Container(l), CheckedRef::Container(r)) => (&*l).equals(&*r),
+                (l, r) => Err(PartialVMError::new(StatusCode::INTERNAL_TYPE_ERROR)
+                    .with_message(format!("cannot compare ref values: {:?}, {:?}", l, r))),
             }
-            (VecU8(r1), Locals(r2)) | (VecU8(r1), Struct(r2)) => {
-                r1.borrow()[self.idx] == *r2.borrow()[other.idx].as_value_ref::<u8>()?
-            }
-
-            (Locals(r1), VecU64(r2)) | (Struct(r1), VecU64(r2)) => {
-                *r1.borrow()[self.idx].as_value_ref::<u64>()? == r2.borrow()[other.idx]
-            }
-            (VecU64(r1), Locals(r2)) | (VecU64(r1), Struct(r2)) => {
-                r1.borrow()[self.idx] == *r2.borrow()[other.idx].as_value_ref::<u64>()?
-            }
-
-            (Locals(r1), VecU128(r2)) | (Struct(r1), VecU128(r2)) => {
-                *r1.borrow()[self.idx].as_value_ref::<u128>()? == r2.borrow()[other.idx]
-            }
-            (VecU128(r1), Locals(r2)) | (VecU128(r1), Struct(r2)) => {
-                r1.borrow()[self.idx] == *r2.borrow()[other.idx].as_value_ref::<u128>()?
-            }
-
-            (Locals(r1), VecBool(r2)) | (Struct(r1), VecBool(r2)) => {
-                *r1.borrow()[self.idx].as_value_ref::<bool>()? == r2.borrow()[other.idx]
-            }
-            (VecBool(r1), Locals(r2)) | (VecBool(r1), Struct(r2)) => {
-                r1.borrow()[self.idx] == *r2.borrow()[other.idx].as_value_ref::<bool>()?
-            }
-
-            (Locals(r1), VecAddress(r2)) | (Struct(r1), VecAddress(r2)) => {
-                *r1.borrow()[self.idx].as_value_ref::<AccountAddress>()? == r2.borrow()[other.idx]
-            }
-            (VecAddress(r1), Locals(r2)) | (VecAddress(r1), Struct(r2)) => {
-                r1.borrow()[self.idx] == *r2.borrow()[other.idx].as_value_ref::<AccountAddress>()?
-            }
-
-            // All other combinations are illegal.
-            (Vec(_), _)
-            | (VecU8(_), _)
-            | (VecU64(_), _)
-            | (VecU128(_), _)
-            | (VecBool(_), _)
-            | (VecAddress(_), _) => {
-                return Err(PartialVMError::new(StatusCode::INTERNAL_TYPE_ERROR)
-                    .with_message(format!("cannot compare references {:?}, {:?}", self, other)))
-            }
-        };
-        Ok(res)
+        }
     }
 }
 
@@ -607,46 +568,24 @@ impl Value {
  *
  **************************************************************************************/
 
-impl ContainerRef {
-    fn read_ref(self) -> PartialVMResult<Value> {
-        Ok(Value(ValueImpl::Container(self.container().copy_value()?)))
-    }
-}
-
-impl IndexedRef {
-    fn read_ref(self) -> PartialVMResult<Value> {
-        use Container::*;
-
-        let res = match &*self.container_ref.container() {
-            Locals(r) | Vec(r) | Struct(r) => r.borrow()[self.idx].copy_value()?,
-            VecU8(r) => ValueImpl::U8(r.borrow()[self.idx]),
-            VecU64(r) => ValueImpl::U64(r.borrow()[self.idx]),
-            VecU128(r) => ValueImpl::U128(r.borrow()[self.idx]),
-            VecBool(r) => ValueImpl::Bool(r.borrow()[self.idx]),
-            VecAddress(r) => ValueImpl::Address(r.borrow()[self.idx]),
-        };
-
-        Ok(Value(res))
-    }
-}
-
 impl ReferenceImpl {
-    fn read_ref(self) -> PartialVMResult<Value> {
-        match self {
-            Self::ContainerRef(r) => r.read_ref(),
-            Self::IndexedRef(r) => r.read_ref(),
-        }
-    }
-}
-
-impl StructRef {
-    pub fn read_ref(self) -> PartialVMResult<Value> {
-        self.0.read_ref()
+    fn read_ref(self) -> Value {
+        let v = unsafe {
+            match self.checked_ref() {
+                CheckedRef::U8(u) => ValueImpl::U8(*u),
+                CheckedRef::U64(u) => ValueImpl::U64(*u),
+                CheckedRef::U128(u) => ValueImpl::U128(*u),
+                CheckedRef::Bool(b) => ValueImpl::Bool(*b),
+                CheckedRef::Address(a) => ValueImpl::Address(*a),
+                CheckedRef::Container(c) => ValueImpl::Container((&*c).clone()),
+            }
+        };
+        Value(v)
     }
 }
 
 impl Reference {
-    pub fn read_ref(self) -> PartialVMResult<Value> {
+    pub fn read_ref(self) -> Value {
         self.0.read_ref()
     }
 }
@@ -659,116 +598,31 @@ impl Reference {
  *
  **************************************************************************************/
 
-impl ContainerRef {
-    fn write_ref(self, v: Value) -> PartialVMResult<()> {
-        match v.0 {
-            ValueImpl::Container(c) => {
-                macro_rules! assign {
-                    ($r1: expr, $tc: ident) => {{
-                        let r = match c {
-                            Container::$tc(v) => v,
-                            _ => {
-                                return Err(PartialVMError::new(
-                                    StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR,
-                                )
-                                .with_message(
-                                    "failed to write_ref: container type mismatch".to_string(),
-                                ))
-                            }
-                        };
-                        *$r1.borrow_mut() = take_unique_ownership(r)?;
-                    }};
-                }
-
-                match self.container() {
-                    Container::Struct(r) => assign!(r, Struct),
-                    Container::Vec(r) => assign!(r, Vec),
-                    Container::VecU8(r) => assign!(r, VecU8),
-                    Container::VecU64(r) => assign!(r, VecU64),
-                    Container::VecU128(r) => assign!(r, VecU128),
-                    Container::VecBool(r) => assign!(r, VecBool),
-                    Container::VecAddress(r) => assign!(r, VecAddress),
-                    Container::Locals(_) => {
-                        return Err(PartialVMError::new(
-                            StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR,
-                        )
-                        .with_message("cannot overwrite Container::Locals".to_string()))
-                    }
-                }
-                self.mark_dirty();
-            }
-            _ => {
-                return Err(
-                    PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
-                        .with_message(format!(
-                            "cannot write value {:?} to container ref {:?}",
-                            v, self
-                        )),
-                )
-            }
-        }
-        Ok(())
-    }
-}
-
-impl IndexedRef {
-    fn write_ref(self, x: Value) -> PartialVMResult<()> {
-        match &x.0 {
-            ValueImpl::IndexedRef(_)
-            | ValueImpl::ContainerRef(_)
-            | ValueImpl::Invalid
-            | ValueImpl::Container(_) => {
-                return Err(
-                    PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
-                        .with_message(format!(
-                            "cannot write value {:?} to indexed ref {:?}",
-                            x, self
-                        )),
-                )
-            }
-            _ => (),
-        }
-
-        match (self.container_ref.container(), &x.0) {
-            (Container::Locals(r), _) | (Container::Vec(r), _) | (Container::Struct(r), _) => {
-                let mut v = r.borrow_mut();
-                v[self.idx] = x.0;
-            }
-            (Container::VecU8(r), ValueImpl::U8(x)) => r.borrow_mut()[self.idx] = *x,
-            (Container::VecU64(r), ValueImpl::U64(x)) => r.borrow_mut()[self.idx] = *x,
-            (Container::VecU128(r), ValueImpl::U128(x)) => r.borrow_mut()[self.idx] = *x,
-            (Container::VecBool(r), ValueImpl::Bool(x)) => r.borrow_mut()[self.idx] = *x,
-            (Container::VecAddress(r), ValueImpl::Address(x)) => r.borrow_mut()[self.idx] = *x,
-
-            (Container::VecU8(_), _)
-            | (Container::VecU64(_), _)
-            | (Container::VecU128(_), _)
-            | (Container::VecBool(_), _)
-            | (Container::VecAddress(_), _) => {
-                return Err(
-                    PartialVMError::new(StatusCode::INTERNAL_TYPE_ERROR).with_message(format!(
-                        "cannot write value {:?} to indexed ref {:?}",
-                        x, self
-                    )),
-                )
-            }
-        }
-        self.container_ref.mark_dirty();
-        Ok(())
-    }
-}
-
 impl ReferenceImpl {
-    fn write_ref(self, x: Value) -> PartialVMResult<()> {
-        match self {
-            Self::ContainerRef(r) => r.write_ref(x),
-            Self::IndexedRef(r) => r.write_ref(x),
-        }
+    fn write_ref(self, v: Value) -> PartialVMResult<()> {
+        self.mark_dirty();
+        unsafe {
+            match (self.checked_ref(), v.0) {
+                (CheckedRef::U8(r), ValueImpl::U8(v)) => *r = v,
+                (CheckedRef::U64(r), ValueImpl::U64(v)) => *r = v,
+                (CheckedRef::U128(r), ValueImpl::U128(v)) => *r = v,
+                (CheckedRef::Bool(r), ValueImpl::Bool(v)) => *r = v,
+                (CheckedRef::Address(r), ValueImpl::Address(v)) => *r = v,
+                (CheckedRef::Container(r), ValueImpl::Container(v)) => *r = v,
+                (r, v) => {
+                    return Err(PartialVMError::new(StatusCode::INTERNAL_TYPE_ERROR)
+                        .with_message(format!("cannot assign ref with value: {:?}, {:?}", r, v)))
+                }
+            }
+        };
+        Ok(())
     }
 }
 
 impl Reference {
-    pub fn write_ref(self, x: Value) -> PartialVMResult<()> {
+    /// Writes to a reference, replacing the value with a new one.
+    /// Potentially unsafe if Move's reference safety rules are not upheld
+    pub unsafe fn write_ref(self, x: Value) -> PartialVMResult<()> {
         self.0.write_ref(x)
     }
 }
@@ -782,105 +636,60 @@ impl Reference {
  *
  **************************************************************************************/
 
-impl ContainerRef {
-    fn borrow_elem(&self, idx: usize) -> PartialVMResult<ValueImpl> {
-        let len = self.container().len();
-        if idx >= len {
-            return Err(
-                PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR).with_message(
-                    format!(
-                        "index out of bounds when borrowing container element: got: {}, len: {}",
-                        idx, len
-                    ),
-                ),
-            );
-        }
-
-        let res = match self.container() {
-            Container::Locals(r) | Container::Vec(r) | Container::Struct(r) => {
-                let v = r.borrow();
-                match &v[idx] {
-                    // TODO: check for the impossible combinations.
-                    ValueImpl::Container(container) => {
-                        let r = match self {
-                            Self::Local(_) => Self::Local(container.copy_by_ref()),
-                            Self::Global { status, .. } => Self::Global {
-                                status: Rc::clone(status),
-                                container: container.copy_by_ref(),
-                            },
-                        };
-                        ValueImpl::ContainerRef(r)
-                    }
-                    _ => ValueImpl::IndexedRef(IndexedRef {
-                        idx,
-                        container_ref: self.copy_value(),
-                    }),
-                }
-            }
-
-            Container::VecU8(_)
-            | Container::VecU64(_)
-            | Container::VecU128(_)
-            | Container::VecAddress(_)
-            | Container::VecBool(_) => ValueImpl::IndexedRef(IndexedRef {
-                idx,
-                container_ref: self.copy_value(),
-            }),
-        };
-
-        Ok(res)
-    }
-}
-
 impl StructRef {
     pub fn borrow_field(&self, idx: usize) -> PartialVMResult<Value> {
-        Ok(Value(self.0.borrow_elem(idx)?))
+        Ok(Value(ValueImpl::Reference(self.0.borrow_elem(idx)?)))
     }
 }
 
 impl Locals {
-    pub fn borrow_loc(&self, idx: usize) -> PartialVMResult<Value> {
-        // TODO: this is very similar to SharedContainer::borrow_elem. Find a way to
-        // reuse that code?
-
-        let v = self.0.borrow();
-        if idx >= v.len() {
+    pub fn borrow_loc(&mut self, idx: usize) -> PartialVMResult<Value> {
+        let locals = &mut self.0;
+        if idx >= locals.len() {
             return Err(
                 PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR).with_message(
                     format!(
                         "index out of bounds when borrowing local: got: {}, len: {}",
                         idx,
-                        v.len()
+                        locals.len()
                     ),
                 ),
             );
         }
-
-        match &v[idx] {
-            ValueImpl::Container(c) => Ok(Value(ValueImpl::ContainerRef(ContainerRef::Local(
-                c.copy_by_ref(),
-            )))),
-
-            ValueImpl::U8(_)
-            | ValueImpl::U64(_)
-            | ValueImpl::U128(_)
-            | ValueImpl::Bool(_)
-            | ValueImpl::Address(_) => Ok(Value(ValueImpl::IndexedRef(IndexedRef {
-                container_ref: ContainerRef::Local(Container::Locals(Rc::clone(&self.0))),
-                idx,
-            }))),
-
-            ValueImpl::ContainerRef(_) | ValueImpl::Invalid | ValueImpl::IndexedRef(_) => Err(
-                PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
-                    .with_message(format!("cannot borrow local {:?}", &v[idx])),
-            ),
-        }
+        let vref = CheckedRef::new(&mut locals[idx])?;
+        Ok(Value(ValueImpl::Reference(ReferenceImpl::CheckedRef(vref))))
     }
 }
 
 impl SignerRef {
     pub fn borrow_signer(&self) -> PartialVMResult<Value> {
-        Ok(Value(self.0.borrow_elem(0)?))
+        Ok(Value(ValueImpl::Reference(self.0.borrow_elem(0)?)))
+    }
+}
+
+/***************************************************************************************
+ *
+ * Reference wrappers
+ *
+ *   Helper functions for the typed reference wrappers
+ *
+ **************************************************************************************/
+
+impl StructRef {
+    pub fn into_ref(self) -> Reference {
+        Reference(self.0)
+    }
+}
+
+impl SignerRef {
+    pub fn into_ref(self) -> Reference {
+        Reference(self.0)
+    }
+}
+
+impl VectorRef {
+    pub fn into_ref(self) -> Reference {
+        Reference(self.0)
     }
 }
 
@@ -891,21 +700,20 @@ impl SignerRef {
  *   Public APIs for Locals to support reading, writing and moving of values.
  *
  **************************************************************************************/
+
 impl Locals {
     pub fn new(n: usize) -> Self {
-        Self(Rc::new(RefCell::new(
-            iter::repeat_with(|| ValueImpl::Invalid).take(n).collect(),
-        )))
+        Self(vec![ValueImpl::Invalid; n])
     }
 
     pub fn copy_loc(&self, idx: usize) -> PartialVMResult<Value> {
-        let v = self.0.borrow();
+        let v = &self.0;
         match v.get(idx) {
             Some(ValueImpl::Invalid) => Err(PartialVMError::new(
                 StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR,
             )
             .with_message(format!("cannot copy invalid value at index {}", idx))),
-            Some(v) => Ok(Value(v.copy_value()?)),
+            Some(v) => Ok(Value(v.clone())),
             None => Err(
                 PartialVMError::new(StatusCode::VERIFIER_INVARIANT_VIOLATION).with_message(
                     format!("local index out of bounds: got {}, len: {}", idx, v.len()),
@@ -915,19 +723,9 @@ impl Locals {
     }
 
     fn swap_loc(&mut self, idx: usize, x: Value) -> PartialVMResult<Value> {
-        let mut v = self.0.borrow_mut();
+        let v = &mut self.0;
         match v.get_mut(idx) {
-            Some(v) => {
-                if let ValueImpl::Container(c) = v {
-                    if c.rc_count() > 1 {
-                        return Err(PartialVMError::new(
-                            StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR,
-                        )
-                        .with_message("moving container with dangling references".to_string()));
-                    }
-                }
-                Ok(Value(std::mem::replace(v, x.0)))
-            }
+            Some(v) => Ok(Value(std::mem::replace(v, x.0))),
             None => Err(
                 PartialVMError::new(StatusCode::VERIFIER_INVARIANT_VIOLATION).with_message(
                     format!("local index out of bounds: got {}, len: {}", idx, v.len()),
@@ -987,53 +785,53 @@ impl Value {
     /// Create a "unowned" reference to a signer value (&signer) for populating the &signer in
     /// execute function
     pub fn signer_reference(x: AccountAddress) -> Self {
-        Self(ValueImpl::ContainerRef(ContainerRef::Local(
-            Container::signer(x),
+        Self(ValueImpl::Reference(ReferenceImpl::ExternalRef(
+            ExternalRef::new_source(None, Rc::new(RefCell::new(Self::signer(x).0))).expect(
+                "impossible to have an invalid reference as the value is a valid container",
+            ),
         )))
     }
 
     pub fn struct_(s: Struct) -> Self {
-        Self(ValueImpl::Container(Container::Struct(Rc::new(
-            RefCell::new(s.fields),
-        ))))
+        Self(ValueImpl::Container(Container::Struct(s.fields)))
     }
 
     // TODO: consider whether we want to replace these with fn vector(v: Vec<Value>).
     pub fn vector_u8(it: impl IntoIterator<Item = u8>) -> Self {
-        Self(ValueImpl::Container(Container::VecU8(Rc::new(
-            RefCell::new(it.into_iter().collect()),
-        ))))
+        Self(ValueImpl::Container(Container::VecU8(
+            it.into_iter().collect(),
+        )))
     }
 
     pub fn vector_u64(it: impl IntoIterator<Item = u64>) -> Self {
-        Self(ValueImpl::Container(Container::VecU64(Rc::new(
-            RefCell::new(it.into_iter().collect()),
-        ))))
+        Self(ValueImpl::Container(Container::VecU64(
+            it.into_iter().collect(),
+        )))
     }
 
     pub fn vector_u128(it: impl IntoIterator<Item = u128>) -> Self {
-        Self(ValueImpl::Container(Container::VecU128(Rc::new(
-            RefCell::new(it.into_iter().collect()),
-        ))))
+        Self(ValueImpl::Container(Container::VecU128(
+            it.into_iter().collect(),
+        )))
     }
 
     pub fn vector_bool(it: impl IntoIterator<Item = bool>) -> Self {
-        Self(ValueImpl::Container(Container::VecBool(Rc::new(
-            RefCell::new(it.into_iter().collect()),
-        ))))
+        Self(ValueImpl::Container(Container::VecBool(
+            it.into_iter().collect(),
+        )))
     }
 
     pub fn vector_address(it: impl IntoIterator<Item = AccountAddress>) -> Self {
-        Self(ValueImpl::Container(Container::VecAddress(Rc::new(
-            RefCell::new(it.into_iter().collect()),
-        ))))
+        Self(ValueImpl::Container(Container::VecAddress(
+            it.into_iter().collect(),
+        )))
     }
 
     // REVIEW: This API can break
     pub fn vector_for_testing_only(it: impl IntoIterator<Item = Value>) -> Self {
-        Self(ValueImpl::Container(Container::Vec(Rc::new(RefCell::new(
+        Self(ValueImpl::Container(Container::Vec(
             it.into_iter().map(|v| v.0).collect(),
-        )))))
+        )))
     }
 }
 
@@ -1073,8 +871,7 @@ impl_vm_value_cast!(u64, U64);
 impl_vm_value_cast!(u128, U128);
 impl_vm_value_cast!(bool, Bool);
 impl_vm_value_cast!(AccountAddress, Address);
-impl_vm_value_cast!(ContainerRef, ContainerRef);
-impl_vm_value_cast!(IndexedRef, IndexedRef);
+impl_vm_value_cast!(ReferenceImpl, Reference);
 
 impl VMValueCast<IntegerValue> for Value {
     fn cast(self) -> PartialVMResult<IntegerValue> {
@@ -1091,8 +888,7 @@ impl VMValueCast<IntegerValue> for Value {
 impl VMValueCast<Reference> for Value {
     fn cast(self) -> PartialVMResult<Reference> {
         match self.0 {
-            ValueImpl::ContainerRef(r) => Ok(Reference(ReferenceImpl::ContainerRef(r))),
-            ValueImpl::IndexedRef(r) => Ok(Reference(ReferenceImpl::IndexedRef(r))),
+            ValueImpl::Reference(r) => Ok(Reference(r)),
             v => Err(PartialVMError::new(StatusCode::INTERNAL_TYPE_ERROR)
                 .with_message(format!("cannot cast {:?} to reference", v,))),
         }
@@ -1112,9 +908,7 @@ impl VMValueCast<Container> for Value {
 impl VMValueCast<Struct> for Value {
     fn cast(self) -> PartialVMResult<Struct> {
         match self.0 {
-            ValueImpl::Container(Container::Struct(r)) => Ok(Struct {
-                fields: take_unique_ownership(r)?,
-            }),
+            ValueImpl::Container(Container::Struct(r)) => Ok(Struct { fields: r }),
             v => Err(PartialVMError::new(StatusCode::INTERNAL_TYPE_ERROR)
                 .with_message(format!("cannot cast {:?} to struct", v,))),
         }
@@ -1130,7 +924,7 @@ impl VMValueCast<StructRef> for Value {
 impl VMValueCast<Vec<u8>> for Value {
     fn cast(self) -> PartialVMResult<Vec<u8>> {
         match self.0 {
-            ValueImpl::Container(Container::VecU8(r)) => take_unique_ownership(r),
+            ValueImpl::Container(Container::VecU8(r)) => Ok(r),
             v => Err(PartialVMError::new(StatusCode::INTERNAL_TYPE_ERROR)
                 .with_message(format!("cannot cast {:?} to vector<u8>", v,))),
         }
@@ -1140,7 +934,7 @@ impl VMValueCast<Vec<u8>> for Value {
 impl VMValueCast<SignerRef> for Value {
     fn cast(self) -> PartialVMResult<SignerRef> {
         match self.0 {
-            ValueImpl::ContainerRef(r) => Ok(SignerRef(r)),
+            ValueImpl::Reference(r) => Ok(SignerRef(r)),
             v => Err(PartialVMError::new(StatusCode::INTERNAL_TYPE_ERROR)
                 .with_message(format!("cannot cast {:?} to Signer reference", v,))),
         }
@@ -1150,7 +944,7 @@ impl VMValueCast<SignerRef> for Value {
 impl VMValueCast<VectorRef> for Value {
     fn cast(self) -> PartialVMResult<VectorRef> {
         match self.0 {
-            ValueImpl::ContainerRef(r) => Ok(VectorRef(r)),
+            ValueImpl::Reference(r) => Ok(VectorRef(r)),
             v => Err(PartialVMError::new(StatusCode::INTERNAL_TYPE_ERROR)
                 .with_message(format!("cannot cast {:?} to vector reference", v,))),
         }
@@ -1566,33 +1360,33 @@ fn check_elem_layout(ty: &Type, v: &Container) -> PartialVMResult<()> {
 
 impl VectorRef {
     pub fn len(&self, type_param: &Type) -> PartialVMResult<Value> {
-        let c = self.0.container();
+        let c = unsafe { &*self.0.container()? };
         check_elem_layout(type_param, c)?;
 
         let len = match c {
-            Container::VecU8(r) => r.borrow().len(),
-            Container::VecU64(r) => r.borrow().len(),
-            Container::VecU128(r) => r.borrow().len(),
-            Container::VecBool(r) => r.borrow().len(),
-            Container::VecAddress(r) => r.borrow().len(),
-            Container::Vec(r) => r.borrow().len(),
-            Container::Locals(_) | Container::Struct(_) => unreachable!(),
+            Container::VecU8(r) => r.len(),
+            Container::VecU64(r) => r.len(),
+            Container::VecU128(r) => r.len(),
+            Container::VecBool(r) => r.len(),
+            Container::VecAddress(r) => r.len(),
+            Container::Vec(r) => r.len(),
+            Container::Struct(_) => unreachable!(),
         };
         Ok(Value::u64(len as u64))
     }
 
     pub fn push_back(&self, e: Value, type_param: &Type) -> PartialVMResult<()> {
-        let c = self.0.container();
+        let c = unsafe { &mut *self.0.container()? };
         check_elem_layout(type_param, c)?;
 
         match c {
-            Container::VecU8(r) => r.borrow_mut().push(e.value_as()?),
-            Container::VecU64(r) => r.borrow_mut().push(e.value_as()?),
-            Container::VecU128(r) => r.borrow_mut().push(e.value_as()?),
-            Container::VecBool(r) => r.borrow_mut().push(e.value_as()?),
-            Container::VecAddress(r) => r.borrow_mut().push(e.value_as()?),
-            Container::Vec(r) => r.borrow_mut().push(e.0),
-            Container::Locals(_) | Container::Struct(_) => unreachable!(),
+            Container::VecU8(r) => r.push(e.value_as()?),
+            Container::VecU64(r) => r.push(e.value_as()?),
+            Container::VecU128(r) => r.push(e.value_as()?),
+            Container::VecBool(r) => r.push(e.value_as()?),
+            Container::VecAddress(r) => r.push(e.value_as()?),
+            Container::Vec(r) => r.push(e.0),
+            Container::Struct(_) => unreachable!(),
         }
 
         self.0.mark_dirty();
@@ -1600,17 +1394,17 @@ impl VectorRef {
     }
 
     pub fn borrow_elem(&self, idx: usize, type_param: &Type) -> PartialVMResult<Value> {
-        let c = self.0.container();
+        let c = unsafe { &mut *self.0.container()? };
         check_elem_layout(type_param, c)?;
         if idx >= c.len() {
             return Err(PartialVMError::new(StatusCode::VECTOR_OPERATION_ERROR)
                 .with_sub_status(INDEX_OUT_OF_BOUNDS));
         }
-        Ok(Value(self.0.borrow_elem(idx)?))
+        Ok(Value(ValueImpl::Reference(self.0.borrow_elem(idx)?)))
     }
 
     pub fn pop(&self, type_param: &Type) -> PartialVMResult<Value> {
-        let c = self.0.container();
+        let c = unsafe { &mut *self.0.container()? };
         check_elem_layout(type_param, c)?;
 
         macro_rules! err_pop_empty_vec {
@@ -1621,31 +1415,31 @@ impl VectorRef {
         }
 
         let res = match c {
-            Container::VecU8(r) => match r.borrow_mut().pop() {
+            Container::VecU8(r) => match r.pop() {
                 Some(x) => Value::u8(x),
                 None => err_pop_empty_vec!(),
             },
-            Container::VecU64(r) => match r.borrow_mut().pop() {
+            Container::VecU64(r) => match r.pop() {
                 Some(x) => Value::u64(x),
                 None => err_pop_empty_vec!(),
             },
-            Container::VecU128(r) => match r.borrow_mut().pop() {
+            Container::VecU128(r) => match r.pop() {
                 Some(x) => Value::u128(x),
                 None => err_pop_empty_vec!(),
             },
-            Container::VecBool(r) => match r.borrow_mut().pop() {
+            Container::VecBool(r) => match r.pop() {
                 Some(x) => Value::bool(x),
                 None => err_pop_empty_vec!(),
             },
-            Container::VecAddress(r) => match r.borrow_mut().pop() {
+            Container::VecAddress(r) => match r.pop() {
                 Some(x) => Value::address(x),
                 None => err_pop_empty_vec!(),
             },
-            Container::Vec(r) => match r.borrow_mut().pop() {
+            Container::Vec(r) => match r.pop() {
                 Some(x) => Value(x),
                 None => err_pop_empty_vec!(),
             },
-            Container::Locals(_) | Container::Struct(_) => unreachable!(),
+            Container::Struct(_) => unreachable!(),
         };
 
         self.0.mark_dirty();
@@ -1653,12 +1447,12 @@ impl VectorRef {
     }
 
     pub fn swap(&self, idx1: usize, idx2: usize, type_param: &Type) -> PartialVMResult<()> {
-        let c = self.0.container();
+        let c = unsafe { &mut *self.0.container()? };
         check_elem_layout(type_param, c)?;
 
         macro_rules! swap {
             ($v: expr) => {{
-                let mut v = $v.borrow_mut();
+                let v = $v;
                 if idx1 >= v.len() || idx2 >= v.len() {
                     return Err(PartialVMError::new(StatusCode::VECTOR_OPERATION_ERROR)
                         .with_sub_status(INDEX_OUT_OF_BOUNDS));
@@ -1674,7 +1468,7 @@ impl VectorRef {
             Container::VecBool(r) => swap!(r),
             Container::VecAddress(r) => swap!(r),
             Container::Vec(r) => swap!(r),
-            Container::Locals(_) | Container::Struct(_) => unreachable!(),
+            Container::Struct(_) => unreachable!(),
         }
 
         self.0.mark_dirty();
@@ -1717,9 +1511,9 @@ impl Vector {
             ),
 
             Type::Signer | Type::Vector(_) | Type::Struct(_) | Type::StructInstantiation(_, _) => {
-                Value(ValueImpl::Container(Container::Vec(Rc::new(RefCell::new(
+                Value(ValueImpl::Container(Container::Vec(
                     elements.into_iter().map(|v| v.0).collect(),
-                )))))
+                )))
             }
 
             Type::Reference(_) | Type::MutableReference(_) | Type::TyParam(_) => {
@@ -1740,28 +1534,13 @@ impl Vector {
     pub fn unpack(self, type_param: &Type, expected_num: u64) -> PartialVMResult<Vec<Value>> {
         check_elem_layout(type_param, &self.0)?;
         let elements: Vec<_> = match self.0 {
-            Container::VecU8(r) => take_unique_ownership(r)?
-                .into_iter()
-                .map(Value::u8)
-                .collect(),
-            Container::VecU64(r) => take_unique_ownership(r)?
-                .into_iter()
-                .map(Value::u64)
-                .collect(),
-            Container::VecU128(r) => take_unique_ownership(r)?
-                .into_iter()
-                .map(Value::u128)
-                .collect(),
-            Container::VecBool(r) => take_unique_ownership(r)?
-                .into_iter()
-                .map(Value::bool)
-                .collect(),
-            Container::VecAddress(r) => take_unique_ownership(r)?
-                .into_iter()
-                .map(Value::address)
-                .collect(),
-            Container::Vec(r) => take_unique_ownership(r)?.into_iter().map(Value).collect(),
-            Container::Locals(_) | Container::Struct(_) => unreachable!(),
+            Container::VecU8(r) => r.into_iter().map(Value::u8).collect(),
+            Container::VecU64(r) => r.into_iter().map(Value::u64).collect(),
+            Container::VecU128(r) => r.into_iter().map(Value::u128).collect(),
+            Container::VecBool(r) => r.into_iter().map(Value::bool).collect(),
+            Container::VecAddress(r) => r.into_iter().map(Value::address).collect(),
+            Container::Vec(r) => r.into_iter().map(Value).collect(),
+            Container::Struct(_) => unreachable!(),
         };
         if expected_num as usize == elements.len() {
             Ok(elements)
@@ -1800,31 +1579,25 @@ impl Vector {
 impl Container {
     fn size(&self) -> AbstractMemorySize<GasCarrier> {
         match self {
-            Self::Locals(r) | Self::Vec(r) | Self::Struct(r) => Struct::size_impl(&*r.borrow()),
-            Self::VecU8(r) => AbstractMemorySize::new((r.borrow().len() * size_of::<u8>()) as u64),
-            Self::VecU64(r) => {
-                AbstractMemorySize::new((r.borrow().len() * size_of::<u64>()) as u64)
-            }
-            Self::VecU128(r) => {
-                AbstractMemorySize::new((r.borrow().len() * size_of::<u128>()) as u64)
-            }
-            Self::VecBool(r) => {
-                AbstractMemorySize::new((r.borrow().len() * size_of::<bool>()) as u64)
-            }
+            Self::Vec(r) | Self::Struct(r) => Struct::size_impl(&*r.borrow()),
+            Self::VecU8(r) => AbstractMemorySize::new((r.len() * size_of::<u8>()) as u64),
+            Self::VecU64(r) => AbstractMemorySize::new((r.len() * size_of::<u64>()) as u64),
+            Self::VecU128(r) => AbstractMemorySize::new((r.len() * size_of::<u128>()) as u64),
+            Self::VecBool(r) => AbstractMemorySize::new((r.len() * size_of::<bool>()) as u64),
             Self::VecAddress(r) => {
-                AbstractMemorySize::new((r.borrow().len() * size_of::<AccountAddress>()) as u64)
+                AbstractMemorySize::new((r.len() * size_of::<AccountAddress>()) as u64)
             }
         }
     }
 }
 
-impl ContainerRef {
+impl CheckedRef {
     fn size(&self) -> AbstractMemorySize<GasCarrier> {
         REFERENCE_SIZE
     }
 }
 
-impl IndexedRef {
+impl ExternalRef {
     fn size(&self) -> AbstractMemorySize<GasCarrier> {
         REFERENCE_SIZE
     }
@@ -1837,8 +1610,7 @@ impl ValueImpl {
         match self {
             Invalid | U8(_) | U64(_) | U128(_) | Bool(_) => CONST_SIZE,
             Address(_) => AbstractMemorySize::new(AccountAddress::LENGTH as u64),
-            ContainerRef(r) => r.size(),
-            IndexedRef(r) => r.size(),
+            Reference(r) => r.size(),
             // TODO: in case the borrow fails the VM will panic.
             Container(c) => c.size(),
         }
@@ -1866,8 +1638,8 @@ impl Value {
 impl ReferenceImpl {
     fn size(&self) -> AbstractMemorySize<GasCarrier> {
         match self {
-            Self::ContainerRef(r) => r.size(),
-            Self::IndexedRef(r) => r.size(),
+            Self::CheckedRef(r) => r.size(),
+            Self::ExternalRef(r) => r.size(),
         }
     }
 }
@@ -1919,11 +1691,14 @@ impl Struct {
  **************************************************************************************/
 #[allow(clippy::unnecessary_wraps)]
 impl GlobalValueImpl {
-    fn cached(val: ValueImpl, status: GlobalDataStatus) -> PartialVMResult<Self> {
-        match val {
-            ValueImpl::Container(Container::Struct(fields)) => {
+    fn cached(val: ValueImpl, status: ExternalDataStatus) -> PartialVMResult<Self> {
+        match &val {
+            ValueImpl::Container(Container::Struct(_)) => {
                 let status = Rc::new(RefCell::new(status));
-                Ok(Self::Cached { fields, status })
+                Ok(Self::Cached {
+                    value: Rc::new(RefCell::new(val)),
+                    status,
+                })
             }
             _ => Err(
                 PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
@@ -1933,8 +1708,10 @@ impl GlobalValueImpl {
     }
 
     fn fresh(val: ValueImpl) -> PartialVMResult<Self> {
-        match val {
-            ValueImpl::Container(Container::Struct(fields)) => Ok(Self::Fresh { fields }),
+        match &val {
+            ValueImpl::Container(Container::Struct(_)) => Ok(Self::Fresh {
+                value: Rc::new(RefCell::new(val)),
+            }),
             _ => Err(
                 PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
                     .with_message("failed to publish fresh: not a resource".to_string()),
@@ -1943,26 +1720,26 @@ impl GlobalValueImpl {
     }
 
     fn move_from(&mut self) -> PartialVMResult<ValueImpl> {
-        let fields = match self {
+        let value = match self {
             Self::None | Self::Deleted => {
                 return Err(PartialVMError::new(StatusCode::MISSING_DATA))
             }
             Self::Fresh { .. } => match std::mem::replace(self, Self::None) {
-                Self::Fresh { fields } => fields,
+                Self::Fresh { value } => value,
                 _ => unreachable!(),
             },
             Self::Cached { .. } => match std::mem::replace(self, Self::Deleted) {
-                Self::Cached { fields, .. } => fields,
+                Self::Cached { value, .. } => value,
                 _ => unreachable!(),
             },
         };
-        if Rc::strong_count(&fields) != 1 {
+        if Rc::strong_count(&value) != 1 {
             return Err(
                 PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
                     .with_message("moving global resource with dangling reference".to_string()),
             );
         }
-        Ok(ValueImpl::Container(Container::Struct(fields)))
+        Ok(value.replace(ValueImpl::Invalid))
     }
 
     fn move_to(&mut self, val: ValueImpl) -> PartialVMResult<()> {
@@ -1971,7 +1748,7 @@ impl GlobalValueImpl {
                 return Err(PartialVMError::new(StatusCode::RESOURCE_ALREADY_EXISTS))
             }
             Self::None => *self = Self::fresh(val)?,
-            Self::Deleted => *self = Self::cached(val, GlobalDataStatus::Dirty)?,
+            Self::Deleted => *self = Self::cached(val, ExternalDataStatus::Dirty)?,
         }
         Ok(())
     }
@@ -1984,30 +1761,28 @@ impl GlobalValueImpl {
     }
 
     fn borrow_global(&self) -> PartialVMResult<ValueImpl> {
-        match self {
-            Self::None | Self::Deleted => Err(PartialVMError::new(StatusCode::MISSING_DATA)),
-            Self::Fresh { fields } => Ok(ValueImpl::ContainerRef(ContainerRef::Local(
-                Container::Struct(Rc::clone(fields)),
-            ))),
-            Self::Cached { fields, status } => Ok(ValueImpl::ContainerRef(ContainerRef::Global {
-                container: Container::Struct(Rc::clone(fields)),
-                status: Rc::clone(status),
-            })),
-        }
+        let (global_status, value) = match self {
+            Self::None | Self::Deleted => {
+                return Err(PartialVMError::new(StatusCode::MISSING_DATA))
+            }
+            Self::Fresh { value } => (None, value),
+            Self::Cached { value, status } => (Some(status.clone()), value),
+        };
+        Ok(ValueImpl::Reference(ReferenceImpl::ExternalRef(
+            ExternalRef::new_source(global_status, value.clone())?,
+        )))
     }
 
     fn into_effect(self) -> PartialVMResult<GlobalValueEffect<ValueImpl>> {
         Ok(match self {
             Self::None => GlobalValueEffect::None,
             Self::Deleted => GlobalValueEffect::Deleted,
-            Self::Fresh { fields } => {
-                GlobalValueEffect::Changed(ValueImpl::Container(Container::Struct(fields)))
-            }
-            Self::Cached { fields, status } => match &*status.borrow() {
-                GlobalDataStatus::Dirty => {
-                    GlobalValueEffect::Changed(ValueImpl::Container(Container::Struct(fields)))
+            Self::Fresh { value } => GlobalValueEffect::Changed(value.replace(ValueImpl::Invalid)),
+            Self::Cached { value, status } => match &*status.as_ref().borrow() {
+                ExternalDataStatus::Dirty => {
+                    GlobalValueEffect::Changed(value.replace(ValueImpl::Invalid))
                 }
-                GlobalDataStatus::Clean => GlobalValueEffect::None,
+                ExternalDataStatus::Clean => GlobalValueEffect::None,
             },
         })
     }
@@ -2016,10 +1791,10 @@ impl GlobalValueImpl {
         match self {
             Self::None => false,
             Self::Deleted => true,
-            Self::Fresh { fields: _ } => true,
-            Self::Cached { fields: _, status } => match &*status.borrow() {
-                GlobalDataStatus::Dirty => true,
-                GlobalDataStatus::Clean => false,
+            Self::Fresh { value: _ } => true,
+            Self::Cached { value: _, status } => match &*status.as_ref().borrow() {
+                ExternalDataStatus::Dirty => true,
+                ExternalDataStatus::Clean => false,
             },
         }
     }
@@ -2033,7 +1808,7 @@ impl GlobalValue {
     pub fn cached(val: Value) -> PartialVMResult<Self> {
         Ok(Self(GlobalValueImpl::cached(
             val.0,
-            GlobalDataStatus::Clean,
+            ExternalDataStatus::Clean,
         )?))
     }
 
@@ -2088,8 +1863,7 @@ impl Display for ValueImpl {
 
             Self::Container(r) => write!(f, "{}", r),
 
-            Self::ContainerRef(r) => write!(f, "{}", r),
-            Self::IndexedRef(r) => write!(f, "{}", r),
+            Self::Reference(r) => write!(f, "{}", r),
         }
     }
 }
@@ -2110,38 +1884,56 @@ where
     write!(f, "]")
 }
 
-impl Display for ContainerRef {
+impl Display for ExternalRef {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            Self::Local(c) => write!(f, "({}, {})", c.rc_count(), c),
-            Self::Global { status, container } => write!(
-                f,
-                "({:?}, {}, {})",
-                &*status.borrow(),
-                container.rc_count(),
-                container
-            ),
+        let Self {
+            data_status: global_status,
+            source,
+            checked_ref,
+        } = self;
+        write!(
+            f,
+            "&({:?}, {}, {})",
+            &*global_status.as_ref().borrow(),
+            Rc::strong_count(source),
+            checked_ref,
+        )
+    }
+}
+
+impl Display for CheckedRef {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        unsafe {
+            match *self {
+                CheckedRef::U8(p) => write!(f, "&{}", ValueImpl::U8(*p)),
+                CheckedRef::U64(p) => write!(f, "&{}", ValueImpl::U64(*p)),
+                CheckedRef::U128(p) => write!(f, "&{}", ValueImpl::U128(*p)),
+                CheckedRef::Bool(p) => write!(f, "&{:?}", ValueImpl::Bool(*p)),
+                CheckedRef::Address(p) => write!(f, "&{}", ValueImpl::Address(*p)),
+                CheckedRef::Container(p) => write!(f, "&{}", &*p),
+            }
         }
     }
 }
 
-impl Display for IndexedRef {
+impl Display for ReferenceImpl {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}<{}>", self.container_ref, self.idx)
+        match self {
+            Self::CheckedRef(r) => write!(f, "{}", r),
+            Self::ExternalRef(r) => write!(f, "{}", r),
+        }
     }
 }
 
 impl Display for Container {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Self::Locals(r) | Self::Vec(r) | Self::Struct(r) => {
-                display_list_of_items(r.borrow().iter(), f)
-            }
-            Self::VecU8(r) => display_list_of_items(r.borrow().iter(), f),
-            Self::VecU64(r) => display_list_of_items(r.borrow().iter(), f),
-            Self::VecU128(r) => display_list_of_items(r.borrow().iter(), f),
-            Self::VecBool(r) => display_list_of_items(r.borrow().iter(), f),
-            Self::VecAddress(r) => display_list_of_items(r.borrow().iter(), f),
+            Self::Vec(r) | Self::Struct(r) => display_list_of_items(r.iter(), f),
+            Self::VecU8(r) => display_list_of_items(r.iter(), f),
+            Self::VecU64(r) => display_list_of_items(r.iter(), f),
+            Self::VecU128(r) => display_list_of_items(r.iter(), f),
+            Self::VecBool(r) => display_list_of_items(r.iter(), f),
+            Self::VecAddress(r) => display_list_of_items(r.iter(), f),
         }
     }
 }
@@ -2158,7 +1950,6 @@ impl Display for Locals {
             f,
             "{}",
             self.0
-                .borrow()
                 .iter()
                 .enumerate()
                 .map(|(idx, val)| format!("[{}] {}", idx, val))
@@ -2209,8 +2000,7 @@ pub mod debug {
 
             ValueImpl::Container(c) => print_container(buf, c),
 
-            ValueImpl::ContainerRef(r) => print_container_ref(buf, r),
-            ValueImpl::IndexedRef(r) => print_indexed_ref(buf, r),
+            ValueImpl::Reference(r) => print_reference_impl(buf, r),
         }
     }
 
@@ -2242,28 +2032,16 @@ pub mod debug {
 
     fn print_container<B: Write>(buf: &mut B, c: &Container) -> PartialVMResult<()> {
         match c {
-            Container::Vec(r) => print_list(buf, "[", r.borrow().iter(), print_value_impl, "]"),
+            Container::Vec(r) => print_list(buf, "[", r.iter(), print_value_impl, "]"),
 
-            Container::Struct(r) => {
-                print_list(buf, "{ ", r.borrow().iter(), print_value_impl, " }")
-            }
+            Container::Struct(r) => print_list(buf, "{ ", r.iter(), print_value_impl, " }"),
 
-            Container::VecU8(r) => print_list(buf, "[", r.borrow().iter(), print_u8, "]"),
-            Container::VecU64(r) => print_list(buf, "[", r.borrow().iter(), print_u64, "]"),
-            Container::VecU128(r) => print_list(buf, "[", r.borrow().iter(), print_u128, "]"),
-            Container::VecBool(r) => print_list(buf, "[", r.borrow().iter(), print_bool, "]"),
-            Container::VecAddress(r) => print_list(buf, "[", r.borrow().iter(), print_address, "]"),
-
-            Container::Locals(_) => Err(PartialVMError::new(
-                StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR,
-            )
-            .with_message("debug print - invalid container: Locals".to_string())),
+            Container::VecU8(r) => print_list(buf, "[", r.iter(), print_u8, "]"),
+            Container::VecU64(r) => print_list(buf, "[", r.iter(), print_u64, "]"),
+            Container::VecU128(r) => print_list(buf, "[", r.iter(), print_u128, "]"),
+            Container::VecBool(r) => print_list(buf, "[", r.iter(), print_bool, "]"),
+            Container::VecAddress(r) => print_list(buf, "[", r.iter(), print_address, "]"),
         }
-    }
-
-    fn print_container_ref<B: Write>(buf: &mut B, r: &ContainerRef) -> PartialVMResult<()> {
-        debug_write!(buf, "(&) ")?;
-        print_container(buf, r.container())
     }
 
     fn print_slice_elem<B, X, F>(buf: &mut B, v: &[X], idx: usize, print: F) -> PartialVMResult<()>
@@ -2280,31 +2058,35 @@ pub mod debug {
         }
     }
 
-    fn print_indexed_ref<B: Write>(buf: &mut B, r: &IndexedRef) -> PartialVMResult<()> {
-        let idx = r.idx;
-        match r.container_ref.container() {
-            Container::Locals(r) | Container::Vec(r) | Container::Struct(r) => {
-                print_slice_elem(buf, &*r.borrow(), idx, print_value_impl)
+    fn print_checked_ref<B: Write>(buf: &mut B, checked_ref: CheckedRef) -> PartialVMResult<()> {
+        unsafe {
+            match checked_ref {
+                CheckedRef::U8(p) => print_value_impl(buf, &ValueImpl::U8(*p)),
+                CheckedRef::U64(p) => print_value_impl(buf, &ValueImpl::U64(*p)),
+                CheckedRef::U128(p) => print_value_impl(buf, &ValueImpl::U128(*p)),
+                CheckedRef::Bool(p) => print_value_impl(buf, &ValueImpl::Bool(*p)),
+                CheckedRef::Address(p) => print_value_impl(buf, &ValueImpl::Address(*p)),
+                CheckedRef::Container(p) => print_container(buf, &*p),
             }
-
-            Container::VecU8(r) => print_slice_elem(buf, &*r.borrow(), idx, print_u8),
-            Container::VecU64(r) => print_slice_elem(buf, &*r.borrow(), idx, print_u64),
-            Container::VecU128(r) => print_slice_elem(buf, &*r.borrow(), idx, print_u128),
-            Container::VecBool(r) => print_slice_elem(buf, &*r.borrow(), idx, print_bool),
-            Container::VecAddress(r) => print_slice_elem(buf, &*r.borrow(), idx, print_address),
         }
     }
 
     pub fn print_reference<B: Write>(buf: &mut B, r: &Reference) -> PartialVMResult<()> {
-        match &r.0 {
-            ReferenceImpl::ContainerRef(r) => print_container_ref(buf, r),
-            ReferenceImpl::IndexedRef(r) => print_indexed_ref(buf, r),
+        print_reference_impl(buf, &r.0)
+    }
+
+    fn print_reference_impl<B: Write>(buf: &mut B, r: &ReferenceImpl) -> PartialVMResult<()> {
+        match r {
+            ReferenceImpl::CheckedRef(checked_ref)
+            | ReferenceImpl::ExternalRef(ExternalRef { checked_ref, .. }) => {
+                print_checked_ref(buf, *checked_ref)
+            }
         }
     }
 
     pub fn print_locals<B: Write>(buf: &mut B, locals: &Locals) -> PartialVMResult<()> {
         // REVIEW: The number of spaces in the indent is currently hard coded.
-        for (idx, val) in locals.0.borrow().iter().enumerate() {
+        for (idx, val) in locals.0.iter().enumerate() {
             debug_write!(buf, "            [{}] ", idx)?;
             print_value_impl(buf, val)?;
             debug_writeln!(buf)?;
@@ -2401,20 +2183,13 @@ impl<'a, 'b> serde::Serialize for AnnotatedValue<'a, 'b, MoveTypeLayout, ValueIm
             (MoveTypeLayout::Vector(layout), ValueImpl::Container(c)) => {
                 let layout = &**layout;
                 match (layout, c) {
-                    (MoveTypeLayout::U8, Container::VecU8(r)) => r.borrow().serialize(serializer),
-                    (MoveTypeLayout::U64, Container::VecU64(r)) => r.borrow().serialize(serializer),
-                    (MoveTypeLayout::U128, Container::VecU128(r)) => {
-                        r.borrow().serialize(serializer)
-                    }
-                    (MoveTypeLayout::Bool, Container::VecBool(r)) => {
-                        r.borrow().serialize(serializer)
-                    }
-                    (MoveTypeLayout::Address, Container::VecAddress(r)) => {
-                        r.borrow().serialize(serializer)
-                    }
+                    (MoveTypeLayout::U8, Container::VecU8(r)) => r.serialize(serializer),
+                    (MoveTypeLayout::U64, Container::VecU64(r)) => r.serialize(serializer),
+                    (MoveTypeLayout::U128, Container::VecU128(r)) => r.serialize(serializer),
+                    (MoveTypeLayout::Bool, Container::VecBool(r)) => r.serialize(serializer),
+                    (MoveTypeLayout::Address, Container::VecAddress(r)) => r.serialize(serializer),
 
-                    (_, Container::Vec(r)) => {
-                        let v = r.borrow();
+                    (_, Container::Vec(v)) => {
                         let mut t = serializer.serialize_seq(Some(v.len()))?;
                         for val in v.iter() {
                             t.serialize_element(&AnnotatedValue { layout, val })?;
@@ -2429,8 +2204,7 @@ impl<'a, 'b> serde::Serialize for AnnotatedValue<'a, 'b, MoveTypeLayout, ValueIm
                 }
             }
 
-            (MoveTypeLayout::Signer, ValueImpl::Container(Container::Struct(r))) => {
-                let v = r.borrow();
+            (MoveTypeLayout::Signer, ValueImpl::Container(Container::Struct(v))) => {
                 if v.len() != 1 {
                     return Err(invariant_violation::<S>(format!(
                         "cannot serialize container as a signer -- expected 1 field got {}",
@@ -2504,25 +2278,15 @@ impl<'d> serde::de::DeserializeSeed<'d> for SeedWrapper<&MoveTypeLayout> {
 
             L::Vector(layout) => {
                 let container = match &**layout {
-                    L::U8 => {
-                        Container::VecU8(Rc::new(RefCell::new(Vec::deserialize(deserializer)?)))
-                    }
-                    L::U64 => {
-                        Container::VecU64(Rc::new(RefCell::new(Vec::deserialize(deserializer)?)))
-                    }
-                    L::U128 => {
-                        Container::VecU128(Rc::new(RefCell::new(Vec::deserialize(deserializer)?)))
-                    }
-                    L::Bool => {
-                        Container::VecBool(Rc::new(RefCell::new(Vec::deserialize(deserializer)?)))
-                    }
-                    L::Address => Container::VecAddress(Rc::new(RefCell::new(Vec::deserialize(
-                        deserializer,
-                    )?))),
+                    L::U8 => Container::VecU8(Vec::deserialize(deserializer)?),
+                    L::U64 => Container::VecU64(Vec::deserialize(deserializer)?),
+                    L::U128 => Container::VecU128(Vec::deserialize(deserializer)?),
+                    L::Bool => Container::VecBool(Vec::deserialize(deserializer)?),
+                    L::Address => Container::VecAddress(Vec::deserialize(deserializer)?),
                     layout => {
                         let v = deserializer
                             .deserialize_seq(VectorElementVisitor(SeedWrapper { layout }))?;
-                        Container::Vec(Rc::new(RefCell::new(v)))
+                        Container::Vec(v)
                     }
                 };
                 Ok(Value(ValueImpl::Container(container)))

--- a/language/testing-infra/transactional-test-runner/src/framework.rs
+++ b/language/testing-infra/transactional-test-runner/src/framework.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 use crate::tasks::{
     taskify, Argument, InitCommand, PrintBytecodeCommand, PrintBytecodeInputChoice, PublishCommand,
     RawAddress, RunCommand, SyntaxChoice, TaskCommand, TaskInput, ViewCommand,
@@ -28,6 +30,7 @@ use move_core_types::{
     identifier::{IdentStr, Identifier},
     language_storage::{ModuleId, TypeTag},
     transaction_argument::TransactionArgument,
+    value::MoveValue,
 };
 use move_disassembler::disassembler::{Disassembler, DisassemblerOptions};
 use move_ir_types::location::Spanned;
@@ -349,41 +352,22 @@ fn display_return_values(return_values: SerializedReturnValues) -> Option<String
     } = return_values;
     let mut output = vec![];
     if !mutable_reference_outputs.is_empty() {
-        let values = mutable_reference_outputs
+        let printed = mutable_reference_outputs
             .iter()
             .map(|(idx, bytes, layout)| {
-                let value =
-                    move_vm_types::values::Value::simple_deserialize(bytes, layout).unwrap();
+                let value = MoveValue::simple_deserialize(bytes, layout).unwrap();
                 (idx, value)
             })
-            .collect::<Vec<_>>();
-        let printed = values
-            .iter()
-            .map(|(idx, v)| {
-                let mut buf = String::new();
-                // contains no refs, so is safe
-                unsafe { move_vm_types::values::debug::print_value(&mut buf, v) }.unwrap();
-                format!("local#{}: {}", idx, buf)
-            })
+            .map(|(idx, v)| format!("local#{}: {}", idx, v))
             .collect::<Vec<_>>()
             .join(", ");
         output.push(format!("mutable inputs after call: {}", printed))
     };
     if !return_values.is_empty() {
-        let values = return_values
+        let printed = return_values
             .iter()
-            .map(|(bytes, layout)| {
-                move_vm_types::values::Value::simple_deserialize(bytes, layout).unwrap()
-            })
-            .collect::<Vec<_>>();
-        let printed = values
-            .iter()
-            .map(|v| {
-                let mut buf = String::new();
-                // contains no refs, so is safe
-                unsafe { move_vm_types::values::debug::print_value(&mut buf, v) }.unwrap();
-                buf
-            })
+            .map(|(bytes, layout)| MoveValue::simple_deserialize(bytes, layout).unwrap())
+            .map(|v| format!("{}", v))
             .collect::<Vec<_>>()
             .join(", ");
         output.push(format!("return values: {}", printed))

--- a/language/testing-infra/transactional-test-runner/src/framework.rs
+++ b/language/testing-infra/transactional-test-runner/src/framework.rs
@@ -1,8 +1,6 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#![forbid(unsafe_code)]
-
 use crate::tasks::{
     taskify, Argument, InitCommand, PrintBytecodeCommand, PrintBytecodeInputChoice, PublishCommand,
     RawAddress, RunCommand, SyntaxChoice, TaskCommand, TaskInput, ViewCommand,
@@ -363,7 +361,8 @@ fn display_return_values(return_values: SerializedReturnValues) -> Option<String
             .iter()
             .map(|(idx, v)| {
                 let mut buf = String::new();
-                move_vm_types::values::debug::print_value(&mut buf, v).unwrap();
+                // contains no refs, so is safe
+                unsafe { move_vm_types::values::debug::print_value(&mut buf, v) }.unwrap();
                 format!("local#{}: {}", idx, buf)
             })
             .collect::<Vec<_>>()
@@ -381,7 +380,8 @@ fn display_return_values(return_values: SerializedReturnValues) -> Option<String
             .iter()
             .map(|v| {
                 let mut buf = String::new();
-                move_vm_types::values::debug::print_value(&mut buf, v).unwrap();
+                // contains no refs, so is safe
+                unsafe { move_vm_types::values::debug::print_value(&mut buf, v) }.unwrap();
                 buf
             })
             .collect::<Vec<_>>()

--- a/language/testing-infra/transactional-test-runner/src/lib.rs
+++ b/language/testing-infra/transactional-test-runner/src/lib.rs
@@ -1,8 +1,6 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#![forbid(unsafe_code)]
-
 pub mod framework;
 pub mod tasks;
 pub mod vm_test_harness;

--- a/language/testing-infra/transactional-test-runner/src/lib.rs
+++ b/language/testing-infra/transactional-test-runner/src/lib.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 pub mod framework;
 pub mod tasks;
 pub mod vm_test_harness;

--- a/language/tools/move-cli/tests/sandbox_tests/print_values/args.exp
+++ b/language/tools/move-cli/tests/sandbox_tests/print_values/args.exp
@@ -1,7 +1,7 @@
 Command `sandbox publish`:
 Command `sandbox run scripts/print_values.move --dry-run`:
 [debug] 42
-[debug] (&) [100, 200, 300]
-[debug] (&) { false }
-[debug] (&) { 404, { false }, true }
-[debug] (&) { { false } }
+[debug] [100, 200, 300]
+[debug] { false }
+[debug] { 404, { false }, true }
+[debug] { { false } }


### PR DESCRIPTION
Migrating from other repo

## Motivation

- RCs are no longer necessary due to Move's reference safety checks
- Some RCs are still needed to update clean/dirty status or hold onto external memory safely
- I feel this greatly simplifies the layout of values in value_impl.rs
- It does however make `write_ref` unsafe, as it could lead to memory issues if the reference safety checks are wrong or not run
- I do not have a reference heavy bench mark to test if this makes any perf difference. My guess is it won't, but might help with memory usage

## Test Plan

- ran tests
- I'm a bit nervous that our tests might not be exhaustive enough though.... 