### PR TITLE
[move package] rebuild only if sources have been modified or outputs are missing or outdated

### DIFF
--- a/language/tools/move-cli/tests/build_tests/rebuild_after_adding_new_source/Move.toml
+++ b/language/tools/move-cli/tests/build_tests/rebuild_after_adding_new_source/Move.toml
@@ -1,0 +1,3 @@
+[package]
+name = "Foo"
+version = "0.0.0"

--- a/language/tools/move-cli/tests/build_tests/rebuild_after_adding_new_source/args.evm.exp
+++ b/language/tools/move-cli/tests/build_tests/rebuild_after_adding_new_source/args.evm.exp
@@ -1,0 +1,7 @@
+Command `package build -v --arch ethereum`:
+COMPILING Foo to Yul
+GENERATING EVM bytecote from Yul
+External Command `touch sources/Bar.move`:
+Command `package build -v --arch ethereum`:
+COMPILING Foo to Yul
+GENERATING EVM bytecote from Yul

--- a/language/tools/move-cli/tests/build_tests/rebuild_after_adding_new_source/args.evm.txt
+++ b/language/tools/move-cli/tests/build_tests/rebuild_after_adding_new_source/args.evm.txt
@@ -1,0 +1,3 @@
+package build -v --arch ethereum
+> touch sources/Bar.move
+package build -v --arch ethereum

--- a/language/tools/move-cli/tests/build_tests/rebuild_after_adding_new_source/sources/Foo.move
+++ b/language/tools/move-cli/tests/build_tests/rebuild_after_adding_new_source/sources/Foo.move
@@ -1,0 +1,1 @@
+module 0x1::Foo {}

--- a/language/tools/move-cli/tests/build_tests/rebuild_after_deleting_output_artifact/Move.toml
+++ b/language/tools/move-cli/tests/build_tests/rebuild_after_deleting_output_artifact/Move.toml
@@ -1,0 +1,3 @@
+[package]
+name = "Foo"
+version = "0.0.0"

--- a/language/tools/move-cli/tests/build_tests/rebuild_after_deleting_output_artifact/args.evm.exp
+++ b/language/tools/move-cli/tests/build_tests/rebuild_after_deleting_output_artifact/args.evm.exp
@@ -1,0 +1,17 @@
+Command `package build -v --arch ethereum`:
+COMPILING Foo to Yul
+GENERATING EVM bytecote from Yul
+Command `package build -v --arch ethereum`:
+CACHED Foo
+External Command `rm build/evm/Foo.yul`:
+Command `package build -v --arch ethereum`:
+COMPILING Foo to Yul
+GENERATING EVM bytecote from Yul
+External Command `rm build/evm/Foo.bin`:
+Command `package build -v --arch ethereum`:
+COMPILING Foo to Yul
+GENERATING EVM bytecote from Yul
+External Command `rm build/evm/Foo.abi.json`:
+Command `package build -v --arch ethereum`:
+COMPILING Foo to Yul
+GENERATING EVM bytecote from Yul

--- a/language/tools/move-cli/tests/build_tests/rebuild_after_deleting_output_artifact/args.evm.txt
+++ b/language/tools/move-cli/tests/build_tests/rebuild_after_deleting_output_artifact/args.evm.txt
@@ -1,0 +1,8 @@
+package build -v --arch ethereum
+package build -v --arch ethereum
+> rm build/evm/Foo.yul
+package build -v --arch ethereum
+> rm build/evm/Foo.bin
+package build -v --arch ethereum
+> rm build/evm/Foo.abi.json
+package build -v --arch ethereum

--- a/language/tools/move-cli/tests/build_tests/rebuild_after_deleting_output_artifact/sources/Foo.move
+++ b/language/tools/move-cli/tests/build_tests/rebuild_after_deleting_output_artifact/sources/Foo.move
@@ -1,0 +1,1 @@
+module 0x1::Foo {}

--- a/language/tools/move-cli/tests/build_tests/rebuild_after_touching_manifest/Move.toml
+++ b/language/tools/move-cli/tests/build_tests/rebuild_after_touching_manifest/Move.toml
@@ -1,0 +1,3 @@
+[package]
+name = "Foo"
+version = "0.0.0"

--- a/language/tools/move-cli/tests/build_tests/rebuild_after_touching_manifest/args.evm.exp
+++ b/language/tools/move-cli/tests/build_tests/rebuild_after_touching_manifest/args.evm.exp
@@ -1,0 +1,7 @@
+Command `package build -v --arch ethereum`:
+COMPILING Foo to Yul
+GENERATING EVM bytecote from Yul
+External Command `touch Move.toml`:
+Command `package build -v --arch ethereum`:
+COMPILING Foo to Yul
+GENERATING EVM bytecote from Yul

--- a/language/tools/move-cli/tests/build_tests/rebuild_after_touching_manifest/args.evm.txt
+++ b/language/tools/move-cli/tests/build_tests/rebuild_after_touching_manifest/args.evm.txt
@@ -1,0 +1,3 @@
+package build -v --arch ethereum
+> touch Move.toml
+package build -v --arch ethereum

--- a/language/tools/move-cli/tests/build_tests/rebuild_after_touching_manifest/sources/Foo.move
+++ b/language/tools/move-cli/tests/build_tests/rebuild_after_touching_manifest/sources/Foo.move
@@ -1,0 +1,1 @@
+module 0x1::Foo {}

--- a/language/tools/move-cli/tests/build_tests/rebuild_after_touching_source/Move.toml
+++ b/language/tools/move-cli/tests/build_tests/rebuild_after_touching_source/Move.toml
@@ -1,0 +1,3 @@
+[package]
+name = "Foo"
+version = "0.0.0"

--- a/language/tools/move-cli/tests/build_tests/rebuild_after_touching_source/args.evm.exp
+++ b/language/tools/move-cli/tests/build_tests/rebuild_after_touching_source/args.evm.exp
@@ -1,0 +1,7 @@
+Command `package build -v --arch ethereum`:
+COMPILING Foo to Yul
+GENERATING EVM bytecote from Yul
+External Command `touch sources/Foo.move`:
+Command `package build -v --arch ethereum`:
+COMPILING Foo to Yul
+GENERATING EVM bytecote from Yul

--- a/language/tools/move-cli/tests/build_tests/rebuild_after_touching_source/args.evm.txt
+++ b/language/tools/move-cli/tests/build_tests/rebuild_after_touching_source/args.evm.txt
@@ -1,0 +1,3 @@
+package build -v --arch ethereum
+> touch sources/Foo.move
+package build -v --arch ethereum

--- a/language/tools/move-cli/tests/build_tests/rebuild_after_touching_source/sources/Foo.move
+++ b/language/tools/move-cli/tests/build_tests/rebuild_after_touching_source/sources/Foo.move
@@ -1,0 +1,1 @@
+module 0x1::Foo {}

--- a/language/tools/move-cli/tests/build_tests/rebuild_no_modification/Move.toml
+++ b/language/tools/move-cli/tests/build_tests/rebuild_no_modification/Move.toml
@@ -1,0 +1,3 @@
+[package]
+name = "Foo"
+version = "0.0.0"

--- a/language/tools/move-cli/tests/build_tests/rebuild_no_modification/args.evm.exp
+++ b/language/tools/move-cli/tests/build_tests/rebuild_no_modification/args.evm.exp
@@ -1,0 +1,5 @@
+Command `package build -v --arch ethereum`:
+COMPILING Foo to Yul
+GENERATING EVM bytecote from Yul
+Command `package build -v --arch ethereum`:
+CACHED Foo

--- a/language/tools/move-cli/tests/build_tests/rebuild_no_modification/args.evm.txt
+++ b/language/tools/move-cli/tests/build_tests/rebuild_no_modification/args.evm.txt
@@ -1,0 +1,2 @@
+package build -v --arch ethereum
+package build -v --arch ethereum

--- a/language/tools/move-cli/tests/build_tests/rebuild_no_modification/sources/Foo.move
+++ b/language/tools/move-cli/tests/build_tests/rebuild_no_modification/sources/Foo.move
@@ -1,0 +1,1 @@
+module 0x1::Foo {}

--- a/language/tools/move-package/src/lib.rs
+++ b/language/tools/move-package/src/lib.rs
@@ -1,8 +1,9 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-pub mod compilation;
 mod package_lock;
+
+pub mod compilation;
 pub mod resolution;
 pub mod source_package;
 


### PR DESCRIPTION
This implements some basic caching mechanism for `move package build --arch ethereum`. Recompilation will only be triggered when any of the following conditions is met:
1. Any of the sources has been modified, or more precisely, has a modification time later than those of the outputs
2. Any expected output file is missing

Tests have been added to ensure the conditions above are coded correctly. To support these new tests, this PR also extends `move-cli` so that it recognizes external commands in `args.txt`:
```
> touch Move.toml
```

It should be noted that this is a rather primitive design, which we may want to revisit in the future. Some possible improvements I can think of:
1. Fingerprints/hashes/build_info.json
  a. https://github.com/rust-lang/cargo/blob/master/src/cargo/core/compiler/fingerprint.rs seems helpful
3. Better integration with the regular `move package build` pipeline
4. Support for multiple compilation units (this may be controversial)