### PR TITLE
[chore] Replace mirai annotations with normal asserts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1832,12 +1832,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mirai-annotations"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9be0862c1b3f26a88803c4a49de6889c10e608b3ee9344e6ef5b45fb37ad3d1"
-
-[[package]]
 name = "module-generation"
 version = "0.1.0"
 dependencies = [
@@ -1909,7 +1903,6 @@ name = "move-binary-format"
 version = "0.0.3"
 dependencies = [
  "anyhow",
- "mirai-annotations",
  "move-core-types",
  "once_cell",
  "proptest",
@@ -1923,9 +1916,6 @@ dependencies = [
 [[package]]
 name = "move-borrow-graph"
 version = "0.0.1"
-dependencies = [
- "mirai-annotations",
-]
 
 [[package]]
 name = "move-bytecode-source-map"
@@ -1958,7 +1948,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "invalid-mutations",
- "mirai-annotations",
  "move-binary-format",
  "move-borrow-graph",
  "move-core-types",
@@ -2080,7 +2069,6 @@ dependencies = [
  "anyhow",
  "bcs",
  "hex",
- "mirai-annotations",
  "once_cell",
  "proptest",
  "proptest-derive",
@@ -2646,7 +2634,6 @@ dependencies = [
  "better_any",
  "fail",
  "hex",
- "mirai-annotations",
  "move-binary-format",
  "move-bytecode-verifier",
  "move-compiler",
@@ -2682,7 +2669,6 @@ name = "move-vm-types"
 version = "0.1.0"
 dependencies = [
  "bcs",
- "mirai-annotations",
  "move-binary-format",
  "move-core-types",
  "once_cell",
@@ -4400,7 +4386,6 @@ dependencies = [
  "getrandom 0.2.2",
  "hex",
  "itertools 0.10.1",
- "mirai-annotations",
  "module-generation",
  "move-binary-format",
  "move-bytecode-verifier",

--- a/language/move-binary-format/Cargo.toml
+++ b/language/move-binary-format/Cargo.toml
@@ -12,7 +12,6 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0.52"
 once_cell = "1.7.2"
-mirai-annotations = "1.10.1"
 proptest = { version = "1.0.0", optional = true }
 proptest-derive = { version = "0.3.0", optional = true }
 ref-cast = "1.0.6"

--- a/language/move-binary-format/src/access.rs
+++ b/language/move-binary-format/src/access.rs
@@ -23,12 +23,9 @@ pub trait ModuleAccess: Sync {
 
     /// Returns the `ModuleHandle` for `self`.
     fn self_handle(&self) -> &ModuleHandle {
-        assume_preconditions!(); // invariant
         let handle = self.module_handle_at(self.self_handle_idx());
-        assumed_postcondition!(
-            handle.address.into_index() < self.as_module().address_identifiers.len()
-        ); // invariant
-        assumed_postcondition!(handle.name.into_index() < self.as_module().identifiers.len()); // invariant
+        debug_assert!(handle.address.into_index() < self.as_module().address_identifiers.len()); // invariant
+        debug_assert!(handle.name.into_index() < self.as_module().identifiers.len()); // invariant
         handle
     }
 
@@ -44,29 +41,27 @@ pub trait ModuleAccess: Sync {
 
     fn module_handle_at(&self, idx: ModuleHandleIndex) -> &ModuleHandle {
         let handle = &self.as_module().module_handles[idx.into_index()];
-        assumed_postcondition!(
-            handle.address.into_index() < self.as_module().address_identifiers.len()
-        ); // invariant
-        assumed_postcondition!(handle.name.into_index() < self.as_module().identifiers.len()); // invariant
+        debug_assert!(handle.address.into_index() < self.as_module().address_identifiers.len()); // invariant
+        debug_assert!(handle.name.into_index() < self.as_module().identifiers.len()); // invariant
         handle
     }
 
     fn struct_handle_at(&self, idx: StructHandleIndex) -> &StructHandle {
         let handle = &self.as_module().struct_handles[idx.into_index()];
-        assumed_postcondition!(handle.module.into_index() < self.as_module().module_handles.len()); // invariant
+        debug_assert!(handle.module.into_index() < self.as_module().module_handles.len()); // invariant
         handle
     }
 
     fn function_handle_at(&self, idx: FunctionHandleIndex) -> &FunctionHandle {
         let handle = &self.as_module().function_handles[idx.into_index()];
-        assumed_postcondition!(handle.parameters.into_index() < self.as_module().signatures.len()); // invariant
-        assumed_postcondition!(handle.return_.into_index() < self.as_module().signatures.len()); // invariant
+        debug_assert!(handle.parameters.into_index() < self.as_module().signatures.len()); // invariant
+        debug_assert!(handle.return_.into_index() < self.as_module().signatures.len()); // invariant
         handle
     }
 
     fn field_handle_at(&self, idx: FieldHandleIndex) -> &FieldHandle {
         let handle = &self.as_module().field_handles[idx.into_index()];
-        assumed_postcondition!(handle.owner.into_index() < self.as_module().struct_defs.len()); // invariant
+        debug_assert!(handle.owner.into_index() < self.as_module().struct_defs.len()); // invariant
         handle
     }
 
@@ -104,8 +99,8 @@ pub trait ModuleAccess: Sync {
 
     fn function_def_at(&self, idx: FunctionDefinitionIndex) -> &FunctionDefinition {
         let result = &self.as_module().function_defs[idx.into_index()];
-        assumed_postcondition!(result.function.into_index() < self.function_handles().len()); // invariant
-        assumed_postcondition!(match &result.code {
+        debug_assert!(result.function.into_index() < self.function_handles().len()); // invariant
+        debug_assert!(match &result.code {
             Some(code) => code.locals.into_index() < self.signatures().len(),
             None => true,
         }); // invariant

--- a/language/move-binary-format/src/file_format.rs
+++ b/language/move-binary-format/src/file_format.rs
@@ -33,7 +33,6 @@ use crate::{
     internals::ModuleIndex,
     IndexKind, SignatureTokenKind,
 };
-use mirai_annotations::*;
 use move_core_types::{
     account_address::AccountAddress,
     identifier::{IdentStr, Identifier},
@@ -1656,7 +1655,7 @@ impl Bytecode {
 
     /// Return the successor offsets of this bytecode instruction.
     pub fn get_successors(pc: CodeOffset, code: &[Bytecode]) -> Vec<CodeOffset> {
-        checked_precondition!(
+        assert!(
             // The program counter could be added to at most twice and must remain
             // within the bounds of the code.
             pc <= u16::max_value() - 2 && (pc as usize) < code.len(),
@@ -1890,7 +1889,7 @@ impl Arbitrary for CompiledModule {
 impl CompiledModule {
     /// Returns the count of a specific `IndexKind`
     pub fn kind_count(&self, kind: IndexKind) -> usize {
-        precondition!(!matches!(
+        debug_assert!(!matches!(
             kind,
             IndexKind::LocalPool
                 | IndexKind::CodeDefinition

--- a/language/move-binary-format/src/lib.rs
+++ b/language/move-binary-format/src/lib.rs
@@ -3,9 +3,6 @@
 
 #![forbid(unsafe_code)]
 
-#[macro_use]
-extern crate mirai_annotations;
-
 use std::fmt;
 
 pub mod access;

--- a/language/move-binary-format/src/proptest_types/functions.rs
+++ b/language/move-binary-format/src/proptest_types/functions.rs
@@ -47,7 +47,7 @@ impl SignatureState {
     }
 
     fn add_signature(&mut self, sig: Signature) -> SignatureIndex {
-        precondition!(self.signatures.len() < TableSize::max_value() as usize);
+        debug_assert!(self.signatures.len() < TableSize::max_value() as usize);
         if let Some(idx) = self.signature_map.get(&sig) {
             return *idx;
         }
@@ -73,7 +73,7 @@ impl FieldHandleState {
 
     #[allow(unused)]
     fn add_field_handle(&mut self, fh: FieldHandle) -> FieldHandleIndex {
-        precondition!(self.field_handles.len() < TableSize::max_value() as usize);
+        debug_assert!(self.field_handles.len() < TableSize::max_value() as usize);
         if let Some(idx) = self.field_map.get(&fh) {
             return *idx;
         }
@@ -112,7 +112,7 @@ where
 
     #[allow(unused)]
     fn add_instantiation(&mut self, inst: T) -> TableIndex {
-        precondition!(self.instantiations.len() < TableSize::max_value() as usize);
+        debug_assert!(self.instantiations.len() < TableSize::max_value() as usize);
         if let Some(idx) = self.instantiation_map.get(&inst) {
             return *idx;
         }
@@ -298,7 +298,7 @@ impl<'a> FnDefnMaterializeState<'a> {
     }
 
     fn add_function_handle(&mut self, handle: FunctionHandle) -> FunctionHandleIndex {
-        precondition!(self.function_handles.len() < TableSize::max_value() as usize);
+        debug_assert!(self.function_handles.len() < TableSize::max_value() as usize);
         self.function_handles.push(handle);
         FunctionHandleIndex((self.function_handles.len() - 1) as TableIndex)
     }

--- a/language/move-binary-format/src/serializer.rs
+++ b/language/move-binary-format/src/serializer.rs
@@ -891,7 +891,7 @@ fn serialize_code(binary: &mut BinaryData, code: &[Bytecode]) -> Result<()> {
 /// Compute the table size with a check for underflow
 fn checked_calculate_table_size(binary: &mut BinaryData, start: u32) -> Result<u32> {
     let offset = check_index_in_binary(binary.len())?;
-    checked_assume!(offset >= start, "table start must be before end");
+    assert!(offset >= start, "table start must be before end");
     Ok(offset - start)
 }
 
@@ -977,11 +977,11 @@ impl CommonSerializer {
         binary: &mut BinaryData,
         tables: &T,
     ) -> Result<()> {
-        verify!(self.table_count == 0); // Should not be necessary, but it helps MIRAI right now
+        debug_assert!(self.table_count == 0);
         self.serialize_module_handles(binary, tables.get_module_handles())?;
         self.serialize_struct_handles(binary, tables.get_struct_handles())?;
         self.serialize_function_handles(binary, tables.get_function_handles())?;
-        verify!(self.table_count < 6); // Should not be necessary, but it helps MIRAI right now
+        debug_assert!(self.table_count < 6);
         self.serialize_function_instantiations(binary, tables.get_function_instantiations())?;
         self.serialize_signatures(binary, tables.get_signatures())?;
         self.serialize_identifiers(binary, tables.get_identifiers())?;

--- a/language/move-borrow-graph/Cargo.toml
+++ b/language/move-borrow-graph/Cargo.toml
@@ -5,6 +5,3 @@ authors = ["Diem Association <opensource@diem.com>"]
 publish = false
 edition = "2018"
 license = "Apache-2.0"
-
-[dependencies]
-mirai-annotations = "1.10.1"

--- a/language/move-borrow-graph/src/graph.rs
+++ b/language/move-borrow-graph/src/graph.rs
@@ -5,7 +5,6 @@ use crate::{
     paths::{self, Path, PathSlice},
     references::*,
 };
-use mirai_annotations::{debug_checked_postcondition, debug_checked_precondition};
 use std::collections::{BTreeMap, BTreeSet};
 
 //**************************************************************************************************
@@ -166,7 +165,7 @@ impl<Loc: Copy, Lbl: Clone + Ord> BorrowGraph<Loc, Lbl> {
     }
 
     fn factor(&mut self, parent_id: RefID, loc: Loc, path: Path<Lbl>, intermediate_id: RefID) {
-        debug_checked_precondition!(self.check_invariant());
+        debug_assert!(self.check_invariant());
         let parent = self.0.get_mut(&parent_id).unwrap();
         let mut needs_factored = vec![];
         for (child_id, parent_to_child_edges) in &parent.borrowed_by.0 {
@@ -214,7 +213,7 @@ impl<Loc: Copy, Lbl: Clone + Ord> BorrowGraph<Loc, Lbl> {
             path,
             intermediate_id,
         );
-        debug_checked_postcondition!(self.check_invariant());
+        debug_assert!(self.check_invariant());
     }
 
     //**********************************************************************************************
@@ -225,7 +224,7 @@ impl<Loc: Copy, Lbl: Clone + Ord> BorrowGraph<Loc, Lbl> {
     /// Fixes any transitive borrows, so if `parent` borrowed by `id` borrowed by `child`
     /// After the release, `parent` borrowed by `child`
     pub fn release(&mut self, id: RefID) {
-        debug_checked_precondition!(self.check_invariant());
+        debug_assert!(self.check_invariant());
         let Ref {
             borrowed_by,
             borrows_from,
@@ -251,7 +250,7 @@ impl<Loc: Copy, Lbl: Clone + Ord> BorrowGraph<Loc, Lbl> {
             let child = self.0.get_mut(child_ref_id).unwrap();
             child.borrows_from.remove(&id);
         }
-        debug_checked_postcondition!(self.check_invariant());
+        debug_assert!(self.check_invariant());
     }
 
     fn splice_out_intermediate(
@@ -324,7 +323,7 @@ impl<Loc: Copy, Lbl: Clone + Ord> BorrowGraph<Loc, Lbl> {
     /// Utility for remapping the reference ids according the `id_map` provided
     /// If it is not in the map, the id remains the same
     pub fn remap_refs(&mut self, id_map: &BTreeMap<RefID, RefID>) {
-        debug_checked_precondition!(self.check_invariant());
+        debug_assert!(self.check_invariant());
         for info in self.0.values_mut() {
             info.remap_refs(id_map);
         }
@@ -333,7 +332,7 @@ impl<Loc: Copy, Lbl: Clone + Ord> BorrowGraph<Loc, Lbl> {
                 self.0.insert(*new, info);
             }
         }
-        debug_checked_postcondition!(self.check_invariant());
+        debug_assert!(self.check_invariant());
     }
 
     //**********************************************************************************************
@@ -344,10 +343,10 @@ impl<Loc: Copy, Lbl: Clone + Ord> BorrowGraph<Loc, Lbl> {
     /// It adds only 'unmatched' edges from other into self, i.e. for any edge in other, if there
     /// is an edge in self that is <= than that edge, it is not added.
     pub fn join(&self, other: &Self) -> Self {
-        debug_checked_precondition!(self.check_invariant());
-        debug_checked_precondition!(other.check_invariant());
-        debug_checked_precondition!(self.0.keys().all(|id| other.0.contains_key(id)));
-        debug_checked_precondition!(other.0.keys().all(|id| self.0.contains_key(id)));
+        debug_assert!(self.check_invariant());
+        debug_assert!(other.check_invariant());
+        debug_assert!(self.0.keys().all(|id| other.0.contains_key(id)));
+        debug_assert!(other.0.keys().all(|id| self.0.contains_key(id)));
 
         let mut joined = self.clone();
         for (parent_id, unmatched_borrowed_by) in self.unmatched_edges(other) {
@@ -357,7 +356,7 @@ impl<Loc: Copy, Lbl: Clone + Ord> BorrowGraph<Loc, Lbl> {
                 }
             }
         }
-        debug_checked_postcondition!(joined.check_invariant());
+        debug_assert!(joined.check_invariant());
         joined
     }
 

--- a/language/move-bytecode-verifier/Cargo.toml
+++ b/language/move-bytecode-verifier/Cargo.toml
@@ -11,7 +11,6 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0.52"
-mirai-annotations = "1.10.1"
 petgraph = "0.5.1"
 
 move-borrow-graph = { path = "../move-borrow-graph" }

--- a/language/move-bytecode-verifier/src/locals_safety/abstract_state.rs
+++ b/language/move-bytecode-verifier/src/locals_safety/abstract_state.rs
@@ -4,7 +4,6 @@
 //! This module defines the abstract state for the local safety analysis.
 
 use crate::absint::{AbstractDomain, JoinResult};
-use mirai_annotations::{checked_precondition, checked_verify};
 use move_binary_format::{
     binary_views::{BinaryIndexedView, FunctionView},
     errors::{PartialVMError, PartialVMResult},
@@ -80,7 +79,7 @@ impl AbstractState {
     }
 
     pub fn set_unavailable(&mut self, idx: LocalIndex) {
-        checked_precondition!(self.local_states[idx as usize] == Available);
+        assert!(self.local_states[idx as usize] == Available);
         self.local_states[idx as usize] = Unavailable
     }
 
@@ -92,9 +91,9 @@ impl AbstractState {
     }
 
     fn join_(&self, other: &Self) -> Self {
-        checked_precondition!(self.current_function == other.current_function);
-        checked_precondition!(self.all_local_abilities.len() == other.all_local_abilities.len());
-        checked_precondition!(self.local_states.len() == other.local_states.len());
+        assert!(self.current_function == other.current_function);
+        assert!(self.all_local_abilities.len() == other.all_local_abilities.len());
+        assert!(self.local_states.len() == other.local_states.len());
         let current_function = self.current_function;
         let all_local_abilities = self.all_local_abilities.clone();
         let local_states = self
@@ -132,7 +131,7 @@ impl AbstractDomain for AbstractState {
     /// attempts to join state to self and returns the result
     fn join(&mut self, state: &AbstractState) -> JoinResult {
         let joined = Self::join_(self, state);
-        checked_verify!(self.local_states.len() == joined.local_states.len());
+        assert!(self.local_states.len() == joined.local_states.len());
         let locals_unchanged = self
             .local_states
             .iter()

--- a/language/move-bytecode-verifier/src/locals_safety/mod.rs
+++ b/language/move-bytecode-verifier/src/locals_safety/mod.rs
@@ -9,7 +9,6 @@ mod abstract_state;
 
 use crate::absint::{AbstractInterpreter, BlockInvariant, BlockPostcondition, TransferFunctions};
 use abstract_state::{AbstractState, LocalState};
-use mirai_annotations::*;
 use move_binary_format::{
     binary_views::{BinaryIndexedView, FunctionView},
     errors::{PartialVMError, PartialVMResult},
@@ -75,7 +74,7 @@ fn execute_inner(
         Bytecode::Ret => {
             let local_states = state.local_states();
             let all_local_abilities = state.all_local_abilities();
-            checked_precondition!(local_states.len() == all_local_abilities.len());
+            assert!(local_states.len() == all_local_abilities.len());
             for (local_state, local_abilities) in local_states.iter().zip(all_local_abilities) {
                 match local_state {
                     LocalState::MaybeAvailable | LocalState::Available

--- a/language/move-bytecode-verifier/src/reference_safety/mod.rs
+++ b/language/move-bytecode-verifier/src/reference_safety/mod.rs
@@ -11,7 +11,6 @@ mod abstract_state;
 
 use crate::absint::{AbstractInterpreter, BlockInvariant, BlockPostcondition, TransferFunctions};
 use abstract_state::{AbstractState, AbstractValue};
-use mirai_annotations::*;
 use move_binary_format::{
     binary_views::{BinaryIndexedView, FunctionView},
     errors::{PartialVMError, PartialVMResult},
@@ -108,14 +107,14 @@ fn num_fields(struct_def: &StructDefinition) -> usize {
 
 fn pack(verifier: &mut ReferenceSafetyAnalysis, struct_def: &StructDefinition) {
     for _ in 0..num_fields(struct_def) {
-        checked_verify!(verifier.stack.pop().unwrap().is_value())
+        assert!(verifier.stack.pop().unwrap().is_value())
     }
     // TODO maybe call state.value_for
     verifier.stack.push(AbstractValue::NonReference)
 }
 
 fn unpack(verifier: &mut ReferenceSafetyAnalysis, struct_def: &StructDefinition) {
-    checked_verify!(verifier.stack.pop().unwrap().is_value());
+    assert!(verifier.stack.pop().unwrap().is_value());
     // TODO maybe call state.value_for
     for _ in 0..num_fields(struct_def) {
         verifier.stack.push(AbstractValue::NonReference)
@@ -172,7 +171,7 @@ fn execute_inner(
         Bytecode::WriteRef => {
             let id = verifier.stack.pop().unwrap().ref_id().unwrap();
             let val_operand = verifier.stack.pop().unwrap();
-            checked_verify!(val_operand.is_value());
+            assert!(val_operand.is_value());
             state.write_ref(offset, id)?
         }
 
@@ -212,34 +211,34 @@ fn execute_inner(
         }
 
         Bytecode::MutBorrowGlobal(idx) => {
-            checked_verify!(verifier.stack.pop().unwrap().is_value());
+            assert!(verifier.stack.pop().unwrap().is_value());
             let value = state.borrow_global(offset, true, *idx)?;
             verifier.stack.push(value)
         }
         Bytecode::MutBorrowGlobalGeneric(idx) => {
-            checked_verify!(verifier.stack.pop().unwrap().is_value());
+            assert!(verifier.stack.pop().unwrap().is_value());
             let struct_inst = verifier.resolver.struct_instantiation_at(*idx)?;
             let value = state.borrow_global(offset, true, struct_inst.def)?;
             verifier.stack.push(value)
         }
         Bytecode::ImmBorrowGlobal(idx) => {
-            checked_verify!(verifier.stack.pop().unwrap().is_value());
+            assert!(verifier.stack.pop().unwrap().is_value());
             let value = state.borrow_global(offset, false, *idx)?;
             verifier.stack.push(value)
         }
         Bytecode::ImmBorrowGlobalGeneric(idx) => {
-            checked_verify!(verifier.stack.pop().unwrap().is_value());
+            assert!(verifier.stack.pop().unwrap().is_value());
             let struct_inst = verifier.resolver.struct_instantiation_at(*idx)?;
             let value = state.borrow_global(offset, false, struct_inst.def)?;
             verifier.stack.push(value)
         }
         Bytecode::MoveFrom(idx) => {
-            checked_verify!(verifier.stack.pop().unwrap().is_value());
+            assert!(verifier.stack.pop().unwrap().is_value());
             let value = state.move_from(offset, *idx)?;
             verifier.stack.push(value)
         }
         Bytecode::MoveFromGeneric(idx) => {
-            checked_verify!(verifier.stack.pop().unwrap().is_value());
+            assert!(verifier.stack.pop().unwrap().is_value());
             let struct_inst = verifier.resolver.struct_instantiation_at(*idx)?;
             let value = state.move_from(offset, struct_inst.def)?;
             verifier.stack.push(value)
@@ -275,11 +274,11 @@ fn execute_inner(
         | Bytecode::ExistsGeneric(_) => (),
 
         Bytecode::BrTrue(_) | Bytecode::BrFalse(_) | Bytecode::Abort => {
-            checked_verify!(verifier.stack.pop().unwrap().is_value());
+            assert!(verifier.stack.pop().unwrap().is_value());
         }
         Bytecode::MoveTo(_) | Bytecode::MoveToGeneric(_) => {
             // resource value
-            checked_verify!(verifier.stack.pop().unwrap().is_value());
+            assert!(verifier.stack.pop().unwrap().is_value());
             // signer reference
             state.release_value(verifier.stack.pop().unwrap());
         }
@@ -311,8 +310,8 @@ fn execute_inner(
         | Bytecode::Gt
         | Bytecode::Le
         | Bytecode::Ge => {
-            checked_verify!(verifier.stack.pop().unwrap().is_value());
-            checked_verify!(verifier.stack.pop().unwrap().is_value());
+            assert!(verifier.stack.pop().unwrap().is_value());
+            assert!(verifier.stack.pop().unwrap().is_value());
             // TODO maybe call state.value_for
             verifier.stack.push(AbstractValue::NonReference)
         }
@@ -338,7 +337,7 @@ fn execute_inner(
 
         Bytecode::VecPack(idx, num) => {
             for _ in 0..*num {
-                checked_verify!(verifier.stack.pop().unwrap().is_value())
+                assert!(verifier.stack.pop().unwrap().is_value())
             }
 
             let element_type = vec_element_type(verifier, *idx)?;
@@ -354,20 +353,20 @@ fn execute_inner(
         }
 
         Bytecode::VecImmBorrow(_) => {
-            checked_verify!(verifier.stack.pop().unwrap().is_value());
+            assert!(verifier.stack.pop().unwrap().is_value());
             let vec_ref = verifier.stack.pop().unwrap();
             let elem_ref = state.vector_element_borrow(offset, vec_ref, false)?;
             verifier.stack.push(elem_ref);
         }
         Bytecode::VecMutBorrow(_) => {
-            checked_verify!(verifier.stack.pop().unwrap().is_value());
+            assert!(verifier.stack.pop().unwrap().is_value());
             let vec_ref = verifier.stack.pop().unwrap();
             let elem_ref = state.vector_element_borrow(offset, vec_ref, true)?;
             verifier.stack.push(elem_ref);
         }
 
         Bytecode::VecPushBack(_) => {
-            checked_verify!(verifier.stack.pop().unwrap().is_value());
+            assert!(verifier.stack.pop().unwrap().is_value());
             let vec_ref = verifier.stack.pop().unwrap();
             state.vector_op(offset, vec_ref, true)?;
         }
@@ -381,7 +380,7 @@ fn execute_inner(
         }
 
         Bytecode::VecUnpack(idx, num) => {
-            checked_verify!(verifier.stack.pop().unwrap().is_value());
+            assert!(verifier.stack.pop().unwrap().is_value());
 
             let element_type = vec_element_type(verifier, *idx)?;
             for _ in 0..*num {
@@ -390,8 +389,8 @@ fn execute_inner(
         }
 
         Bytecode::VecSwap(_) => {
-            checked_verify!(verifier.stack.pop().unwrap().is_value());
-            checked_verify!(verifier.stack.pop().unwrap().is_value());
+            assert!(verifier.stack.pop().unwrap().is_value());
+            assert!(verifier.stack.pop().unwrap().is_value());
             let vec_ref = verifier.stack.pop().unwrap();
             state.vector_op(offset, vec_ref, true)?;
         }
@@ -412,7 +411,7 @@ impl<'a> TransferFunctions for ReferenceSafetyAnalysis<'a> {
     ) -> Result<(), Self::AnalysisError> {
         execute_inner(self, state, bytecode, index)?;
         if index == last_index {
-            checked_verify!(self.stack.is_empty());
+            assert!(self.stack.is_empty());
             *state = state.construct_canonical_state()
         }
         Ok(())

--- a/language/move-bytecode-verifier/src/type_safety.rs
+++ b/language/move-bytecode-verifier/src/type_safety.rs
@@ -4,7 +4,6 @@
 //! This module defines the transfer functions for verifying type safety of a procedure body.
 //! It does not utilize control flow, but does check each block independently
 
-use mirai_annotations::*;
 use move_binary_format::{
     binary_views::{BinaryIndexedView, FunctionView},
     control_flow_graph::ControlFlowGraph,
@@ -837,7 +836,7 @@ fn instantiate(token: &SignatureToken, subst: &Signature) -> SignatureToken {
         TypeParameter(idx) => {
             // Assume that the caller has previously parsed and verified the structure of the
             // file and that this guarantees that type parameter indices are always in bounds.
-            assume!((*idx as usize) < subst.len());
+            debug_assert!((*idx as usize) < subst.len());
             subst.0[*idx as usize].clone()
         }
     }

--- a/language/move-core/types/Cargo.toml
+++ b/language/move-core/types/Cargo.toml
@@ -13,7 +13,6 @@ edition = "2018"
 anyhow = "1.0.52"
 bcs = "0.1.2"
 hex = "0.4.3"
-mirai-annotations = "1.10.1"
 once_cell = "1.7.2"
 proptest = { version = "1.0.0", default-features = false, optional = true }
 proptest-derive = { version = "0.3.0", default-features = false, optional = true }

--- a/language/move-core/types/src/gas_schedule.rs
+++ b/language/move-core/types/src/gas_schedule.rs
@@ -6,7 +6,6 @@
 //! It is important to note that the cost schedule defined in this file does not track hashing
 //! operations or other native operations; the cost of each native operation will be returned by the
 //! native function itself.
-use mirai_annotations::*;
 use serde::{Deserialize, Serialize};
 use std::{
     ops::{Add, Div, Mul, Sub},
@@ -241,13 +240,13 @@ pub struct CostTable {
 impl CostTable {
     #[inline]
     pub fn instruction_cost(&self, instr_index: u8) -> &GasCost {
-        precondition!(instr_index > 0 && instr_index <= (self.instruction_table.len() as u8));
+        debug_assert!(instr_index > 0 && instr_index <= (self.instruction_table.len() as u8));
         &self.instruction_table[(instr_index - 1) as usize]
     }
 
     #[inline]
     pub fn native_cost(&self, native_index: u8) -> &GasCost {
-        precondition!(native_index < (self.native_table.len() as u8));
+        debug_assert!(native_index < (self.native_table.len() as u8));
         &self.native_table[native_index as usize]
     }
 }

--- a/language/move-vm/runtime/Cargo.toml
+++ b/language/move-vm/runtime/Cargo.toml
@@ -14,7 +14,6 @@ edition = "2018"
 [dependencies]
 better_any = "0.1.1"
 fail = "0.4.0"
-mirai-annotations = "1.10.1"
 once_cell = "1.7.2"
 parking_lot = "0.11.1"
 sha3 = "0.9.1"

--- a/language/move-vm/runtime/src/lib.rs
+++ b/language/move-vm/runtime/src/lib.rs
@@ -9,9 +9,6 @@
 //! other blockchains can use it as well. The VM isn't there yet, but hopefully will be there
 //! soon.
 
-#[macro_use]
-extern crate mirai_annotations;
-
 pub mod data_cache;
 mod interpreter;
 mod loader;

--- a/language/move-vm/runtime/src/loader.rs
+++ b/language/move-vm/runtime/src/loader.rs
@@ -244,7 +244,7 @@ impl ModuleCache {
             let mut field_tys = vec![];
             for field in fields {
                 let ty = self.make_type_while_loading(module, &field.signature.0)?;
-                assume!(field_tys.len() < usize::max_value());
+                debug_assert!(field_tys.len() < usize::max_value());
                 field_tys.push(ty);
             }
 

--- a/language/move-vm/types/Cargo.toml
+++ b/language/move-vm/types/Cargo.toml
@@ -10,7 +10,6 @@ publish = false
 edition = "2018"
 
 [dependencies]
-mirai-annotations = "1.10.1"
 once_cell = "1.7.2"
 proptest = { version = "1.0.0", optional = true }
 serde = { version = "1.0.124", features = ["derive", "rc"] }

--- a/language/move-vm/types/src/gas_schedule.rs
+++ b/language/move-vm/types/src/gas_schedule.rs
@@ -6,7 +6,6 @@
 //! It is important to note that the cost schedule defined in this file does not track hashing
 //! operations or other native operations; the cost of each native operation will be returned by the
 //! native function itself.
-use mirai_annotations::*;
 use move_binary_format::{
     errors::{Location, PartialVMError, PartialVMResult, VMResult},
     file_format::{
@@ -446,7 +445,7 @@ pub fn calculate_intrinsic_gas(
     transaction_size: AbstractMemorySize<GasCarrier>,
     gas_constants: &GasConstants,
 ) -> InternalGasUnits<GasCarrier> {
-    precondition!(transaction_size.get() <= MAX_TRANSACTION_SIZE_IN_BYTES as GasCarrier);
+    debug_assert!(transaction_size.get() <= MAX_TRANSACTION_SIZE_IN_BYTES as GasCarrier);
     let min_transaction_fee = gas_constants.min_transaction_gas_units;
 
     if transaction_size.get() > gas_constants.large_transaction_cutoff.get() {

--- a/language/testing-infra/test-generation/Cargo.toml
+++ b/language/testing-infra/test-generation/Cargo.toml
@@ -12,7 +12,6 @@ edition = "2018"
 [dependencies]
 rand = "0.8.3"
 num_cpus = "1.13.0"
-mirai-annotations = "1.10.1"
 clap = { version = "3.1.8", features = ["derive"] }
 itertools = "0.10.0"
 hex = "0.4.3"
@@ -31,6 +30,3 @@ module-generation = { path = "../module-generation" }
 move-binary-format = { path = "../../move-binary-format" }
 move-stdlib = { path = "../../move-stdlib" }
 move-compiler = { path = "../../move-compiler" }
-
-[features]
-mirai-contracts = []

--- a/language/testing-infra/test-generation/src/abstract_state.rs
+++ b/language/testing-infra/test-generation/src/abstract_state.rs
@@ -51,7 +51,7 @@ pub enum Mutability {
 impl AbstractValue {
     /// Create a new primitive `AbstractValue` given its type; the kind will be `Copyable`
     pub fn new_primitive(token: SignatureToken) -> AbstractValue {
-        checked_precondition!(
+        assert!(
             match token {
                 SignatureToken::Struct(_)
                 | SignatureToken::StructInstantiation(_, _)
@@ -76,7 +76,7 @@ impl AbstractValue {
 
     /// Create a new reference `AbstractValue` given its type and kind
     pub fn new_reference(token: SignatureToken, abilities: AbilitySet) -> AbstractValue {
-        checked_precondition!(
+        assert!(
             matches!(
                 token,
                 SignatureToken::Reference(_) | SignatureToken::MutableReference(_)
@@ -88,7 +88,7 @@ impl AbstractValue {
 
     /// Create a new struct `AbstractValue` given its type and kind
     pub fn new_struct(token: SignatureToken, abilities: AbilitySet) -> AbstractValue {
-        checked_precondition!(
+        assert!(
             matches!(token, SignatureToken::Struct(_)),
             "AbstractValue::new_struct must be applied with a struct type"
         );
@@ -513,7 +513,7 @@ impl AbstractState {
     pub fn stack_push(&mut self, item: AbstractValue) {
         // Programs that are large enough to exceed this bound
         // will not be generated
-        assume!(self.stack.len() < usize::max_value());
+        debug_assert!(self.stack.len() < usize::max_value());
         self.stack.push(item);
     }
 
@@ -523,7 +523,7 @@ impl AbstractState {
         if let Some(abstract_value) = self.register_move() {
             // Programs that are large enough to exceed this bound
             // will not be generated
-            assume!(self.stack.len() < usize::max_value());
+            debug_assert!(self.stack.len() < usize::max_value());
             self.stack.push(abstract_value);
             Ok(())
         } else {

--- a/language/testing-infra/test-generation/src/borrow_graph.rs
+++ b/language/testing-infra/test-generation/src/borrow_graph.rs
@@ -66,7 +66,7 @@ impl BorrowGraph {
             }
             self.partition_map.insert(self.partition_counter, vec![n]);
             // Implication of `checked_add`
-            assume!(self.partitions.len() < usize::max_value());
+            debug_assert!(self.partitions.len() < usize::max_value());
             self.partitions.push(self.partition_counter);
             Ok(())
         } else {

--- a/language/testing-infra/test-generation/src/bytecode_generator.rs
+++ b/language/testing-infra/test-generation/src/bytecode_generator.rs
@@ -443,7 +443,7 @@ impl<'a> BytecodeGenerator<'a> {
                     || unsatisfied_preconditions == 0
                 {
                     // The size of matches cannot be greater than the number of bytecode instructions
-                    verify!(matches.len() < usize::max_value());
+                    debug_assert!(matches.len() < usize::max_value());
                     matches.push((*stack_effect, instruction));
                 }
             }
@@ -573,7 +573,7 @@ impl<'a> BytecodeGenerator<'a> {
         exact: bool,
     ) -> Option<AbstractState> {
         // Bytecode will never be generated this large
-        assume!(bytecode.len() < usize::max_value());
+        debug_assert!(bytecode.len() < usize::max_value());
         debug!("**********************");
         debug!("State1: {}", state);
         debug!("Next instr: {:?}", instruction);
@@ -726,7 +726,7 @@ impl<'a> BytecodeGenerator<'a> {
         let number_of_blocks = self.rng.gen_range(1..=MAX_CFG_BLOCKS);
         // The number of basic blocks must be at least one based on the
         // generation range.
-        assume!(number_of_blocks > 0);
+        debug_assert!(number_of_blocks > 0);
         let mut cfg = CFG::new(
             &mut self.rng,
             locals,
@@ -827,7 +827,7 @@ impl<'a> BytecodeGenerator<'a> {
         }
         // The CFG will be non-empty if we set the number of basic blocks to generate
         // to be non-zero
-        verify!(number_of_blocks > 0 || cfg.get_basic_blocks().is_empty());
+        debug_assert!(number_of_blocks > 0 || cfg.get_basic_blocks().is_empty());
         Some(cfg.serialize())
     }
 

--- a/language/testing-infra/test-generation/src/lib.rs
+++ b/language/testing-infra/test-generation/src/lib.rs
@@ -12,9 +12,6 @@ pub mod error;
 pub mod summaries;
 pub mod transitions;
 
-#[macro_use]
-extern crate mirai_annotations;
-
 use crate::config::{Args, EXECUTE_UNVERIFIED_MODULE, RUN_ON_VM};
 use bytecode_generator::BytecodeGenerator;
 use crossbeam_channel::{bounded, unbounded, Receiver, Sender};
@@ -399,7 +396,7 @@ pub(crate) fn substitute(token: &SignatureToken, tys: &[SignatureToken]) -> Sign
         TypeParameter(idx) => {
             // Assume that the caller has previously parsed and verified the structure of the
             // file and that this guarantees that type parameter indices are always in bounds.
-            assume!((*idx as usize) < tys.len());
+            debug_assert!((*idx as usize) < tys.len());
             tys[*idx as usize].clone()
         }
     }


### PR DESCRIPTION
- mirai is not being run. Replaced the annotations with the corresponding assert/debug_assert
- The mirai-only annotations are now debug_asserts, because why not

