### PR TITLE
[move-cli] Include stdlib in Move.toml

### DIFF
--- a/language/tools/move-cli/README.md
+++ b/language/tools/move-cli/README.md
@@ -16,7 +16,7 @@ $ cargo install --path move/language/tools/move-cli
 ```
 or
 ```shell
-$ cargo install --git https://github.com/diem/move move-cli --branch main
+$ cargo install --git https://github.com/move-language/move move-cli --branch main
 ```
 
 This will install the `move` binary in your Cargo binary directory. On
@@ -73,11 +73,11 @@ $ move package prove -p <path> # Verify the specifications in the package at <pa
 ```
 
 In order to run the Move Prover [additional tools need to be
-installed](https://github.com/diem/move/blob/main/language/move-prover/doc/user/install.md).
+installed](https://github.com/move-language/move/blob/main/language/move-prover/doc/user/install.md).
 Information on the Move Prover and its configuration options can be found
-[here](https://github.com/diem/move/blob/main/language/move-prover/doc/user/prover-guide.md)
+[here](https://github.com/move-language/move/blob/main/language/move-prover/doc/user/prover-guide.md)
 and
-[here](https://github.com/diem/move/blob/main/language/move-prover/doc/user/spec-lang.md).
+[here](https://github.com/move-language/move/blob/main/language/move-prover/doc/user/spec-lang.md).
 
 You can also run unit tests in a package using the `test` command
 
@@ -128,7 +128,7 @@ directory:
 Std = "0x1" # Specify and assign 0x1 to the named address "Std"
 
 [dependencies]
-MoveNursery = { git = "https://github.com/diem/move.git", subdir = "language/move-stdlib/nursery", rev = "d45f20a" }
+MoveNursery = { git = "https://github.com/move-language/move.git", subdir = "language/move-stdlib/nursery", rev = "d45f20a" }
 #                ^                    ^                     ^                                       ^
 #            Git dependency       Git clone URL       Subdir under git repo (optional)           Git revision to use
 ```

--- a/language/tools/move-cli/src/package/cli.rs
+++ b/language/tools/move-cli/src/package/cli.rs
@@ -593,8 +593,15 @@ pub fn create_move_package<S: AsRef<str> + fmt::Display>(
     let mut w = std::fs::File::create(creation_path.join(SourcePackageLayout::Manifest.path()))?;
     writeln!(
         &mut w,
-        "[package]\nname = \"{}\"\nversion = \"0.0.0\"",
-        name
-    )?;
+        "[package]
+name = \"{}\"
+version = \"0.0.0\"
+
+[dependencies]
+MoveStdlib = {{ git = \"https://github.com/move-language/move.git\", subdir = \"language/move-stdlib\", rev = \"main\" }}
+
+[addresses]
+Std = \"0x1\"
+", name)?;
     Ok(())
 }


### PR DESCRIPTION
## Motivation

This is a pure DevEx change.

Move CLI is the main tool for the most developers starting with Move, and so is the standard library. While writing a Move tutorial I discovered that developers need to manually install (first they have to find - already a challenge) Standard library so they can work with Signers or Vectors or a Debug. 

Another reason to add both `[addresses]` and `[dependencies]` sections to the default manifest is to showcase its features given the lack of easily-accessible documentation. 

## Test Plan

This PR does not introduce new logic nor does it change anything except the `Move.toml` template.