### PR TITLE
[account-address] Make display and hex outputs consistent

### DIFF
--- a/language/evm/move-to-yul/src/generator.rs
+++ b/language/evm/move-to-yul/src/generator.rs
@@ -278,7 +278,7 @@ impl Generator {
                 emit!(ctx.writer, "let $arg{} := ", idx);
                 match arg {
                     MoveValue::Address(addr) => {
-                        emitln!(ctx.writer, "{}", addr.to_hex_literal());
+                        emitln!(ctx.writer, "{}", addr);
                     }
                     _ => unreachable!(
                         "only address literals are allowed as test arguments currently"

--- a/language/tools/move-package/src/source_package/manifest_parser.rs
+++ b/language/tools/move-package/src/source_package/manifest_parser.rs
@@ -3,7 +3,7 @@
 
 use crate::{source_package::parsed_manifest as PM, Architecture};
 use anyhow::{bail, format_err, Context, Result};
-use move_core_types::account_address::{AccountAddress, AccountAddressParseError};
+use move_core_types::account_address::AccountAddress;
 use move_symbol_pool::symbol::Symbol;
 use std::{
     collections::{BTreeMap, BTreeSet},
@@ -213,10 +213,9 @@ pub fn parse_addresses(tval: TV) -> Result<PM::AddressDeclarations> {
                         } else if addresses
                             .insert(
                                 ident,
-                                Some(parse_address_literal(entry_str).context(format!(
-                                    "Invalid address '{}' encountered.",
-                                    entry_str
-                                ))?),
+                                Some(AccountAddress::from_hex_fuzzy(entry_str).context(
+                                    format!("Invalid address '{}' encountered.", entry_str)
+                                )?),
                             )
                             .is_some()
                         {
@@ -254,7 +253,7 @@ pub fn parse_dev_addresses(tval: TV) -> Result<PM::DevAddressDeclarations> {
                         } else if addresses
                             .insert(
                                 ident,
-                                parse_address_literal(entry_str).context(format!(
+                                AccountAddress::from_hex_fuzzy(entry_str).context(format!(
                                     "Invalid address '{}' encountered.",
                                     entry_str
                                 ))?,
@@ -279,14 +278,6 @@ pub fn parse_dev_addresses(tval: TV) -> Result<PM::DevAddressDeclarations> {
             x.type_str()
         ),
     }
-}
-
-// Safely parses address for both the 0x and non prefixed hex format.
-fn parse_address_literal(address_str: &str) -> Result<AccountAddress, AccountAddressParseError> {
-    if !address_str.starts_with("0x") {
-        return AccountAddress::from_hex(address_str);
-    }
-    AccountAddress::from_hex_literal(address_str)
 }
 
 fn parse_dependency(tval: TV) -> Result<PM::Dependency> {


### PR DESCRIPTION
## Motivation

Now, all default outputs should be `0xCAPS`.  Additionally, there is now a `from_hex_fuzzy()` which handles both `0x` and non-`0x` inputs for the time being.

This is built as follows:
1. `from_hex` -> Only hex characters, exact length
2. `from_hex_literal` -> Only 0x with hex characters, with length extension
3. `from_hex_fuzzy` -> Match either condition
4. `short_str_lossless` -> With 0x, but drop leading 0s
5. Drop the `to_hex` and `to_hex_literal` since we can now use `Display` or `Debug` using the proper formatter.  Additionally to remove any confusion around it.  All of are now consistent as upper case.

https://github.com/move-language/move/issues/53
