### PR TITLE
MoveValueAnnotator: get_type_layout_*

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2415,6 +2415,7 @@ dependencies = [
  "bcs",
  "hex",
  "move-binary-format",
+ "move-bytecode-utils",
  "move-core-types",
  "once_cell",
  "serde 1.0.130",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,6 +102,6 @@ debug = true
 [profile.ci]
 inherits = "test"
 opt-level = 3
-debug = 1 # for saving disk space during linking
+debug = 0 # for saving disk space during linking
 incremental = false
 codegen-units = 16

--- a/language/move-core/types/src/value.rs
+++ b/language/move-core/types/src/value.rs
@@ -54,8 +54,8 @@ pub enum MoveValue {
 /// A layout associated with a named field
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MoveFieldLayout {
-    name: Identifier,
-    layout: MoveTypeLayout,
+    pub name: Identifier,
+    pub layout: MoveTypeLayout,
 }
 
 impl MoveFieldLayout {

--- a/language/tools/move-resource-viewer/Cargo.toml
+++ b/language/tools/move-resource-viewer/Cargo.toml
@@ -13,6 +13,7 @@ edition = "2018"
 bcs = "0.1.2"
 move-core-types = { path = "../../move-core/types" }
 move-binary-format = { path = "../../move-binary-format" }
+move-bytecode-utils = { path = "../move-bytecode-utils" }
 serde = { version = "1.0.124", features = ["derive", "rc"] }
 
 anyhow = "1.0.52"

--- a/language/tools/move-resource-viewer/src/lib.rs
+++ b/language/tools/move-resource-viewer/src/lib.rs
@@ -11,12 +11,13 @@ use move_binary_format::{
     file_format::{Ability, AbilitySet},
     CompiledModule,
 };
+use move_bytecode_utils::layout::TypeLayoutBuilder;
 use move_core_types::{
     account_address::AccountAddress,
     identifier::{IdentStr, Identifier},
     language_storage::{ModuleId, StructTag, TypeTag},
     resolver::MoveResolver,
-    value::{MoveStruct, MoveValue},
+    value::{MoveStruct, MoveTypeLayout, MoveValue},
     vm_status::VMStatus,
 };
 use serde::ser::{SerializeMap, SerializeSeq};
@@ -85,7 +86,19 @@ impl<'a, T: MoveResolver + ?Sized> MoveValueAnnotator<'a, T> {
     }
 
     pub fn get_module(&self, module: &ModuleId) -> Result<Rc<CompiledModule>> {
-        self.cache.get_module_by_id(module)
+        self.cache.get_module_by_id_or_err(module)
+    }
+
+    pub fn get_type_layout_runtime(&self, type_tag: &TypeTag) -> Result<MoveTypeLayout> {
+        TypeLayoutBuilder::build_runtime(type_tag, &self.cache)
+    }
+
+    pub fn get_type_layout_with_fields(&self, type_tag: &TypeTag) -> Result<MoveTypeLayout> {
+        TypeLayoutBuilder::build_with_fields(type_tag, &self.cache)
+    }
+
+    pub fn get_type_layout_with_types(&self, type_tag: &TypeTag) -> Result<MoveTypeLayout> {
+        TypeLayoutBuilder::build_with_types(type_tag, &self.cache)
     }
 
     pub fn view_function_arguments(

--- a/language/tools/move-resource-viewer/src/resolver.rs
+++ b/language/tools/move-resource-viewer/src/resolver.rs
@@ -5,7 +5,7 @@ use crate::{
     fat_type::{FatStructType, FatType, WrappedAbilitySet},
     module_cache::ModuleCache,
 };
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Error, Result};
 use move_binary_format::{
     access::ModuleAccess,
     errors::PartialVMError,
@@ -15,6 +15,7 @@ use move_binary_format::{
     views::FunctionHandleView,
     CompiledModule,
 };
+use move_bytecode_utils::module_cache::GetModule;
 use move_core_types::{
     account_address::AccountAddress,
     identifier::{IdentStr, Identifier},
@@ -28,22 +29,13 @@ pub(crate) struct Resolver<'a, T: ?Sized> {
     cache: ModuleCache,
 }
 
-impl<'a, T: MoveResolver + ?Sized> Resolver<'a, T> {
-    pub fn new(state: &'a T) -> Self {
-        Resolver {
-            state,
-            cache: ModuleCache::new(),
-        }
-    }
+impl<'a, T: MoveResolver + ?Sized> GetModule for Resolver<'a, T> {
+    type Error = Error;
+    type Item = Rc<CompiledModule>;
 
-    fn get_module(&self, address: &AccountAddress, name: &IdentStr) -> Result<Rc<CompiledModule>> {
-        let module_id = ModuleId::new(*address, name.to_owned());
-        self.get_module_by_id(&module_id)
-    }
-
-    pub fn get_module_by_id(&self, module_id: &ModuleId) -> Result<Rc<CompiledModule>> {
+    fn get_module_by_id(&self, module_id: &ModuleId) -> Result<Option<Self::Item>, Self::Error> {
         if let Some(module) = self.cache.get(module_id) {
-            return Ok(module);
+            return Ok(Some(module));
         }
         let blob = self
             .state
@@ -57,7 +49,26 @@ impl<'a, T: MoveResolver + ?Sized> Resolver<'a, T> {
                 status
             )
         })?;
-        Ok(self.cache.insert(module_id.clone(), compiled_module))
+        Ok(Some(self.cache.insert(module_id.clone(), compiled_module)))
+    }
+}
+
+impl<'a, T: MoveResolver + ?Sized> Resolver<'a, T> {
+    pub fn new(state: &'a T) -> Self {
+        Resolver {
+            state,
+            cache: ModuleCache::new(),
+        }
+    }
+
+    fn get_module(&self, address: &AccountAddress, name: &IdentStr) -> Result<Rc<CompiledModule>> {
+        let module_id = ModuleId::new(*address, name.to_owned());
+        self.get_module_by_id_or_err(&module_id)
+    }
+
+    pub fn get_module_by_id_or_err(&self, module_id: &ModuleId) -> Result<Rc<CompiledModule>> {
+        self.get_module_by_id(module_id)
+            .map(|opt| opt.expect("My GetModule impl always returns Some."))
     }
 
     pub fn resolve_function_arguments(
@@ -65,7 +76,7 @@ impl<'a, T: MoveResolver + ?Sized> Resolver<'a, T> {
         module: &ModuleId,
         function: &IdentStr,
     ) -> Result<Vec<FatType>> {
-        let m = self.get_module_by_id(module)?;
+        let m = self.get_module_by_id_or_err(module)?;
         for def in m.function_defs.iter() {
             let fhandle = m.function_handle_at(def.function);
             let fhandle_view = FunctionHandleView::new(m.as_ref(), fhandle);


### PR DESCRIPTION
## Motivation

Expose MoveTypeLayout from the MoveValueAnnotaor. This can be got elsewhere, but the callsite I'm focusing on has this annotator, and it'll be nice if the cache inside can be leveraged.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan
https://github.com/aptos-labs/aptos-core/pull/568 introduced unit tests to utilize this.