### PR TITLE
[move-core-types] [move-package] Make manifest address parsing error more descriptive

### DIFF
--- a/language/move-core/types/src/account_address.rs
+++ b/language/move-core/types/src/account_address.rs
@@ -267,7 +267,11 @@ pub struct AccountAddressParseError;
 
 impl fmt::Display for AccountAddressParseError {
     fn fmt(&self, f: &mut fmt::Formatter) -> std::fmt::Result {
-        write!(f, "Unable to parse AccountAddress")
+        write!(
+            f,
+            "Unable to parse AccountAddress (must be hex string of length {})",
+            AccountAddress::LENGTH
+        )
     }
 }
 

--- a/language/tools/move-package/src/source_package/manifest_parser.rs
+++ b/language/tools/move-package/src/source_package/manifest_parser.rs
@@ -213,7 +213,10 @@ pub fn parse_addresses(tval: TV) -> Result<PM::AddressDeclarations> {
                         } else if addresses
                             .insert(
                                 ident,
-                                Some(parse_address_literal(entry_str).context("Invalid address")?),
+                                Some(parse_address_literal(entry_str).context(format!(
+                                    "Invalid address '{}' encountered.",
+                                    entry_str
+                                ))?),
                             )
                             .is_some()
                         {
@@ -251,7 +254,10 @@ pub fn parse_dev_addresses(tval: TV) -> Result<PM::DevAddressDeclarations> {
                         } else if addresses
                             .insert(
                                 ident,
-                                parse_address_literal(entry_str).context("Invalid address")?,
+                                parse_address_literal(entry_str).context(format!(
+                                    "Invalid address '{}' encountered.",
+                                    entry_str
+                                ))?,
                             )
                             .is_some()
                         {


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Move Language.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Error message is non-descriptive.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Tests pass