### PR TITLE
[evm] Contract modules and storage parameters (1st step)

### DIFF
--- a/language/evm/examples/sources/ERC1155.move
+++ b/language/evm/examples/sources/ERC1155.move
@@ -1,4 +1,4 @@
-#[contract]
+#[evm_contract]
 /// An implementation of the ERC-1155 Multi Token Standard.
 module Evm::ERC1155 {
     use Evm::Evm::{sender, self, sign, emit, isContract};

--- a/language/evm/examples/sources/ERC165.move
+++ b/language/evm/examples/sources/ERC165.move
@@ -1,4 +1,4 @@
-#[contract]
+#[evm_contract]
 /// An implementation of the ERC-165.
 module Evm::ERC165 {
     use Evm::IERC165;

--- a/language/evm/examples/sources/ERC20.move
+++ b/language/evm/examples/sources/ERC20.move
@@ -1,4 +1,4 @@
-#[contract]
+#[evm_contract]
 /// An implementation of the ERC-20 Token Standard.
 module Evm::ERC20 {
     use Evm::Evm::{sender, self, sign, emit};

--- a/language/evm/examples/sources/ERC721.move
+++ b/language/evm/examples/sources/ERC721.move
@@ -1,4 +1,4 @@
-#[contract]
+#[evm_contract]
 /// An implementation of the ERC-721 Non-Fungible Token Standard.
 module Evm::ERC721 {
     use Evm::Evm::{sender, self, sign, emit, isContract, tokenURI_with_baseURI};

--- a/language/evm/examples/sources/Faucet.move
+++ b/language/evm/examples/sources/Faucet.move
@@ -1,4 +1,4 @@
-#[contract]
+#[evm_contract]
 /// Faucet example in the Ethereum book.
 module 0x42::Faucet {
     use Evm::Evm::{sender, value, self, sign, balance, transfer, emit};

--- a/language/evm/examples/sources/Token.move
+++ b/language/evm/examples/sources/Token.move
@@ -1,4 +1,4 @@
-#[contract]
+#[evm_contract]
 /// An implementation of ERC20.
 module Evm::ERC20Token {
     use Evm::Evm::{sender, self, sign};

--- a/language/evm/exec-utils/src/compile.rs
+++ b/language/evm/exec-utils/src/compile.rs
@@ -21,7 +21,11 @@ fn solc_path() -> Result<PathBuf> {
     let solc_exe = move_command_line_common::env::read_env_var("SOLC_EXE");
 
     if solc_exe.is_empty() {
-        bail!("failed to find path to solc -- is the environment variable SOLC_EXE set?")
+        bail!(
+            "failed to resolve path to solc (Solidity compiler).
+            Is the environment variable SOLC_EXE set?
+            Did you run `./scripts/dev_setup.sh -d`?"
+        )
     }
 
     Ok(PathBuf::from(&solc_exe))
@@ -37,7 +41,7 @@ fn solc_impl(
         .arg("-o")
         .arg(output_dir)
         .output()
-        .map_err(|err| format_err!("failed to call solc: {:?}", err))?;
+        .map_err(|err| format_err!("failed to call solc (solidity compiler): {:?}", err))?;
 
     let mut compiled_contracts = BTreeMap::new();
 

--- a/language/evm/hardhat-examples/contracts/Caller/sources/Caller.move
+++ b/language/evm/hardhat-examples/contracts/Caller/sources/Caller.move
@@ -1,4 +1,4 @@
-#[contract]
+#[evm_contract]
 module Evm::Caller {
     use Evm::U256::{Self, U256};
     use Evm::ExternalResult::{Self, ExternalResult};

--- a/language/evm/hardhat-examples/contracts/ERC1155Mock/sources/ERC1155Mock.move
+++ b/language/evm/hardhat-examples/contracts/ERC1155Mock/sources/ERC1155Mock.move
@@ -1,4 +1,4 @@
-#[contract]
+#[evm_contract]
 /// An implementation of the ERC-1155 Multi Token Standard.
 module Evm::ERC1155Mock {
     use Evm::Evm::{sender, self, sign, emit, isContract, abort_with, require};
@@ -119,7 +119,6 @@ module Evm::ERC1155Mock {
         id: U256,
     }
 
-    #[storage]
     /// Represents the state of this contract. This is located at `borrow_global<State>(self())`.
     struct State has key {
         balances: Table<U256, Table<address, U256>>,

--- a/language/evm/hardhat-examples/contracts/ERC1155Tradable/sources/ERC1155Tradable.move
+++ b/language/evm/hardhat-examples/contracts/ERC1155Tradable/sources/ERC1155Tradable.move
@@ -1,4 +1,4 @@
-#[contract]
+#[evm_contract]
 /// An implementation of the ERC1155Tradable (https://github.com/ProjectOpenSea/opensea-erc1155/blob/master/contracts/ERC1155Tradable.sol).
 module Evm::ERC1155Tradable {
     use Evm::Evm::{sender, self, sign, emit, isContract, abort_with, require, tokenURI_with_baseURI};
@@ -114,7 +114,6 @@ module Evm::ERC1155Tradable {
         id: U256,
     }
 
-    #[storage]
     /// Represents the state of this contract. This is located at `borrow_global<State>(self())`.
     struct State has key {
         name: vector<u8>,

--- a/language/evm/hardhat-examples/contracts/ERC20DecimalsMock/sources/ERC20DecimalsMock.move
+++ b/language/evm/hardhat-examples/contracts/ERC20DecimalsMock/sources/ERC20DecimalsMock.move
@@ -1,4 +1,4 @@
-#[contract]
+#[evm_contract]
 /// An implementation of the ERC-20 Token Standard.
 module Evm::ERC20DecimalsMock {
     use Evm::Evm::{sender, self, sign, emit, require};
@@ -19,7 +19,6 @@ module Evm::ERC20DecimalsMock {
         value: U256,
     }
 
-    #[storage]
     /// Represents the state of this contract. This is located at `borrow_global<State>(self())`.
     struct State has key {
         balances: Table<address, U256>,

--- a/language/evm/hardhat-examples/contracts/ERC20Mock/sources/ERC20Mock.move
+++ b/language/evm/hardhat-examples/contracts/ERC20Mock/sources/ERC20Mock.move
@@ -1,4 +1,4 @@
-#[contract]
+#[evm_contract]
 /// An implementation of the ERC-20 Token Standard.
 module Evm::ERC20Mock {
     use Evm::Evm::{sender, self, sign, emit, require};
@@ -19,7 +19,6 @@ module Evm::ERC20Mock {
         value: U256,
     }
 
-    #[storage]
     /// Represents the state of this contract. This is located at `borrow_global<State>(self())`.
     struct State has key {
         balances: Table<address, U256>,

--- a/language/evm/hardhat-examples/contracts/ERC721Mock/sources/ERC721Mock.move
+++ b/language/evm/hardhat-examples/contracts/ERC721Mock/sources/ERC721Mock.move
@@ -1,4 +1,4 @@
-#[contract]
+#[evm_contract]
 /// An implementation of the ERC-721 Non-Fungible Token Standard.
 module Evm::ERC721 {
     use Evm::Evm::{sender, self, sign, emit, isContract, tokenURI_with_baseURI, require, abort_with};
@@ -130,7 +130,6 @@ module Evm::ERC721 {
         approved: bool,
     }
 
-    #[storage]
     /// Represents the state of this contract.
     /// This is located at `borrow_global<State>(self())`.
     struct State has key {

--- a/language/evm/hardhat-examples/contracts/ERC721Tradable/sources/ERC721Tradable.move
+++ b/language/evm/hardhat-examples/contracts/ERC721Tradable/sources/ERC721Tradable.move
@@ -1,4 +1,4 @@
-#[contract]
+#[evm_contract]
 /// An implementation of the ERC-721 Non-Fungible Token Standard.
 module Evm::ERC721Tradable {
     use Evm::Evm::{sender, self, sign, emit, isContract, tokenURI_with_baseURI, require, abort_with};
@@ -134,7 +134,6 @@ module Evm::ERC721Tradable {
         approved: bool,
     }
 
-    #[storage]
     /// Represents the state of this contract. This is located at `borrow_global<State>(self())`.
     struct State has key {
         name: vector<u8>,
@@ -148,8 +147,8 @@ module Evm::ERC721Tradable {
         proxyRegistryAddress: address,
     }
 
-    /// Constructor of this contract.
     #[create(sig=b"constructor(string,string,address,string)")]
+    /// Constructor of this contract.
     public fun create(name: vector<u8>, symbol: vector<u8>, proxyRegistryAddress: address, baseURI: vector<u8>) acquires State {
         // Initial state of contract
         move_to<State>(

--- a/language/evm/hardhat-examples/contracts/Event/sources/Event.move
+++ b/language/evm/hardhat-examples/contracts/Event/sources/Event.move
@@ -1,3 +1,4 @@
+#[evm_contract]
 module 0x1::FortyTwo {
     use Evm::Evm::{emit};
     use Evm::U256::U256;

--- a/language/evm/hardhat-examples/contracts/ExternalCall/sources/ExternalCall.move
+++ b/language/evm/hardhat-examples/contracts/ExternalCall/sources/ExternalCall.move
@@ -1,4 +1,4 @@
-#[contract]
+#[evm_contract]
 module Evm::ExternalCall {
     use Evm::ExternalResult::{Self, ExternalResult};
     use Evm::Evm::Unit;

--- a/language/evm/hardhat-examples/contracts/FortyTwo/sources/FortyTwo.move
+++ b/language/evm/hardhat-examples/contracts/FortyTwo/sources/FortyTwo.move
@@ -1,3 +1,4 @@
+#[evm_contract]
 module 0x1::FortyTwo {
     use Evm::U256::{u256_from_u128, U256};
 

--- a/language/evm/hardhat-examples/contracts/Greeter/sources/Greeter.move
+++ b/language/evm/hardhat-examples/contracts/Greeter/sources/Greeter.move
@@ -1,9 +1,8 @@
-#[contract]
+#[evm_contract]
 module Evm::Greeter {
     use Evm::Evm::{self};
     use Evm::Evm::sign;
 
-    #[storage]
     struct State has key {
         greeting: vector<u8>,
     }

--- a/language/evm/hardhat-examples/contracts/Native/sources/Native.move
+++ b/language/evm/hardhat-examples/contracts/Native/sources/Native.move
@@ -1,3 +1,4 @@
+#[evm_contract]
 module 0x1::Native {
     use Evm::Evm::{self, sender, isContract};
 

--- a/language/evm/hardhat-examples/contracts/Revert/sources/Revert.move
+++ b/language/evm/hardhat-examples/contracts/Revert/sources/Revert.move
@@ -1,3 +1,4 @@
+#[evm_contract]
 module 0x1::Revert {
     use Evm::U256::{u256_from_u128, U256};
     use Evm::Evm::abort_with;

--- a/language/evm/hardhat-examples/contracts/Token/sources/Token.move
+++ b/language/evm/hardhat-examples/contracts/Token/sources/Token.move
@@ -1,10 +1,10 @@
+#[evm_contract]
 module Evm::Token {
     use Evm::Evm::{self, sender, sign};
     use Evm::Table::{Self, Table};
     use Evm::U256::{Self, U256};
     use Std::Errors;
 
-    #[storage]
     /// Represents the state of this contract. This is located at `borrow_global<State>(self())`.
     struct State has key {
         total_supply: U256,

--- a/language/evm/move-to-yul/src/attributes.rs
+++ b/language/evm/move-to-yul/src/attributes.rs
@@ -8,6 +8,8 @@ use move_model::{
     model::{FunctionEnv, GlobalEnv, ModuleEnv, StructEnv},
 };
 
+const CONTRACT_ATTR: &str = "evm_contract";
+const STORAGE_ATTR: &str = "storage";
 const CREATE_ATTR: &str = "create";
 const CALLABLE_ATTR: &str = "callable";
 const EVM_ARITH_ATTR: &str = "evm_arith";
@@ -113,6 +115,11 @@ pub fn extract_encode_signature(fun: &FunctionEnv<'_>, packed_flag: bool) -> Opt
     extract_attr_value_str(fun.module_env.env, fun.get_attributes(), attr, SIGNATURE)
 }
 
+/// Extract the contract name.
+pub fn extract_contract_name(module: &ModuleEnv<'_>) -> Option<String> {
+    extract_attr_value_str(module.env, module.get_attributes(), CONTRACT_ATTR, "name")
+}
+
 /// Check whether an attribute is present in an attribute list.
 pub fn has_attr(env: &GlobalEnv, attrs: &[Attribute], name: &str, simple_flag: bool) -> bool {
     let is_empty = |args: &Vec<Attribute>| {
@@ -132,9 +139,29 @@ pub fn has_attr(env: &GlobalEnv, attrs: &[Attribute], name: &str, simple_flag: b
     })
 }
 
+/// Check whether the module has a `#[evm_contract]` attribute.
+pub fn is_evm_contract_module(module: &ModuleEnv) -> bool {
+    has_attr(module.env, module.get_attributes(), CONTRACT_ATTR, false)
+}
+
 /// Check whether the module has a `#[evm_arith]` attribute.
 pub fn is_evm_arith_module(module: &ModuleEnv) -> bool {
     has_attr(module.env, module.get_attributes(), EVM_ARITH_ATTR, true)
+}
+
+/// Check whether the struct has a `#[storage]` attribute.
+pub fn is_storage_struct(str: &StructEnv) -> bool {
+    has_attr(
+        str.module_env.env,
+        str.get_attributes(),
+        STORAGE_ATTR,
+        false,
+    )
+}
+
+/// Check whether the struct has a `#[event]` attribute.
+pub fn is_event_struct(str: &StructEnv) -> bool {
+    has_attr(str.module_env.env, str.get_attributes(), EVENT_ATTR, false)
 }
 
 /// Check whether the function has a `#[callable]` attribute.
@@ -200,11 +227,6 @@ pub fn is_external_fun(fun: &FunctionEnv<'_>) -> bool {
         EXTERNAL_ATTR,
         false,
     )
-}
-
-/// Check whether the struct has a `#[event]` attribute.
-pub fn is_event_struct(st: &StructEnv<'_>) -> bool {
-    has_attr(st.module_env.env, st.get_attributes(), EVENT_ATTR, false)
 }
 
 pub(crate) fn construct_fun_attribute(fun: &FunctionEnv<'_>) -> Option<FunctionAttribute> {

--- a/language/evm/move-to-yul/src/lib.rs
+++ b/language/evm/move-to-yul/src/lib.rs
@@ -17,13 +17,17 @@ pub mod generator;
 mod native_functions;
 pub mod options;
 mod solidity_ty;
+mod storage;
 mod tables;
 mod vectors;
 mod yul_functions;
 
 use crate::{generator::Generator, options::Options};
 use anyhow::anyhow;
-use codespan_reporting::term::termcolor::{ColorChoice, StandardStream, WriteColor};
+use codespan_reporting::{
+    diagnostic::Severity,
+    term::termcolor::{ColorChoice, StandardStream, WriteColor},
+};
 use move_compiler::shared::PackagePaths;
 use move_model::{
     model::GlobalEnv, options::ModelBuilderOptions, parse_addresses_from_options,
@@ -61,18 +65,28 @@ pub fn run_to_yul<W: WriteColor>(error_writer: &mut W, mut options: Options) -> 
         error_writer,
         "exiting with Move build errors",
     )?;
-    let (_, content, abi_content) = Generator::run(&options, &env);
+    let mut contracts = Generator::run(&options, &env);
+    if contracts.len() > 1 {
+        env.diag(
+            Severity::Warning,
+            &env.unknown_loc(),
+            "current restriction: \
+        only one contract per compiler run (additional contracts ignored)",
+        );
+    }
     check_errors(
         &env,
         &options,
         error_writer,
         "exiting with Yul generation errors",
     )?;
-    if let Some(i) = options.output.rfind('.') {
-        options.abi_output = format!("{}.abi.json", &options.output[..i]);
+    if let Some((_, content, abi_content)) = contracts.pop() {
+        if let Some(i) = options.output.rfind('.') {
+            options.abi_output = format!("{}.abi.json", &options.output[..i]);
+        }
+        fs::write(options.output, &content)?;
+        fs::write(options.abi_output, &abi_content)?;
     }
-    fs::write(options.output, &content)?;
-    fs::write(options.abi_output, &abi_content)?;
     Ok(())
 }
 

--- a/language/evm/move-to-yul/src/native_functions.rs
+++ b/language/evm/move-to-yul/src/native_functions.rs
@@ -73,10 +73,11 @@ impl NativeFunctions {
                         ctx.env.error(
                             &gen.parent.contract_loc,
                             &format!(
-                                "native function {} can only emit event structs",
+                                "native function {} can only emit event structs but `{}` is not an #[event]",
                                 ctx.env
                                     .get_function(fun_id.to_qualified_id())
-                                    .get_full_name_str()
+                                    .get_full_name_str(),
+                                ctx.env.display(&st_id)
                             ),
                         )
                     }

--- a/language/evm/move-to-yul/src/storage.rs
+++ b/language/evm/move-to-yul/src/storage.rs
@@ -1,0 +1,344 @@
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{context::Context, yul_functions::YulFunction, Generator};
+use move_model::{
+    emitln,
+    model::{QualifiedInstId, StructId},
+    ty::Type,
+};
+
+impl Generator {
+    /// Move resource from memory to storage.
+    pub(crate) fn move_to(
+        &mut self,
+        ctx: &Context,
+        struct_id: QualifiedInstId<StructId>,
+        signer_ref: String,
+        value: String,
+    ) {
+        let addr = self.call_builtin_str(ctx, YulFunction::LoadU256, std::iter::once(signer_ref));
+        self.move_to_addr(ctx, struct_id, addr, value)
+    }
+
+    /// Move resource from memory to storage, with direct address.
+    pub(crate) fn move_to_addr(
+        &mut self,
+        ctx: &Context,
+        struct_id: QualifiedInstId<StructId>,
+        addr: String,
+        value: String,
+    ) {
+        ctx.emit_block(|| {
+            emitln!(
+                ctx.writer,
+                "let $base_offset := {}",
+                self.type_storage_base(
+                    ctx,
+                    &struct_id.to_type(),
+                    "${RESOURCE_STORAGE_CATEGORY}",
+                    addr,
+                )
+            );
+            let base_offset = "$base_offset";
+
+            // At the base offset we store a boolean indicating whether the resource exists. Check this
+            // and if it is set, abort. Otherwise set this bit.
+            let exists_call = self.call_builtin_str(
+                ctx,
+                YulFunction::AlignedStorageLoad,
+                std::iter::once(base_offset.to_string()),
+            );
+            let abort_call =
+                self.call_builtin_str(ctx, YulFunction::AbortBuiltin, std::iter::empty());
+            emitln!(ctx.writer, "if {} {{\n  {}\n}}", exists_call, abort_call);
+            self.call_builtin(
+                ctx,
+                YulFunction::AlignedStorageStore,
+                vec![base_offset.to_string(), "true".to_string()].into_iter(),
+            );
+
+            // Move the struct to storage.
+            ctx.emit_block(|| {
+                // The actual resource data starts at base_offset + 32. Set the destination address
+                // to this.
+                emitln!(
+                    ctx.writer,
+                    "let $dst := add({}, ${{RESOURCE_EXISTS_FLAG_SIZE}})",
+                    base_offset
+                );
+                emitln!(ctx.writer, "let $src := {}", value);
+                // Perform the move.
+                self.move_struct_to_storage(
+                    ctx,
+                    &struct_id,
+                    "$src".to_string(),
+                    "$dst".to_string(),
+                    true,
+                );
+            });
+        })
+    }
+
+    /// Moves a struct from memory to storage. This recursively moves linked data like
+    /// nested structs and vectors.
+    pub(crate) fn move_struct_to_storage(
+        &mut self,
+        ctx: &Context,
+        struct_id: &QualifiedInstId<StructId>,
+        src: String,
+        dst: String,
+        clean_flag: bool,
+    ) {
+        let layout = ctx.get_struct_layout(struct_id);
+
+        // By invariant we know that the leading fields are pointer fields. Copy them first.
+        for field_offs in layout.field_order.iter().take(layout.pointer_count) {
+            let (byte_offs, ty) = layout.offsets.get(field_offs).unwrap();
+            assert_eq!(byte_offs % 32, 0, "pointer fields are on word boundary");
+            ctx.emit_block(|| {
+                let linked_src_name = format!("$linked_src_{}", self.type_hash(ctx, ty));
+                let linked_dst_name = format!("$linked_dst_{}", self.type_hash(ctx, ty));
+
+                // Load the pointer to the linked memory.
+                emitln!(
+                    ctx.writer,
+                    "let {} := mload({})",
+                    linked_src_name,
+                    format!("add({}, {})", src, byte_offs)
+                );
+                self.create_and_move_data_to_linked_storage(
+                    ctx,
+                    ty,
+                    linked_src_name,
+                    linked_dst_name.clone(),
+                    clean_flag,
+                );
+                // Store the result at the destination
+                self.call_builtin(
+                    ctx,
+                    YulFunction::AlignedStorageStore,
+                    vec![format!("add({}, {})", dst, byte_offs), linked_dst_name].into_iter(),
+                )
+            });
+        }
+
+        // The remaining fields are all primitive. We also know that memory is padded to word size,
+        // so we can just copy directly word by word, which has the lowest gas cost.
+        if layout.pointer_count < layout.field_order.len() {
+            let mut byte_offs = layout
+                .offsets
+                .get(&layout.field_order[layout.pointer_count])
+                .unwrap()
+                .0;
+            assert_eq!(
+                byte_offs % 32,
+                0,
+                "first non-pointer field on word boundary"
+            );
+            while byte_offs < layout.size {
+                self.call_builtin(
+                    ctx,
+                    YulFunction::AlignedStorageStore,
+                    vec![
+                        format!("add({}, {})", dst, byte_offs),
+                        format!("mload(add({}, {}))", src, byte_offs),
+                    ]
+                    .into_iter(),
+                );
+                byte_offs += 32
+            }
+        }
+
+        // Free the memory allocated by this struct.
+        if clean_flag {
+            self.call_builtin(
+                ctx,
+                YulFunction::Free,
+                vec![src, layout.size.to_string()].into_iter(),
+            )
+        }
+    }
+
+    /// Move a struct from storage to memory, zeroing all associated storage. This recursively
+    /// moves linked data like nested structs and vectors.
+    pub(crate) fn move_struct_to_memory(
+        &mut self,
+        ctx: &Context,
+        struct_id: &QualifiedInstId<StructId>,
+        src: String,
+        dst: String,
+        clean_flag: bool, // whether to clean the storage
+    ) {
+        // Allocate struct.
+        let layout = ctx.get_struct_layout(struct_id);
+        emitln!(
+            ctx.writer,
+            "{} := {}",
+            dst,
+            self.call_builtin_str(
+                ctx,
+                YulFunction::Malloc,
+                std::iter::once(layout.size.to_string()),
+            )
+        );
+
+        // Copy fields. By invariant we know that the leading fields are pointer fields.
+        for field_offs in layout.field_order.iter().take(layout.pointer_count) {
+            let (byte_offs, ty) = layout.offsets.get(field_offs).unwrap();
+            assert_eq!(byte_offs % 32, 0, "pointer fields are on word boundary");
+            let field_src_ptr = format!("add({}, {})", src, byte_offs);
+            let field_dst_ptr = format!("add({}, {})", dst, byte_offs);
+            ctx.emit_block(|| {
+                let hash = self.type_hash(ctx, ty);
+                let linked_src_name = format!("$linked_src_{}", hash);
+                let linked_dst_name = format!("$linked_dst_{}", hash);
+
+                // Load the pointer to the linked storage.
+                let load_call = self.call_builtin_str(
+                    ctx,
+                    YulFunction::AlignedStorageLoad,
+                    std::iter::once(field_src_ptr.clone()),
+                );
+
+                emitln!(ctx.writer, "let {} := {}", linked_src_name, load_call);
+
+                // Declare where to store the result and recursively move
+                emitln!(ctx.writer, "let {}", linked_dst_name);
+                self.move_data_from_linked_storage(
+                    ctx,
+                    ty,
+                    linked_src_name,
+                    linked_dst_name.clone(),
+                    clean_flag,
+                );
+                // Store the result at the destination.
+                emitln!(ctx.writer, "mstore({}, {})", field_dst_ptr, linked_dst_name);
+                // Clear the storage to get a refund
+                if clean_flag {
+                    self.call_builtin(
+                        ctx,
+                        YulFunction::AlignedStorageStore,
+                        vec![field_src_ptr, 0.to_string()].into_iter(),
+                    );
+                }
+            });
+        }
+
+        // The remaining fields are all primitive. We also know that memory is padded to word size,
+        // so we can just copy directly word by word, which has the lowest gas cost.
+        if layout.pointer_count < layout.field_order.len() {
+            let mut byte_offs = layout
+                .offsets
+                .get(&layout.field_order[layout.pointer_count])
+                .unwrap()
+                .0;
+            assert_eq!(
+                byte_offs % 32,
+                0,
+                "first non-pointer field on word boundary"
+            );
+            while byte_offs < layout.size {
+                let field_src_ptr = format!("add({}, {})", src, byte_offs);
+                let field_dst_ptr = format!("add({}, {})", dst, byte_offs);
+                let load_call = self.call_builtin_str(
+                    ctx,
+                    YulFunction::AlignedStorageLoad,
+                    std::iter::once(field_src_ptr.clone()),
+                );
+                emitln!(ctx.writer, "mstore({}, {})", field_dst_ptr, load_call);
+                if clean_flag {
+                    self.call_builtin(
+                        ctx,
+                        YulFunction::AlignedStorageStore,
+                        vec![field_src_ptr, 0.to_string()].into_iter(),
+                    );
+                }
+                byte_offs += 32
+            }
+        }
+    }
+
+    // Recursively move struct or vector data to corresponding linked storage.
+    // This function calls `move_struct_to_storage` and `move_vector_to_storage`, and
+    // is called by these two functions too.
+    pub(crate) fn create_and_move_data_to_linked_storage(
+        &mut self,
+        ctx: &Context,
+        ty: &Type,
+        linked_src_name: String,
+        linked_dst_name: String,
+        clean_flag: bool,
+    ) {
+        let hash = self.type_hash(ctx, ty);
+        // Allocate a new storage pointer.
+        emitln!(
+            ctx.writer,
+            "let {} := {}",
+            linked_dst_name,
+            self.call_builtin_str(
+                ctx,
+                YulFunction::NewLinkedStorageBase,
+                std::iter::once(format!("0x{:x}", hash))
+            )
+        );
+
+        // Recursively move.
+        if ty.is_vector() {
+            self.move_vector_to_storage(ctx, ty, linked_src_name, linked_dst_name, clean_flag);
+        } else if ctx.type_is_struct(ty) {
+            let field_struct_id = ty.get_struct_id(ctx.env).expect("struct");
+            self.move_struct_to_storage(
+                ctx,
+                &field_struct_id,
+                linked_src_name,
+                linked_dst_name,
+                clean_flag,
+            );
+        } else {
+            // Primitive type so directly store the src at the location
+            self.call_builtin(
+                ctx,
+                ctx.storage_store_builtin_fun(ty),
+                vec![linked_dst_name, linked_src_name].into_iter(),
+            );
+        }
+    }
+
+    // Recursively move struct or vector data from linked storage to memory.
+    // This function calls `move_struct_to_memory` and `move_vector_to_memory`, and
+    // is called by these two functions too.
+    pub(crate) fn move_data_from_linked_storage(
+        &mut self,
+        ctx: &Context,
+        ty: &Type,
+        linked_src_name: String,
+        linked_dst_name: String,
+        clean_flag: bool,
+    ) {
+        if ty.is_vector() {
+            self.move_vector_to_memory(ctx, ty, linked_src_name, linked_dst_name, clean_flag);
+        } else if ctx.type_is_struct(ty) {
+            let field_struct_id = ty.get_struct_id(ctx.env).expect("struct");
+            self.move_struct_to_memory(
+                ctx,
+                &field_struct_id,
+                linked_src_name,
+                linked_dst_name,
+                clean_flag,
+            );
+        } else {
+            // Primitive type
+            emitln!(
+                ctx.writer,
+                "{} := {}",
+                linked_dst_name,
+                self.call_builtin_str(
+                    ctx,
+                    ctx.storage_load_builtin_fun(ty),
+                    std::iter::once(linked_src_name)
+                )
+            );
+        }
+    }
+}

--- a/language/evm/move-to-yul/src/tables.rs
+++ b/language/evm/move-to-yul/src/tables.rs
@@ -198,10 +198,10 @@ fn define_insert_fun(gen: &mut FunctionGenerator, ctx: &Context, fun_id: &Qualif
             .call_builtin_str(ctx, YulFunction::AbortBuiltin, std::iter::empty())
     );
 
-    let hash = gen.type_hash(ctx, value_type);
+    let hash = gen.parent.type_hash(ctx, value_type);
     let linked_dst_name = format!("$linked_dst_{}", hash);
 
-    gen.create_and_move_data_to_linked_storage(
+    gen.parent.create_and_move_data_to_linked_storage(
         ctx,
         value_type,
         "value".to_string(),
@@ -392,7 +392,7 @@ fn define_remove_fun(gen: &mut FunctionGenerator, ctx: &Context, fun_id: &Qualif
         emitln!(ctx.writer, "linked_src := vector_linked_src");
     }
 
-    gen.move_data_from_linked_storage(
+    gen.parent.move_data_from_linked_storage(
         ctx,
         value_type,
         "linked_src".to_string(),

--- a/language/evm/move-to-yul/tests/Arithm.move
+++ b/language/evm/move-to-yul/tests/Arithm.move
@@ -1,5 +1,6 @@
 // Tests basic arithmetic. We only test for u64. Existing move unit tests (once ready for Move on EVM) should cover
 // all other basic types.
+#[evm_contract]
 module 0x2::M {
 
     // ==============================

--- a/language/evm/move-to-yul/tests/ConstructorTest.move
+++ b/language/evm/move-to-yul/tests/ConstructorTest.move
@@ -1,3 +1,4 @@
+#[evm_contract]
 module 0x2::ConstructorTest {
     use Evm::Evm::sign;
 

--- a/language/evm/move-to-yul/tests/ControlStructures.move
+++ b/language/evm/move-to-yul/tests/ControlStructures.move
@@ -1,5 +1,5 @@
 // Tests basic control structures.
-#[contract]
+#[evm_contract]
 module 0x2::M {
   #[callable]
   fun h1(x: u64): u64 {

--- a/language/evm/move-to-yul/tests/GlobalVectors.exp
+++ b/language/evm/move-to-yul/tests/GlobalVectors.exp
@@ -3,12 +3,12 @@
  * ======================================= */
 
 
-object "Empty" {
+object "A2_GlobalVectors" {
     code {
-        codecopy(0, dataoffset("Empty_deployed"), datasize("Empty_deployed"))
-        return(0, datasize("Empty_deployed"))
+        codecopy(0, dataoffset("A2_GlobalVectors_deployed"), datasize("A2_GlobalVectors_deployed"))
+        return(0, datasize("A2_GlobalVectors_deployed"))
     }
-    object "Empty_deployed" {
+    object "A2_GlobalVectors_deployed" {
         code {
             mstore(0, memoryguard(160))
             if iszero(lt(calldatasize(), 4))

--- a/language/evm/move-to-yul/tests/GlobalVectors.move
+++ b/language/evm/move-to-yul/tests/GlobalVectors.move
@@ -1,3 +1,4 @@
+#[evm_contract]
 module 0x2::GlobalVectors {
     use Std::Vector;
     use Evm::Evm::sign;

--- a/language/evm/move-to-yul/tests/Locals.move
+++ b/language/evm/move-to-yul/tests/Locals.move
@@ -1,4 +1,4 @@
-#[contract]
+#[evm_contract]
 module 0x2::M {
     #[callable]
     fun evaded(a: u64, b: u64): (u64, u64, u64, u64) {

--- a/language/evm/move-to-yul/tests/MoveCalls.move
+++ b/language/evm/move-to-yul/tests/MoveCalls.move
@@ -1,5 +1,5 @@
 // Tests Move functions calling other Move functions, including generic ones which are then specialized.
-#[contract]
+#[evm_contract]
 module 0x2::M {
   #[callable]
   fun f(x: u64): u64 {

--- a/language/evm/move-to-yul/tests/NativeFunctions.move
+++ b/language/evm/move-to-yul/tests/NativeFunctions.move
@@ -1,7 +1,7 @@
 // Tests native functions.
 // dep: ../stdlib/sources/Evm.move
 // dep: ../stdlib/sources/U256.move
-#[contract]
+#[evm_contract]
 module 0x2::NativeFunctions {
     use Evm::Evm::{Self, abort_with, to_string, concat};
     use Evm::U256::{zero, one, u256_from_u128, u256_from_words};

--- a/language/evm/move-to-yul/tests/NoGenericCallable.move
+++ b/language/evm/move-to-yul/tests/NoGenericCallable.move
@@ -1,5 +1,5 @@
 // Tests error on generic callable.
-#[contract]
+#[evm_contract]
 module 0x2::M {
     #[callable]
     fun f<T>(x: u64): u64 { x }

--- a/language/evm/move-to-yul/tests/Resources.exp
+++ b/language/evm/move-to-yul/tests/Resources.exp
@@ -3,12 +3,12 @@
  * ======================================= */
 
 
-object "Empty" {
+object "A2_M" {
     code {
-        codecopy(0, dataoffset("Empty_deployed"), datasize("Empty_deployed"))
-        return(0, datasize("Empty_deployed"))
+        codecopy(0, dataoffset("A2_M_deployed"), datasize("A2_M_deployed"))
+        return(0, datasize("A2_M_deployed"))
     }
-    object "Empty_deployed" {
+    object "A2_M_deployed" {
         code {
             mstore(0, memoryguard(160))
             if iszero(lt(calldatasize(), 4))

--- a/language/evm/move-to-yul/tests/Resources.exp.capture-source-info
+++ b/language/evm/move-to-yul/tests/Resources.exp.capture-source-info
@@ -4,12 +4,12 @@
 
 
 
-object "Empty" {
+object "A2_M" {
     code {
-        codecopy(0, dataoffset("Empty_deployed"), datasize("Empty_deployed"))
-        return(0, datasize("Empty_deployed"))
+        codecopy(0, dataoffset("A2_M_deployed"), datasize("A2_M_deployed"))
+        return(0, datasize("A2_M_deployed"))
     }
-    object "Empty_deployed" {
+    object "A2_M_deployed" {
         code {
             mstore(0, memoryguard(160))
             if iszero(lt(calldatasize(), 4))
@@ -59,46 +59,46 @@ object "test_A2_M_test_increment_a" {
                 case 2 {
                     // label L1
                     // $t11 := 100
-                    /// @src 1:1307:1310
+                    /// @src 1:1323:1326
                     $t11 := 100
                     // abort($t11)
-                    /// @src 1:1268:1311
+                    /// @src 1:1284:1327
                     $Abort($t11)
                 }
                 case 3 {
                     // label L0
                     // return ()
-                    /// @src 1:1311:1312
+                    /// @src 1:1327:1328
                     $Free($locals, 32)
                     leave
                 }
                 case 4 {
                     // $t1 := 0x3
-                    /// @src 1:1224:1226
+                    /// @src 1:1240:1242
                     $t1 := 0x3
                     // $t0 := Evm::sign($t1)
-                    /// @src 1:1219:1227
+                    /// @src 1:1235:1243
                     mstore($locals, A2_Evm_sign($t1))
                     // $t2 := borrow_local($t0)
-                    /// @src 1:1218:1227
+                    /// @src 1:1234:1243
                     $t2 := $MakePtr(false, $locals)
                     // $t3 := 510
-                    /// @src 1:1229:1232
+                    /// @src 1:1245:1248
                     $t3 := 510
                     // M::publish($t2, $t3)
-                    /// @src 1:1210:1233
+                    /// @src 1:1226:1249
                     A2_M_publish($t2, $t3)
                     // $t4 := 0x3
-                    /// @src 1:1255:1257
+                    /// @src 1:1271:1273
                     $t4 := 0x3
                     // M::increment_a($t4)
-                    /// @src 1:1243:1258
+                    /// @src 1:1259:1274
                     A2_M_increment_a($t4)
                     // $t5 := 0x3
-                    /// @src 1:1293:1295
+                    /// @src 1:1309:1311
                     $t5 := 0x3
                     // $t6 := borrow_global<M::S>($t5)
-                    /// @src 1:1276:1289
+                    /// @src 1:1292:1305
                     {
                         let $base_offset := $MakeTypeStorageBase(0, 0x698265eb, $t5)
                         if iszero($AlignedStorageLoad($base_offset)) {
@@ -107,19 +107,19 @@ object "test_A2_M_test_increment_a" {
                         $t6 := $MakePtr(true, add($base_offset, 32))
                     }
                     // $t7 := borrow_field<M::S>.a($t6)
-                    /// @src 1:1276:1298
+                    /// @src 1:1292:1314
                     $t7 := $IndexPtr($t6, 32)
                     // $t8 := read_ref($t7)
-                    /// @src 1:1276:1298
+                    /// @src 1:1292:1314
                     $t8 := $LoadU64($t7)
                     // $t9 := 511
-                    /// @src 1:1302:1305
+                    /// @src 1:1318:1321
                     $t9 := 511
                     // $t10 := ==($t8, $t9)
-                    /// @src 1:1299:1301
+                    /// @src 1:1315:1317
                     $t10 := $Eq($t8, $t9)
                     // if ($t10) goto L0 else goto L1
-                    /// @src 1:1268:1311
+                    /// @src 1:1284:1327
                     switch $t10
                     case 0  { $block := 2 }
                     default { $block := 3 }
@@ -130,7 +130,7 @@ object "test_A2_M_test_increment_a" {
         function A2_M_increment_a(addr) {
             let r, $t2, $t3, $t4, $t5, $t6, $t7
             // $t2 := borrow_global<M::S>($t0)
-            /// @src 1:1090:1107
+            /// @src 1:1106:1123
             {
                 let $base_offset := $MakeTypeStorageBase(0, 0x698265eb, addr)
                 if iszero($AlignedStorageLoad($base_offset)) {
@@ -139,53 +139,53 @@ object "test_A2_M_test_increment_a" {
                 $t2 := $MakePtr(true, add($base_offset, 32))
             }
             // $t3 := borrow_field<M::S>.a($t2)
-            /// @src 1:1132:1135
+            /// @src 1:1148:1151
             $t3 := $IndexPtr($t2, 32)
             // $t4 := read_ref($t3)
-            /// @src 1:1132:1135
+            /// @src 1:1148:1151
             $t4 := $LoadU64($t3)
             // $t5 := 1
-            /// @src 1:1138:1139
+            /// @src 1:1154:1155
             $t5 := 1
             // $t6 := +($t4, $t5)
-            /// @src 1:1136:1137
+            /// @src 1:1152:1153
             $t6 := $AddU64($t4, $t5)
             // $t7 := borrow_field<M::S>.a($t2)
-            /// @src 1:1126:1129
+            /// @src 1:1142:1145
             $t7 := $IndexPtr($t2, 32)
             // write_ref($t7, $t6)
-            /// @src 1:1126:1139
+            /// @src 1:1142:1155
             $StoreU64($t7, $t6)
             // return ()
-            /// @src 1:1126:1139
+            /// @src 1:1142:1155
         }
 
         function A2_M_publish(sg, a) {
             let s, $t3, $t4, $t5, $t6, $t7, $t8, $t9
             // $t3 := 2
-            /// @src 1:369:370
+            /// @src 1:385:386
             $t3 := 2
             // $t4 := /($t1, $t3)
-            /// @src 1:367:368
+            /// @src 1:383:384
             $t4 := $Div(a, $t3)
             // $t5 := (u8)($t4)
-            /// @src 1:363:378
+            /// @src 1:379:394
             $t5 := $CastU8($t4)
             // $t6 := +($t1, $t1)
-            /// @src 1:393:394
+            /// @src 1:409:410
             $t6 := $AddU64(a, a)
             // $t7 := (u128)($t6)
-            /// @src 1:389:406
+            /// @src 1:405:422
             $t7 := $CastU128($t6)
             // $t8 := pack M::S2($t7)
-            /// @src 1:383:407
+            /// @src 1:399:423
             {
                 let $mem := $Malloc(16)
                 $MemoryStoreU128(add($mem, 0), $t7)
                 $t8 := $mem
             }
             // $t9 := pack M::S($t1, $t5, $t8)
-            /// @src 1:355:408
+            /// @src 1:371:424
             {
                 let $mem := $Malloc(41)
                 $MemoryStoreU64(add($mem, 32), a)
@@ -194,7 +194,7 @@ object "test_A2_M_test_increment_a" {
                 $t9 := $mem
             }
             // move_to<M::S>($t9, $t0)
-            /// @src 1:418:425
+            /// @src 1:434:441
             {
                 let $base_offset := $MakeTypeStorageBase(0, 0x698265eb, $LoadU256(sg))
                 if $AlignedStorageLoad($base_offset) {
@@ -216,7 +216,7 @@ object "test_A2_M_test_increment_a" {
                 }
             }
             // return ()
-            /// @src 1:418:435
+            /// @src 1:434:451
         }
 
         function A2_Evm_sign(addr) -> signer {
@@ -455,19 +455,19 @@ object "test_A2_M_test_publish" {
                 case 2 {
                     // label L1
                     // $t6 := 100
-                    /// @src 1:555:558
+                    /// @src 1:571:574
                     $t6 := 100
                     // abort($t6)
-                    /// @src 1:532:559
+                    /// @src 1:548:575
                     $Abort($t6)
                 }
                 case 3 {
                     // label L0
                     // $t7 := 0x3
-                    /// @src 1:593:595
+                    /// @src 1:609:611
                     $t7 := 0x3
                     // $t8 := borrow_global<M::S>($t7)
-                    /// @src 1:576:589
+                    /// @src 1:592:605
                     {
                         let $base_offset := $MakeTypeStorageBase(0, 0x698265eb, $t7)
                         if iszero($AlignedStorageLoad($base_offset)) {
@@ -476,47 +476,47 @@ object "test_A2_M_test_publish" {
                         $t8 := $MakePtr(true, add($base_offset, 32))
                     }
                     // $t9 := borrow_field<M::S>.a($t8)
-                    /// @src 1:576:598
+                    /// @src 1:592:614
                     $t9 := $IndexPtr($t8, 32)
                     // $t10 := read_ref($t9)
-                    /// @src 1:576:598
+                    /// @src 1:592:614
                     $t10 := $LoadU64($t9)
                     // $t11 := 22
-                    /// @src 1:602:604
+                    /// @src 1:618:620
                     $t11 := 22
                     // $t12 := ==($t10, $t11)
-                    /// @src 1:599:601
+                    /// @src 1:615:617
                     $t12 := $Eq($t10, $t11)
                     // if ($t12) goto L2 else goto L3
-                    /// @src 1:568:610
+                    /// @src 1:584:626
                     switch $t12
                     case 0  { $block := 5 }
                     default { $block := 6 }
                 }
                 case 4 {
                     // $t1 := 0x3
-                    /// @src 1:515:517
+                    /// @src 1:531:533
                     $t1 := 0x3
                     // $t0 := Evm::sign($t1)
-                    /// @src 1:510:518
+                    /// @src 1:526:534
                     mstore($locals, A2_Evm_sign($t1))
                     // $t2 := borrow_local($t0)
-                    /// @src 1:509:518
+                    /// @src 1:525:534
                     $t2 := $MakePtr(false, $locals)
                     // $t3 := 22
-                    /// @src 1:520:522
+                    /// @src 1:536:538
                     $t3 := 22
                     // M::publish($t2, $t3)
-                    /// @src 1:501:523
+                    /// @src 1:517:539
                     A2_M_publish($t2, $t3)
                     // $t4 := 0x3
-                    /// @src 1:550:552
+                    /// @src 1:566:568
                     $t4 := 0x3
                     // $t5 := exists<M::S>($t4)
-                    /// @src 1:540:546
+                    /// @src 1:556:562
                     $t5 := $AlignedStorageLoad($MakeTypeStorageBase(0, 0x698265eb, $t4))
                     // if ($t5) goto L0 else goto L1
-                    /// @src 1:532:559
+                    /// @src 1:548:575
                     switch $t5
                     case 0  { $block := 2 }
                     default { $block := 3 }
@@ -524,19 +524,19 @@ object "test_A2_M_test_publish" {
                 case 5 {
                     // label L3
                     // $t13 := 101
-                    /// @src 1:606:609
+                    /// @src 1:622:625
                     $t13 := 101
                     // abort($t13)
-                    /// @src 1:568:610
+                    /// @src 1:584:626
                     $Abort($t13)
                 }
                 case 6 {
                     // label L2
                     // $t14 := 0x3
-                    /// @src 1:644:646
+                    /// @src 1:660:662
                     $t14 := 0x3
                     // $t15 := borrow_global<M::S>($t14)
-                    /// @src 1:627:640
+                    /// @src 1:643:656
                     {
                         let $base_offset := $MakeTypeStorageBase(0, 0x698265eb, $t14)
                         if iszero($AlignedStorageLoad($base_offset)) {
@@ -545,19 +545,19 @@ object "test_A2_M_test_publish" {
                         $t15 := $MakePtr(true, add($base_offset, 32))
                     }
                     // $t16 := borrow_field<M::S>.b($t15)
-                    /// @src 1:627:649
+                    /// @src 1:643:665
                     $t16 := $IndexPtr($t15, 40)
                     // $t17 := read_ref($t16)
-                    /// @src 1:627:649
+                    /// @src 1:643:665
                     $t17 := $LoadU8($t16)
                     // $t18 := 11
-                    /// @src 1:653:655
+                    /// @src 1:669:671
                     $t18 := 11
                     // $t19 := ==($t17, $t18)
-                    /// @src 1:650:652
+                    /// @src 1:666:668
                     $t19 := $Eq($t17, $t18)
                     // if ($t19) goto L4 else goto L5
-                    /// @src 1:619:661
+                    /// @src 1:635:677
                     switch $t19
                     case 0  { $block := 7 }
                     default { $block := 8 }
@@ -565,19 +565,19 @@ object "test_A2_M_test_publish" {
                 case 7 {
                     // label L5
                     // $t20 := 102
-                    /// @src 1:657:660
+                    /// @src 1:673:676
                     $t20 := 102
                     // abort($t20)
-                    /// @src 1:619:661
+                    /// @src 1:635:677
                     $Abort($t20)
                 }
                 case 8 {
                     // label L4
                     // $t21 := 0x3
-                    /// @src 1:695:697
+                    /// @src 1:711:713
                     $t21 := 0x3
                     // $t22 := borrow_global<M::S>($t21)
-                    /// @src 1:678:691
+                    /// @src 1:694:707
                     {
                         let $base_offset := $MakeTypeStorageBase(0, 0x698265eb, $t21)
                         if iszero($AlignedStorageLoad($base_offset)) {
@@ -586,24 +586,24 @@ object "test_A2_M_test_publish" {
                         $t22 := $MakePtr(true, add($base_offset, 32))
                     }
                     // $t23 := borrow_field<M::S>.c($t22)
-                    /// @src 1:678:700
+                    /// @src 1:694:716
                     {
                         $t23 := $MakePtr($IsStoragePtr($t22), $LoadU256($t22))
                     }
                     // $t24 := borrow_field<M::S2>.x($t23)
-                    /// @src 1:678:702
+                    /// @src 1:694:718
                     $t24 := $t23
                     // $t25 := read_ref($t24)
-                    /// @src 1:678:702
+                    /// @src 1:694:718
                     $t25 := $LoadU128($t24)
                     // $t26 := 44
-                    /// @src 1:706:708
+                    /// @src 1:722:724
                     $t26 := 44
                     // $t27 := ==($t25, $t26)
-                    /// @src 1:703:705
+                    /// @src 1:719:721
                     $t27 := $Eq($t25, $t26)
                     // if ($t27) goto L6 else goto L7
-                    /// @src 1:670:714
+                    /// @src 1:686:730
                     switch $t27
                     case 0  { $block := 9 }
                     default { $block := 10 }
@@ -611,16 +611,16 @@ object "test_A2_M_test_publish" {
                 case 9 {
                     // label L7
                     // $t28 := 103
-                    /// @src 1:710:713
+                    /// @src 1:726:729
                     $t28 := 103
                     // abort($t28)
-                    /// @src 1:670:714
+                    /// @src 1:686:730
                     $Abort($t28)
                 }
                 case 10 {
                     // label L6
                     // return ()
-                    /// @src 1:714:715
+                    /// @src 1:730:731
                     $Free($locals, 32)
                     leave
                 }
@@ -630,29 +630,29 @@ object "test_A2_M_test_publish" {
         function A2_M_publish(sg, a) {
             let s, $t3, $t4, $t5, $t6, $t7, $t8, $t9
             // $t3 := 2
-            /// @src 1:369:370
+            /// @src 1:385:386
             $t3 := 2
             // $t4 := /($t1, $t3)
-            /// @src 1:367:368
+            /// @src 1:383:384
             $t4 := $Div(a, $t3)
             // $t5 := (u8)($t4)
-            /// @src 1:363:378
+            /// @src 1:379:394
             $t5 := $CastU8($t4)
             // $t6 := +($t1, $t1)
-            /// @src 1:393:394
+            /// @src 1:409:410
             $t6 := $AddU64(a, a)
             // $t7 := (u128)($t6)
-            /// @src 1:389:406
+            /// @src 1:405:422
             $t7 := $CastU128($t6)
             // $t8 := pack M::S2($t7)
-            /// @src 1:383:407
+            /// @src 1:399:423
             {
                 let $mem := $Malloc(16)
                 $MemoryStoreU128(add($mem, 0), $t7)
                 $t8 := $mem
             }
             // $t9 := pack M::S($t1, $t5, $t8)
-            /// @src 1:355:408
+            /// @src 1:371:424
             {
                 let $mem := $Malloc(41)
                 $MemoryStoreU64(add($mem, 32), a)
@@ -661,7 +661,7 @@ object "test_A2_M_test_publish" {
                 $t9 := $mem
             }
             // move_to<M::S>($t9, $t0)
-            /// @src 1:418:425
+            /// @src 1:434:441
             {
                 let $base_offset := $MakeTypeStorageBase(0, 0x698265eb, $LoadU256(sg))
                 if $AlignedStorageLoad($base_offset) {
@@ -683,7 +683,7 @@ object "test_A2_M_test_publish" {
                 }
             }
             // return ()
-            /// @src 1:418:435
+            /// @src 1:434:451
         }
 
         function A2_Evm_sign(addr) -> signer {
@@ -915,19 +915,19 @@ object "test_A2_M_test_publish_t" {
                 case 2 {
                     // label L1
                     // $t6 := 100
-                    /// @src 1:1591:1594
+                    /// @src 1:1607:1610
                     $t6 := 100
                     // abort($t6)
-                    /// @src 1:1568:1595
+                    /// @src 1:1584:1611
                     $Abort($t6)
                 }
                 case 3 {
                     // label L0
                     // $t7 := 0x3
-                    /// @src 1:1630:1632
+                    /// @src 1:1646:1648
                     $t7 := 0x3
                     // $t8 := borrow_global<M::T>($t7)
-                    /// @src 1:1613:1626
+                    /// @src 1:1629:1642
                     {
                         let $base_offset := $MakeTypeStorageBase(0, 0x3948ca0a, $t7)
                         if iszero($AlignedStorageLoad($base_offset)) {
@@ -936,52 +936,52 @@ object "test_A2_M_test_publish_t" {
                         $t8 := $MakePtr(true, add($base_offset, 32))
                     }
                     // $t9 := borrow_field<M::T>.s($t8)
-                    /// @src 1:1613:1635
+                    /// @src 1:1629:1651
                     {
                         $t9 := $MakePtr($IsStoragePtr($t8), $LoadU256($t8))
                     }
                     // $t10 := borrow_field<M::S>.a($t9)
-                    /// @src 1:1613:1637
+                    /// @src 1:1629:1653
                     $t10 := $IndexPtr($t9, 32)
                     // $t11 := read_ref($t10)
-                    /// @src 1:1613:1637
+                    /// @src 1:1629:1653
                     $t11 := $LoadU64($t10)
                     // $t12 := 22
-                    /// @src 1:1641:1643
+                    /// @src 1:1657:1659
                     $t12 := 22
                     // $t13 := ==($t11, $t12)
-                    /// @src 1:1638:1640
+                    /// @src 1:1654:1656
                     $t13 := $Eq($t11, $t12)
                     // if ($t13) goto L2 else goto L3
-                    /// @src 1:1605:1649
+                    /// @src 1:1621:1665
                     switch $t13
                     case 0  { $block := 5 }
                     default { $block := 6 }
                 }
                 case 4 {
                     // $t1 := 0x3
-                    /// @src 1:1550:1552
+                    /// @src 1:1566:1568
                     $t1 := 0x3
                     // $t0 := Evm::sign($t1)
-                    /// @src 1:1545:1553
+                    /// @src 1:1561:1569
                     mstore($locals, A2_Evm_sign($t1))
                     // $t2 := borrow_local($t0)
-                    /// @src 1:1544:1553
+                    /// @src 1:1560:1569
                     $t2 := $MakePtr(false, $locals)
                     // $t3 := 22
-                    /// @src 1:1555:1557
+                    /// @src 1:1571:1573
                     $t3 := 22
                     // M::publish_t($t2, $t3)
-                    /// @src 1:1534:1558
+                    /// @src 1:1550:1574
                     A2_M_publish_t($t2, $t3)
                     // $t4 := 0x3
-                    /// @src 1:1586:1588
+                    /// @src 1:1602:1604
                     $t4 := 0x3
                     // $t5 := exists<M::T>($t4)
-                    /// @src 1:1576:1582
+                    /// @src 1:1592:1598
                     $t5 := $AlignedStorageLoad($MakeTypeStorageBase(0, 0x3948ca0a, $t4))
                     // if ($t5) goto L0 else goto L1
-                    /// @src 1:1568:1595
+                    /// @src 1:1584:1611
                     switch $t5
                     case 0  { $block := 2 }
                     default { $block := 3 }
@@ -989,19 +989,19 @@ object "test_A2_M_test_publish_t" {
                 case 5 {
                     // label L3
                     // $t14 := 101
-                    /// @src 1:1645:1648
+                    /// @src 1:1661:1664
                     $t14 := 101
                     // abort($t14)
-                    /// @src 1:1605:1649
+                    /// @src 1:1621:1665
                     $Abort($t14)
                 }
                 case 6 {
                     // label L2
                     // $t15 := 0x3
-                    /// @src 1:1684:1686
+                    /// @src 1:1700:1702
                     $t15 := 0x3
                     // $t16 := borrow_global<M::T>($t15)
-                    /// @src 1:1667:1680
+                    /// @src 1:1683:1696
                     {
                         let $base_offset := $MakeTypeStorageBase(0, 0x3948ca0a, $t15)
                         if iszero($AlignedStorageLoad($base_offset)) {
@@ -1010,24 +1010,24 @@ object "test_A2_M_test_publish_t" {
                         $t16 := $MakePtr(true, add($base_offset, 32))
                     }
                     // $t17 := borrow_field<M::T>.s($t16)
-                    /// @src 1:1667:1689
+                    /// @src 1:1683:1705
                     {
                         $t17 := $MakePtr($IsStoragePtr($t16), $LoadU256($t16))
                     }
                     // $t18 := borrow_field<M::S>.b($t17)
-                    /// @src 1:1667:1691
+                    /// @src 1:1683:1707
                     $t18 := $IndexPtr($t17, 40)
                     // $t19 := read_ref($t18)
-                    /// @src 1:1667:1691
+                    /// @src 1:1683:1707
                     $t19 := $LoadU8($t18)
                     // $t20 := 11
-                    /// @src 1:1695:1697
+                    /// @src 1:1711:1713
                     $t20 := 11
                     // $t21 := ==($t19, $t20)
-                    /// @src 1:1692:1694
+                    /// @src 1:1708:1710
                     $t21 := $Eq($t19, $t20)
                     // if ($t21) goto L4 else goto L5
-                    /// @src 1:1659:1703
+                    /// @src 1:1675:1719
                     switch $t21
                     case 0  { $block := 7 }
                     default { $block := 8 }
@@ -1035,19 +1035,19 @@ object "test_A2_M_test_publish_t" {
                 case 7 {
                     // label L5
                     // $t22 := 102
-                    /// @src 1:1699:1702
+                    /// @src 1:1715:1718
                     $t22 := 102
                     // abort($t22)
-                    /// @src 1:1659:1703
+                    /// @src 1:1675:1719
                     $Abort($t22)
                 }
                 case 8 {
                     // label L4
                     // $t23 := 0x3
-                    /// @src 1:1738:1740
+                    /// @src 1:1754:1756
                     $t23 := 0x3
                     // $t24 := borrow_global<M::T>($t23)
-                    /// @src 1:1721:1734
+                    /// @src 1:1737:1750
                     {
                         let $base_offset := $MakeTypeStorageBase(0, 0x3948ca0a, $t23)
                         if iszero($AlignedStorageLoad($base_offset)) {
@@ -1056,29 +1056,29 @@ object "test_A2_M_test_publish_t" {
                         $t24 := $MakePtr(true, add($base_offset, 32))
                     }
                     // $t25 := borrow_field<M::T>.s($t24)
-                    /// @src 1:1721:1743
+                    /// @src 1:1737:1759
                     {
                         $t25 := $MakePtr($IsStoragePtr($t24), $LoadU256($t24))
                     }
                     // $t26 := borrow_field<M::S>.c($t25)
-                    /// @src 1:1721:1745
+                    /// @src 1:1737:1761
                     {
                         $t26 := $MakePtr($IsStoragePtr($t25), $LoadU256($t25))
                     }
                     // $t27 := borrow_field<M::S2>.x($t26)
-                    /// @src 1:1721:1747
+                    /// @src 1:1737:1763
                     $t27 := $t26
                     // $t28 := read_ref($t27)
-                    /// @src 1:1721:1747
+                    /// @src 1:1737:1763
                     $t28 := $LoadU128($t27)
                     // $t29 := 44
-                    /// @src 1:1751:1753
+                    /// @src 1:1767:1769
                     $t29 := 44
                     // $t30 := ==($t28, $t29)
-                    /// @src 1:1748:1750
+                    /// @src 1:1764:1766
                     $t30 := $Eq($t28, $t29)
                     // if ($t30) goto L6 else goto L7
-                    /// @src 1:1713:1759
+                    /// @src 1:1729:1775
                     switch $t30
                     case 0  { $block := 9 }
                     default { $block := 10 }
@@ -1086,16 +1086,16 @@ object "test_A2_M_test_publish_t" {
                 case 9 {
                     // label L7
                     // $t31 := 103
-                    /// @src 1:1755:1758
+                    /// @src 1:1771:1774
                     $t31 := 103
                     // abort($t31)
-                    /// @src 1:1713:1759
+                    /// @src 1:1729:1775
                     $Abort($t31)
                 }
                 case 10 {
                     // label L6
                     // return ()
-                    /// @src 1:1759:1760
+                    /// @src 1:1775:1776
                     $Free($locals, 32)
                     leave
                 }
@@ -1105,29 +1105,29 @@ object "test_A2_M_test_publish_t" {
         function A2_M_publish_t(sg, a) {
             let t, $t3, $t4, $t5, $t6, $t7, $t8, $t9, $t10
             // $t3 := 2
-            /// @src 1:1398:1399
+            /// @src 1:1414:1415
             $t3 := 2
             // $t4 := /($t1, $t3)
-            /// @src 1:1396:1397
+            /// @src 1:1412:1413
             $t4 := $Div(a, $t3)
             // $t5 := (u8)($t4)
-            /// @src 1:1392:1407
+            /// @src 1:1408:1423
             $t5 := $CastU8($t4)
             // $t6 := +($t1, $t1)
-            /// @src 1:1422:1423
+            /// @src 1:1438:1439
             $t6 := $AddU64(a, a)
             // $t7 := (u128)($t6)
-            /// @src 1:1418:1435
+            /// @src 1:1434:1451
             $t7 := $CastU128($t6)
             // $t8 := pack M::S2($t7)
-            /// @src 1:1412:1436
+            /// @src 1:1428:1452
             {
                 let $mem := $Malloc(16)
                 $MemoryStoreU128(add($mem, 0), $t7)
                 $t8 := $mem
             }
             // $t9 := pack M::S($t1, $t5, $t8)
-            /// @src 1:1384:1437
+            /// @src 1:1400:1453
             {
                 let $mem := $Malloc(41)
                 $MemoryStoreU64(add($mem, 32), a)
@@ -1136,14 +1136,14 @@ object "test_A2_M_test_publish_t" {
                 $t9 := $mem
             }
             // $t10 := pack M::T($t9)
-            /// @src 1:1377:1438
+            /// @src 1:1393:1454
             {
                 let $mem := $Malloc(32)
                 $MemoryStoreU256(add($mem, 0), $t9)
                 $t10 := $mem
             }
             // move_to<M::T>($t10, $t0)
-            /// @src 1:1448:1455
+            /// @src 1:1464:1471
             {
                 let $base_offset := $MakeTypeStorageBase(0, 0x3948ca0a, $LoadU256(sg))
                 if $AlignedStorageLoad($base_offset) {
@@ -1171,7 +1171,7 @@ object "test_A2_M_test_publish_t" {
                 }
             }
             // return ()
-            /// @src 1:1448:1465
+            /// @src 1:1464:1481
         }
 
         function A2_Evm_sign(addr) -> signer {
@@ -1403,66 +1403,66 @@ object "test_A2_M_test_unpublish" {
                 case 2 {
                     // label L1
                     // $t15 := 101
-                    /// @src 1:954:957
+                    /// @src 1:970:973
                     $t15 := 101
                     // abort($t15)
-                    /// @src 1:937:958
+                    /// @src 1:953:974
                     $Abort($t15)
                 }
                 case 3 {
                     // label L0
                     // $t16 := 16
-                    /// @src 1:980:982
+                    /// @src 1:996:998
                     $t16 := 16
                     // $t17 := ==($t10, $t16)
-                    /// @src 1:977:979
+                    /// @src 1:993:995
                     $t17 := $Eq($t10, $t16)
                     // if ($t17) goto L2 else goto L3
-                    /// @src 1:967:988
+                    /// @src 1:983:1004
                     switch $t17
                     case 0  { $block := 5 }
                     default { $block := 6 }
                 }
                 case 4 {
                     // $t4 := 0x3
-                    /// @src 1:874:876
+                    /// @src 1:890:892
                     $t4 := 0x3
                     // $t0 := Evm::sign($t4)
-                    /// @src 1:869:877
+                    /// @src 1:885:893
                     mstore($locals, A2_Evm_sign($t4))
                     // $t5 := borrow_local($t0)
-                    /// @src 1:868:877
+                    /// @src 1:884:893
                     $t5 := $MakePtr(false, $locals)
                     // $t6 := 33
-                    /// @src 1:879:881
+                    /// @src 1:895:897
                     $t6 := 33
                     // M::publish($t5, $t6)
-                    /// @src 1:860:882
+                    /// @src 1:876:898
                     A2_M_publish($t5, $t6)
                     // $t7 := 0x3
-                    /// @src 1:925:927
+                    /// @src 1:941:943
                     $t7 := 0x3
                     // $t8 := M::unpublish($t7)
-                    /// @src 1:915:928
+                    /// @src 1:931:944
                     $t8 := A2_M_unpublish($t7)
                     // ($t9, $t10, $t11) := unpack M::S($t8)
-                    /// @src 1:895:912
+                    /// @src 1:911:928
                     $t9 := $MemoryLoadU64(add($t8, 32))
                     $t10 := $MemoryLoadU8(add($t8, 40))
                     $t11 := $MemoryLoadU256(add($t8, 0))
                     $Free($t8, 41)
                     // $t12 := unpack M::S2($t11)
-                    /// @src 1:906:911
+                    /// @src 1:922:927
                     $t12 := $MemoryLoadU128(add($t11, 0))
                     $Free($t11, 16)
                     // $t13 := 33
-                    /// @src 1:950:952
+                    /// @src 1:966:968
                     $t13 := 33
                     // $t14 := ==($t9, $t13)
-                    /// @src 1:947:949
+                    /// @src 1:963:965
                     $t14 := $Eq($t9, $t13)
                     // if ($t14) goto L0 else goto L1
-                    /// @src 1:937:958
+                    /// @src 1:953:974
                     switch $t14
                     case 0  { $block := 2 }
                     default { $block := 3 }
@@ -1470,22 +1470,22 @@ object "test_A2_M_test_unpublish" {
                 case 5 {
                     // label L3
                     // $t18 := 102
-                    /// @src 1:984:987
+                    /// @src 1:1000:1003
                     $t18 := 102
                     // abort($t18)
-                    /// @src 1:967:988
+                    /// @src 1:983:1004
                     $Abort($t18)
                 }
                 case 6 {
                     // label L2
                     // $t19 := 66
-                    /// @src 1:1010:1012
+                    /// @src 1:1026:1028
                     $t19 := 66
                     // $t20 := ==($t12, $t19)
-                    /// @src 1:1007:1009
+                    /// @src 1:1023:1025
                     $t20 := $Eq($t12, $t19)
                     // if ($t20) goto L4 else goto L5
-                    /// @src 1:997:1018
+                    /// @src 1:1013:1034
                     switch $t20
                     case 0  { $block := 7 }
                     default { $block := 8 }
@@ -1493,16 +1493,16 @@ object "test_A2_M_test_unpublish" {
                 case 7 {
                     // label L5
                     // $t21 := 103
-                    /// @src 1:1014:1017
+                    /// @src 1:1030:1033
                     $t21 := 103
                     // abort($t21)
-                    /// @src 1:997:1018
+                    /// @src 1:1013:1034
                     $Abort($t21)
                 }
                 case 8 {
                     // label L4
                     // return ()
-                    /// @src 1:1018:1019
+                    /// @src 1:1034:1035
                     $Free($locals, 32)
                     leave
                 }
@@ -1512,7 +1512,7 @@ object "test_A2_M_test_unpublish" {
         function A2_M_unpublish(a) -> $result {
             let $t1
             // $t1 := move_from<M::S>($t0)
-            /// @src 1:777:786
+            /// @src 1:793:802
             {
                 let $base_offset := $MakeTypeStorageBase(0, 0x698265eb, a)
                 if iszero($AlignedStorageLoad($base_offset)) {
@@ -1538,36 +1538,36 @@ object "test_A2_M_test_unpublish" {
                 }
             }
             // return $t1
-            /// @src 1:777:792
+            /// @src 1:793:808
             $result := $t1
         }
 
         function A2_M_publish(sg, a) {
             let s, $t3, $t4, $t5, $t6, $t7, $t8, $t9
             // $t3 := 2
-            /// @src 1:369:370
+            /// @src 1:385:386
             $t3 := 2
             // $t4 := /($t1, $t3)
-            /// @src 1:367:368
+            /// @src 1:383:384
             $t4 := $Div(a, $t3)
             // $t5 := (u8)($t4)
-            /// @src 1:363:378
+            /// @src 1:379:394
             $t5 := $CastU8($t4)
             // $t6 := +($t1, $t1)
-            /// @src 1:393:394
+            /// @src 1:409:410
             $t6 := $AddU64(a, a)
             // $t7 := (u128)($t6)
-            /// @src 1:389:406
+            /// @src 1:405:422
             $t7 := $CastU128($t6)
             // $t8 := pack M::S2($t7)
-            /// @src 1:383:407
+            /// @src 1:399:423
             {
                 let $mem := $Malloc(16)
                 $MemoryStoreU128(add($mem, 0), $t7)
                 $t8 := $mem
             }
             // $t9 := pack M::S($t1, $t5, $t8)
-            /// @src 1:355:408
+            /// @src 1:371:424
             {
                 let $mem := $Malloc(41)
                 $MemoryStoreU64(add($mem, 32), a)
@@ -1576,7 +1576,7 @@ object "test_A2_M_test_unpublish" {
                 $t9 := $mem
             }
             // move_to<M::S>($t9, $t0)
-            /// @src 1:418:425
+            /// @src 1:434:441
             {
                 let $base_offset := $MakeTypeStorageBase(0, 0x698265eb, $LoadU256(sg))
                 if $AlignedStorageLoad($base_offset) {
@@ -1598,7 +1598,7 @@ object "test_A2_M_test_unpublish" {
                 }
             }
             // return ()
-            /// @src 1:418:435
+            /// @src 1:434:451
         }
 
         function A2_Evm_sign(addr) -> signer {

--- a/language/evm/move-to-yul/tests/Resources.move
+++ b/language/evm/move-to-yul/tests/Resources.move
@@ -2,6 +2,7 @@
 //
 // experiment: capture-source-info
 //
+#[evm_contract]
 module 0x2::M {
     use Evm::Evm::sign;
 

--- a/language/evm/move-to-yul/tests/Structs.exp
+++ b/language/evm/move-to-yul/tests/Structs.exp
@@ -3,12 +3,12 @@
  * ======================================= */
 
 
-object "Empty" {
+object "A2_M" {
     code {
-        codecopy(0, dataoffset("Empty_deployed"), datasize("Empty_deployed"))
-        return(0, datasize("Empty_deployed"))
+        codecopy(0, dataoffset("A2_M_deployed"), datasize("A2_M_deployed"))
+        return(0, datasize("A2_M_deployed"))
     }
-    object "Empty_deployed" {
+    object "A2_M_deployed" {
         code {
             mstore(0, memoryguard(160))
             if iszero(lt(calldatasize(), 4))

--- a/language/evm/move-to-yul/tests/Structs.move
+++ b/language/evm/move-to-yul/tests/Structs.move
@@ -1,3 +1,4 @@
+#[evm_contract]
 module 0x2::M {
     struct S has drop {
       a: u64,

--- a/language/evm/move-to-yul/tests/Tables.exp
+++ b/language/evm/move-to-yul/tests/Tables.exp
@@ -3,12 +3,12 @@
  * ======================================= */
 
 
-object "Empty" {
+object "A2_Tables" {
     code {
-        codecopy(0, dataoffset("Empty_deployed"), datasize("Empty_deployed"))
-        return(0, datasize("Empty_deployed"))
+        codecopy(0, dataoffset("A2_Tables_deployed"), datasize("A2_Tables_deployed"))
+        return(0, datasize("A2_Tables_deployed"))
     }
-    object "Empty_deployed" {
+    object "A2_Tables_deployed" {
         code {
             mstore(0, memoryguard(160))
             if iszero(lt(calldatasize(), 4))

--- a/language/evm/move-to-yul/tests/Tables.move
+++ b/language/evm/move-to-yul/tests/Tables.move
@@ -1,3 +1,4 @@
+#[evm_contract]
 module 0x2::Tables {
     use Evm::Evm::sign;
     use Evm::Table::{Self, Table};

--- a/language/evm/move-to-yul/tests/TestABINative.exp
+++ b/language/evm/move-to-yul/tests/TestABINative.exp
@@ -3,12 +3,12 @@
  * ======================================= */
 
 
-object "Empty" {
+object "A2_M" {
     code {
-        codecopy(0, dataoffset("Empty_deployed"), datasize("Empty_deployed"))
-        return(0, datasize("Empty_deployed"))
+        codecopy(0, dataoffset("A2_M_deployed"), datasize("A2_M_deployed"))
+        return(0, datasize("A2_M_deployed"))
     }
-    object "Empty_deployed" {
+    object "A2_M_deployed" {
         code {
             mstore(0, memoryguard(160))
             if iszero(lt(calldatasize(), 4))

--- a/language/evm/move-to-yul/tests/TestABINative.move
+++ b/language/evm/move-to-yul/tests/TestABINative.move
@@ -1,4 +1,4 @@
-#[contract]
+#[evm_contract]
 module 0x2::M {
      use Evm::Evm::concat;
     use Std::Vector;

--- a/language/evm/move-to-yul/tests/TestABINativeError.exp
+++ b/language/evm/move-to-yul/tests/TestABINativeError.exp
@@ -3,12 +3,12 @@
  * ======================================= */
 
 
-object "Empty" {
+object "A2_M" {
     code {
-        codecopy(0, dataoffset("Empty_deployed"), datasize("Empty_deployed"))
-        return(0, datasize("Empty_deployed"))
+        codecopy(0, dataoffset("A2_M_deployed"), datasize("A2_M_deployed"))
+        return(0, datasize("A2_M_deployed"))
     }
-    object "Empty_deployed" {
+    object "A2_M_deployed" {
         code {
             mstore(0, memoryguard(160))
             if iszero(lt(calldatasize(), 4))

--- a/language/evm/move-to-yul/tests/TestABINativeError.move
+++ b/language/evm/move-to-yul/tests/TestABINativeError.move
@@ -1,4 +1,4 @@
-#[contract]
+#[evm_contract]
 module 0x2::M {
     use Std::Vector;
 

--- a/language/evm/move-to-yul/tests/TestExternalResult.exp
+++ b/language/evm/move-to-yul/tests/TestExternalResult.exp
@@ -3,12 +3,12 @@
  * ======================================= */
 
 
-object "Empty" {
+object "A2_M" {
     code {
-        codecopy(0, dataoffset("Empty_deployed"), datasize("Empty_deployed"))
-        return(0, datasize("Empty_deployed"))
+        codecopy(0, dataoffset("A2_M_deployed"), datasize("A2_M_deployed"))
+        return(0, datasize("A2_M_deployed"))
     }
-    object "Empty_deployed" {
+    object "A2_M_deployed" {
         code {
             mstore(0, memoryguard(160))
             if iszero(lt(calldatasize(), 4))

--- a/language/evm/move-to-yul/tests/TestExternalResult.move
+++ b/language/evm/move-to-yul/tests/TestExternalResult.move
@@ -1,3 +1,4 @@
+#[evm_contract]
 module 0x2::M {
     use Evm::ExternalResult::{Self, ExternalResult};
     use Evm::U256::{Self, U256};

--- a/language/evm/move-to-yul/tests/TestStringLiteral.exp
+++ b/language/evm/move-to-yul/tests/TestStringLiteral.exp
@@ -3,12 +3,12 @@
  * ======================================= */
 
 
-object "Empty" {
+object "A2_M" {
     code {
-        codecopy(0, dataoffset("Empty_deployed"), datasize("Empty_deployed"))
-        return(0, datasize("Empty_deployed"))
+        codecopy(0, dataoffset("A2_M_deployed"), datasize("A2_M_deployed"))
+        return(0, datasize("A2_M_deployed"))
     }
-    object "Empty_deployed" {
+    object "A2_M_deployed" {
         code {
             mstore(0, memoryguard(160))
             if iszero(lt(calldatasize(), 4))

--- a/language/evm/move-to-yul/tests/TestStringLiteral.move
+++ b/language/evm/move-to-yul/tests/TestStringLiteral.move
@@ -1,3 +1,4 @@
+#[evm_contract]
 module 0x2::M {
     use Std::Vector;
     use Evm::Evm::{sign, require};

--- a/language/evm/move-to-yul/tests/U256Arith.move
+++ b/language/evm/move-to-yul/tests/U256Arith.move
@@ -1,6 +1,6 @@
 // Tests basic arithmetics with u256s.
 // dep: ../stdlib/sources/U256.move
-#[contract]
+#[evm_contract]
 module 0x2::U256Arith {
     use Evm::U256::{Self, U256, u256_from_words};
 

--- a/language/evm/move-to-yul/tests/Vectors.move
+++ b/language/evm/move-to-yul/tests/Vectors.move
@@ -1,3 +1,4 @@
+#[evm_contract]
 module 0x2::Vectors {
     use Std::Vector;
 

--- a/language/evm/move-to-yul/tests/dispatcher_testsuite.rs
+++ b/language/evm/move-to-yul/tests/dispatcher_testsuite.rs
@@ -69,7 +69,9 @@ fn compile_yul_to_bytecode_bytes(filename: &str) -> Result<Vec<u8>> {
         ModelBuilderOptions::default(),
     )?;
     let options = Options::default();
-    let (_, out, _) = Generator::run(&options, &env);
+    let (_, out, _) = Generator::run(&options, &env)
+        .pop()
+        .expect("not contract in test case");
     let (bc, _) = compile::solc_yul(&out, false)?;
     Ok(bc)
 }

--- a/language/evm/move-to-yul/tests/fallback-receive-test/FallbackOnly.move
+++ b/language/evm/move-to-yul/tests/fallback-receive-test/FallbackOnly.move
@@ -1,4 +1,4 @@
-#[contract]
+#[evm_contract]
 module 0x2::M {
 
     #[fallback]

--- a/language/evm/move-to-yul/tests/fallback-receive-test/FallbackPayableOnly.move
+++ b/language/evm/move-to-yul/tests/fallback-receive-test/FallbackPayableOnly.move
@@ -1,4 +1,4 @@
-#[contract]
+#[evm_contract]
 module 0x2::M {
 
     #[fallback, payable]

--- a/language/evm/move-to-yul/tests/fallback-receive-test/ReceiveFallback.move
+++ b/language/evm/move-to-yul/tests/fallback-receive-test/ReceiveFallback.move
@@ -1,4 +1,4 @@
-#[contract]
+#[evm_contract]
 module 0x2::M {
 
     #[receive, payable]

--- a/language/evm/move-to-yul/tests/fallback-receive-test/ReceiveOnly.move
+++ b/language/evm/move-to-yul/tests/fallback-receive-test/ReceiveOnly.move
@@ -1,4 +1,4 @@
-#[contract]
+#[evm_contract]
 module 0x2::M {
 
     #[receive, payable]

--- a/language/evm/move-to-yul/tests/fallback-receive-test/expect-failure/FallbackMultipleParams.move
+++ b/language/evm/move-to-yul/tests/fallback-receive-test/expect-failure/FallbackMultipleParams.move
@@ -1,4 +1,4 @@
-#[contract]
+#[evm_contract]
 module 0x2::M {
 
     #[fallback]

--- a/language/evm/move-to-yul/tests/fallback-receive-test/expect-failure/FallbackReciveFailure.move
+++ b/language/evm/move-to-yul/tests/fallback-receive-test/expect-failure/FallbackReciveFailure.move
@@ -1,4 +1,4 @@
-#[contract]
+#[evm_contract]
 module 0x2::M {
 
     #[fallback, callable, receive]

--- a/language/evm/move-to-yul/tests/test-dispatcher/DispatcherArrayDecoding.move
+++ b/language/evm/move-to-yul/tests/test-dispatcher/DispatcherArrayDecoding.move
@@ -1,4 +1,4 @@
-#[contract]
+#[evm_contract]
 module 0x2::M {
     use Std::Vector;
     use Evm::U256::{Self, U256};

--- a/language/evm/move-to-yul/tests/test-dispatcher/DispatcherArrayEncoding.move
+++ b/language/evm/move-to-yul/tests/test-dispatcher/DispatcherArrayEncoding.move
@@ -1,4 +1,4 @@
-#[contract]
+#[evm_contract]
 module 0x2::M {
     use Evm::U256::U256;
 

--- a/language/evm/move-to-yul/tests/test-dispatcher/DispatcherBasic.move
+++ b/language/evm/move-to-yul/tests/test-dispatcher/DispatcherBasic.move
@@ -1,4 +1,4 @@
-#[contract]
+#[evm_contract]
 module 0x2::M {
     #[callable]
     fun return_0(): u128 {

--- a/language/evm/move-to-yul/tests/test-dispatcher/DispatcherBytesDecoding.move
+++ b/language/evm/move-to-yul/tests/test-dispatcher/DispatcherBytesDecoding.move
@@ -1,4 +1,4 @@
-#[contract]
+#[evm_contract]
 module 0x2::M {
     use Std::Vector;
 

--- a/language/evm/move-to-yul/tests/test-dispatcher/DispatcherBytesEncoding.move
+++ b/language/evm/move-to-yul/tests/test-dispatcher/DispatcherBytesEncoding.move
@@ -1,4 +1,4 @@
-#[contract]
+#[evm_contract]
 module 0x2::M {
     use Std::Vector;
 

--- a/language/evm/move-to-yul/tests/test-dispatcher/DispatcherEncodingStorage.move
+++ b/language/evm/move-to-yul/tests/test-dispatcher/DispatcherEncodingStorage.move
@@ -1,4 +1,4 @@
-#[contract]
+#[evm_contract]
 module 0x2::M {
     use Std::Vector;
     use Evm::U256::{Self, U256};

--- a/language/evm/move-to-yul/tests/test-dispatcher/DispatcherFallback.move
+++ b/language/evm/move-to-yul/tests/test-dispatcher/DispatcherFallback.move
@@ -1,4 +1,4 @@
-#[contract]
+#[evm_contract]
 module 0x2::M {
 
     #[callable]

--- a/language/evm/move-to-yul/tests/test-dispatcher/DispatcherMultiParaDecoding.move
+++ b/language/evm/move-to-yul/tests/test-dispatcher/DispatcherMultiParaDecoding.move
@@ -1,4 +1,4 @@
-#[contract]
+#[evm_contract]
 module 0x2::M {
     use Std::Vector;
 

--- a/language/evm/move-to-yul/tests/test-dispatcher/DispatcherMultiRetEncoding.move
+++ b/language/evm/move-to-yul/tests/test-dispatcher/DispatcherMultiRetEncoding.move
@@ -1,4 +1,4 @@
-#[contract]
+#[evm_contract]
 module 0x2::M {
     use Std::Vector;
 

--- a/language/evm/move-to-yul/tests/test-dispatcher/DispatcherRevert.move
+++ b/language/evm/move-to-yul/tests/test-dispatcher/DispatcherRevert.move
@@ -1,4 +1,4 @@
-#[contract]
+#[evm_contract]
 module 0x2::M {
 
     #[callable]

--- a/language/evm/move-to-yul/tests/test-dispatcher/ExternalCall.move
+++ b/language/evm/move-to-yul/tests/test-dispatcher/ExternalCall.move
@@ -1,4 +1,4 @@
-#[contract]
+#[evm_contract]
 module 0x2::M {
     use Evm::U256::{Self, U256, u256_from_words};
     use Evm::ExternalResult::{Self, ExternalResult};

--- a/language/evm/move-to-yul/tests/test-dispatcher/ExternalCallFailure.move
+++ b/language/evm/move-to-yul/tests/test-dispatcher/ExternalCallFailure.move
@@ -1,4 +1,4 @@
-#[contract]
+#[evm_contract]
 module 0x2::M {
 
     #[external(sig=b"noPara()")]

--- a/language/evm/move-to-yul/tests/test-dispatcher/signature-parsing-test/baseline/ParsingSoliditySig.move
+++ b/language/evm/move-to-yul/tests/test-dispatcher/signature-parsing-test/baseline/ParsingSoliditySig.move
@@ -1,4 +1,4 @@
-#[contract]
+#[evm_contract]
 module 0x2::M {
     use Evm::U256::U256;
 

--- a/language/evm/move-to-yul/tests/test-dispatcher/signature-parsing-test/baseline/evm-examples/ERC1155.move
+++ b/language/evm/move-to-yul/tests/test-dispatcher/signature-parsing-test/baseline/evm-examples/ERC1155.move
@@ -1,4 +1,4 @@
-#[contract]
+#[evm_contract]
 /// An implementation of the ERC-1155 Multi Token Standard.
 module 0x2::ERC1155 {
     use Std::ASCII::{String};

--- a/language/evm/move-to-yul/tests/test-dispatcher/signature-parsing-test/baseline/evm-examples/ERC721.move
+++ b/language/evm/move-to-yul/tests/test-dispatcher/signature-parsing-test/baseline/evm-examples/ERC721.move
@@ -1,4 +1,4 @@
-#[contract]
+#[evm_contract]
 /// An implementation of the ERC-721 Non-Fungible Token Standard.
 module 0x2::ERC721 {
     use Evm::U256::{U256, u256_from_words};

--- a/language/evm/move-to-yul/tests/test-dispatcher/signature-parsing-test/baseline/evm-examples/Token.move
+++ b/language/evm/move-to-yul/tests/test-dispatcher/signature-parsing-test/baseline/evm-examples/Token.move
@@ -1,4 +1,4 @@
-#[contract]
+#[evm_contract]
 /// An implementation of ERC20.
 module 0x2::ERC20 {
     use Evm::U256::{U256, u256_from_words};

--- a/language/evm/move-to-yul/tests/test-dispatcher/signature-parsing-test/baseline/parsing_failure/IllegalDataLocation.move
+++ b/language/evm/move-to-yul/tests/test-dispatcher/signature-parsing-test/baseline/parsing_failure/IllegalDataLocation.move
@@ -1,4 +1,4 @@
-#[contract]
+#[evm_contract]
 module 0x2::M {
 
     #[callable(sig=b"f(uint64 memory)")]

--- a/language/evm/move-to-yul/tests/test-dispatcher/signature-parsing-test/baseline/parsing_failure/IllegalFunctionName.move
+++ b/language/evm/move-to-yul/tests/test-dispatcher/signature-parsing-test/baseline/parsing_failure/IllegalFunctionName.move
@@ -1,4 +1,4 @@
-#[contract]
+#[evm_contract]
 module 0x2::M {
 
     #[callable(sig=b"1add()")]

--- a/language/evm/move-to-yul/tests/test-dispatcher/signature-parsing-test/baseline/parsing_failure/IllegalTypeList.move
+++ b/language/evm/move-to-yul/tests/test-dispatcher/signature-parsing-test/baseline/parsing_failure/IllegalTypeList.move
@@ -1,4 +1,4 @@
-#[contract]
+#[evm_contract]
 module 0x2::M {
 
     // Extra commas

--- a/language/evm/move-to-yul/tests/test-dispatcher/signature-parsing-test/baseline/parsing_failure/IncompatibileType.move
+++ b/language/evm/move-to-yul/tests/test-dispatcher/signature-parsing-test/baseline/parsing_failure/IncompatibileType.move
@@ -1,4 +1,4 @@
-#[contract]
+#[evm_contract]
 module 0x2::M {
 
     // Length difference

--- a/language/evm/move-to-yul/tests/test-events/CallEmit.move
+++ b/language/evm/move-to-yul/tests/test-events/CallEmit.move
@@ -1,4 +1,4 @@
-#[contract]
+#[evm_contract]
 module 0x2::M {
     use Evm::Evm::{emit};
     use Evm::U256::U256;

--- a/language/evm/move-to-yul/tests/test-events/compilation_failure/EventSigCompatibilityFailure.exp
+++ b/language/evm/move-to-yul/tests/test-events/compilation_failure/EventSigCompatibilityFailure.exp
@@ -3,12 +3,12 @@
  * ======================================= */
 
 
-object "Empty" {
+object "A2_M" {
     code {
-        codecopy(0, dataoffset("Empty_deployed"), datasize("Empty_deployed"))
-        return(0, datasize("Empty_deployed"))
+        codecopy(0, dataoffset("A2_M_deployed"), datasize("A2_M_deployed"))
+        return(0, datasize("A2_M_deployed"))
     }
-    object "Empty_deployed" {
+    object "A2_M_deployed" {
         code {
             mstore(0, memoryguard(160))
             if iszero(lt(calldatasize(), 4))

--- a/language/evm/move-to-yul/tests/test-events/compilation_failure/EventSigCompatibilityFailure.move
+++ b/language/evm/move-to-yul/tests/test-events/compilation_failure/EventSigCompatibilityFailure.move
@@ -1,4 +1,4 @@
-#[contract]
+#[evm_contract]
 module 0x2::M {
     use Evm::U256::U256;
 

--- a/language/evm/move-to-yul/tests/test-events/compilation_failure/EventTooManyTopics.exp
+++ b/language/evm/move-to-yul/tests/test-events/compilation_failure/EventTooManyTopics.exp
@@ -3,12 +3,12 @@
  * ======================================= */
 
 
-object "Empty" {
+object "A2_M" {
     code {
-        codecopy(0, dataoffset("Empty_deployed"), datasize("Empty_deployed"))
-        return(0, datasize("Empty_deployed"))
+        codecopy(0, dataoffset("A2_M_deployed"), datasize("A2_M_deployed"))
+        return(0, datasize("A2_M_deployed"))
     }
-    object "Empty_deployed" {
+    object "A2_M_deployed" {
         code {
             mstore(0, memoryguard(160))
             if iszero(lt(calldatasize(), 4))

--- a/language/evm/move-to-yul/tests/test-events/compilation_failure/EventTooManyTopics.move
+++ b/language/evm/move-to-yul/tests/test-events/compilation_failure/EventTooManyTopics.move
@@ -1,4 +1,4 @@
-#[contract]
+#[evm_contract]
 module 0x2::M {
 
 #[event(sig=b"Transfer(address indexed,address indexed, uint128 indexed, uint128 indexed)")]

--- a/language/evm/move-to-yul/tests/test-events/compilation_failure/ParsingEventSigFailure.exp
+++ b/language/evm/move-to-yul/tests/test-events/compilation_failure/ParsingEventSigFailure.exp
@@ -3,12 +3,12 @@
  * ======================================= */
 
 
-object "Empty" {
+object "A2_M" {
     code {
-        codecopy(0, dataoffset("Empty_deployed"), datasize("Empty_deployed"))
-        return(0, datasize("Empty_deployed"))
+        codecopy(0, dataoffset("A2_M_deployed"), datasize("A2_M_deployed"))
+        return(0, datasize("A2_M_deployed"))
     }
-    object "Empty_deployed" {
+    object "A2_M_deployed" {
         code {
             mstore(0, memoryguard(160))
             if iszero(lt(calldatasize(), 4))

--- a/language/evm/move-to-yul/tests/test-events/compilation_failure/ParsingEventSigFailure.move
+++ b/language/evm/move-to-yul/tests/test-events/compilation_failure/ParsingEventSigFailure.move
@@ -1,4 +1,4 @@
-#[contract]
+#[evm_contract]
 module 0x2::M {
     use Evm::U256::U256;
 

--- a/language/evm/move-to-yul/tests/test-events/compilation_failure/ParsingEventSigFailureGeneric.exp
+++ b/language/evm/move-to-yul/tests/test-events/compilation_failure/ParsingEventSigFailureGeneric.exp
@@ -3,12 +3,12 @@
  * ======================================= */
 
 
-object "Empty" {
+object "A2_M" {
     code {
-        codecopy(0, dataoffset("Empty_deployed"), datasize("Empty_deployed"))
-        return(0, datasize("Empty_deployed"))
+        codecopy(0, dataoffset("A2_M_deployed"), datasize("A2_M_deployed"))
+        return(0, datasize("A2_M_deployed"))
     }
-    object "Empty_deployed" {
+    object "A2_M_deployed" {
         code {
             mstore(0, memoryguard(160))
             if iszero(lt(calldatasize(), 4))

--- a/language/evm/move-to-yul/tests/test-events/compilation_failure/ParsingEventSigFailureGeneric.move
+++ b/language/evm/move-to-yul/tests/test-events/compilation_failure/ParsingEventSigFailureGeneric.move
@@ -1,4 +1,4 @@
-#[contract]
+#[evm_contract]
 module 0x2::M {
 
     use Evm::U256::U256;

--- a/language/evm/move-to-yul/tests/testsuite.rs
+++ b/language/evm/move-to-yul/tests/testsuite.rs
@@ -64,7 +64,7 @@ fn test_runner(path: &Path) -> datatest_stable::Result<()> {
             options.experiments.push(exp.clone());
             format!("{}.{}", EXP_EXT, exp)
         };
-        let (_, mut out, _) = Generator::run(&options, &env);
+        let (_, mut out, _) = Generator::run(&options, &env).pop().expect("contract");
         if !env.has_errors() {
             out = format!("{}\n\n{}", out, compile_check(&options, &out));
 

--- a/language/move-model/src/exp_generator.rs
+++ b/language/move-model/src/exp_generator.rs
@@ -150,7 +150,7 @@ pub trait ExpGenerator<'env> {
 
     /// Join an iterator of boolean expressions with a boolean binary operator.
     fn mk_join_bool(&self, oper: Operation, args: impl Iterator<Item = Exp>) -> Option<Exp> {
-        args.fold1(|a, b| self.mk_bool_call(oper.clone(), vec![a, b]))
+        args.reduce(|a, b| self.mk_bool_call(oper.clone(), vec![a, b]))
     }
 
     /// Join two boolean optional expression with binary operator.

--- a/language/tools/move-cli/src/package/cli.rs
+++ b/language/tools/move-cli/src/package/cli.rs
@@ -301,12 +301,12 @@ pub fn handle_package_commands(
 
             match architecture {
                 Architecture::Move | Architecture::AsyncMove => {
-                    config.compile_package(&rerooted_path, &mut std::io::stdout())?;
+                    config.compile_package(&rerooted_path, &mut std::io::stderr())?;
                 }
 
                 #[cfg(feature = "evm-backend")]
                 Architecture::Ethereum => {
-                    config.compile_package_evm(&rerooted_path, &mut std::io::stdout())?;
+                    config.compile_package_evm(&rerooted_path, &mut std::io::stderr())?;
                 }
             }
         }

--- a/language/tools/move-cli/tests/build_tests/circular_dependencies/sources/Foo.move
+++ b/language/tools/move-cli/tests/build_tests/circular_dependencies/sources/Foo.move
@@ -1,3 +1,4 @@
+#[evm_contract] // for passing evm test flavor
 module 0x1::Foo {
     use 0x1::Bar;
 

--- a/language/tools/move-cli/tests/build_tests/dependency_chain/sources/A.move
+++ b/language/tools/move-cli/tests/build_tests/dependency_chain/sources/A.move
@@ -1,3 +1,4 @@
+#[evm_contract] // for passing evm test flavor
 module A::A {
     use A::Foo;
 

--- a/language/tools/move-cli/tests/build_tests/dev_address/sources/A.move
+++ b/language/tools/move-cli/tests/build_tests/dev_address/sources/A.move
@@ -1,1 +1,2 @@
+#[evm_contract] // for passing evm test flavor
 module A::A {}

--- a/language/tools/move-cli/tests/build_tests/empty_module_no_deps/sources/A.move
+++ b/language/tools/move-cli/tests/build_tests/empty_module_no_deps/sources/A.move
@@ -1,1 +1,2 @@
+#[evm_contract] // for passing evm test flavor
 module 0x1::M {}

--- a/language/tools/move-cli/tests/build_tests/include_exclude_stdlib/args.evm.exp
+++ b/language/tools/move-cli/tests/build_tests/include_exclude_stdlib/args.evm.exp
@@ -1,16 +1,16 @@
 Command `package build -v --arch ethereum`:
 COMPILING build_include_exclude_stdlib to Yul
-ERROR Failed to compile Move into Yul
+exiting with Move build errors Failed to compile Move into Yul ERROR
 [0m[1m[38;5;9merror[0m[1m: unbound module[0m
-  [0m[34m┌─[0m ./sources/UseSigner.move:2:7
+  [0m[34m┌─[0m ./sources/UseSigner.move:3:7
   [0m[34m│[0m
-[0m[34m2[0m [0m[34m│[0m   use [0m[31mStd::Signer[0m;
+[0m[34m3[0m [0m[34m│[0m   use [0m[31mStd::Signer[0m;
   [0m[34m│[0m       [0m[31m^^^^^^^^^^^[0m [0m[31mInvalid 'use'. Unbound module: '(Std=1)::Signer'[0m
 
 [0m[1m[38;5;9merror[0m[1m: unbound module[0m
-  [0m[34m┌─[0m ./sources/UseSigner.move:5:5
+  [0m[34m┌─[0m ./sources/UseSigner.move:6:5
   [0m[34m│[0m
-[0m[34m5[0m [0m[34m│[0m     [0m[31mSigner[0m::address_of(account)
+[0m[34m6[0m [0m[34m│[0m     [0m[31mSigner[0m::address_of(account)
   [0m[34m│[0m     [0m[31m^^^^^^[0m [0m[31mUnbound module alias 'Signer'[0m
 
 

--- a/language/tools/move-cli/tests/build_tests/include_exclude_stdlib/args.exp
+++ b/language/tools/move-cli/tests/build_tests/include_exclude_stdlib/args.exp
@@ -1,15 +1,15 @@
 Command `package build -v`:
 BUILDING build_include_exclude_stdlib
 error[E03002]: unbound module
-  ┌─ ./sources/UseSigner.move:2:7
+  ┌─ ./sources/UseSigner.move:3:7
   │
-2 │   use Std::Signer;
+3 │   use Std::Signer;
   │       ^^^^^^^^^^^ Invalid 'use'. Unbound module: '(Std=0x1)::Signer'
 
 error[E03002]: unbound module
-  ┌─ ./sources/UseSigner.move:5:5
+  ┌─ ./sources/UseSigner.move:6:5
   │
-5 │     Signer::address_of(account)
+6 │     Signer::address_of(account)
   │     ^^^^^^ Unbound module alias 'Signer'
 
 Command `-d -v package build`:

--- a/language/tools/move-cli/tests/build_tests/include_exclude_stdlib/sources/UseSigner.move
+++ b/language/tools/move-cli/tests/build_tests/include_exclude_stdlib/sources/UseSigner.move
@@ -1,3 +1,4 @@
+#[evm_contract] // for passing evm test flavor
 module 0x1::Example {
   use Std::Signer;
 

--- a/language/tools/move-cli/tests/build_tests/rebuild_after_adding_new_source/sources/Foo.move
+++ b/language/tools/move-cli/tests/build_tests/rebuild_after_adding_new_source/sources/Foo.move
@@ -1,1 +1,2 @@
+#[evm_contract] // for passing evm test flavor
 module 0x1::Foo {}

--- a/language/tools/move-cli/tests/build_tests/rebuild_after_deleting_output_artifact/sources/Foo.move
+++ b/language/tools/move-cli/tests/build_tests/rebuild_after_deleting_output_artifact/sources/Foo.move
@@ -1,1 +1,2 @@
+#[evm_contract] // for passing evm test flavor
 module 0x1::Foo {}

--- a/language/tools/move-cli/tests/build_tests/rebuild_after_touching_manifest/sources/Foo.move
+++ b/language/tools/move-cli/tests/build_tests/rebuild_after_touching_manifest/sources/Foo.move
@@ -1,1 +1,2 @@
+#[evm_contract] // for passing evm test flavor
 module 0x1::Foo {}

--- a/language/tools/move-cli/tests/build_tests/rebuild_after_touching_source/sources/Foo.move
+++ b/language/tools/move-cli/tests/build_tests/rebuild_after_touching_source/sources/Foo.move
@@ -1,1 +1,2 @@
+#[evm_contract] // for passing evm test flavor
 module 0x1::Foo {}

--- a/language/tools/move-cli/tests/build_tests/rebuild_no_modification/sources/Foo.move
+++ b/language/tools/move-cli/tests/build_tests/rebuild_no_modification/sources/Foo.move
@@ -1,1 +1,2 @@
+#[evm_contract] // for passing evm test flavor
 module 0x1::Foo {}

--- a/language/tools/move-cli/tests/build_tests/unbound_address/sources/A.move
+++ b/language/tools/move-cli/tests/build_tests/unbound_address/sources/A.move
@@ -1,1 +1,2 @@
+#[evm_contract] // for passing evm test flavor
 module A::A {}

--- a/language/tools/move-cli/tests/build_tests/unbound_dependency/sources/A.move
+++ b/language/tools/move-cli/tests/build_tests/unbound_dependency/sources/A.move
@@ -1,1 +1,2 @@
+#[evm_contract] // for passing evm test flavor
 module 0x1::A {}

--- a/language/tools/move-package/src/compilation/build_plan.rs
+++ b/language/tools/move-package/src/compilation/build_plan.rs
@@ -275,7 +275,8 @@ impl BuildPlan {
         ) {
             writeln!(
                 writer,
-                "{} Failed to compile Move into Yul",
+                "{} Failed to compile Move into Yul {}",
+                err,
                 "ERROR".bold().red()
             )?;
 

--- a/scripts/check_pr.sh
+++ b/scripts/check_pr.sh
@@ -108,10 +108,10 @@ fi
 
 if [ ! -z "$HARDHAT_CHECKS" ]; then
   echo "*************** [check-pr] Running hardhat tests (expecting hardhat configured)"
-  # (
-  #   cd $BASE/language/tools/move-cli
-  #   cargo install --path .
-  # )
+  (
+     cd $BASE/language/tools/move-cli
+     cargo install --path . --features evm-backend
+  )
   # (
   #   cd $BASE/language/evm/hardhat-move
   #   npm install


### PR DESCRIPTION
This implements the first step towards passing references to contract storage to callables instead of requiring to use `borrow_global<T>(self())`. The intended functionality is not yet implemented but this prepares it.

- Now contracts are associated with modules. One has to use `#[evm_contract]` as a module attribute to identify an EVM contract. Only callables inside of that particular module are recognized to belong to the EVM contract. This also addresses and closes #91.
- As a result, one package can contain multiple contracts. However, the compiler will issue a warning if there is more than one contract and ignore all but the first because the remaining tool chain isn't yet prepared for dealing with multiple contracts.
- The `#[storage]` attribute now indicates that callables should take a reference to this struct. This attribute is optional, so old-style contracts which use `move_to` and `borrow` are still supported. Because `#[storage]` is not fully implemented yet, it has been removed where it was used, as all existing tests still use old-style storage.
- There was some heavier refactoring needed to be able to emit code for `move_to` and other storage related operations. Because the new regime requires to call `move_to`, `borrow` etc. outside of the `FunctionGenerator`, those functions had to be moved on `Generator` level. This is only partly used until now and will be fully leveraged in the 2nd step.

Nits:
- Compiler output of the package system has been redirected to stderr instead of stdout. This was done because hardhat drops stdout somehow, and seems cleaner anyway.


## Test Plan

Existing tests