### PR TITLE
[compiler] Added support for preserving locations of aliased identifiers

### DIFF
--- a/language/move-compiler/src/expansion/aliases.rs
+++ b/language/move-compiler/src/expansion/aliases.rs
@@ -161,13 +161,10 @@ impl AliasMap {
                     self.unused[*depth].modules.remove(n);
                 }
                 *depth_opt = None;
-                // We are preserving the name's original location,
-                // rather than referring to where the alias was
-                // defined. The name represents JUST the module name,
-                // though, so we do not change location of the address
-                // as we don't have this information.
-                // TODO maybe we should also keep the alias reference
-                // (or its location)?
+                // We are preserving the name's original location, rather than referring to where the alias was
+                // defined. The name represents JUST the module name, though, so we do not change location of
+                // the address as we don't have this information.
+                // TODO maybe we should also keep the alias reference (or its location)?
                 let sp!(
                     _,
                     ModuleIdent_ {
@@ -190,13 +187,10 @@ impl AliasMap {
                     self.unused[*depth].members.remove(n);
                 }
                 *depth_opt = None;
-                // We are preserving the name's original location,
-                // rather than referring to where the alias was
-                // defined. The name represents JUST the member name,
-                // though, so we do not change location of the module
-                // as we don't have this information.
-                // TODO maybe we should also keep the alias reference
-                // (or its location)?
+                // We are preserving the name's original location, rather than referring to where the alias was
+                // defined. The name represents JUST the member name, though, so we do not change location of
+                // the module as we don't have this information.
+                // TODO maybe we should also keep the alias reference (or its location)?
                 Some((sp(*mem_mod_loc, *mem_mod), sp(n.loc, *mem_name)))
             }
         }

--- a/language/move-compiler/src/expansion/aliases.rs
+++ b/language/move-compiler/src/expansion/aliases.rs
@@ -161,9 +161,9 @@ impl AliasMap {
                     self.unused[*depth].modules.remove(n);
                 }
                 *depth_opt = None;
-                // We are preserving the name's original location, rather than referring to where the alias was
-                // defined. The name represents JUST the module name, though, so we do not change location of
-                // the address as we don't have this information.
+                // We are preserving the name's original location, rather than referring to where
+                // the alias was defined. The name represents JUST the module name, though, so we do
+                // not change location of the address as we don't have this information.
                 // TODO maybe we should also keep the alias reference (or its location)?
                 let sp!(
                     _,
@@ -187,9 +187,9 @@ impl AliasMap {
                     self.unused[*depth].members.remove(n);
                 }
                 *depth_opt = None;
-                // We are preserving the name's original location, rather than referring to where the alias was
-                // defined. The name represents JUST the member name, though, so we do not change location of
-                // the module as we don't have this information.
+                // We are preserving the name's original location, rather than referring to where
+                // the alias was defined. The name represents JUST the member name, though, so we do
+                // not change location of the module as we don't have this information.
                 // TODO maybe we should also keep the alias reference (or its location)?
                 Some((sp(*mem_mod_loc, *mem_mod), sp(n.loc, *mem_name)))
             }

--- a/language/move-compiler/src/expansion/translate.rs
+++ b/language/move-compiler/src/expansion/translate.rs
@@ -437,9 +437,7 @@ fn module_(
     for member in members {
         match member {
             P::ModuleMember::Use(_) => unreachable!(),
-            P::ModuleMember::Friend(f) => {
-                friend(context, &mut friends, f);
-            }
+            P::ModuleMember::Friend(f) => friend(context, &mut friends, f),
             P::ModuleMember::Function(mut f) => {
                 if !context.is_source_definition {
                     f.body.value = P::FunctionBody_::Native

--- a/language/move-compiler/src/expansion/translate.rs
+++ b/language/move-compiler/src/expansion/translate.rs
@@ -437,7 +437,9 @@ fn module_(
     for member in members {
         match member {
             P::ModuleMember::Use(_) => unreachable!(),
-            P::ModuleMember::Friend(f) => friend(context, &mut friends, f),
+            P::ModuleMember::Friend(f) => {
+                friend(context, &mut friends, f);
+            }
             P::ModuleMember::Function(mut f) => {
                 if !context.is_source_definition {
                     f.body.value = P::FunctionBody_::Native
@@ -1570,12 +1572,12 @@ fn name_access_chain(
         (Access::ApplyPositional, PN::One(n))
         | (Access::ApplyNamed, PN::One(n))
         | (Access::Type, PN::One(n)) => match context.aliases.member_alias_get(&n) {
-            Some((mident, mem)) => EN::ModuleAccess(*mident, *mem),
+            Some((mident, mem)) => EN::ModuleAccess(mident, mem),
             None => EN::Name(n),
         },
         (Access::Term, PN::One(n)) if is_valid_struct_constant_or_schema_name(n.value.as_str()) => {
             match context.aliases.member_alias_get(&n) {
-                Some((mident, mem)) => EN::ModuleAccess(*mident, *mem),
+                Some((mident, mem)) => EN::ModuleAccess(mident, mem),
                 None => EN::Name(n),
             }
         }
@@ -1595,7 +1597,7 @@ fn name_access_chain(
                 ));
                 return None;
             }
-            Some(mident) => EN::ModuleAccess(*mident, n2),
+            Some(mident) => EN::ModuleAccess(mident, n2),
         },
         (_, PN::Three(sp!(ident_loc, (ln, n2)), n3)) => {
             let addr = address(context, /* suggest_declaration */ false, ln);
@@ -1620,7 +1622,7 @@ fn name_access_chain_to_module_ident(
                 ));
                 None
             }
-            Some(mident) => Some(*mident),
+            Some(mident) => Some(mident),
         },
         PN::Two(ln, n) => {
             let pmident_ = P::ModuleIdent_ {

--- a/language/move-compiler/tests/move_check/naming/friend_decl_self.exp
+++ b/language/move-compiler/tests/move_check/naming/friend_decl_self.exp
@@ -1,10 +1,11 @@
 error[E02011]: invalid 'friend' declaration
   ┌─ tests/move_check/naming/friend_decl_self.move:3:5
   │
-2 │ module M {
-  │        - Cannot declare the module itself as a friend
 3 │     friend Self;
-  │     ^^^^^^^^^^^^ Invalid friend declaration
+  │     ^^^^^^^^^^^^
+  │     │      │
+  │     │      Cannot declare the module itself as a friend
+  │     Invalid friend declaration
 
 error[E02011]: invalid 'friend' declaration
   ┌─ tests/move_check/naming/friend_decl_self.move:9:5


### PR DESCRIPTION
## Motivation

This is a fix for a problem described in https://github.com/move-language/move/issues/84. In short, we want to preserve locations of identifiers that are aliases to modules or module-level definitions. It fixes the problem more generally (e.g., also for `Pack` and other AST nodes).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#pull-requests)?

Yes
