### PR TITLE
[move-compiler] Fix empty vector constants. [move-vm] Fix function return types

### DIFF
--- a/language/move-compiler/tests/move_check/folding/non_constant_empty_vec.move
+++ b/language/move-compiler/tests/move_check/folding/non_constant_empty_vec.move
@@ -1,0 +1,30 @@
+// These vectors should not be made constants
+// If they are made constants, the IR will error
+
+module 0x42::M {
+    struct S {}
+
+    public fun empty_struct_vec(): vector<S> {
+        vector[]
+    }
+
+    public fun empty_signer_vec(): vector<signer> {
+        vector[]
+    }
+
+    public fun empty_generic_vec<T>(): vector<T> {
+        vector[]
+    }
+
+    public fun empty_struct_vec_vec(): vector<vector<S>> {
+        vector[]
+    }
+
+    public fun empty_signer_vec_vec(): vector<vector<signer>> {
+        vector[]
+    }
+
+    public fun empty_generic_vec_vec<T>(): vector<vector<T>> {
+        vector[]
+    }
+}

--- a/language/move-compiler/transactional-tests/tests/constants/non_constant_empty_vec.exp
+++ b/language/move-compiler/transactional-tests/tests/constants/non_constant_empty_vec.exp
@@ -1,0 +1,22 @@
+processed 8 tasks
+
+task 1 'run'. lines 33-33:
+return values: []
+
+task 2 'run'. lines 35-35:
+return values: []
+
+task 3 'run'. lines 37-37:
+return values: []
+
+task 4 'run'. lines 39-39:
+return values: []
+
+task 5 'run'. lines 41-41:
+return values: []
+
+task 6 'run'. lines 43-43:
+return values: []
+
+task 7 'run'. lines 45-45:
+return values: []

--- a/language/move-compiler/transactional-tests/tests/constants/non_constant_empty_vec.move
+++ b/language/move-compiler/transactional-tests/tests/constants/non_constant_empty_vec.move
@@ -1,0 +1,45 @@
+//# publish
+// These vectors should not be made constants
+// If they are made constants, the IR will error
+
+module 0x42::M {
+    struct S {}
+
+    public fun empty_struct_vec(): vector<S> {
+        vector[]
+    }
+
+    public fun empty_signer_vec(): vector<signer> {
+        vector[]
+    }
+
+    public fun empty_generic_vec<T>(): vector<T> {
+        vector[]
+    }
+
+    public fun empty_struct_vec_vec(): vector<vector<S>> {
+        vector[]
+    }
+
+    public fun empty_signer_vec_vec(): vector<vector<signer>> {
+        vector[]
+    }
+
+    public fun empty_generic_vec_vec<T>(): vector<vector<T>> {
+        vector[]
+    }
+}
+
+//# run 0x42::M::empty_struct_vec
+
+//# run 0x42::M::empty_struct_vec
+
+//# run 0x42::M::empty_signer_vec
+
+//# run 0x42::M::empty_generic_vec --type-args 0x42::M::S
+
+//# run 0x42::M::empty_struct_vec_vec
+
+//# run 0x42::M::empty_signer_vec_vec
+
+//# run 0x42::M::empty_generic_vec_vec --type-args 0x42::M::S

--- a/language/move-vm/runtime/src/runtime.rs
+++ b/language/move-vm/runtime/src/runtime.rs
@@ -335,6 +335,11 @@ impl VMRuntime {
         let (mut dummy_locals, deserialized_args) = self
             .deserialize_args(arg_types, serialized_args)
             .map_err(|e| e.finish(Location::Undefined))?;
+        let return_types = return_types
+            .into_iter()
+            .map(|ty| ty.subst(&ty_args))
+            .collect::<PartialVMResult<Vec<_>>>()
+            .map_err(|err| err.finish(Location::Undefined))?;
 
         let return_values = Interpreter::entrypoint(
             func,

--- a/language/move-vm/transactional-tests/tests/entry_points/generic_return_values.exp
+++ b/language/move-vm/transactional-tests/tests/entry_points/generic_return_values.exp
@@ -1,0 +1,49 @@
+processed 17 tasks
+
+task 1 'run'. lines 25-25:
+return values: 0
+
+task 2 'run'. lines 27-27:
+return values: 0
+
+task 3 'run'. lines 29-29:
+return values: [119, 97, 116]
+
+task 4 'run'. lines 31-31:
+return values: { 0 }
+
+task 5 'run'. lines 35-35:
+return values: [0]
+
+task 6 'run'. lines 37-37:
+return values: [0]
+
+task 7 'run'. lines 39-39:
+return values: [[119, 97, 116]]
+
+task 8 'run'. lines 41-41:
+return values: [{ 0 }]
+
+task 9 'run'. lines 45-45:
+return values: { 0 }
+
+task 10 'run'. lines 47-47:
+return values: { 0 }
+
+task 11 'run'. lines 49-49:
+return values: { [119, 97, 116] }
+
+task 12 'run'. lines 51-51:
+return values: { { 0 } }
+
+task 13 'run'. lines 55-55:
+return values: 0, 0
+
+task 14 'run'. lines 57-57:
+return values: false, 0
+
+task 15 'run'. lines 59-59:
+return values: { 0 }, [119, 97, 116]
+
+task 16 'run'. lines 61-61:
+return values: 00000000000000000000000000000042, { 0 }

--- a/language/move-vm/transactional-tests/tests/entry_points/generic_return_values.move
+++ b/language/move-vm/transactional-tests/tests/entry_points/generic_return_values.move
@@ -1,0 +1,61 @@
+//# publish
+
+module 0x42::Test {
+
+    struct Cup<T> { value: T }
+
+    public fun t1<T>(x: T): T {
+        x
+    }
+
+    public fun t2<T>(x: T): vector<T> {
+        vector[x]
+    }
+
+    public fun t3<T>(x: T): Cup<T> {
+        Cup { value: x }
+    }
+
+    public fun t4<T,U>(x: T, y: U): (U, T) {
+        (y, x)
+    }
+
+}
+
+//# run 0x42::Test::t1 --type-args u64 --args 0
+
+//# run 0x42::Test::t1 --type-args u8 --args 0u8
+
+//# run 0x42::Test::t1 --type-args vector<u8> --args b"wat"
+
+//# run 0x42::Test::t1 --type-args 0x42::Test::Cup<u64> --args 0
+
+
+
+//# run 0x42::Test::t2 --type-args u64 --args 0
+
+//# run 0x42::Test::t2 --type-args u8 --args 0u8
+
+//# run 0x42::Test::t2 --type-args vector<u8> --args b"wat"
+
+//# run 0x42::Test::t2 --type-args 0x42::Test::Cup<u64> --args 0
+
+
+
+//# run 0x42::Test::t3 --type-args u64 --args 0
+
+//# run 0x42::Test::t3 --type-args u8 --args 0u8
+
+//# run 0x42::Test::t3 --type-args vector<u8> --args b"wat"
+
+//# run 0x42::Test::t3 --type-args 0x42::Test::Cup<u64> --args 0
+
+
+
+//# run 0x42::Test::t4 --type-args u64 u8 --args 0 0u8
+
+//# run 0x42::Test::t4 --type-args u8 bool --args 0u8 false
+
+//# run 0x42::Test::t4 --type-args vector<u8> 0x42::Test::Cup<u64> --args b"wat" 0
+
+//# run 0x42::Test::t4 --type-args 0x42::Test::Cup<u64> address --args 0 0x42


### PR DESCRIPTION
- Fixed the compiler making empty vectors constants even if they had an invalid type for constants
- Fixed the vm runtime not substituting type arguments

## Motivation

- Fixing a bug @lxfind found
- Sorry for lumping in the VM fix in this PR too, but it is relatively small 


## Test Plan

- new tests
