### PR TITLE
[move-compiler] Support CRLF as newline for Move files

### DIFF
--- a/language/move-command-line-common/src/character_sets.rs
+++ b/language/move-command-line-common/src/character_sets.rs
@@ -15,10 +15,12 @@ pub fn is_permitted_printable_char(c: char) -> bool {
 
 /// Determine if a character is a permitted newline character.
 ///
-/// The only permitted newline character is \n. All others are invalid.
+/// The only permitted newline character is \n or \r\n. All others are invalid.
 pub fn is_permitted_newline_char(c: char) -> bool {
     let x = c as u32;
-    x == 0x0A
+    let is_cr = x == 0x0D; // \r
+    let is_lf = x == 0x0A; // \n
+    is_cr || is_lf
 }
 
 /// Determine if a character is permitted character.
@@ -34,6 +36,7 @@ mod tests {
     #[test]
     fn test_permitted_characters() {
         let mut good_chars = (0x20..=0x7E).collect::<Vec<u8>>();
+        good_chars.push(0x0D); // \r
         good_chars.push(0x0A); // \n
         good_chars.push(0x09); // \t
         for c in good_chars {

--- a/language/move-compiler/src/parser/comments.rs
+++ b/language/move-compiler/src/parser/comments.rs
@@ -12,7 +12,7 @@ pub type MatchedFileCommentMap = BTreeMap<u32, String>;
 pub type FileCommentMap = BTreeMap<(u32, u32), String>;
 
 // We restrict strings to only ascii visual characters (0x20 <= c <= 0x7E) or a permitted newline
-// character--\n--or a tab--\t.
+// character--\r--,--\n--or a tab--\t.
 pub fn verify_string(file_hash: FileHash, string: &str) -> Result<(), Diagnostics> {
     match string
         .chars()
@@ -24,7 +24,7 @@ pub fn verify_string(file_hash: FileHash, string: &str) -> Result<(), Diagnostic
             let loc = Loc::new(file_hash, idx as u32, idx as u32);
             let msg = format!(
                 "Invalid character '{}' found when reading file. Only ASCII printable characters, \
-                 tabs (\\t), and line endings (\\n) are permitted.",
+                 tabs (\\t), and line endings (\\r)(\\n) are permitted.",
                 chr
             );
             Err(Diagnostics::from(vec![diag!(

--- a/language/move-compiler/src/parser/lexer.rs
+++ b/language/move-compiler/src/parser/lexer.rs
@@ -223,7 +223,8 @@ impl<'input> Lexer<'input> {
         // Loop until we find text that isn't whitespace, and that isn't part of
         // a multi-line or single-line comment.
         loop {
-            // Trim only the whitespace characters we recognize: newline, tab, and space.
+            // Trim only the whitespace characters we recognize: newline(\n|\r\n), tab, and space.
+            text = text.trim_start_matches("\r\n");
             text = text.trim_start_matches(|c: char| matches!(c, '\n' | '\t' | ' '));
 
             if text.starts_with("/*") {
@@ -294,9 +295,12 @@ impl<'input> Lexer<'input> {
                 // If this was a documentation comment, record it in our map.
                 if is_doc {
                     let end = get_offset(text);
+                    let mut comment = &self.text[(start + 3)..end];
+                    comment = comment.trim_end_matches(|c: char| c != '\r');
+
                     self.doc_comments.insert(
                         (start as u32, end as u32),
-                        self.text[(start + 3)..end].to_string(),
+                        comment.to_string(),
                     );
                 }
 

--- a/language/move-compiler/tests/move_check/parser/invalid_character_comment.exp
+++ b/language/move-compiler/tests/move_check/parser/invalid_character_comment.exp
@@ -2,5 +2,5 @@ error[E01001]: invalid character
   ┌─ tests/move_check/parser/invalid_character_comment.move:3:44
   │
 3 │ // Non-ASCII characters in comments (e.g., ф) are also not allowed.
-  │                                            ^ Invalid character 'ф' found when reading file. Only ASCII printable characters, tabs (\t), and line endings (\n) are permitted.
+  │                                            ^ Invalid character 'ф' found when reading file. Only ASCII printable characters, tabs (\t), and line endings (\r)(\n) are permitted.
 

--- a/language/move-compiler/tests/move_check/parser/invalid_character_non_ascii.exp
+++ b/language/move-compiler/tests/move_check/parser/invalid_character_non_ascii.exp
@@ -2,5 +2,5 @@ error[E01001]: invalid character
   ┌─ tests/move_check/parser/invalid_character_non_ascii.move:5:4
   │
 5 │    ф
-  │    ^ Invalid character 'ф' found when reading file. Only ASCII printable characters, tabs (\t), and line endings (\n) are permitted.
+  │    ^ Invalid character 'ф' found when reading file. Only ASCII printable characters, tabs (\t), and line endings (\r)(\n) are permitted.
 

--- a/language/move-compiler/tests/move_check/parser/newline_crlf.move
+++ b/language/move-compiler/tests/move_check/parser/newline_crlf.move
@@ -1,0 +1,21 @@
+/// This is a test.
+module 0x8675309::M {
+    /**
+     * One can have /* nested */
+     * // block comments
+     */
+    fun f() { }
+
+    /* This is a nested /* regular comment // */ */
+    fun g() {}
+
+    // This is a line comment which contains unbalanced /* delimiter.
+    fun h() {}
+
+    // Comments in strings are not comments at all.
+    fun str(): vector<u8> {
+        b"http://diem.com"
+    }
+
+    // This is a regular comment which appears where a doc comment would not be allowed.
+}

--- a/language/move-ir-compiler/move-ir-to-bytecode/src/parser.rs
+++ b/language/move-ir-compiler/move-ir-to-bytecode/src/parser.rs
@@ -16,7 +16,7 @@ use move_ir_to_bytecode_syntax::syntax::{self, ParseError};
 use move_ir_types::{ast, location::*};
 
 // We restrict strings to only ascii visual characters (0x20 <= c <= 0x7E) or a permitted newline
-// character--\n--or a tab--\t. Checking each character in the input string is more fool-proof
+// character--\r--,--\n--or a tab--\t. Checking each character in the input string is more fool-proof
 // than checking each character later during lexing & tokenization, since that would require special
 // handling of characters inside of comments (usually not included as tokens) and within byte
 // array literals.
@@ -27,7 +27,7 @@ fn verify_string(string: &str) -> Result<()> {
         .map_or(Ok(()), |chr| {
             bail!(
                 "Parser Error: invalid character {} found when reading file.\
-                 Only ascii printable, tabs (\\t), and \\n line ending characters are permitted.",
+                 Only ascii printable, tabs (\\t), and \\r \\n line ending characters are permitted.",
                 chr
             )
         })
@@ -86,7 +86,8 @@ mod tests {
         good_chars.push(0x09);
 
         let mut bad_chars = (0x0..0x09).collect::<Vec<_>>();
-        bad_chars.append(&mut (0x0B..=0x1F).collect::<Vec<_>>());
+        bad_chars.append(&mut vec![0x0B, 0x0C]);
+        bad_chars.append(&mut (0x0E..=0x1F).collect::<Vec<_>>());
         bad_chars.push(0x7F);
 
         // Test to make sure that all the characters that are in the allowlist pass.

--- a/language/move-ir-compiler/move-ir-to-bytecode/syntax/src/lexer.rs
+++ b/language/move-ir-compiler/move-ir-to-bytecode/syntax/src/lexer.rs
@@ -174,7 +174,9 @@ impl<'input> Lexer<'input> {
         let mut text = &self.text[self.cur_end..];
         loop {
             // Trim the only whitespace characters we recognize: newline, tab, and space.
+            text = text.trim_start_matches("\r\n");
             text = text.trim_start_matches(|c: char| matches!(c, '\n' | '\t' | ' '));
+            
             // Trim the only comments we recognize: '// ... \n'.
             if text.starts_with("//") {
                 text = text.trim_start_matches(|c: char| c != '\n');

--- a/language/move-ir-compiler/transactional-tests/tests/parsing/crlf.exp
+++ b/language/move-ir-compiler/transactional-tests/tests/parsing/crlf.exp
@@ -1,0 +1,59 @@
+processed 6 tasks
+
+task 0 'print-bytecode'. lines 1-6:
+// Move bytecode v5
+script {
+
+
+main() {
+B0:
+	0: Ret
+}
+}
+
+task 1 'print-bytecode'. lines 8-14:
+// Move bytecode v5
+script {
+
+
+main() {
+B0:
+	0: Ret
+}
+}
+
+task 2 'print-bytecode'. lines 16-20:
+// Move bytecode v5
+script {
+
+
+main() {
+B0:
+	0: Ret
+}
+}
+
+task 3 'print-bytecode'. lines 22-27:
+// Move bytecode v5
+script {
+
+
+main() {
+B0:
+	0: Ret
+}
+}
+
+task 4 'print-bytecode'. lines 29-36:
+Error: ParserError: Invalid Token: invalid token kind for statement Slash
+
+task 5 'print-bytecode'. lines 38-46:
+// Move bytecode v5
+script {
+
+
+main() {
+B0:
+	0: Ret
+}
+}

--- a/language/move-ir-compiler/transactional-tests/tests/parsing/crlf.mvir
+++ b/language/move-ir-compiler/transactional-tests/tests/parsing/crlf.mvir
@@ -1,0 +1,46 @@
+//# print-bytecode
+main() {
+label b0:
+    // return;
+    return;
+}
+
+//# print-bytecode
+main() {
+label b0:
+    // return;
+    // return;
+    return;
+}
+
+//# print-bytecode
+main() {
+label b0:
+    return; // return;
+}
+
+//# print-bytecode
+main() {
+label b0:
+    // return;
+    return; // return;
+}
+
+//# print-bytecode
+// In Move, /* */ are block comment delimiters. Not so in Move IR, so the `/*` below
+// cannot be parsed.
+main() {
+label b0:
+    return;
+    /* return; */
+}
+
+//# print-bytecode
+// Since /* */ are not block comment delimiters, they do not behave in any unique way when
+// they appear within comments.
+main() {
+label b0:
+    // /*
+    return;
+    // */
+}


### PR DESCRIPTION
## Motivation

Fix issue: https://github.com/starcoinorg/starcoin/issues/3130

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

### move-ir-compiler
* test case
language/move-ir-compiler/transactional-tests/tests/parsing/crlf.mvir

* run test
``
  cd language/move-ir-compiler/transactional-tests && cargo test
``

### move-compiler
* test case
language/move-compiler/tests/move_check/parser/newline_crlf.move

* run test
``
  cd language/move-compiler && cargo test
``