### PR TITLE
Revert "[account-address] Input and output with a 0x for hex output (…

### DIFF
--- a/language/move-core/types/src/account_address.rs
+++ b/language/move-core/types/src/account_address.rs
@@ -68,7 +68,7 @@ impl AccountAddress {
 
         let hex_len = literal.len() - 2;
 
-        // If the string is too short, pad it because it needs to be exactly the right number of bytes
+        // If the string is too short, pad it
         if hex_len < Self::LENGTH * 2 {
             let mut hex_str = String::with_capacity(Self::LENGTH * 2);
             for _ in 0..Self::LENGTH * 2 - hex_len {
@@ -92,7 +92,7 @@ impl AccountAddress {
     }
 
     pub fn to_hex(&self) -> String {
-        self.short_str_lossless()
+        format!("{:x}", self)
     }
 
     pub fn from_bytes<T: AsRef<[u8]>>(bytes: T) -> Result<Self, AccountAddressParseError> {
@@ -206,7 +206,7 @@ impl From<&AccountAddress> for [u8; AccountAddress::LENGTH] {
 
 impl From<&AccountAddress> for String {
     fn from(addr: &AccountAddress) -> String {
-        addr.to_hex_literal()
+        ::hex::encode(addr.as_ref())
     }
 }
 
@@ -214,7 +214,7 @@ impl TryFrom<String> for AccountAddress {
     type Error = AccountAddressParseError;
 
     fn try_from(s: String) -> Result<AccountAddress, AccountAddressParseError> {
-        AccountAddress::from_str(&s)
+        Self::from_hex(s)
     }
 }
 
@@ -222,7 +222,7 @@ impl FromStr for AccountAddress {
     type Err = AccountAddressParseError;
 
     fn from_str(s: &str) -> Result<Self, AccountAddressParseError> {
-        Self::from_hex_literal(s)
+        Self::from_hex(s)
     }
 }
 
@@ -233,7 +233,7 @@ impl<'de> Deserialize<'de> for AccountAddress {
     {
         if deserializer.is_human_readable() {
             let s = <String>::deserialize(deserializer)?;
-            AccountAddress::from_hex_literal(&s).map_err(D::Error::custom)
+            AccountAddress::from_hex(s).map_err(D::Error::custom)
         } else {
             // In order to preserve the Serde data model and help analysis tools,
             // make sure to wrap our value in a container with the same name
@@ -254,7 +254,7 @@ impl Serialize for AccountAddress {
         S: Serializer,
     {
         if serializer.is_human_readable() {
-            self.to_hex_literal().serialize(serializer)
+            self.to_hex().serialize(serializer)
         } else {
             // See comment in deserialize.
             serializer.serialize_newtype_struct("AccountAddress", &self.0)
@@ -346,16 +346,8 @@ mod tests {
         assert_eq!(address_from_literal, address);
         assert_eq!(hex_literal, address.to_hex_literal());
 
-        // Check other variations of 0x1
-        assert_eq!(AccountAddress::from_str("0x01").unwrap(), address);
-        assert_eq!(
-            AccountAddress::from_str("0x00000000000000000000000000000001").unwrap(),
-            address
-        );
-
-        // Missing '0x' should fail
+        // Missing '0x'
         AccountAddress::from_hex_literal(hex).unwrap_err();
-
         // Too long
         AccountAddress::from_hex_literal("0x100000000000000000000000000000001").unwrap_err();
     }
@@ -384,12 +376,14 @@ mod tests {
     #[test]
     fn test_serde_json() {
         let hex = "ca843279e3427144cead5e4d5999a3d0";
-        let json_hex = "\"0xca843279e3427144cead5e4d5999a3d0\"";
+        let json_hex = "\"ca843279e3427144cead5e4d5999a3d0\"";
 
         let address = AccountAddress::from_hex(hex).unwrap();
 
+        let json = serde_json::to_string(&address).unwrap();
         let json_address: AccountAddress = serde_json::from_str(json_hex).unwrap();
 
+        assert_eq!(json, json_hex);
         assert_eq!(address, json_address);
     }
 

--- a/language/tools/move-package/tests/test_sources/parsing/invalid_non_hex_address/Move.exp
+++ b/language/tools/move-package/tests/test_sources/parsing/invalid_non_hex_address/Move.exp
@@ -1,1 +1,0 @@
-Error parsing '[addresses]' section of manifest: Invalid address: Unable to parse AccountAddress

--- a/language/tools/move-package/tests/test_sources/parsing/invalid_non_hex_address/Move.toml
+++ b/language/tools/move-package/tests/test_sources/parsing/invalid_non_hex_address/Move.toml
@@ -1,6 +1,0 @@
-[package]
-name = "name"
-version = "0.1.2"
-
-[addresses]
-A = "1234"


### PR DESCRIPTION
…#7)"

This reverts commit ba7c06401ea94a2f712962e00dcf27aebc02cfc4.

This change causes issues with module publishing and transactions, as it doesn't properly convert all hex versions.  I'll fix it in this PR https://github.com/move-language/move/pull/54 but for now I need to revert it

@tnowacki 