### PR TITLE
Idiomatic "clap" usage (implements --version switch for tools)

### DIFF
--- a/devtools/x/src/main.rs
+++ b/devtools/x/src/main.rs
@@ -38,6 +38,7 @@ struct Args {
 }
 
 #[derive(Debug, Parser)]
+#[clap(author, version, about)]
 enum Command {
     #[clap(name = "bench")]
     /// Run `cargo bench`

--- a/language/evm/move-to-yul/Cargo.toml
+++ b/language/evm/move-to-yul/Cargo.toml
@@ -2,6 +2,7 @@
 name = "move-to-yul"
 version = "0.1.0"
 authors = ["Diem Association <opensource@diem.com>"]
+description = "Move Solidity Generator"
 publish = false
 edition = "2018"
 license = "Apache-2.0"

--- a/language/evm/move-to-yul/src/options.rs
+++ b/language/evm/move-to-yul/src/options.rs
@@ -7,7 +7,7 @@ use codespan_reporting::diagnostic::Severity;
 
 /// Options for a run of the compiler.
 #[derive(Parser, Debug)]
-#[clap(name = "move-to-yul", about = "Move Solidity Generator")]
+#[clap(author, version, about)]
 pub struct Options {
     /// Directories where to lookup dependencies.
     #[clap(

--- a/language/move-analyzer/src/bin/move-analyzer.rs
+++ b/language/move-analyzer/src/bin/move-analyzer.rs
@@ -15,7 +15,7 @@ use move_analyzer::{
 };
 
 #[derive(Parser)]
-#[clap(name = "move-analyzer", about = "A language server for Move")]
+#[clap(author, version, about)]
 struct Options {}
 
 fn main() {

--- a/language/move-compiler/Cargo.toml
+++ b/language/move-compiler/Cargo.toml
@@ -2,6 +2,7 @@
 name = "move-compiler"
 version = "0.0.1"
 authors = ["Diem Association <opensource@diem.com>"]
+description = "The definition of the Move source language, and its compiler"
 publish = false
 edition = "2018"
 license = "Apache-2.0"

--- a/language/move-compiler/src/bin/move-build.rs
+++ b/language/move-compiler/src/bin/move-build.rs
@@ -11,7 +11,12 @@ use move_compiler::{
 };
 
 #[derive(Debug, Parser)]
-#[clap(name = "Move Build", about = "Compile Move source to Move bytecode.")]
+#[clap(
+    name = "move-build",
+    about = "Compile Move source to Move bytecode",
+    author,
+    version
+)]
 pub struct Options {
     /// The source files to check and compile
     #[clap(

--- a/language/move-compiler/src/bin/move-check.rs
+++ b/language/move-compiler/src/bin/move-check.rs
@@ -12,8 +12,10 @@ use move_compiler::{
 
 #[derive(Debug, Parser)]
 #[clap(
-    name = "Move Check",
-    about = "Check Move source code, without compiling to bytecode."
+    name = "move-check",
+    about = "Check Move source code, without compiling to bytecode",
+    author,
+    version
 )]
 pub struct Options {
     /// The source files to check

--- a/language/move-ir-compiler/Cargo.toml
+++ b/language/move-ir-compiler/Cargo.toml
@@ -2,7 +2,7 @@
 name = "move-ir-compiler"
 version = "0.1.0"
 authors = ["Diem Association <opensource@diem.com>"]
-description = "Diem compiler"
+description = "Move IR to bytecode compiler"
 repository = "https://github.com/diem/diem"
 homepage = "https://diem.com"
 license = "Apache-2.0"

--- a/language/move-ir-compiler/src/main.rs
+++ b/language/move-ir-compiler/src/main.rs
@@ -22,7 +22,7 @@ use std::{
 };
 
 #[derive(Debug, Parser)]
-#[clap(name = "IR Compiler", about = "Move IR to bytecode compiler.")]
+#[clap(author, version, about)]
 struct Args {
     /// Treat input file as a module (default is to treat file as a script)
     #[clap(short = 'm', long = "module")]

--- a/language/move-prover/tools/spec-flatten/Cargo.toml
+++ b/language/move-prover/tools/spec-flatten/Cargo.toml
@@ -2,6 +2,7 @@
 name = "spec-flatten"
 version = "0.1.0"
 authors = ["Diem Association <opensource@diem.com>"]
+description = "Formal specification flattening tool"
 publish = false
 edition = "2018"
 license = "Apache-2.0"

--- a/language/move-prover/tools/spec-flatten/src/lib.rs
+++ b/language/move-prover/tools/spec-flatten/src/lib.rs
@@ -37,6 +37,7 @@ impl FromStr for FlattenPass {
 
 /// Options passed into the specification flattening tool.
 #[derive(Parser, Clone)]
+#[clap(author, version, about)]
 pub struct FlattenOptions {
     /// Options common and shared by the proving workflow and all passes
     #[clap(flatten)]

--- a/language/testing-infra/test-generation/Cargo.toml
+++ b/language/testing-infra/test-generation/Cargo.toml
@@ -2,7 +2,7 @@
 name = "test-generation"
 version = "0.1.0"
 authors = ["Diem Association <opensource@diem.com>"]
-description = "Diem test generation"
+description = "Tool for generating tests for the bytecode verifier and Move VM runtime"
 repository = "https://github.com/diem/diem"
 homepage = "https://diem.com"
 license = "Apache-2.0"

--- a/language/testing-infra/test-generation/src/config.rs
+++ b/language/testing-infra/test-generation/src/config.rs
@@ -82,11 +82,7 @@ pub fn module_generation_settings() -> ModuleGeneratorOptions {
 
 /// Command line arguments for the tool
 #[derive(Debug, Parser)]
-#[clap(
-    name = "Bytecode Test Generator",
-    author = "Diem",
-    about = "Tool for generating tests for the bytecode verifier and Move VM runtime."
-)]
+#[clap(author, version, about)]
 pub struct Args {
     /// The optional number of programs that will be generated. If not specified, program
     /// generation will run infinitely.

--- a/language/tools/move-bytecode-viewer/Cargo.toml
+++ b/language/tools/move-bytecode-viewer/Cargo.toml
@@ -2,6 +2,7 @@
 name = "move-bytecode-viewer"
 version = "0.1.0"
 authors = ["Diem Association <opensource@diem.com>"]
+description = "Explore Move bytecode and how the source code compiles to it"
 license = "Apache-2.0"
 publish = false
 edition = "2018"

--- a/language/tools/move-bytecode-viewer/src/lib.rs
+++ b/language/tools/move-bytecode-viewer/src/lib.rs
@@ -20,10 +20,7 @@ pub mod tui;
 pub mod viewer;
 
 #[derive(Debug, Parser)]
-#[clap(
-    name = "Move Bytecode Explorer",
-    about = "Explore Move bytecode and how the source code compiles to it"
-)]
+#[clap(author, version, about)]
 pub struct BytecodeViewerConfig {
     /// The path to the module binary
     #[clap(long = "module-path", short = 'b')]

--- a/language/tools/move-cli/src/lib.rs
+++ b/language/tools/move-cli/src/lib.rs
@@ -29,11 +29,7 @@ use std::path::PathBuf;
 type NativeFunctionRecord = (AccountAddress, Identifier, Identifier, NativeFunction);
 
 #[derive(Parser)]
-#[clap(
-    name = "move",
-    about = "CLI frontend for Move compiler and VM",
-    rename_all = "kebab-case"
-)]
+#[clap(author, version, about)]
 pub struct Move {
     /// Path to a package which the command should be run with respect to.
     #[clap(

--- a/language/tools/move-coverage/src/bin/coverage-summaries.rs
+++ b/language/tools/move-coverage/src/bin/coverage-summaries.rs
@@ -17,8 +17,10 @@ use std::{
 
 #[derive(Debug, Parser)]
 #[clap(
-    name = "Move VM Coverage Summary",
-    about = "Creates a coverage summary from the trace data collected from the Move VM"
+    name = "coverage-summaries",
+    about = "Creates a coverage summary from the trace data collected from the Move VM",
+    author,
+    version
 )]
 struct Args {
     /// The path to the coverage map or trace file

--- a/language/tools/move-coverage/src/bin/move-trace-conversion.rs
+++ b/language/tools/move-coverage/src/bin/move-trace-conversion.rs
@@ -9,8 +9,10 @@ use std::path::Path;
 
 #[derive(Debug, Parser)]
 #[clap(
-    name = "Move VM Coverage",
-    about = "Creates a coverage map from the raw data collected from the Move VM"
+    name = "move-trace-conversion",
+    about = "Creates a coverage map from the raw data collected from the Move VM",
+    author,
+    version
 )]
 struct Args {
     /// The path to the input file

--- a/language/tools/move-coverage/src/bin/source-coverage.rs
+++ b/language/tools/move-coverage/src/bin/source-coverage.rs
@@ -17,8 +17,10 @@ use std::{
 
 #[derive(Debug, Parser)]
 #[clap(
-    name = "Move Source Coverage",
-    about = "Annotate Move Source Code with Coverage Information"
+    name = "source-coverage",
+    about = "Annotate Move Source Code with Coverage Information",
+    author,
+    version
 )]
 struct Args {
     /// The path to the coverage map or trace file

--- a/language/tools/move-disassembler/Cargo.toml
+++ b/language/tools/move-disassembler/Cargo.toml
@@ -2,6 +2,7 @@
 name = "move-disassembler"
 version = "0.1.0"
 authors = ["Diem Association <opensource@diem.com>"]
+description = "Print a human-readable version of Move bytecode (.mv files)"
 license = "Apache-2.0"
 publish = false
 edition = "2018"

--- a/language/tools/move-disassembler/src/main.rs
+++ b/language/tools/move-disassembler/src/main.rs
@@ -18,10 +18,7 @@ use move_ir_types::location::Spanned;
 use std::{fs, path::Path};
 
 #[derive(Debug, Parser)]
-#[clap(
-    name = "Move Bytecode Disassembler",
-    about = "Print a human-readable version of Move bytecode (.mv files)"
-)]
+#[clap(author, version, about)]
 struct Args {
     /// Skip printing of private functions.
     #[clap(long = "skip-private")]

--- a/language/tools/move-explain/Cargo.toml
+++ b/language/tools/move-explain/Cargo.toml
@@ -2,7 +2,7 @@
 name = "move-explain"
 version = "0.1.0"
 authors = ["Diem Association <opensource@diem.com>"]
-description = "Diem Move abort code explanations"
+description = "Explain Move abort codes. Errors are defined as a global category + module-specific reason for the error"
 repository = "https://github.com/diem/diem"
 homepage = "https://diem.com"
 license = "Apache-2.0"

--- a/language/tools/move-explain/src/main.rs
+++ b/language/tools/move-explain/src/main.rs
@@ -8,10 +8,7 @@ use move_core_types::{
     language_storage::ModuleId,
 };
 #[derive(Debug, Parser)]
-#[clap(
-    name = "Move Explain",
-    about = "Explain Move abort codes. Errors are defined as a global category + module-specific reason for the error."
-)]
+#[clap(author, version, about)]
 struct Args {
     /// The location (module id) returned with a `MoveAbort` error
     #[clap(long = "location", short = 'l')]

--- a/language/tools/move-package/Cargo.toml
+++ b/language/tools/move-package/Cargo.toml
@@ -2,6 +2,7 @@
 name = "move-package"
 version = "0.1.0"
 authors = ["Diem Association <opensource@diem.com>"]
+description = "Package and build system for Move code"
 license = "Apache-2.0"
 publish = false
 edition = "2018"

--- a/language/tools/move-package/src/lib.rs
+++ b/language/tools/move-package/src/lib.rs
@@ -92,10 +92,7 @@ impl Architecture {
 }
 
 #[derive(Debug, Parser, Clone, Serialize, Deserialize, Eq, PartialEq, PartialOrd)]
-#[clap(
-    name = "Move Package",
-    about = "Package and build system for Move code."
-)]
+#[clap(author, version, about)]
 pub struct BuildConfig {
     /// Compile in 'dev' mode. The 'dev-addresses' and 'dev-dependencies' fields will be used if
     /// this flag is set. This flag is useful for development of packages that expose named

--- a/language/tools/move-unit-test/Cargo.toml
+++ b/language/tools/move-unit-test/Cargo.toml
@@ -2,7 +2,7 @@
 name = "move-unit-test"
 version = "0.1.0"
 authors = ["Diem Association <opensource@diem.com>"]
-description = "Unit testing framework for Move"
+description = "Unit testing framework for Move code"
 repository = "https://github.com/diem/diem"
 homepage = "https://diem.com"
 license = "Apache-2.0"

--- a/language/tools/move-unit-test/src/lib.rs
+++ b/language/tools/move-unit-test/src/lib.rs
@@ -26,7 +26,7 @@ use std::{
 };
 
 #[derive(Debug, Parser, Clone)]
-#[clap(name = "Move Unit Test", about = "Unit testing for Move code.")]
+#[clap(author, version, about)]
 pub struct UnitTestingConfig {
     /// Bound the number of instructions that can be executed by any one test.
     #[clap(


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Move Language.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

I wanted to provide `--version` switches for some of the tools. However, I noticed that almost none of the tools implemented that switch. Also, "clap" usage was inconsistent across the tools. So, ended up updating Cargo.toml for each of the tools, and simplified the "clap" usage for these tools.

When Move returns to versioned releases, the tools are now ready to communicate that information to the user :+1: 

The main commit:
```
[language] Idiomatic "clap" usage in CLI tools

Following the "clap" documentation on basic "clap" usage (fetching
the information from Cargo.toml). Now "clap" usage is (mostly)
consistent across the tools, the only exceptions being
move-compiler's move-check tool, and move-coverage's
coverage-summaries, move-trace-conversion and source-coverage. These
tools do not have their own Cargo.tomls.

Followed example:
github.com/clap-rs/clap/blob/v3.1.7/examples/cargo-example-derive.rs

Related commit (updating Cargo.toml descriptions for these tools):
096562e61 ("[language] Updated descriptions for some tools",
2022-04-26).

```

I followed this [example](github.com/clap-rs/clap/blob/v3.1.7/examples/cargo-example-derive.rs) on clap `derive` usage.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#pull-requests)?

Yes. Still the anchor `#pull-requests` is missing.

## Test Plan

Went manually through each binary, and executed `-V` switch on them. Only CLI tools not implementing the `-V` switch were non-clap-based `prover-lab`, `move-stdlib` and `prover-mutation`.