### PR TITLE
[transactional-tests] Use source files properly

### DIFF
--- a/language/move-compiler/src/command_line/compiler.rs
+++ b/language/move-compiler/src/command_line/compiler.rs
@@ -387,15 +387,17 @@ impl<'a> SteppedCompiler<'a, PASS_COMPILATION> {
 /// Given a set of dependencies, precompile them and save the ASTs so that they can be used again
 /// to compile against without having to recompile these dependencies
 pub fn construct_pre_compiled_lib<Paths: Into<Symbol>, NamedAddress: Into<Symbol>>(
-    deps: Vec<AddressScopedFiles<Paths, NamedAddress>>,
+    targets: Vec<AddressScopedFiles<Paths, NamedAddress>>,
     interface_files_dir_opt: Option<String>,
     flags: Flags,
 ) -> anyhow::Result<Result<FullyCompiledProgram, (FilesSourceText, Diagnostics)>> {
-    let (files, pprog_and_comments_res) =
-        Compiler::new(Vec::<AddressScopedFiles<Paths, NamedAddress>>::new(), deps)
-            .set_interface_files_dir_opt(interface_files_dir_opt)
-            .set_flags(flags)
-            .run::<PASS_PARSER>()?;
+    let (files, pprog_and_comments_res) = Compiler::new(
+        targets,
+        Vec::<AddressScopedFiles<Paths, NamedAddress>>::new(),
+    )
+    .set_interface_files_dir_opt(interface_files_dir_opt)
+    .set_flags(flags)
+    .run::<PASS_PARSER>()?;
 
     let (_comments, stepped) = match pprog_and_comments_res {
         Err(errors) => return Ok(Err((files, errors))),

--- a/language/move-compiler/src/expansion/translate.rs
+++ b/language/move-compiler/src/expansion/translate.rs
@@ -114,13 +114,13 @@ pub fn program(
             &prog.lib_definitions,
         );
         if let Some(pre_compiled) = pre_compiled_lib {
-            assert!(pre_compiled.parser.source_definitions.is_empty());
+            assert!(pre_compiled.parser.lib_definitions.is_empty());
             all_module_members(
                 compilation_env,
                 &pre_compiled.parser.named_address_maps,
                 &mut members,
                 false,
-                &pre_compiled.parser.lib_definitions,
+                &pre_compiled.parser.source_definitions,
             );
         }
         members


### PR DESCRIPTION
- Used source files instead of interface files for source language tests
- Very marginal perf improvement for transactional tests

## Motivation

- Package manager was recently changed to use source files instead of interface files. This change wasn't reflected in the transactional test runner (will still need to be done for the CLI too)

## Test Plan

- Ran em