### PR TITLE
[move-core-types] Upgrade the version of move-core-types to 0.0.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2075,7 +2075,7 @@ dependencies = [
 
 [[package]]
 name = "move-core-types"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "anyhow",
  "bcs",

--- a/language/move-binary-format/Cargo.toml
+++ b/language/move-binary-format/Cargo.toml
@@ -17,7 +17,7 @@ proptest = { version = "1.0.0", optional = true }
 proptest-derive = { version = "0.3.0", optional = true }
 ref-cast = "1.0.6"
 variant_count = "1.1.0"
-move-core-types = { path = "../move-core/types", version = "0.0.3" }
+move-core-types = { path = "../move-core/types", version = "0.0.4" }
 serde = { version = "1.0.124", default-features = false }
 
 [dev-dependencies]

--- a/language/move-core/types/Cargo.toml
+++ b/language/move-core/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "move-core-types"
-version = "0.0.3"
+version = "0.0.4"
 authors = ["Diem Association <opensource@diem.com>"]
 description = "Core types for Move"
 repository = "https://github.com/diem/diem"

--- a/language/tools/read-write-set/types/Cargo.toml
+++ b/language/tools/read-write-set/types/Cargo.toml
@@ -12,5 +12,5 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0.52"
 move-binary-format = { path = "../../../move-binary-format", version = "0.0.3" }
-move-core-types = { path = "../../../move-core/types", version = "0.0.3" }
+move-core-types = { path = "../../../move-core/types", version = "0.0.4" }
 serde = { version = "1.0.124", default-features = false }


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Move Language.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Bump the version for `move-core-types` to 0.0.4. The reason is following: all crates in the old `diem` repo still has a dependency on `move-core-types` at 0.0.3. We need to bump the version in the crate in order to not get a conflict dependency.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

`cargo check`
