### PR TITLE
[runtime] add type_to_type_tag support for native functions

### DIFF
--- a/language/move-vm/runtime/src/native_functions.rs
+++ b/language/move-vm/runtime/src/native_functions.rs
@@ -9,6 +9,7 @@ use move_core_types::{
     account_address::AccountAddress,
     gas_schedule::CostTable,
     identifier::Identifier,
+    language_storage::TypeTag,
     value::MoveTypeLayout,
     vm_status::{StatusCode, StatusType},
 };
@@ -129,6 +130,10 @@ impl<'a, 'b> NativeContext<'a, 'b> {
 
     pub fn events(&self) -> &Vec<(Vec<u8>, u64, Type, MoveTypeLayout, Value)> {
         self.data_store.events()
+    }
+
+    pub fn type_to_type_tag(&self, ty: &Type) -> PartialVMResult<TypeTag> {
+        self.resolver.loader().type_to_type_tag(ty)
     }
 
     pub fn type_to_type_layout(&self, ty: &Type) -> PartialVMResult<Option<MoveTypeLayout>> {


### PR DESCRIPTION
I want to be able to obtain type information at run time from a Type.