### PR TITLE
MoveValue::undecorate

### DIFF
--- a/language/move-core/types/src/value.rs
+++ b/language/move-core/types/src/value.rs
@@ -123,6 +123,16 @@ impl MoveValue {
             (v, _) => v,
         }
     }
+
+    pub fn undecorate(self) -> Self {
+        match self {
+            Self::Struct(s) => MoveValue::Struct(s.undecorate()),
+            Self::Vector(vals) => {
+                MoveValue::Vector(vals.into_iter().map(MoveValue::undecorate).collect())
+            }
+            v => v,
+        }
+    }
 }
 
 pub fn serialize_values<'a, I>(vals: I) -> Vec<Vec<u8>>
@@ -206,6 +216,15 @@ impl MoveStruct {
                 fields.into_iter().map(|(_, f)| f).collect()
             }
         }
+    }
+
+    pub fn undecorate(self) -> Self {
+        Self::Runtime(
+            self.into_fields()
+                .into_iter()
+                .map(MoveValue::undecorate)
+                .collect(),
+        )
     }
 }
 


### PR DESCRIPTION


## Motivation

Get a `Runtime` flavor of the same type, which can be serialized into
the runtime representation.




### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

used here to serialize a struct from json to bcs runtime representation:
https://github.com/aptos-labs/aptos-core/pull/568/commits/c7a8e7a198e5c56a904886d79103bf0156da951a