### PR TITLE
[table-extenstion] Add trait bounds (copy + drop) to Table key

### DIFF
--- a/language/extensions/move-table-extension/sources/Table.move
+++ b/language/extensions/move-table-extension/sources/Table.move
@@ -9,13 +9,13 @@ module Extensions::Table {
     const ENOT_EMPTY: u64 = 102;
 
     /// Type of tables
-    struct Table<phantom K, phantom V> has store {
+    struct Table<phantom K: copy + drop, phantom V> has store {
         handle: u128,
         length: u64,
     }
 
     /// Create a new Table.
-    public fun new<K, V: store>(): Table<K, V> {
+    public fun new<K: copy + drop, V: store>(): Table<K, V> {
         Table{
             handle: new_table_handle(),
             length: 0,
@@ -23,7 +23,7 @@ module Extensions::Table {
     }
 
     /// Destroy a table. The table must be empty to succeed.
-    public fun destroy_empty<K, V>(table: Table<K, V>) {
+    public fun destroy_empty<K: copy + drop, V>(table: Table<K, V>) {
         assert!(table.length == 0, Errors::invalid_state(ENOT_EMPTY));
         destroy_empty_box<K, V, Box<V>>(&table);
         drop_unchecked_box<K, V, Box<V>>(table)
@@ -32,58 +32,58 @@ module Extensions::Table {
     /// Add a new entry to the table. Aborts if an entry for this
     /// key already exists. The entry itself is not stored in the
     /// table, and cannot be discovered from it.
-    public fun add<K, V>(table: &mut Table<K, V>, key: &K, val: V) {
+    public fun add<K: copy + drop, V>(table: &mut Table<K, V>, key: K, val: V) {
         add_box<K, V, Box<V>>(table, key, Box{val});
         table.length = table.length + 1
     }
 
     /// Acquire an immutable reference to the value which `key` maps to.
     /// Aborts if there is no entry for `key`.
-    public fun borrow<K, V>(table: &Table<K, V>, key: &K): &V {
+    public fun borrow<K: copy + drop, V>(table: &Table<K, V>, key: K): &V {
         &borrow_box<K, V, Box<V>>(table, key).val
     }
 
     /// Acquire a mutable reference to the value which `key` maps to.
     /// Aborts if there is no entry for `key`.
-    public fun borrow_mut<K, V>(table: &mut Table<K, V>, key: &K): &mut V {
+    public fun borrow_mut<K: copy + drop, V>(table: &mut Table<K, V>, key: K): &mut V {
         &mut borrow_box_mut<K, V, Box<V>>(table, key).val
     }
 
     /// Returns the length of the table, i.e. the number of entries.
-    public fun length<K, V>(table: &Table<K, V>): u64 {
+    public fun length<K: copy + drop, V>(table: &Table<K, V>): u64 {
         table.length
     }
 
     /// Returns true if this table is empty.
-    public fun empty<K, V>(table: &Table<K, V>): bool {
+    public fun empty<K: copy + drop, V>(table: &Table<K, V>): bool {
         table.length == 0
     }
 
     /// Acquire a mutable reference to the value which `key` maps to.
     /// Insert the pair (`key`, `default`) first if there is no entry for `key`.
-    public fun borrow_mut_with_default<K, V: drop>(table: &mut Table<K, V>, key: &K, default: V): &mut V {
-        if (!contains(table, key)) {
-            add(table, key, default)
+    public fun borrow_mut_with_default<K: copy + drop, V: drop>(table: &mut Table<K, V>, key: K, default: V): &mut V {
+        if (!contains(table, copy key)) {
+            add(table, copy key, default)
         };
         borrow_mut(table, key)
     }
 
     /// Remove from `table` and return the value which `key` maps to.
     /// Aborts if there is no entry for `key`.
-    public fun remove<K, V>(table: &mut Table<K, V>, key: &K): V {
+    public fun remove<K: copy + drop, V>(table: &mut Table<K, V>, key: K): V {
         let Box{val} = remove_box<K, V, Box<V>>(table, key);
         table.length = table.length - 1;
         val
     }
 
     /// Returns true iff `table` contains an entry for `key`.
-    public fun contains<K, V>(table: &Table<K, V>, key: &K): bool {
+    public fun contains<K: copy + drop, V>(table: &Table<K, V>, key: K): bool {
         contains_box<K, V, Box<V>>(table, key)
     }
 
     #[test_only]
     /// Testing only: allows to drop a table even if it is not empty.
-    public fun drop_unchecked<K, V>(table: Table<K, V>) {
+    public fun drop_unchecked<K: copy + drop, V>(table: Table<K, V>) {
         drop_unchecked_box<K, V, Box<V>>(table)
     }
 
@@ -98,11 +98,11 @@ module Extensions::Table {
     // Primitives which take as an additional type parameter `Box<V>`, so the implementation
     // can use this to determine serialization layout.
     native fun new_table_handle(): u128;
-    native fun add_box<K, V, B>(table: &mut Table<K, V>, key: &K, val: Box<V>);
-    native fun borrow_box<K, V, B>(table: &Table<K, V>, key: &K): &Box<V>;
-    native fun borrow_box_mut<K, V, B>(table: &mut Table<K, V>, key: &K): &mut Box<V>;
-    native fun contains_box<K, V, B>(table: &Table<K, V>, key: &K): bool;
-    native fun remove_box<K, V, B>(table: &mut Table<K, V>, key: &K): Box<V>;
-    native fun destroy_empty_box<K, V, B>(table: &Table<K, V>);
-    native fun drop_unchecked_box<K, V, B>(table: Table<K, V>);
+    native fun add_box<K: copy + drop, V, B>(table: &mut Table<K, V>, key: K, val: Box<V>);
+    native fun borrow_box<K: copy + drop, V, B>(table: &Table<K, V>, key: K): &Box<V>;
+    native fun borrow_box_mut<K: copy + drop, V, B>(table: &mut Table<K, V>, key: K): &mut Box<V>;
+    native fun contains_box<K: copy + drop, V, B>(table: &Table<K, V>, key: K): bool;
+    native fun remove_box<K: copy + drop, V, B>(table: &mut Table<K, V>, key: K): Box<V>;
+    native fun destroy_empty_box<K: copy + drop, V, B>(table: &Table<K, V>);
+    native fun drop_unchecked_box<K: copy + drop, V, B>(table: Table<K, V>);
 }

--- a/language/extensions/move-table-extension/src/lib.rs
+++ b/language/extensions/move-table-extension/src/lib.rs
@@ -367,18 +367,14 @@ fn native_add_box(
     ty_args: Vec<Type>,
     mut args: VecDeque<Value>,
 ) -> PartialVMResult<NativeResult> {
-    assert!(ty_args.len() == 3);
-    assert!(args.len() == 3);
+    assert_eq!(ty_args.len(), 3);
+    assert_eq!(args.len(), 3);
 
     let table_context = context.extensions().get::<NativeTableContext>();
     let mut table_data = table_context.table_data.borrow_mut();
 
     let val = args.pop_back().unwrap();
-    let key = args
-        .pop_back()
-        .unwrap()
-        .value_as::<Reference>()?
-        .read_ref()?;
+    let key = args.pop_back().unwrap();
     let handle = get_table_handle(&pop_arg!(args, StructRef))?;
 
     let table = table_data.get_or_create_table(context, handle, &ty_args[0], &ty_args[2])?;
@@ -398,17 +394,13 @@ fn native_borrow_box(
     ty_args: Vec<Type>,
     mut args: VecDeque<Value>,
 ) -> PartialVMResult<NativeResult> {
-    assert!(ty_args.len() == 3);
-    assert!(args.len() == 2);
+    assert_eq!(ty_args.len(), 3);
+    assert_eq!(args.len(), 2);
 
     let table_context = context.extensions().get::<NativeTableContext>();
     let mut table_data = table_context.table_data.borrow_mut();
 
-    let key = args
-        .pop_back()
-        .unwrap()
-        .value_as::<Reference>()?
-        .read_ref()?;
+    let key = args.pop_back().unwrap();
     let handle = get_table_handle(&pop_arg!(args, StructRef))?;
 
     let table = table_data.get_or_create_table(context, handle, &ty_args[0], &ty_args[2])?;
@@ -427,17 +419,13 @@ fn native_contains_box(
     ty_args: Vec<Type>,
     mut args: VecDeque<Value>,
 ) -> PartialVMResult<NativeResult> {
-    assert!(ty_args.len() == 3);
-    assert!(args.len() == 2);
+    assert_eq!(ty_args.len(), 3);
+    assert_eq!(args.len(), 2);
 
     let table_context = context.extensions().get::<NativeTableContext>();
     let mut table_data = table_context.table_data.borrow_mut();
 
-    let key = args
-        .pop_back()
-        .unwrap()
-        .value_as::<Reference>()?
-        .read_ref()?;
+    let key = args.pop_back().unwrap();
     let handle = get_table_handle(&pop_arg!(args, StructRef))?;
 
     let table = table_data.get_or_create_table(context, handle, &ty_args[0], &ty_args[2])?;
@@ -456,17 +444,13 @@ fn native_remove_box(
     ty_args: Vec<Type>,
     mut args: VecDeque<Value>,
 ) -> PartialVMResult<NativeResult> {
-    assert!(ty_args.len() == 3);
-    assert!(args.len() == 2);
+    assert_eq!(ty_args.len(), 3);
+    assert_eq!(args.len(), 2);
 
     let table_context = context.extensions().get::<NativeTableContext>();
     let mut table_data = table_context.table_data.borrow_mut();
 
-    let key = args
-        .pop_back()
-        .unwrap()
-        .value_as::<Reference>()?
-        .read_ref()?;
+    let key = args.pop_back().unwrap();
     let handle = get_table_handle(&pop_arg!(args, StructRef))?;
     let table = table_data.get_or_create_table(context, handle, &ty_args[0], &ty_args[2])?;
     let (val, key_size, val_size) = table.remove(table_context, &key)?;
@@ -484,8 +468,8 @@ fn native_destroy_empty_box(
     ty_args: Vec<Type>,
     mut args: VecDeque<Value>,
 ) -> PartialVMResult<NativeResult> {
-    assert!(ty_args.len() == 3);
-    assert!(args.len() == 1);
+    assert_eq!(ty_args.len(), 3);
+    assert_eq!(args.len(), 1);
 
     let table_context = context.extensions().get::<NativeTableContext>();
     let mut table_data = table_context.table_data.borrow_mut();
@@ -509,8 +493,8 @@ fn native_drop_unchecked_box(
     ty_args: Vec<Type>,
     args: VecDeque<Value>,
 ) -> PartialVMResult<NativeResult> {
-    assert!(ty_args.len() == 3);
-    assert!(args.len() == 1);
+    assert_eq!(ty_args.len(), 3);
+    assert_eq!(args.len(), 1);
 
     Ok(NativeResult::ok(InternalGasUnits::new(0_u64), smallvec![]))
 }

--- a/language/extensions/move-table-extension/tests/TableTests.move
+++ b/language/extensions/move-table-extension/tests/TableTests.move
@@ -3,7 +3,7 @@ module Extensions::TableTests {
     use Std::Vector;
     use Extensions::Table as T;
 
-    struct S<phantom K, phantom V> has key {
+    struct S<phantom K: copy + drop, phantom V> has key {
         t: T::Table<K, V>
     }
 
@@ -14,29 +14,29 @@ module Extensions::TableTests {
     #[test]
     fun simple_read_write() {
         let t = T::new<u64, u64>();
-        T::add(&mut t, &1, 2);
-        T::add(&mut t, &10, 33);
-        assert!(*T::borrow(&t, &1) == 2, 1);
-        assert!(*T::borrow(&t, &10) == 33, 1);
+        T::add(&mut t, 1, 2);
+        T::add(&mut t, 10, 33);
+        assert!(*T::borrow(&t, 1) == 2, 1);
+        assert!(*T::borrow(&t, 10) == 33, 1);
         T::drop_unchecked(t)
     }
 
     #[test]
     fun simple_update() {
         let t = T::new<u64, u64>();
-        T::add(&mut t, &1, 2);
-        assert!(*T::borrow(&t, &1) == 2, 1);
-        *T::borrow_mut(&mut t, &1) = 3;
-        assert!(*T::borrow(&t, &1) == 3, 1);
+        T::add(&mut t, 1, 2);
+        assert!(*T::borrow(&t, 1) == 2, 1);
+        *T::borrow_mut(&mut t, 1) = 3;
+        assert!(*T::borrow(&t, 1) == 3, 1);
         T::drop_unchecked(t)
     }
 
     #[test]
     fun test_destroy() {
         let t = T::new<u64, u64>();
-        T::add(&mut t, &1, 2);
-        assert!(*T::borrow(&t, &1) == 2, 1);
-        T::remove(&mut t, &1);
+        T::add(&mut t, 1, 2);
+        assert!(*T::borrow(&t, 1) == 2, 1);
+        T::remove(&mut t, 1);
         T::destroy_empty(t)
     }
 
@@ -44,18 +44,18 @@ module Extensions::TableTests {
     #[expected_failure(abort_code = 26113)]
     fun test_destroy_fails() {
         let t = T::new<u64, u64>();
-        T::add(&mut t, &1, 2);
-        assert!(*T::borrow(&t, &1) == 2, 1);
+        T::add(&mut t, 1, 2);
+        assert!(*T::borrow(&t, 1) == 2, 1);
         T::destroy_empty(t) // expected to fail
     }
 
     #[test]
     fun test_length() {
         let t = T::new<u64, u64>();
-        T::add(&mut t, &1, 2);
-        T::add(&mut t, &2, 2);
+        T::add(&mut t, 1, 2);
+        T::add(&mut t, 2, 2);
         assert!(T::length(&t) == 2, 1);
-        T::remove(&mut t, &1);
+        T::remove(&mut t, 1);
         assert!(T::length(&t) == 1, 2);
         T::drop_unchecked(t)
     }
@@ -63,30 +63,30 @@ module Extensions::TableTests {
     #[test(s = @0x42)]
     fun test_primitive(s: signer) acquires S {
         let t = T::new<u64, u128>();
-        assert!(!T::contains(&t, &42), 100);
+        assert!(!T::contains(&t, 42), 100);
 
-        T::add(&mut t, &42, 1012);
-        assert!(T::contains(&t, &42), 101);
-        assert!(!T::contains(&t, &0), 102);
-        assert!(*T::borrow(&t, &42) == 1012, 103);
+        T::add(&mut t, 42, 1012);
+        assert!(T::contains(&t, 42), 101);
+        assert!(!T::contains(&t, 0), 102);
+        assert!(*T::borrow(&t, 42) == 1012, 103);
 
-        T::add(&mut t, &43, 1013);
-        assert!(T::contains(&t, &42), 104);
-        assert!(!T::contains(&t, &0), 105);
-        assert!(T::contains(&t, &43), 106);
-        assert!(*T::borrow(&t, &43) == 1013, 107);
+        T::add(&mut t, 43, 1013);
+        assert!(T::contains(&t, 42), 104);
+        assert!(!T::contains(&t, 0), 105);
+        assert!(T::contains(&t, 43), 106);
+        assert!(*T::borrow(&t, 43) == 1013, 107);
 
-        let v = T::remove(&mut t, &42);
+        let v = T::remove(&mut t, 42);
         assert!(v == 1012, 108);
 
         move_to(&s, S { t });
 
         let t_ref = &borrow_global<S<u64, u128>>(@0x42).t;
-        let v = *T::borrow(t_ref, &43);
+        let v = *T::borrow(t_ref, 43);
         assert!(v == 1013, 110);
 
         let S { t: local_t } = move_from<S<u64, u128>>(@0x42);
-        assert!(*T::borrow(&local_t, &43) == 1013, 111);
+        assert!(*T::borrow(&local_t, 43) == 1013, 111);
 
         move_to(&s, S { t: local_t });
     }
@@ -95,25 +95,25 @@ module Extensions::TableTests {
     fun test_vector(s: signer) acquires S {
         let t = T::new<u8, vector<address>>();
 
-        T::add(&mut t, &42, Vector::singleton<address>(@0x1012));
-        assert!(T::contains(&t, &42), 101);
-        assert!(!T::contains(&t, &0), 102);
-        assert!(Vector::length(T::borrow(&t, &42)) == 1, 103);
-        assert!(*Vector::borrow(T::borrow(&t, &42), 0) == @0x1012, 104);
+        T::add(&mut t, 42, Vector::singleton<address>(@0x1012));
+        assert!(T::contains(&t, 42), 101);
+        assert!(!T::contains(&t, 0), 102);
+        assert!(Vector::length(T::borrow(&t, 42)) == 1, 103);
+        assert!(*Vector::borrow(T::borrow(&t, 42), 0) == @0x1012, 104);
 
         move_to(&s, S { t });
 
         let s = borrow_global_mut<S<u8, vector<address>>>(@0x42);
-        let v_mut_ref = T::borrow_mut(&mut s.t, &42);
+        let v_mut_ref = T::borrow_mut(&mut s.t, 42);
         Vector::push_back(v_mut_ref, @0x1013);
-        assert!(Vector::length(T::borrow(&s.t, &42)) == 2, 105);
-        assert!(*Vector::borrow(T::borrow(&s.t, &42), 1) == @0x1013, 106);
+        assert!(Vector::length(T::borrow(&s.t, 42)) == 2, 105);
+        assert!(*Vector::borrow(T::borrow(&s.t, 42), 1) == @0x1013, 106);
 
-        let v = T::remove(&mut s.t, &42);
+        let v = T::remove(&mut s.t, 42);
         assert!(Vector::length(&v) == 2, 107);
         assert!(*Vector::borrow(&v, 0) == @0x1012, 108);
         assert!(*Vector::borrow(&v, 1) == @0x1013, 109);
-        assert!(!T::contains(&s.t, &42), 110);
+        assert!(!T::contains(&s.t, 42), 110);
     }
 
     #[test(s = @0x42)]
@@ -122,26 +122,26 @@ module Extensions::TableTests {
         let val_1 = 11;
         let val_2 = 45;
 
-        T::add(&mut t, &@0xAB, Balance{ value: val_1 });
-        assert!(T::contains(&t, &@0xAB), 101);
-        assert!(*&T::borrow(&t, &@0xAB).value == val_1, 102);
+        T::add(&mut t, @0xAB, Balance{ value: val_1 });
+        assert!(T::contains(&t, @0xAB), 101);
+        assert!(*&T::borrow(&t, @0xAB).value == val_1, 102);
 
         move_to(&s, S { t });
 
         let global_t = &mut borrow_global_mut<S<address, Balance>>(@0x42).t;
 
-        T::add(global_t, &@0xCD, Balance{ value: val_2 });
-        assert!(*&T::borrow(global_t, &@0xAB).value == val_1, 103);
-        assert!(*&T::borrow(global_t, &@0xCD).value == val_2, 104);
+        T::add(global_t, @0xCD, Balance{ value: val_2 });
+        assert!(*&T::borrow(global_t, @0xAB).value == val_1, 103);
+        assert!(*&T::borrow(global_t, @0xCD).value == val_2, 104);
 
 
-        let entry_mut_ref = T::borrow_mut(global_t , &@0xCD);
+        let entry_mut_ref = T::borrow_mut(global_t , @0xCD);
         *&mut entry_mut_ref.value = entry_mut_ref.value - 1;
-        assert!(*&T::borrow(global_t, &@0xCD).value == val_2 - 1, 105);
+        assert!(*&T::borrow(global_t, @0xCD).value == val_2 - 1, 105);
 
-        let Balance { value } = T::remove(global_t, &@0xAB);
+        let Balance { value } = T::remove(global_t, @0xAB);
         assert!(value == val_1, 106);
-        assert!(!T::contains(global_t, &@0xAB), 107);
+        assert!(!T::contains(global_t, @0xAB), 107);
     }
 
     #[test(s = @0x42)]
@@ -153,28 +153,28 @@ module Extensions::TableTests {
 
         // Create two small tables
         let t1 = T::new<address, u128>();
-        T::add(&mut t1, &@0xAB, val_1);
+        T::add(&mut t1, @0xAB, val_1);
 
         let t2 = T::new<address, u128>();
-        T::add(&mut t2, &@0xCD, val_2);
+        T::add(&mut t2, @0xCD, val_2);
 
         // Insert two small tables into the big table
-        T::add(&mut t, &@0x12, t1);
-        T::add(&mut t, &@0x34, t2);
+        T::add(&mut t, @0x12, t1);
+        T::add(&mut t, @0x34, t2);
 
 
-        assert!(T::contains(T::borrow(&t, &@0x12), &@0xAB), 101);
-        assert!(T::contains(T::borrow(&t, &@0x34), &@0xCD), 102);
-        assert!(*T::borrow(T::borrow(&t, &@0x12), &@0xAB) == val_1, 103);
-        assert!(*T::borrow(T::borrow(&t, &@0x34), &@0xCD) == val_2, 104);
+        assert!(T::contains(T::borrow(&t, @0x12), @0xAB), 101);
+        assert!(T::contains(T::borrow(&t, @0x34), @0xCD), 102);
+        assert!(*T::borrow(T::borrow(&t, @0x12), @0xAB) == val_1, 103);
+        assert!(*T::borrow(T::borrow(&t, @0x34), @0xCD) == val_2, 104);
 
-        T::add(T::borrow_mut(&mut t, &@0x12), &@0xEF, val_3);
-        assert!(*T::borrow(T::borrow(&t, &@0x12), &@0xEF) == val_3, 105);
-        assert!(*T::borrow(T::borrow(&t, &@0x12), &@0xAB) == val_1, 106);
+        T::add(T::borrow_mut(&mut t, @0x12), @0xEF, val_3);
+        assert!(*T::borrow(T::borrow(&t, @0x12), @0xEF) == val_3, 105);
+        assert!(*T::borrow(T::borrow(&t, @0x12), @0xAB) == val_1, 106);
 
-        let val = T::remove(T::borrow_mut(&mut t, &@0x34), &@0xCD);
+        let val = T::remove(T::borrow_mut(&mut t, @0x34), @0xCD);
         assert!(val == val_2, 107);
-        assert!(!T::contains(T::borrow(&t, &@0x34), &@0xCD), 108);
+        assert!(!T::contains(T::borrow(&t, @0x34), @0xCD), 108);
 
         move_to(&s, S { t });
     }
@@ -183,11 +183,11 @@ module Extensions::TableTests {
     #[expected_failure(abort_code = 25607)]
     fun test_insert_fail(s: signer) {
         let t = T::new<u64, u128>();
-        assert!(!T::contains(&t, &42), 100);
+        assert!(!T::contains(&t, 42), 100);
 
-        T::add(&mut t, &42, 1012);
-        assert!(T::contains(&t, &42), 101);
-        T::add(&mut t, &42, 1013); // should fail here since key 42 already exists
+        T::add(&mut t, 42, 1012);
+        assert!(T::contains(&t, 42), 101);
+        T::add(&mut t, 42, 1013); // should fail here since key 42 already exists
 
         move_to(&s, S { t });
     }
@@ -196,9 +196,9 @@ module Extensions::TableTests {
     #[expected_failure(abort_code = 25863)]
     fun test_borrow_fail(s: signer) {
         let t = T::new<u64, u128>();
-        assert!(!T::contains(&t, &42), 100);
+        assert!(!T::contains(&t, 42), 100);
 
-        let entry_ref = T::borrow_mut(&mut t, &42); // should fail here since key 42 doesn't exist
+        let entry_ref = T::borrow_mut(&mut t, 42); // should fail here since key 42 doesn't exist
         *entry_ref = 1;
 
         move_to(&s, S { t });
@@ -208,7 +208,7 @@ module Extensions::TableTests {
     #[expected_failure(abort_code = 25863)]
     fun test_remove_fail(s: signer) {
         let t = T::new<u64, Balance>();
-        let Balance { value } = T::remove(&mut t, &42); // should fail here since key 42 doesn't exist
+        let Balance { value } = T::remove(&mut t, 42); // should fail here since key 42 doesn't exist
         assert!(value == 0, 101);
         move_to(&s, S { t });
     }
@@ -216,12 +216,12 @@ module Extensions::TableTests {
     #[test]
     fun test_add_after_remove() {
         let t = T::new<u64, u64>();
-        T::add(&mut t, &42, 42);
-        let forty_two = T::remove(&mut t, &42);
+        T::add(&mut t, 42, 42);
+        let forty_two = T::remove(&mut t, 42);
         assert!(forty_two == 42, 101);
 
-        T::add(&mut t, &42, 0);
-        let zero = T::borrow(&mut t, &42);
+        T::add(&mut t, 42, 0);
+        let zero = T::borrow(&mut t, 42);
         assert!(*zero == 0, 102);
 
         T::drop_unchecked(t)
@@ -231,12 +231,12 @@ module Extensions::TableTests {
     #[expected_failure(abort_code = 25863)]
     fun test_remove_removed() {
         let t = T::new<u64, u64>();
-        T::add(&mut t, &42, 42);
-        let forty_two = T::remove(&mut t, &42);
+        T::add(&mut t, 42, 42);
+        let forty_two = T::remove(&mut t, 42);
         assert!(forty_two == 42, 101);
 
         // remove removed value
-        let _r = T::remove(&mut t, &42);
+        let _r = T::remove(&mut t, 42);
 
         T::drop_unchecked(t)
     }
@@ -245,12 +245,12 @@ module Extensions::TableTests {
     #[expected_failure(abort_code = 25863)]
     fun test_borrow_removed() {
         let t = T::new<u64, u64>();
-        T::add(&mut t, &42, 42);
-        let forty_two = T::remove(&mut t, &42);
+        T::add(&mut t, 42, 42);
+        let forty_two = T::remove(&mut t, 42);
         assert!(forty_two == 42, 101);
 
         // borrow removed value
-        let _r = T::borrow(&mut t, &42);
+        let _r = T::borrow(&mut t, 42);
 
         T::drop_unchecked(t)
     }


### PR DESCRIPTION
## Motivation

According to https://github.com/move-language/move/issues/95, Move lacks of lifetime support so we have to find a way to work around this. Otherwise, there is no way to implement clean APIs for many struct built on top of `Table` such as `IterableTable`.

This PR add trait bounds (copy + drop) to the `key`

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

cargo test
