### PR TITLE
[lint] Update license requirement. Added 'Move contributors' license to all files

### DIFF
--- a/.github/actions/slack-file/message_file_to_slack.sh
+++ b/.github/actions/slack-file/message_file_to_slack.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # Copyright (c) The Diem Core Contributors
+# Copyright (c) The Move Contributors
 # SPDX-License-Identifier: Apache-2.0
 
 function echoerr() {

--- a/devtools/x-core/src/core_config.rs
+++ b/devtools/x-core/src/core_config.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use serde::{Deserialize, Serialize};

--- a/devtools/x-core/src/errors.rs
+++ b/devtools/x-core/src/errors.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use camino::{Utf8Path, Utf8PathBuf};

--- a/devtools/x-core/src/git.rs
+++ b/devtools/x-core/src/git.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::errors::*;

--- a/devtools/x-core/src/graph.rs
+++ b/devtools/x-core/src/graph.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{Result, SystemError, WorkspaceSubsets, XCoreContext};

--- a/devtools/x-core/src/lib.rs
+++ b/devtools/x-core/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{core_config::XCoreConfig, git::GitCli};

--- a/devtools/x-core/src/workspace_subset.rs
+++ b/devtools/x-core/src/workspace_subset.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{core_config::SubsetConfig, Result, SystemError};

--- a/devtools/x-lint/src/content.rs
+++ b/devtools/x-lint/src/content.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{prelude::*, LintContext};

--- a/devtools/x-lint/src/file_path.rs
+++ b/devtools/x-lint/src/file_path.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{prelude::*, LintContext};

--- a/devtools/x-lint/src/lib.rs
+++ b/devtools/x-lint/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! Lint engine.

--- a/devtools/x-lint/src/package.rs
+++ b/devtools/x-lint/src/package.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{prelude::*, LintContext};

--- a/devtools/x-lint/src/project.rs
+++ b/devtools/x-lint/src/project.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{prelude::*, LintContext};

--- a/devtools/x-lint/src/runner.rs
+++ b/devtools/x-lint/src/runner.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{prelude::*, LintContext};

--- a/devtools/x/src/bench.rs
+++ b/devtools/x/src/bench.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/devtools/x/src/build.rs
+++ b/devtools/x/src/build.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 use crate::{
     cargo::{build_args::BuildArgs, selected_package::SelectedPackageArgs, CargoCommand},

--- a/devtools/x/src/cargo.rs
+++ b/devtools/x/src/cargo.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/devtools/x/src/cargo/build_args.rs
+++ b/devtools/x/src/cargo/build_args.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use clap::{ArgEnum, Parser};

--- a/devtools/x/src/cargo/selected_package.rs
+++ b/devtools/x/src/cargo/selected_package.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{changed_since::changed_since_impl, context::XContext, Result};

--- a/devtools/x/src/changed_since.rs
+++ b/devtools/x/src/changed_since.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{context::XContext, Result};

--- a/devtools/x/src/check.rs
+++ b/devtools/x/src/check.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/devtools/x/src/clippy.rs
+++ b/devtools/x/src/clippy.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/devtools/x/src/config.rs
+++ b/devtools/x/src/config.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{utils::project_root, Result};

--- a/devtools/x/src/context.rs
+++ b/devtools/x/src/context.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/devtools/x/src/diff_summary.rs
+++ b/devtools/x/src/diff_summary.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::context::XContext;

--- a/devtools/x/src/fix.rs
+++ b/devtools/x/src/fix.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/devtools/x/src/fmt.rs
+++ b/devtools/x/src/fmt.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{cargo::Cargo, context::XContext, Result};

--- a/devtools/x/src/generate_summaries.rs
+++ b/devtools/x/src/generate_summaries.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::context::XContext;

--- a/devtools/x/src/generate_workspace_hack.rs
+++ b/devtools/x/src/generate_workspace_hack.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{cargo::Cargo, context::XContext, Result};

--- a/devtools/x/src/installer.rs
+++ b/devtools/x/src/installer.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/devtools/x/src/lint/allowed_paths.rs
+++ b/devtools/x/src/lint/allowed_paths.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Context;

--- a/devtools/x/src/lint/determinator.rs
+++ b/devtools/x/src/lint/determinator.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Context;

--- a/devtools/x/src/lint/guppy.rs
+++ b/devtools/x/src/lint/guppy.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! Project and package linters that run queries on guppy.

--- a/devtools/x/src/lint/license.rs
+++ b/devtools/x/src/lint/license.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use x_lint::prelude::*;

--- a/devtools/x/src/lint/mod.rs
+++ b/devtools/x/src/lint/mod.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::context::XContext;

--- a/devtools/x/src/lint/toml.rs
+++ b/devtools/x/src/lint/toml.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use camino::Utf8Path;

--- a/devtools/x/src/lint/whitespace.rs
+++ b/devtools/x/src/lint/whitespace.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Context;

--- a/devtools/x/src/lint/workspace_classify.rs
+++ b/devtools/x/src/lint/workspace_classify.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::config::TestOnlyConfig;

--- a/devtools/x/src/main.rs
+++ b/devtools/x/src/main.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 #![forbid(unsafe_code)]

--- a/devtools/x/src/nextest.rs
+++ b/devtools/x/src/nextest.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/devtools/x/src/playground.rs
+++ b/devtools/x/src/playground.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! Playground for arbitrary code.

--- a/devtools/x/src/test.rs
+++ b/devtools/x/src/test.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/devtools/x/src/tools.rs
+++ b/devtools/x/src/tools.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{context::XContext, Result};

--- a/devtools/x/src/utils.rs
+++ b/devtools/x/src/utils.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{config::CargoConfig, installer::install_cargo_component_if_needed, Result};

--- a/language/benchmarks/benches/vm_benches.rs
+++ b/language/benchmarks/benches/vm_benches.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use criterion::{criterion_group, criterion_main, measurement::Measurement, Criterion};

--- a/language/benchmarks/src/lib.rs
+++ b/language/benchmarks/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 #![forbid(unsafe_code)]

--- a/language/benchmarks/src/measurement.rs
+++ b/language/benchmarks/src/measurement.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use criterion::Criterion;

--- a/language/benchmarks/src/move_vm.rs
+++ b/language/benchmarks/src/move_vm.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use criterion::{measurement::Measurement, Criterion};

--- a/language/documentation/examples/diem-framework/build_all.sh
+++ b/language/documentation/examples/diem-framework/build_all.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # Copyright (c) The Diem Core Contributors
+# Copyright (c) The Move Contributors
 # SPDX-License-Identifier: Apache-2.0
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )

--- a/language/documentation/examples/diem-framework/crates/cli/src/main.rs
+++ b/language/documentation/examples/diem-framework/crates/cli/src/main.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;

--- a/language/documentation/examples/diem-framework/crates/crypto-derive/src/hasher.rs
+++ b/language/documentation/examples/diem-framework/crates/crypto-derive/src/hasher.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 /// Converts a camel-case string to snake-case

--- a/language/documentation/examples/diem-framework/crates/crypto-derive/src/lib.rs
+++ b/language/documentation/examples/diem-framework/crates/crypto-derive/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 #![forbid(unsafe_code)]

--- a/language/documentation/examples/diem-framework/crates/crypto-derive/src/unions.rs
+++ b/language/documentation/examples/diem-framework/crates/crypto-derive/src/unions.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use proc_macro::TokenStream;

--- a/language/documentation/examples/diem-framework/crates/crypto/benches/ed25519.rs
+++ b/language/documentation/examples/diem-framework/crates/crypto/benches/ed25519.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 #[macro_use]

--- a/language/documentation/examples/diem-framework/crates/crypto/benches/noise.rs
+++ b/language/documentation/examples/diem-framework/crates/crypto/benches/noise.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! Don't forget to run this benchmark with AES-NI enable.

--- a/language/documentation/examples/diem-framework/crates/crypto/src/compat.rs
+++ b/language/documentation/examples/diem-framework/crates/crypto/src/compat.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! Wrapper structs for types that need [RustCrypto](https://github.com/RustCrypto)

--- a/language/documentation/examples/diem-framework/crates/crypto/src/ed25519.rs
+++ b/language/documentation/examples/diem-framework/crates/crypto/src/ed25519.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! This module provides an API for the PureEdDSA signature scheme over the ed25519 twisted

--- a/language/documentation/examples/diem-framework/crates/crypto/src/error.rs
+++ b/language/documentation/examples/diem-framework/crates/crypto/src/error.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! Rexport the error types needed for the various crypto traits

--- a/language/documentation/examples/diem-framework/crates/crypto/src/hash.rs
+++ b/language/documentation/examples/diem-framework/crates/crypto/src/hash.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! This module defines traits and implementations of

--- a/language/documentation/examples/diem-framework/crates/crypto/src/hkdf.rs
+++ b/language/documentation/examples/diem-framework/crates/crypto/src/hkdf.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! An implementation of HKDF, the HMAC-based Extract-and-Expand Key Derivation Function for the

--- a/language/documentation/examples/diem-framework/crates/crypto/src/lib.rs
+++ b/language/documentation/examples/diem-framework/crates/crypto/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 #![forbid(unsafe_code)]

--- a/language/documentation/examples/diem-framework/crates/crypto/src/multi_ed25519.rs
+++ b/language/documentation/examples/diem-framework/crates/crypto/src/multi_ed25519.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! This module provides an API for the accountable threshold multi-sig PureEdDSA signature scheme

--- a/language/documentation/examples/diem-framework/crates/crypto/src/noise.rs
+++ b/language/documentation/examples/diem-framework/crates/crypto/src/noise.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! Noise is a [protocol framework](https://noiseprotocol.org/) which we use in Diem to

--- a/language/documentation/examples/diem-framework/crates/crypto/src/tags.rs
+++ b/language/documentation/examples/diem-framework/crates/crypto/src/tags.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! This module provides definitions of tag types to be used by MIRAI analyzing diem-crypto.

--- a/language/documentation/examples/diem-framework/crates/crypto/src/test_utils.rs
+++ b/language/documentation/examples/diem-framework/crates/crypto/src/test_utils.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! Internal module containing convenience utility functions mainly for testing

--- a/language/documentation/examples/diem-framework/crates/crypto/src/traits.rs
+++ b/language/documentation/examples/diem-framework/crates/crypto/src/traits.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! This module provides a generic set of traits for dealing with cryptographic primitives.

--- a/language/documentation/examples/diem-framework/crates/crypto/src/unit_tests/bcs_test.rs
+++ b/language/documentation/examples/diem-framework/crates/crypto/src/unit_tests/bcs_test.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use rand::{rngs::StdRng, SeedableRng};

--- a/language/documentation/examples/diem-framework/crates/crypto/src/unit_tests/compat_test.rs
+++ b/language/documentation/examples/diem-framework/crates/crypto/src/unit_tests/compat_test.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::compat;

--- a/language/documentation/examples/diem-framework/crates/crypto/src/unit_tests/compilation/cross_test.rs
+++ b/language/documentation/examples/diem-framework/crates/crypto/src/unit_tests/compilation/cross_test.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use diem_crypto::{

--- a/language/documentation/examples/diem-framework/crates/crypto/src/unit_tests/compilation/cross_test_trait_obj.rs
+++ b/language/documentation/examples/diem-framework/crates/crypto/src/unit_tests/compilation/cross_test_trait_obj.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use diem_crypto::traits::*;

--- a/language/documentation/examples/diem-framework/crates/crypto/src/unit_tests/compilation/cross_test_trait_obj_pub.rs
+++ b/language/documentation/examples/diem-framework/crates/crypto/src/unit_tests/compilation/cross_test_trait_obj_pub.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use diem_crypto::traits::*;

--- a/language/documentation/examples/diem-framework/crates/crypto/src/unit_tests/compilation/cross_test_trait_obj_sig.rs
+++ b/language/documentation/examples/diem-framework/crates/crypto/src/unit_tests/compilation/cross_test_trait_obj_sig.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use diem_crypto::traits::*;

--- a/language/documentation/examples/diem-framework/crates/crypto/src/unit_tests/compilation/small_kdf.rs
+++ b/language/documentation/examples/diem-framework/crates/crypto/src/unit_tests/compilation/small_kdf.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 fn main() {

--- a/language/documentation/examples/diem-framework/crates/crypto/src/unit_tests/cross_test.rs
+++ b/language/documentation/examples/diem-framework/crates/crypto/src/unit_tests/cross_test.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 // This is necessary for the derive macros which rely on being used in a

--- a/language/documentation/examples/diem-framework/crates/crypto/src/unit_tests/cryptohasher.rs
+++ b/language/documentation/examples/diem-framework/crates/crypto/src/unit_tests/cryptohasher.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! Test file for the procedural macros CryptoHasher and BCSCryptoHash.

--- a/language/documentation/examples/diem-framework/crates/crypto/src/unit_tests/ed25519_test.rs
+++ b/language/documentation/examples/diem-framework/crates/crypto/src/unit_tests/ed25519_test.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate as diem_crypto;

--- a/language/documentation/examples/diem-framework/crates/crypto/src/unit_tests/hash_test.rs
+++ b/language/documentation/examples/diem-framework/crates/crypto/src/unit_tests/hash_test.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::hash::*;

--- a/language/documentation/examples/diem-framework/crates/crypto/src/unit_tests/hkdf_test.rs
+++ b/language/documentation/examples/diem-framework/crates/crypto/src/unit_tests/hkdf_test.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{compat::Sha3_256, hkdf::*};

--- a/language/documentation/examples/diem-framework/crates/crypto/src/unit_tests/mod.rs
+++ b/language/documentation/examples/diem-framework/crates/crypto/src/unit_tests/mod.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 mod bcs_test;

--- a/language/documentation/examples/diem-framework/crates/crypto/src/unit_tests/multi_ed25519_test.rs
+++ b/language/documentation/examples/diem-framework/crates/crypto/src/unit_tests/multi_ed25519_test.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/language/documentation/examples/diem-framework/crates/crypto/src/unit_tests/noise_test.rs
+++ b/language/documentation/examples/diem-framework/crates/crypto/src/unit_tests/noise_test.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{fs::File, io::BufReader, path::PathBuf};

--- a/language/documentation/examples/diem-framework/crates/crypto/src/validatable.rs
+++ b/language/documentation/examples/diem-framework/crates/crypto/src/validatable.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! This module provides the `Validate` trait and `Validatable` type in order to aid in deferred

--- a/language/documentation/examples/diem-framework/crates/crypto/src/x25519.rs
+++ b/language/documentation/examples/diem-framework/crates/crypto/src/x25519.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! An abstraction of x25519 elliptic curve keys required for

--- a/language/documentation/examples/diem-framework/crates/natives/src/account.rs
+++ b/language/documentation/examples/diem-framework/crates/natives/src/account.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use move_binary_format::errors::PartialVMResult;

--- a/language/documentation/examples/diem-framework/crates/natives/src/lib.rs
+++ b/language/documentation/examples/diem-framework/crates/natives/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod account;

--- a/language/documentation/examples/diem-framework/crates/natives/src/signature.rs
+++ b/language/documentation/examples/diem-framework/crates/natives/src/signature.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use diem_crypto::{ed25519, traits::*};

--- a/language/documentation/examples/diem-framework/test_all.sh
+++ b/language/documentation/examples/diem-framework/test_all.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # Copyright (c) The Diem Core Contributors
+# Copyright (c) The Move Contributors
 # SPDX-License-Identifier: Apache-2.0
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )

--- a/language/evm/exec-utils/contracts/a_plus_b.sol
+++ b/language/evm/exec-utils/contracts/a_plus_b.sol
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 pragma solidity ^0.8.10;

--- a/language/evm/exec-utils/contracts/hello_world.sol
+++ b/language/evm/exec-utils/contracts/hello_world.sol
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 pragma solidity ^0.8.10;

--- a/language/evm/exec-utils/contracts/stateful.sol
+++ b/language/evm/exec-utils/contracts/stateful.sol
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 pragma solidity ^0.8.10;

--- a/language/evm/exec-utils/contracts/two_functions.sol
+++ b/language/evm/exec-utils/contracts/two_functions.sol
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 pragma solidity ^0.8.10;

--- a/language/evm/exec-utils/src/compile.rs
+++ b/language/evm/exec-utils/src/compile.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::{anyhow, bail, format_err, Result};

--- a/language/evm/exec-utils/src/exec.rs
+++ b/language/evm/exec-utils/src/exec.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use evm::{

--- a/language/evm/exec-utils/src/lib.rs
+++ b/language/evm/exec-utils/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod compile;

--- a/language/evm/exec-utils/src/tests.rs
+++ b/language/evm/exec-utils/src/tests.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{compile::solc, exec::Executor};

--- a/language/evm/exec-utils/src/tracing.rs
+++ b/language/evm/exec-utils/src/tracing.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use evm::Opcode;

--- a/language/evm/hardhat-examples/setup.sh
+++ b/language/evm/hardhat-examples/setup.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # Copyright (c) The Diem Core Contributors
+# Copyright (c) The Move Contributors
 # SPDX-License-Identifier: Apache-2.0
 
 # Hardhat packages, along with their dependencies, are not checked into the Move repo.

--- a/language/evm/move-to-yul/src/abi_native_functions.rs
+++ b/language/evm/move-to-yul/src/abi_native_functions.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/language/evm/move-to-yul/src/abi_signature.rs
+++ b/language/evm/move-to-yul/src/abi_signature.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 // This file defines functions for generating JSON-ABI.

--- a/language/evm/move-to-yul/src/attributes.rs
+++ b/language/evm/move-to-yul/src/attributes.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 // ! Module defining attributes used by the generator.

--- a/language/evm/move-to-yul/src/context.rs
+++ b/language/evm/move-to-yul/src/context.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/language/evm/move-to-yul/src/dispatcher_generator.rs
+++ b/language/evm/move-to-yul/src/dispatcher_generator.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use codespan_reporting::diagnostic::Severity;

--- a/language/evm/move-to-yul/src/events.rs
+++ b/language/evm/move-to-yul/src/events.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/language/evm/move-to-yul/src/evm_transformation.rs
+++ b/language/evm/move-to-yul/src/evm_transformation.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! Performs transformations specific for compiling stackless bytecode to

--- a/language/evm/move-to-yul/src/experiments.rs
+++ b/language/evm/move-to-yul/src/experiments.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 /// Container for experiments in the compiler. Those can be activated

--- a/language/evm/move-to-yul/src/external_functions.rs
+++ b/language/evm/move-to-yul/src/external_functions.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/language/evm/move-to-yul/src/functions.rs
+++ b/language/evm/move-to-yul/src/functions.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{context::Context, yul_functions, yul_functions::YulFunction, Generator};

--- a/language/evm/move-to-yul/src/generator.rs
+++ b/language/evm/move-to-yul/src/generator.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use codespan_reporting::{diagnostic::Severity, term::termcolor::Buffer};

--- a/language/evm/move-to-yul/src/lib.rs
+++ b/language/evm/move-to-yul/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 #![forbid(unsafe_code)]

--- a/language/evm/move-to-yul/src/main.rs
+++ b/language/evm/move-to-yul/src/main.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 #![forbid(unsafe_code)]

--- a/language/evm/move-to-yul/src/native_functions.rs
+++ b/language/evm/move-to-yul/src/native_functions.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/language/evm/move-to-yul/src/options.rs
+++ b/language/evm/move-to-yul/src/options.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::experiments::Experiment;

--- a/language/evm/move-to-yul/src/solidity_ty.rs
+++ b/language/evm/move-to-yul/src/solidity_ty.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! Representation of solidity types and related functions.

--- a/language/evm/move-to-yul/src/tables.rs
+++ b/language/evm/move-to-yul/src/tables.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 // This file defines functionalities regarding tables.

--- a/language/evm/move-to-yul/src/vectors.rs
+++ b/language/evm/move-to-yul/src/vectors.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 // This file defines vector functionalities.

--- a/language/evm/move-to-yul/src/yul_functions.rs
+++ b/language/evm/move-to-yul/src/yul_functions.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use maplit::btreemap;

--- a/language/evm/move-to-yul/tests/dispatcher_testsuite.rs
+++ b/language/evm/move-to-yul/tests/dispatcher_testsuite.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;

--- a/language/evm/move-to-yul/tests/testsuite.rs
+++ b/language/evm/move-to-yul/tests/testsuite.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Context;

--- a/language/extensions/async/move-async-vm/src/actor_metadata.rs
+++ b/language/extensions/async/move-async-vm/src/actor_metadata.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use move_core_types::{

--- a/language/extensions/async/move-async-vm/src/async_vm.rs
+++ b/language/extensions/async/move-async-vm/src/async_vm.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{

--- a/language/extensions/async/move-async-vm/src/lib.rs
+++ b/language/extensions/async/move-async-vm/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 pub mod actor_metadata;
 pub mod async_vm;

--- a/language/extensions/async/move-async-vm/src/natives.rs
+++ b/language/extensions/async/move-async-vm/src/natives.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::async_vm::Message;

--- a/language/extensions/async/move-async-vm/tests/testsuite.rs
+++ b/language/extensions/async/move-async-vm/tests/testsuite.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::bail;

--- a/language/extensions/move-table-extension/src/lib.rs
+++ b/language/extensions/move-table-extension/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! A crate which extends Move by tables.

--- a/language/extensions/move-table-extension/tests/move_unit_tests.rs
+++ b/language/extensions/move-table-extension/tests/move_unit_tests.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use move_cli::package::cli;

--- a/language/move-analyzer/editors/code/src/configuration.ts
+++ b/language/move-analyzer/editors/code/src/configuration.ts
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 import * as os from 'os';

--- a/language/move-analyzer/editors/code/src/context.ts
+++ b/language/move-analyzer/editors/code/src/context.ts
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 import type { Configuration } from './configuration';

--- a/language/move-analyzer/editors/code/src/extension.ts
+++ b/language/move-analyzer/editors/code/src/extension.ts
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 import * as assert from 'assert';

--- a/language/move-analyzer/editors/code/src/log.ts
+++ b/language/move-analyzer/editors/code/src/log.ts
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 import * as vscode from 'vscode';

--- a/language/move-analyzer/editors/code/src/main.ts
+++ b/language/move-analyzer/editors/code/src/main.ts
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 import { Configuration } from './configuration';

--- a/language/move-analyzer/editors/code/tests/colorization.test.ts
+++ b/language/move-analyzer/editors/code/tests/colorization.test.ts
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 import * as assert from 'assert';

--- a/language/move-analyzer/editors/code/tests/index.ts
+++ b/language/move-analyzer/editors/code/tests/index.ts
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 /**

--- a/language/move-analyzer/editors/code/tests/runTests.ts
+++ b/language/move-analyzer/editors/code/tests/runTests.ts
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 /**

--- a/language/move-analyzer/src/bin/move-analyzer.rs
+++ b/language/move-analyzer/src/bin/move-analyzer.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use clap::Parser;

--- a/language/move-analyzer/src/completion.rs
+++ b/language/move-analyzer/src/completion.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::context::Context;

--- a/language/move-analyzer/src/context.rs
+++ b/language/move-analyzer/src/context.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::vfs::VirtualFileSystem;

--- a/language/move-analyzer/src/lib.rs
+++ b/language/move-analyzer/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod completion;

--- a/language/move-analyzer/src/vfs.rs
+++ b/language/move-analyzer/src/vfs.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! The language server must operate upon Move source buffers as they are being edited.

--- a/language/move-binary-format/serializer-tests/src/lib.rs
+++ b/language/move-binary-format/serializer-tests/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 #![forbid(unsafe_code)]

--- a/language/move-binary-format/serializer-tests/tests/serializer_tests.rs
+++ b/language/move-binary-format/serializer-tests/tests/serializer_tests.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use move_binary_format::file_format::CompiledModule;

--- a/language/move-binary-format/src/access.rs
+++ b/language/move-binary-format/src/access.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! Defines accessors for compiled modules.

--- a/language/move-binary-format/src/binary_views.rs
+++ b/language/move-binary-format/src/binary_views.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/language/move-binary-format/src/check_bounds.rs
+++ b/language/move-binary-format/src/check_bounds.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/language/move-binary-format/src/compatibility.rs
+++ b/language/move-binary-format/src/compatibility.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/language/move-binary-format/src/constant.rs
+++ b/language/move-binary-format/src/constant.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::file_format::{Constant, SignatureToken};

--- a/language/move-binary-format/src/control_flow_graph.rs
+++ b/language/move-binary-format/src/control_flow_graph.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! This module defines the control-flow graph uses for bytecode verification.

--- a/language/move-binary-format/src/deserializer.rs
+++ b/language/move-binary-format/src/deserializer.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{check_bounds::BoundsChecker, errors::*, file_format::*, file_format_common::*};

--- a/language/move-binary-format/src/errors.rs
+++ b/language/move-binary-format/src/errors.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/language/move-binary-format/src/file_format.rs
+++ b/language/move-binary-format/src/file_format.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! Binary format for transactions and modules.

--- a/language/move-binary-format/src/file_format_common.rs
+++ b/language/move-binary-format/src/file_format_common.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! Constants for the binary format.

--- a/language/move-binary-format/src/internals.rs
+++ b/language/move-binary-format/src/internals.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! Types meant for use by other parts of this crate, and by other crates that are designed to

--- a/language/move-binary-format/src/lib.rs
+++ b/language/move-binary-format/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 #![forbid(unsafe_code)]

--- a/language/move-binary-format/src/normalized.rs
+++ b/language/move-binary-format/src/normalized.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/language/move-binary-format/src/proptest_types.rs
+++ b/language/move-binary-format/src/proptest_types.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! Utilities for property-based testing.

--- a/language/move-binary-format/src/proptest_types/constants.rs
+++ b/language/move-binary-format/src/proptest_types/constants.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::file_format::{Constant, SignatureToken};

--- a/language/move-binary-format/src/proptest_types/functions.rs
+++ b/language/move-binary-format/src/proptest_types/functions.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/language/move-binary-format/src/proptest_types/signature.rs
+++ b/language/move-binary-format/src/proptest_types/signature.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::file_format::{

--- a/language/move-binary-format/src/proptest_types/types.rs
+++ b/language/move-binary-format/src/proptest_types/types.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/language/move-binary-format/src/serializer.rs
+++ b/language/move-binary-format/src/serializer.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! Serialization of transactions and modules.

--- a/language/move-binary-format/src/unit_tests/binary_tests.rs
+++ b/language/move-binary-format/src/unit_tests/binary_tests.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::file_format_common::*;

--- a/language/move-binary-format/src/unit_tests/deserializer_tests.rs
+++ b/language/move-binary-format/src/unit_tests/deserializer_tests.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/language/move-binary-format/src/unit_tests/mod.rs
+++ b/language/move-binary-format/src/unit_tests/mod.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 mod binary_tests;

--- a/language/move-binary-format/src/unit_tests/number_tests.rs
+++ b/language/move-binary-format/src/unit_tests/number_tests.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::file_format_common::*;

--- a/language/move-binary-format/src/unit_tests/signature_token_tests.rs
+++ b/language/move-binary-format/src/unit_tests/signature_token_tests.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/language/move-binary-format/src/views.rs
+++ b/language/move-binary-format/src/views.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! An alternate representation of the file format built on top of the existing format.

--- a/language/move-borrow-graph/src/graph.rs
+++ b/language/move-borrow-graph/src/graph.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/language/move-borrow-graph/src/lib.rs
+++ b/language/move-borrow-graph/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 #![forbid(unsafe_code)]

--- a/language/move-borrow-graph/src/paths.rs
+++ b/language/move-borrow-graph/src/paths.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 pub type PathSlice<Lbl> = [Lbl];

--- a/language/move-borrow-graph/src/references.rs
+++ b/language/move-borrow-graph/src/references.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/language/move-borrow-graph/src/shared.rs
+++ b/language/move-borrow-graph/src/shared.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 use std::collections::{BTreeMap, BTreeSet};
 

--- a/language/move-bytecode-verifier/bytecode-verifier-tests/src/lib.rs
+++ b/language/move-bytecode-verifier/bytecode-verifier-tests/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 #![forbid(unsafe_code)]

--- a/language/move-bytecode-verifier/bytecode-verifier-tests/src/support/mod.rs
+++ b/language/move-bytecode-verifier/bytecode-verifier-tests/src/support/mod.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use move_binary_format::{

--- a/language/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/ability_field_requirements_tests.rs
+++ b/language/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/ability_field_requirements_tests.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use move_binary_format::file_format::CompiledModule;

--- a/language/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/bounds_tests.rs
+++ b/language/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/bounds_tests.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use invalid_mutations::bounds::{

--- a/language/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/code_unit_tests.rs
+++ b/language/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/code_unit_tests.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::support::dummy_procedure_module;

--- a/language/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/constants_tests.rs
+++ b/language/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/constants_tests.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 use move_binary_format::file_format::{empty_module, CompiledModule, Constant, SignatureToken};
 use move_bytecode_verifier::constants;

--- a/language/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/control_flow_tests.rs
+++ b/language/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/control_flow_tests.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::support::dummy_procedure_module;

--- a/language/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/duplication_tests.rs
+++ b/language/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/duplication_tests.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use move_binary_format::file_format::*;

--- a/language/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/generic_ops_tests.rs
+++ b/language/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/generic_ops_tests.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use move_binary_format::file_format::*;

--- a/language/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/mod.rs
+++ b/language/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/mod.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod ability_field_requirements_tests;

--- a/language/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/multi_pass_tests.rs
+++ b/language/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/multi_pass_tests.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use move_binary_format::CompiledModule;

--- a/language/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/negative_stack_size_tests.rs
+++ b/language/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/negative_stack_size_tests.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::support::dummy_procedure_module;

--- a/language/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/signature_tests.rs
+++ b/language/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/signature_tests.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use invalid_mutations::signature::{FieldRefMutation, SignatureRefMutation};

--- a/language/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/struct_defs_tests.rs
+++ b/language/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/struct_defs_tests.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use move_binary_format::file_format::CompiledModule;

--- a/language/move-bytecode-verifier/invalid-mutations/src/bounds.rs
+++ b/language/move-bytecode-verifier/invalid-mutations/src/bounds.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use move_binary_format::{

--- a/language/move-bytecode-verifier/invalid-mutations/src/bounds/code_unit.rs
+++ b/language/move-bytecode-verifier/invalid-mutations/src/bounds/code_unit.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use move_binary_format::{

--- a/language/move-bytecode-verifier/invalid-mutations/src/helpers.rs
+++ b/language/move-bytecode-verifier/invalid-mutations/src/helpers.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use proptest::sample::Index as PropIndex;

--- a/language/move-bytecode-verifier/invalid-mutations/src/lib.rs
+++ b/language/move-bytecode-verifier/invalid-mutations/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 #![forbid(unsafe_code)]

--- a/language/move-bytecode-verifier/invalid-mutations/src/signature.rs
+++ b/language/move-bytecode-verifier/invalid-mutations/src/signature.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use move_binary_format::file_format::{

--- a/language/move-bytecode-verifier/src/ability_field_requirements.rs
+++ b/language/move-bytecode-verifier/src/ability_field_requirements.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! This module implements a checker for verifying that all of the struct's fields satisfy the

--- a/language/move-bytecode-verifier/src/absint.rs
+++ b/language/move-bytecode-verifier/src/absint.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use move_binary_format::{

--- a/language/move-bytecode-verifier/src/acquires_list_verifier.rs
+++ b/language/move-bytecode-verifier/src/acquires_list_verifier.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! This module implements a checker for verifying properties about the acquires list on function

--- a/language/move-bytecode-verifier/src/check_duplication.rs
+++ b/language/move-bytecode-verifier/src/check_duplication.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! This module implements a checker for verifying that each vector in a CompiledModule contains

--- a/language/move-bytecode-verifier/src/code_unit_verifier.rs
+++ b/language/move-bytecode-verifier/src/code_unit_verifier.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! This module implements the checker for verifying correctness of function bodies.

--- a/language/move-bytecode-verifier/src/constants.rs
+++ b/language/move-bytecode-verifier/src/constants.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! This module implements a checker for verifying that

--- a/language/move-bytecode-verifier/src/control_flow.rs
+++ b/language/move-bytecode-verifier/src/control_flow.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! This module implements a checker for verifies control flow. The following properties are

--- a/language/move-bytecode-verifier/src/cyclic_dependencies.rs
+++ b/language/move-bytecode-verifier/src/cyclic_dependencies.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! This module contains verification of usage of dependencies for modules

--- a/language/move-bytecode-verifier/src/dependencies.rs
+++ b/language/move-bytecode-verifier/src/dependencies.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! This module contains verification of usage of dependencies for modules and scripts.

--- a/language/move-bytecode-verifier/src/friends.rs
+++ b/language/move-bytecode-verifier/src/friends.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! This module contains verification of usage of dependencies for modules

--- a/language/move-bytecode-verifier/src/instantiation_loops.rs
+++ b/language/move-bytecode-verifier/src/instantiation_loops.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! This implements an algorithm that detects loops during the instantiation of generics.

--- a/language/move-bytecode-verifier/src/instruction_consistency.rs
+++ b/language/move-bytecode-verifier/src/instruction_consistency.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! This module defines the transfer functions for verifying consistency of each bytecode

--- a/language/move-bytecode-verifier/src/lib.rs
+++ b/language/move-bytecode-verifier/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 #![forbid(unsafe_code)]

--- a/language/move-bytecode-verifier/src/locals_safety/abstract_state.rs
+++ b/language/move-bytecode-verifier/src/locals_safety/abstract_state.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! This module defines the abstract state for the local safety analysis.

--- a/language/move-bytecode-verifier/src/locals_safety/mod.rs
+++ b/language/move-bytecode-verifier/src/locals_safety/mod.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! This module defines the transfer functions for verifying local safety of a procedure body.

--- a/language/move-bytecode-verifier/src/reference_safety/abstract_state.rs
+++ b/language/move-bytecode-verifier/src/reference_safety/abstract_state.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! This module defines the abstract state for the type and memory safety analysis.

--- a/language/move-bytecode-verifier/src/reference_safety/mod.rs
+++ b/language/move-bytecode-verifier/src/reference_safety/mod.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! This module defines the transfer functions for verifying reference safety of a procedure body.

--- a/language/move-bytecode-verifier/src/script_signature.rs
+++ b/language/move-bytecode-verifier/src/script_signature.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! This module implements a checker for verifying that a script, public(script), or other entry

--- a/language/move-bytecode-verifier/src/signature.rs
+++ b/language/move-bytecode-verifier/src/signature.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! This module implements a checker for verifying signature tokens used in types of function

--- a/language/move-bytecode-verifier/src/stack_usage_verifier.rs
+++ b/language/move-bytecode-verifier/src/stack_usage_verifier.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! This module implements a checker for verifying that basic blocks in the bytecode instruction

--- a/language/move-bytecode-verifier/src/struct_defs.rs
+++ b/language/move-bytecode-verifier/src/struct_defs.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! This module provides a checker for verifying that struct definitions in a module are not

--- a/language/move-bytecode-verifier/src/type_safety.rs
+++ b/language/move-bytecode-verifier/src/type_safety.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! This module defines the transfer functions for verifying type safety of a procedure body.

--- a/language/move-bytecode-verifier/src/verifier.rs
+++ b/language/move-bytecode-verifier/src/verifier.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! This module contains the public APIs supported by the bytecode verifier.

--- a/language/move-bytecode-verifier/transactional-tests/src/lib.rs
+++ b/language/move-bytecode-verifier/transactional-tests/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 #![forbid(unsafe_code)]

--- a/language/move-bytecode-verifier/transactional-tests/tests/tests.rs
+++ b/language/move-bytecode-verifier/transactional-tests/tests/tests.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 pub const TEST_DIR: &str = "tests";

--- a/language/move-command-line-common/src/character_sets.rs
+++ b/language/move-command-line-common/src/character_sets.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 /// Determine if a character is an allowed eye-visible (printable) character.

--- a/language/move-command-line-common/src/env.rs
+++ b/language/move-command-line-common/src/env.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 pub fn read_env_var(v: &str) -> String {

--- a/language/move-command-line-common/src/files.rs
+++ b/language/move-command-line-common/src/files.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::{anyhow, bail, *};

--- a/language/move-command-line-common/src/lib.rs
+++ b/language/move-command-line-common/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 #![forbid(unsafe_code)]

--- a/language/move-command-line-common/src/testing.rs
+++ b/language/move-command-line-common/src/testing.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::env::read_bool_env_var;

--- a/language/move-compiler/src/attr_derivation/async_deriver.rs
+++ b/language/move-compiler/src/attr_derivation/async_deriver.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/language/move-compiler/src/attr_derivation/evm_deriver.rs
+++ b/language/move-compiler/src/attr_derivation/evm_deriver.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/language/move-compiler/src/attr_derivation/mod.rs
+++ b/language/move-compiler/src/attr_derivation/mod.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use move_ir_types::location::{sp, Loc};

--- a/language/move-compiler/src/bin/move-build.rs
+++ b/language/move-compiler/src/bin/move-build.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 #![forbid(unsafe_code)]

--- a/language/move-compiler/src/bin/move-check.rs
+++ b/language/move-compiler/src/bin/move-check.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 #![forbid(unsafe_code)]

--- a/language/move-compiler/src/cfgir/absint.rs
+++ b/language/move-compiler/src/cfgir/absint.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use super::cfg::CFG;

--- a/language/move-compiler/src/cfgir/ast.rs
+++ b/language/move-compiler/src/cfgir/ast.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/language/move-compiler/src/cfgir/borrows/mod.rs
+++ b/language/move-compiler/src/cfgir/borrows/mod.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 mod state;

--- a/language/move-compiler/src/cfgir/borrows/state.rs
+++ b/language/move-compiler/src/cfgir/borrows/state.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //**************************************************************************************************

--- a/language/move-compiler/src/cfgir/cfg.rs
+++ b/language/move-compiler/src/cfgir/cfg.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/language/move-compiler/src/cfgir/constant_fold.rs
+++ b/language/move-compiler/src/cfgir/constant_fold.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use super::cfg::BlockCFG;

--- a/language/move-compiler/src/cfgir/eliminate_locals.rs
+++ b/language/move-compiler/src/cfgir/eliminate_locals.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use super::cfg::BlockCFG;

--- a/language/move-compiler/src/cfgir/inline_blocks.rs
+++ b/language/move-compiler/src/cfgir/inline_blocks.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use super::cfg::{BlockCFG, CFG};

--- a/language/move-compiler/src/cfgir/liveness/mod.rs
+++ b/language/move-compiler/src/cfgir/liveness/mod.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 mod state;

--- a/language/move-compiler/src/cfgir/liveness/state.rs
+++ b/language/move-compiler/src/cfgir/liveness/state.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //**************************************************************************************************

--- a/language/move-compiler/src/cfgir/locals/mod.rs
+++ b/language/move-compiler/src/cfgir/locals/mod.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod state;

--- a/language/move-compiler/src/cfgir/locals/state.rs
+++ b/language/move-compiler/src/cfgir/locals/state.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/language/move-compiler/src/cfgir/mod.rs
+++ b/language/move-compiler/src/cfgir/mod.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 mod absint;

--- a/language/move-compiler/src/cfgir/remove_no_ops.rs
+++ b/language/move-compiler/src/cfgir/remove_no_ops.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use super::{ast::*, cfg::BlockCFG};

--- a/language/move-compiler/src/cfgir/simplify_jumps.rs
+++ b/language/move-compiler/src/cfgir/simplify_jumps.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use super::cfg::BlockCFG;

--- a/language/move-compiler/src/cfgir/translate.rs
+++ b/language/move-compiler/src/cfgir/translate.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/language/move-compiler/src/command_line/compiler.rs
+++ b/language/move-compiler/src/command_line/compiler.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/language/move-compiler/src/command_line/mod.rs
+++ b/language/move-compiler/src/command_line/mod.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod compiler;

--- a/language/move-compiler/src/compiled_unit.rs
+++ b/language/move-compiler/src/compiled_unit.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/language/move-compiler/src/diagnostics/codes.rs
+++ b/language/move-compiler/src/diagnostics/codes.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //**************************************************************************************************

--- a/language/move-compiler/src/diagnostics/mod.rs
+++ b/language/move-compiler/src/diagnostics/mod.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod codes;

--- a/language/move-compiler/src/expansion/aliases.rs
+++ b/language/move-compiler/src/expansion/aliases.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/language/move-compiler/src/expansion/ast.rs
+++ b/language/move-compiler/src/expansion/ast.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/language/move-compiler/src/expansion/byte_string.rs
+++ b/language/move-compiler/src/expansion/byte_string.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{diag, diagnostics::Diagnostics, parser::syntax::make_loc};

--- a/language/move-compiler/src/expansion/dependency_ordering.rs
+++ b/language/move-compiler/src/expansion/dependency_ordering.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/language/move-compiler/src/expansion/hex_string.rs
+++ b/language/move-compiler/src/expansion/hex_string.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{diag, diagnostics::Diagnostic, parser::syntax::make_loc};

--- a/language/move-compiler/src/expansion/mod.rs
+++ b/language/move-compiler/src/expansion/mod.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 mod aliases;

--- a/language/move-compiler/src/expansion/translate.rs
+++ b/language/move-compiler/src/expansion/translate.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/language/move-compiler/src/hlir/ast.rs
+++ b/language/move-compiler/src/hlir/ast.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/language/move-compiler/src/hlir/mod.rs
+++ b/language/move-compiler/src/hlir/mod.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod ast;

--- a/language/move-compiler/src/hlir/translate.rs
+++ b/language/move-compiler/src/hlir/translate.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/language/move-compiler/src/interface_generator.rs
+++ b/language/move-compiler/src/interface_generator.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::shared::{NumberFormat, NumericalAddress};

--- a/language/move-compiler/src/ir_translation.rs
+++ b/language/move-compiler/src/ir_translation.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use regex::{Captures, NoExpand, Regex};

--- a/language/move-compiler/src/lib.rs
+++ b/language/move-compiler/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 #![forbid(unsafe_code)]

--- a/language/move-compiler/src/naming/ast.rs
+++ b/language/move-compiler/src/naming/ast.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/language/move-compiler/src/naming/mod.rs
+++ b/language/move-compiler/src/naming/mod.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod ast;

--- a/language/move-compiler/src/naming/translate.rs
+++ b/language/move-compiler/src/naming/translate.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/language/move-compiler/src/parser/ast.rs
+++ b/language/move-compiler/src/parser/ast.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::shared::{

--- a/language/move-compiler/src/parser/comments.rs
+++ b/language/move-compiler/src/parser/comments.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{diag, diagnostics::Diagnostics};

--- a/language/move-compiler/src/parser/keywords.rs
+++ b/language/move-compiler/src/parser/keywords.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 pub const KEYWORDS: &[&str] = &[

--- a/language/move-compiler/src/parser/lexer.rs
+++ b/language/move-compiler/src/parser/lexer.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/language/move-compiler/src/parser/merge_spec_modules.rs
+++ b/language/move-compiler/src/parser/merge_spec_modules.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! Merges specification modules into their target modules.

--- a/language/move-compiler/src/parser/mod.rs
+++ b/language/move-compiler/src/parser/mod.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod lexer;

--- a/language/move-compiler/src/parser/syntax.rs
+++ b/language/move-compiler/src/parser/syntax.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 // In the informal grammar comments in this file, Comma<T> is shorthand for:

--- a/language/move-compiler/src/shared/ast_debug.rs
+++ b/language/move-compiler/src/shared/ast_debug.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 /// Simple trait used for pretty printing the various AST

--- a/language/move-compiler/src/shared/mod.rs
+++ b/language/move-compiler/src/shared/mod.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/language/move-compiler/src/shared/remembering_unique_map.rs
+++ b/language/move-compiler/src/shared/remembering_unique_map.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use super::{unique_map::UniqueMap, *};

--- a/language/move-compiler/src/shared/unique_map.rs
+++ b/language/move-compiler/src/shared/unique_map.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use super::*;

--- a/language/move-compiler/src/shared/unique_set.rs
+++ b/language/move-compiler/src/shared/unique_set.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use super::{unique_map::UniqueMap, *};

--- a/language/move-compiler/src/to_bytecode/context.rs
+++ b/language/move-compiler/src/to_bytecode/context.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/language/move-compiler/src/to_bytecode/mod.rs
+++ b/language/move-compiler/src/to_bytecode/mod.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 #[macro_use]

--- a/language/move-compiler/src/to_bytecode/remove_fallthrough_jumps.rs
+++ b/language/move-compiler/src/to_bytecode/remove_fallthrough_jumps.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use move_ir_types::ast as IR;

--- a/language/move-compiler/src/to_bytecode/translate.rs
+++ b/language/move-compiler/src/to_bytecode/translate.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use super::{context::*, remove_fallthrough_jumps};

--- a/language/move-compiler/src/typing/ast.rs
+++ b/language/move-compiler/src/typing/ast.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/language/move-compiler/src/typing/core.rs
+++ b/language/move-compiler/src/typing/core.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/language/move-compiler/src/typing/expand.rs
+++ b/language/move-compiler/src/typing/expand.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use super::core::{self, Context};

--- a/language/move-compiler/src/typing/globals.rs
+++ b/language/move-compiler/src/typing/globals.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use super::core::{self, Context, Subst};

--- a/language/move-compiler/src/typing/infinite_instantiations.rs
+++ b/language/move-compiler/src/typing/infinite_instantiations.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use super::core::{self, Subst, TParamSubst};

--- a/language/move-compiler/src/typing/mod.rs
+++ b/language/move-compiler/src/typing/mod.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod ast;

--- a/language/move-compiler/src/typing/recursive_structs.rs
+++ b/language/move-compiler/src/typing/recursive_structs.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/language/move-compiler/src/typing/translate.rs
+++ b/language/move-compiler/src/typing/translate.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use super::{

--- a/language/move-compiler/src/unit_test/filter_test_members.rs
+++ b/language/move-compiler/src/unit_test/filter_test_members.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/language/move-compiler/src/unit_test/mod.rs
+++ b/language/move-compiler/src/unit_test/mod.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/language/move-compiler/src/unit_test/plan_builder.rs
+++ b/language/move-compiler/src/unit_test/plan_builder.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/language/move-compiler/tests/move_check_testsuite.rs
+++ b/language/move-compiler/tests/move_check_testsuite.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use move_command_line_common::{

--- a/language/move-compiler/transactional-tests/src/lib.rs
+++ b/language/move-compiler/transactional-tests/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 #![forbid(unsafe_code)]

--- a/language/move-compiler/transactional-tests/tests/tests.rs
+++ b/language/move-compiler/transactional-tests/tests/tests.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 pub const TEST_DIR: &str = "tests";

--- a/language/move-core/types/src/abi.rs
+++ b/language/move-core/types/src/abi.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::language_storage::{ModuleId, TypeTag};

--- a/language/move-core/types/src/account_address.rs
+++ b/language/move-core/types/src/account_address.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use hex::FromHex;

--- a/language/move-core/types/src/effects.rs
+++ b/language/move-core/types/src/effects.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/language/move-core/types/src/errmap.rs
+++ b/language/move-core/types/src/errmap.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::language_storage::ModuleId;

--- a/language/move-core/types/src/gas_schedule.rs
+++ b/language/move-core/types/src/gas_schedule.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! This module lays out the basic abstract costing schedule for bytecode instructions.

--- a/language/move-core/types/src/identifier.rs
+++ b/language/move-core/types/src/identifier.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! An identifier is the name of an entity (module, resource, function, etc) in Move.

--- a/language/move-core/types/src/language_storage.rs
+++ b/language/move-core/types/src/language_storage.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/language/move-core/types/src/lib.rs
+++ b/language/move-core/types/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! Core types for Move.

--- a/language/move-core/types/src/move_resource.rs
+++ b/language/move-core/types/src/move_resource.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/language/move-core/types/src/parser.rs
+++ b/language/move-core/types/src/parser.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/language/move-core/types/src/proptest_types.rs
+++ b/language/move-core/types/src/proptest_types.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/language/move-core/types/src/resolver.rs
+++ b/language/move-core/types/src/resolver.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/language/move-core/types/src/transaction_argument.rs
+++ b/language/move-core/types/src/transaction_argument.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{account_address::AccountAddress, value::MoveValue};

--- a/language/move-core/types/src/unit_tests/identifier_test.rs
+++ b/language/move-core/types/src/unit_tests/identifier_test.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::identifier::{IdentStr, Identifier, ALLOWED_IDENTIFIERS, ALLOWED_NO_SELF_IDENTIFIERS};

--- a/language/move-core/types/src/unit_tests/language_storage_test.rs
+++ b/language/move-core/types/src/unit_tests/language_storage_test.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/language/move-core/types/src/unit_tests/mod.rs
+++ b/language/move-core/types/src/unit_tests/mod.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 mod identifier_test;

--- a/language/move-core/types/src/unit_tests/value_test.rs
+++ b/language/move-core/types/src/unit_tests/value_test.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/language/move-core/types/src/value.rs
+++ b/language/move-core/types/src/value.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/language/move-core/types/src/vm_status.rs
+++ b/language/move-core/types/src/vm_status.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 #![allow(clippy::unit_arg)]

--- a/language/move-ir-compiler/move-bytecode-source-map/src/lib.rs
+++ b/language/move-ir-compiler/move-bytecode-source-map/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 #![forbid(unsafe_code)]

--- a/language/move-ir-compiler/move-bytecode-source-map/src/mapping.rs
+++ b/language/move-ir-compiler/move-bytecode-source-map/src/mapping.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{marking::MarkedSourceMapping, source_map::SourceMap};

--- a/language/move-ir-compiler/move-bytecode-source-map/src/marking.rs
+++ b/language/move-ir-compiler/move-bytecode-source-map/src/marking.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use move_binary_format::file_format::{

--- a/language/move-ir-compiler/move-bytecode-source-map/src/source_map.rs
+++ b/language/move-ir-compiler/move-bytecode-source-map/src/source_map.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::{format_err, Result};

--- a/language/move-ir-compiler/move-bytecode-source-map/src/utils.rs
+++ b/language/move-ir-compiler/move-bytecode-source-map/src/utils.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::source_map::SourceMap;

--- a/language/move-ir-compiler/move-bytecode-source-map/tests/dummies.rs
+++ b/language/move-ir-compiler/move-bytecode-source-map/tests/dummies.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use move_binary_format::{binary_views::BinaryIndexedView, file_format::empty_script};

--- a/language/move-ir-compiler/move-ir-to-bytecode/src/compiler.rs
+++ b/language/move-ir-compiler/move-ir-to-bytecode/src/compiler.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::context::{CompiledDependency, Context, MaterializedPools, TABLE_MAX_SIZE};

--- a/language/move-ir-compiler/move-ir-to-bytecode/src/context.rs
+++ b/language/move-ir-compiler/move-ir-to-bytecode/src/context.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::{bail, format_err, Result};

--- a/language/move-ir-compiler/move-ir-to-bytecode/src/lib.rs
+++ b/language/move-ir-compiler/move-ir-to-bytecode/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 extern crate log;

--- a/language/move-ir-compiler/move-ir-to-bytecode/src/parser.rs
+++ b/language/move-ir-compiler/move-ir-to-bytecode/src/parser.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::{bail, Result};

--- a/language/move-ir-compiler/move-ir-to-bytecode/syntax/src/lexer.rs
+++ b/language/move-ir-compiler/move-ir-to-bytecode/syntax/src/lexer.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::syntax::ParseError;

--- a/language/move-ir-compiler/move-ir-to-bytecode/syntax/src/lib.rs
+++ b/language/move-ir-compiler/move-ir-to-bytecode/syntax/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 #![forbid(unsafe_code)]

--- a/language/move-ir-compiler/move-ir-to-bytecode/syntax/src/syntax.rs
+++ b/language/move-ir-compiler/move-ir-to-bytecode/syntax/src/syntax.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::{anyhow, Context};

--- a/language/move-ir-compiler/src/lib.rs
+++ b/language/move-ir-compiler/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 #![forbid(unsafe_code)]

--- a/language/move-ir-compiler/src/main.rs
+++ b/language/move-ir-compiler/src/main.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 #![forbid(unsafe_code)]

--- a/language/move-ir-compiler/src/unit_tests/cfg_tests.rs
+++ b/language/move-ir-compiler/src/unit_tests/cfg_tests.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::unit_tests::testutils::compile_script_string;

--- a/language/move-ir-compiler/src/unit_tests/function_tests.rs
+++ b/language/move-ir-compiler/src/unit_tests/function_tests.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::unit_tests::testutils::compile_module_string;

--- a/language/move-ir-compiler/src/unit_tests/mod.rs
+++ b/language/move-ir-compiler/src/unit_tests/mod.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 // Needs to be at the top to allow macros defined in here to be used in tests.

--- a/language/move-ir-compiler/src/unit_tests/testutils.rs
+++ b/language/move-ir-compiler/src/unit_tests/testutils.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;

--- a/language/move-ir-compiler/src/util.rs
+++ b/language/move-ir-compiler/src/util.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Context;

--- a/language/move-ir-compiler/transactional-tests/tests/tests.rs
+++ b/language/move-ir-compiler/transactional-tests/tests/tests.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 pub const TEST_DIR: &str = "tests";

--- a/language/move-ir/types/src/ast.rs
+++ b/language/move-ir/types/src/ast.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/language/move-ir/types/src/lib.rs
+++ b/language/move-ir/types/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! Base types for the Move IR.

--- a/language/move-ir/types/src/location.rs
+++ b/language/move-ir/types/src/location.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use move_command_line_common::files::FileHash;

--- a/language/move-ir/types/src/spec_language_ast.rs
+++ b/language/move-ir/types/src/spec_language_ast.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/language/move-model/src/ast.rs
+++ b/language/move-model/src/ast.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! Contains AST definitions for the specification language fragments of the Move language.

--- a/language/move-model/src/builder/exp_translator.rs
+++ b/language/move-model/src/builder/exp_translator.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{

--- a/language/move-model/src/builder/mod.rs
+++ b/language/move-model/src/builder/mod.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 mod exp_translator;

--- a/language/move-model/src/builder/model_builder.rs
+++ b/language/move-model/src/builder/model_builder.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! Translates and validates specification language fragments as they are output from the Move

--- a/language/move-model/src/builder/module_builder.rs
+++ b/language/move-model/src/builder/module_builder.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{

--- a/language/move-model/src/builder/spec_builtins.rs
+++ b/language/move-model/src/builder/spec_builtins.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! Defines builtin functions for specifications, adding them to the build

--- a/language/move-model/src/code_writer.rs
+++ b/language/move-model/src/code_writer.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! A helper for generating structured code.

--- a/language/move-model/src/exp_generator.rs
+++ b/language/move-model/src/exp_generator.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use itertools::Itertools;

--- a/language/move-model/src/exp_rewriter.rs
+++ b/language/move-model/src/exp_rewriter.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use std::collections::{BTreeSet, VecDeque};

--- a/language/move-model/src/lib.rs
+++ b/language/move-model/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 #![forbid(unsafe_code)]

--- a/language/move-model/src/model.rs
+++ b/language/move-model/src/model.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! Provides a model for a set of Move modules (and scripts, which

--- a/language/move-model/src/native.rs
+++ b/language/move-model/src/native.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! Contains constants for well-known names of native functions

--- a/language/move-model/src/options.rs
+++ b/language/move-model/src/options.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use serde::{Deserialize, Serialize};

--- a/language/move-model/src/pragmas.rs
+++ b/language/move-model/src/pragmas.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! Provides pragmas and properties of the specification language.

--- a/language/move-model/src/simplifier/mod.rs
+++ b/language/move-model/src/simplifier/mod.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;

--- a/language/move-model/src/simplifier/pass.rs
+++ b/language/move-model/src/simplifier/pass.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;

--- a/language/move-model/src/simplifier/pass_inline.rs
+++ b/language/move-model/src/simplifier/pass_inline.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;

--- a/language/move-model/src/spec_translator.rs
+++ b/language/move-model/src/spec_translator.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! This module supports translations of specifications as found in the move-model to

--- a/language/move-model/src/symbol.rs
+++ b/language/move-model/src/symbol.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! Contains definitions of symbols -- internalized strings which support fast hashing and

--- a/language/move-model/src/ty.rs
+++ b/language/move-model/src/ty.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! Contains types and related functions.

--- a/language/move-model/tests/testsuite.rs
+++ b/language/move-model/tests/testsuite.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use codespan_reporting::{diagnostic::Severity, term::termcolor::Buffer};

--- a/language/move-prover/boogie-backend/src/boogie_helpers.rs
+++ b/language/move-prover/boogie-backend/src/boogie_helpers.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! Helpers for emitting Boogie code.

--- a/language/move-prover/boogie-backend/src/boogie_wrapper.rs
+++ b/language/move-prover/boogie-backend/src/boogie_wrapper.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! Wrapper around the boogie program. Allows to call boogie and analyze the output.

--- a/language/move-prover/boogie-backend/src/bytecode_translator.rs
+++ b/language/move-prover/boogie-backend/src/bytecode_translator.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! This module translates the bytecode of a module to Boogie code.

--- a/language/move-prover/boogie-backend/src/lib.rs
+++ b/language/move-prover/boogie-backend/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 #![forbid(unsafe_code)]

--- a/language/move-prover/boogie-backend/src/options.rs
+++ b/language/move-prover/boogie-backend/src/options.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::anyhow;

--- a/language/move-prover/boogie-backend/src/prelude/multiset-array-theory.bpl
+++ b/language/move-prover/boogie-backend/src/prelude/multiset-array-theory.bpl
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 // Boogie model for multisets, based on Boogie arrays. This theory assumes extensional equality for element types.

--- a/language/move-prover/boogie-backend/src/prelude/vector-array-intern-theory.bpl
+++ b/language/move-prover/boogie-backend/src/prelude/vector-array-intern-theory.bpl
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 // Boogie model for vectors, based on Boogie arrays.

--- a/language/move-prover/boogie-backend/src/prelude/vector-array-theory.bpl
+++ b/language/move-prover/boogie-backend/src/prelude/vector-array-theory.bpl
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 // Basic theory for vectors using arrays. This version of vectors is not extensional.

--- a/language/move-prover/boogie-backend/src/prelude/vector-smt-array-ext-theory.bpl
+++ b/language/move-prover/boogie-backend/src/prelude/vector-smt-array-ext-theory.bpl
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 // Boogie model for vectors, based on smt arrays.

--- a/language/move-prover/boogie-backend/src/prelude/vector-smt-array-theory.bpl
+++ b/language/move-prover/boogie-backend/src/prelude/vector-smt-array-theory.bpl
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 // Boogie model for vectors, based on smt arrays.

--- a/language/move-prover/boogie-backend/src/prelude/vector-smt-seq-theory.bpl
+++ b/language/move-prover/boogie-backend/src/prelude/vector-smt-seq-theory.bpl
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 // Boogie model for vectors, based on Z3 sequences.

--- a/language/move-prover/boogie-backend/src/prover_task_runner.rs
+++ b/language/move-prover/boogie-backend/src/prover_task_runner.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! Prover task runner that runs multiple instances of the prover task and returns

--- a/language/move-prover/boogie-backend/src/spec_translator.rs
+++ b/language/move-prover/boogie-backend/src/spec_translator.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! This module translates specification conditions to Boogie code.

--- a/language/move-prover/bytecode/src/access_path.rs
+++ b/language/move-prover/bytecode/src/access_path.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! This file contains an abstraction of concrete *access paths*, which are canonical names for a particular cell in

--- a/language/move-prover/bytecode/src/access_path_trie.rs
+++ b/language/move-prover/bytecode/src/access_path_trie.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! The obvious approach to abstracting a set of concrete paths is using a set of abstract paths.

--- a/language/move-prover/bytecode/src/annotations.rs
+++ b/language/move-prover/bytecode/src/annotations.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use itertools::Itertools;

--- a/language/move-prover/bytecode/src/borrow_analysis.rs
+++ b/language/move-prover/bytecode/src/borrow_analysis.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! Data flow analysis computing borrow information for preparation of memory_instrumentation.

--- a/language/move-prover/bytecode/src/clean_and_optimize.rs
+++ b/language/move-prover/bytecode/src/clean_and_optimize.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 // Final phase of cleanup and optimization.

--- a/language/move-prover/bytecode/src/compositional_analysis.rs
+++ b/language/move-prover/bytecode/src/compositional_analysis.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/language/move-prover/bytecode/src/data_invariant_instrumentation.rs
+++ b/language/move-prover/bytecode/src/data_invariant_instrumentation.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! Transformation which injects data invariants into the bytecode.

--- a/language/move-prover/bytecode/src/dataflow_analysis.rs
+++ b/language/move-prover/bytecode/src/dataflow_analysis.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! Adapted from AbstractInterpreter for Bytecode, this module defines the data-flow analysis

--- a/language/move-prover/bytecode/src/dataflow_domains.rs
+++ b/language/move-prover/bytecode/src/dataflow_domains.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! This module defines traits and representations of domains used in dataflow analysis.

--- a/language/move-prover/bytecode/src/debug_instrumentation.rs
+++ b/language/move-prover/bytecode/src/debug_instrumentation.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! Transformation which injects trace instructions which are used to visualize execution.

--- a/language/move-prover/bytecode/src/eliminate_imm_refs.rs
+++ b/language/move-prover/bytecode/src/eliminate_imm_refs.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/language/move-prover/bytecode/src/escape_analysis.rs
+++ b/language/move-prover/bytecode/src/escape_analysis.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! This escape analysis flags procedures that return a reference pointing inside of a struct type

--- a/language/move-prover/bytecode/src/function_data_builder.rs
+++ b/language/move-prover/bytecode/src/function_data_builder.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! Provides a builder for `FunctionData`, including building expressions and rewriting

--- a/language/move-prover/bytecode/src/function_target.rs
+++ b/language/move-prover/bytecode/src/function_target.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/language/move-prover/bytecode/src/function_target_pipeline.rs
+++ b/language/move-prover/bytecode/src/function_target_pipeline.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/language/move-prover/bytecode/src/global_invariant_analysis.rs
+++ b/language/move-prover/bytecode/src/global_invariant_analysis.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 // Analysis pass which analyzes how to injects global invariants into the bytecode.

--- a/language/move-prover/bytecode/src/global_invariant_instrumentation.rs
+++ b/language/move-prover/bytecode/src/global_invariant_instrumentation.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 // Instrumentation pass which injects global invariants into the bytecode.

--- a/language/move-prover/bytecode/src/global_invariant_instrumentation_v2.rs
+++ b/language/move-prover/bytecode/src/global_invariant_instrumentation_v2.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 // Transformation which injects global invariants into the bytecode.

--- a/language/move-prover/bytecode/src/graph.rs
+++ b/language/move-prover/bytecode/src/graph.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 // This module implements a technique to compute the natural loops of a graph.

--- a/language/move-prover/bytecode/src/inconsistency_check.rs
+++ b/language/move-prover/bytecode/src/inconsistency_check.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! Instrument `assert false;` in strategic locations in the program such that if proved, signals

--- a/language/move-prover/bytecode/src/lib.rs
+++ b/language/move-prover/bytecode/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 #![forbid(unsafe_code)]

--- a/language/move-prover/bytecode/src/livevar_analysis.rs
+++ b/language/move-prover/bytecode/src/livevar_analysis.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 // Live variable analysis with subsequent dead assignment elimination and

--- a/language/move-prover/bytecode/src/loop_analysis.rs
+++ b/language/move-prover/bytecode/src/loop_analysis.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/language/move-prover/bytecode/src/memory_instrumentation.rs
+++ b/language/move-prover/bytecode/src/memory_instrumentation.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/language/move-prover/bytecode/src/mono_analysis.rs
+++ b/language/move-prover/bytecode/src/mono_analysis.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! Analysis which computes information needed in backends for monomorphization. This

--- a/language/move-prover/bytecode/src/mut_ref_instrumentation.rs
+++ b/language/move-prover/bytecode/src/mut_ref_instrumentation.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/language/move-prover/bytecode/src/mutation_tester.rs
+++ b/language/move-prover/bytecode/src/mutation_tester.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! Transformation which mutates code for mutation testing in various ways

--- a/language/move-prover/bytecode/src/options.rs
+++ b/language/move-prover/bytecode/src/options.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use codespan_reporting::diagnostic::Severity;

--- a/language/move-prover/bytecode/src/packed_types_analysis.rs
+++ b/language/move-prover/bytecode/src/packed_types_analysis.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/language/move-prover/bytecode/src/pipeline_factory.rs
+++ b/language/move-prover/bytecode/src/pipeline_factory.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/language/move-prover/bytecode/src/reaching_def_analysis.rs
+++ b/language/move-prover/bytecode/src/reaching_def_analysis.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 // Reaching definition analysis with subsequent copy propagation.

--- a/language/move-prover/bytecode/src/read_write_set_analysis.rs
+++ b/language/move-prover/bytecode/src/read_write_set_analysis.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! The read/write set analysis is a compositional analysis that starts from the leaves of the

--- a/language/move-prover/bytecode/src/spec_instrumentation.rs
+++ b/language/move-prover/bytecode/src/spec_instrumentation.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 // Transformation which injects specifications (Move function spec blocks) into the bytecode.

--- a/language/move-prover/bytecode/src/stackless_bytecode.rs
+++ b/language/move-prover/bytecode/src/stackless_bytecode.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::function_target::FunctionTarget;

--- a/language/move-prover/bytecode/src/stackless_bytecode_generator.rs
+++ b/language/move-prover/bytecode/src/stackless_bytecode_generator.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/language/move-prover/bytecode/src/stackless_control_flow_graph.rs
+++ b/language/move-prover/bytecode/src/stackless_control_flow_graph.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! Adapted from control_flow_graph for Bytecode, this module defines the control-flow graph on

--- a/language/move-prover/bytecode/src/usage_analysis.rs
+++ b/language/move-prover/bytecode/src/usage_analysis.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/language/move-prover/bytecode/src/verification_analysis.rs
+++ b/language/move-prover/bytecode/src/verification_analysis.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! Analysis which computes an annotation for each function on whether this function should be

--- a/language/move-prover/bytecode/src/verification_analysis_v2.rs
+++ b/language/move-prover/bytecode/src/verification_analysis_v2.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! Analysis which computes an annotation for each function whether

--- a/language/move-prover/bytecode/src/well_formed_instrumentation.rs
+++ b/language/move-prover/bytecode/src/well_formed_instrumentation.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! Transformation which injects well-formed assumptions at top-level entry points of verified

--- a/language/move-prover/bytecode/tests/testsuite.rs
+++ b/language/move-prover/bytecode/tests/testsuite.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::anyhow;

--- a/language/move-prover/interpreter-testsuite/tests/concrete_check_testsuite.rs
+++ b/language/move-prover/interpreter-testsuite/tests/concrete_check_testsuite.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{env, path::Path};

--- a/language/move-prover/interpreter/crypto/src/lib.rs
+++ b/language/move-prover/interpreter/crypto/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! This file duplicates the code in the diem-crypto crate to support

--- a/language/move-prover/interpreter/src/concrete/evaluator.rs
+++ b/language/move-prover/interpreter/src/concrete/evaluator.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! This file implements the expression evaluation part of the stackless bytecode interpreter.

--- a/language/move-prover/interpreter/src/concrete/local_state.rs
+++ b/language/move-prover/interpreter/src/concrete/local_state.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! This file implements the information needed in the local interpretation context, i.e., the

--- a/language/move-prover/interpreter/src/concrete/mod.rs
+++ b/language/move-prover/interpreter/src/concrete/mod.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod evaluator;

--- a/language/move-prover/interpreter/src/concrete/player.rs
+++ b/language/move-prover/interpreter/src/concrete/player.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! This file implements the statement interpretation part of the stackless bytecode interpreter.

--- a/language/move-prover/interpreter/src/concrete/runtime.rs
+++ b/language/move-prover/interpreter/src/concrete/runtime.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! This file implements the orchestration part of the stackless bytecode interpreter and also

--- a/language/move-prover/interpreter/src/concrete/settings.rs
+++ b/language/move-prover/interpreter/src/concrete/settings.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 #[derive(Default, Clone)]

--- a/language/move-prover/interpreter/src/concrete/ty.rs
+++ b/language/move-prover/interpreter/src/concrete/ty.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! The type system in move-model is a fat type system that is designed to cover all cases that can

--- a/language/move-prover/interpreter/src/concrete/value.rs
+++ b/language/move-prover/interpreter/src/concrete/value.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! This file implements several value representations to track values produced and consumed during

--- a/language/move-prover/interpreter/src/lib.rs
+++ b/language/move-prover/interpreter/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::{bail, Result};

--- a/language/move-prover/interpreter/src/shared/bridge.rs
+++ b/language/move-prover/interpreter/src/shared/bridge.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use move_binary_format::errors::{PartialVMError, VMResult};

--- a/language/move-prover/interpreter/src/shared/ident.rs
+++ b/language/move-prover/interpreter/src/shared/ident.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use std::fmt;

--- a/language/move-prover/interpreter/src/shared/mod.rs
+++ b/language/move-prover/interpreter/src/shared/mod.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod bridge;

--- a/language/move-prover/interpreter/src/shared/variant.rs
+++ b/language/move-prover/interpreter/src/shared/variant.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use move_model::model::FunctionEnv;

--- a/language/move-prover/lab/data/cvc/plot.sh
+++ b/language/move-prover/lab/data/cvc/plot.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 # Copyright (c) The Diem Core Contributors
+# Copyright (c) The Move Contributors
 # SPDX-License-Identifier: Apache-2.0
 
 FUN_RESULTS="experiments/z3_boogie_array.fun_data experiments/cvc_boogie_array.fun_data"

--- a/language/move-prover/lab/data/cvc/run.sh
+++ b/language/move-prover/lab/data/cvc/run.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 # Copyright (c) The Diem Core Contributors
+# Copyright (c) The Move Contributors
 # SPDX-License-Identifier: Apache-2.0
 
 DIEM="$(git rev-parse --show-toplevel)"

--- a/language/move-prover/lab/data/mono/plot.sh
+++ b/language/move-prover/lab/data/mono/plot.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 # Copyright (c) The Diem Core Contributors
+# Copyright (c) The Move Contributors
 # SPDX-License-Identifier: Apache-2.0
 
 FUN_RESULTS="poly_backend.fun_data mono_backend.fun_data"

--- a/language/move-prover/lab/data/mono/run.sh
+++ b/language/move-prover/lab/data/mono/run.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 # Copyright (c) The Diem Core Contributors
+# Copyright (c) The Move Contributors
 # SPDX-License-Identifier: Apache-2.0
 
 echo "This lab cannot be run at head because the poly backend has been removed!"

--- a/language/move-prover/lab/data/new-boogie/plot.sh
+++ b/language/move-prover/lab/data/new-boogie/plot.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 # Copyright (c) The Diem Core Contributors
+# Copyright (c) The Move Contributors
 # SPDX-License-Identifier: Apache-2.0
 
 FUN_RESULTS="current_boogie.fun_data new_boogie.fun_data"

--- a/language/move-prover/lab/data/new-boogie/run.sh
+++ b/language/move-prover/lab/data/new-boogie/run.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # Copyright (c) The Diem Core Contributors
+# Copyright (c) The Move Contributors
 # SPDX-License-Identifier: Apache-2.0
 
 DIEM="$(git rev-parse --show-toplevel)"

--- a/language/move-prover/lab/data/opaque/plot.sh
+++ b/language/move-prover/lab/data/opaque/plot.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 # Copyright (c) The Diem Core Contributors
+# Copyright (c) The Move Contributors
 # SPDX-License-Identifier: Apache-2.0
 
 FUN_RESULTS="opaque.fun_data ignore_internal_opaque.fun_data ignore_opaque.fun_data"

--- a/language/move-prover/lab/data/opaque/run.sh
+++ b/language/move-prover/lab/data/opaque/run.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 # Copyright (c) The Diem Core Contributors
+# Copyright (c) The Move Contributors
 # SPDX-License-Identifier: Apache-2.0
 
 DIEM="$(git rev-parse --show-toplevel)"

--- a/language/move-prover/lab/data/quantifiers/notebook.sh
+++ b/language/move-prover/lab/data/quantifiers/notebook.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 # Copyright (c) The Diem Core Contributors
+# Copyright (c) The Move Contributors
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/language/move-prover/lab/data/struct-as-adt/plot.sh
+++ b/language/move-prover/lab/data/struct-as-adt/plot.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 # Copyright (c) The Diem Core Contributors
+# Copyright (c) The Move Contributors
 # SPDX-License-Identifier: Apache-2.0
 
 FUN_RESULTS="struct_as_vec.fun_data struct_as_adt.fun_data"

--- a/language/move-prover/lab/data/struct-as-adt/run.sh
+++ b/language/move-prover/lab/data/struct-as-adt/run.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 # Copyright (c) The Diem Core Contributors
+# Copyright (c) The Move Contributors
 # SPDX-License-Identifier: Apache-2.0
 
 echo "Lab cannot be run at head"

--- a/language/move-prover/lab/data/vector-theories/plot.sh
+++ b/language/move-prover/lab/data/vector-theories/plot.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 # Copyright (c) The Diem Core Contributors
+# Copyright (c) The Move Contributors
 # SPDX-License-Identifier: Apache-2.0
 
 FUN_RESULTS="boogie_array.fun_data boogie_array_intern.fun_data smt_array.fun_data smt_array_ext.fun_data smt_seq.fun_data"

--- a/language/move-prover/lab/data/vector-theories/run.sh
+++ b/language/move-prover/lab/data/vector-theories/run.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 # Copyright (c) The Diem Core Contributors
+# Copyright (c) The Move Contributors
 # SPDX-License-Identifier: Apache-2.0
 
 DIEM="$(git rev-parse --show-toplevel)"

--- a/language/move-prover/lab/src/benchmark.rs
+++ b/language/move-prover/lab/src/benchmark.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 // Functions for running benchmarks and storing the results as files, as well as reading

--- a/language/move-prover/lab/src/lib.rs
+++ b/language/move-prover/lab/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 #![forbid(unsafe_code)]

--- a/language/move-prover/lab/src/main.rs
+++ b/language/move-prover/lab/src/main.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 #![forbid(unsafe_code)]

--- a/language/move-prover/lab/src/plot.rs
+++ b/language/move-prover/lab/src/plot.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 // Functions for reading benchmark data and converting them to graphics.

--- a/language/move-prover/lab/src/z3log.rs
+++ b/language/move-prover/lab/src/z3log.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use plotters::{

--- a/language/move-prover/move-abigen/src/abigen.rs
+++ b/language/move-prover/move-abigen/src/abigen.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 #[allow(unused_imports)]

--- a/language/move-prover/move-abigen/src/lib.rs
+++ b/language/move-prover/move-abigen/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 #![forbid(unsafe_code)]

--- a/language/move-prover/move-abigen/tests/testsuite.rs
+++ b/language/move-prover/move-abigen/tests/testsuite.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{ffi::OsStr, path::Path};

--- a/language/move-prover/move-docgen/src/docgen.rs
+++ b/language/move-prover/move-docgen/src/docgen.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 #[allow(unused_imports)]

--- a/language/move-prover/move-docgen/src/lib.rs
+++ b/language/move-prover/move-docgen/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 #![forbid(unsafe_code)]

--- a/language/move-prover/move-docgen/tests/testsuite.rs
+++ b/language/move-prover/move-docgen/tests/testsuite.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use std::path::Path;

--- a/language/move-prover/move-errmapgen/src/errmapgen.rs
+++ b/language/move-prover/move-errmapgen/src/errmapgen.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::{bail, Result};

--- a/language/move-prover/move-errmapgen/src/lib.rs
+++ b/language/move-prover/move-errmapgen/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 #![forbid(unsafe_code)]

--- a/language/move-prover/mutation/src/lib.rs
+++ b/language/move-prover/mutation/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 #![forbid(unsafe_code)]

--- a/language/move-prover/mutation/src/main.rs
+++ b/language/move-prover/mutation/src/main.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 #![forbid(unsafe_code)]

--- a/language/move-prover/mutation/src/mutator.rs
+++ b/language/move-prover/mutation/src/mutator.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 // Functions for running move programs with mutations and reporting errors if found

--- a/language/move-prover/src/cli.rs
+++ b/language/move-prover/src/cli.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 #![forbid(unsafe_code)]

--- a/language/move-prover/src/lib.rs
+++ b/language/move-prover/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 #![forbid(unsafe_code)]

--- a/language/move-prover/src/main.rs
+++ b/language/move-prover/src/main.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 #![forbid(unsafe_code)]

--- a/language/move-prover/test-utils/src/baseline_test.rs
+++ b/language/move-prover/test-utils/src/baseline_test.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! A module supporting baseline (golden) tests.

--- a/language/move-prover/test-utils/src/lib.rs
+++ b/language/move-prover/test-utils/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use regex::Regex;

--- a/language/move-prover/tests/testsuite.rs
+++ b/language/move-prover/tests/testsuite.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{

--- a/language/move-prover/tests/xsources/design/regen.sh
+++ b/language/move-prover/tests/xsources/design/regen.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # Copyright (c) The Diem Core Contributors
+# Copyright (c) The Move Contributors
 # SPDX-License-Identifier: Apache-2.0
 
 set -e

--- a/language/move-prover/tools/check_pr.sh
+++ b/language/move-prover/tools/check_pr.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # Copyright (c) The Diem Core Contributors
+# Copyright (c) The Move Contributors
 # SPDX-License-Identifier: Apache-2.0
 
 # A script to check whether a local commit related to Move repo is ready for a PR.

--- a/language/move-prover/tools/check_stability.sh
+++ b/language/move-prover/tools/check_stability.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # Copyright (c) The Diem Core Contributors
+# Copyright (c) The Move Contributors
 # SPDX-License-Identifier: Apache-2.0
 
 # A script to check stability of a verification outcome. This runs the same prover

--- a/language/move-prover/tools/migrate_spec_fun_syntax.sh
+++ b/language/move-prover/tools/migrate_spec_fun_syntax.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # Copyright (c) The Diem Core Contributors
+# Copyright (c) The Move Contributors
 # SPDX-License-Identifier: Apache-2.0
 
 # A script to upgrade from `spec fun name` style syntax and related changes to `spec name`. This can create

--- a/language/move-prover/tools/spec-flatten/src/ast_print.rs
+++ b/language/move-prover/tools/spec-flatten/src/ast_print.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use itertools::Itertools;

--- a/language/move-prover/tools/spec-flatten/src/exp_trimming.rs
+++ b/language/move-prover/tools/spec-flatten/src/exp_trimming.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;

--- a/language/move-prover/tools/spec-flatten/src/lib.rs
+++ b/language/move-prover/tools/spec-flatten/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::{anyhow, Result};

--- a/language/move-prover/tools/spec-flatten/src/main.rs
+++ b/language/move-prover/tools/spec-flatten/src/main.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;

--- a/language/move-prover/tools/spec-flatten/src/workflow.rs
+++ b/language/move-prover/tools/spec-flatten/src/workflow.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::{anyhow, Result};

--- a/language/move-stdlib/src/lib.rs
+++ b/language/move-stdlib/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use log::LevelFilter;

--- a/language/move-stdlib/src/main.rs
+++ b/language/move-stdlib/src/main.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use move_stdlib::utils::time_it;

--- a/language/move-stdlib/src/natives/bcs.rs
+++ b/language/move-stdlib/src/natives/bcs.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use move_binary_format::errors::PartialVMResult;

--- a/language/move-stdlib/src/natives/debug.rs
+++ b/language/move-stdlib/src/natives/debug.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use move_binary_format::errors::PartialVMResult;

--- a/language/move-stdlib/src/natives/event.rs
+++ b/language/move-stdlib/src/natives/event.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use move_binary_format::errors::PartialVMResult;

--- a/language/move-stdlib/src/natives/hash.rs
+++ b/language/move-stdlib/src/natives/hash.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use move_binary_format::errors::PartialVMResult;

--- a/language/move-stdlib/src/natives/mod.rs
+++ b/language/move-stdlib/src/natives/mod.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod bcs;

--- a/language/move-stdlib/src/natives/signer.rs
+++ b/language/move-stdlib/src/natives/signer.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use move_binary_format::errors::PartialVMResult;

--- a/language/move-stdlib/src/natives/unit_test.rs
+++ b/language/move-stdlib/src/natives/unit_test.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use move_binary_format::errors::PartialVMResult;

--- a/language/move-stdlib/src/natives/vector.rs
+++ b/language/move-stdlib/src/natives/vector.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use move_binary_format::errors::{PartialVMError, PartialVMResult};

--- a/language/move-stdlib/src/tests.rs
+++ b/language/move-stdlib/src/tests.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use tempfile::tempdir;

--- a/language/move-stdlib/src/utils.rs
+++ b/language/move-stdlib/src/utils.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{io::Write, time::Instant};

--- a/language/move-stdlib/tests/move_unit_test.rs
+++ b/language/move-stdlib/tests/move_unit_test.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use move_cli::package::cli;

--- a/language/move-stdlib/tests/move_verification_test.rs
+++ b/language/move-stdlib/tests/move_verification_test.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use move_cli::package::prover::ProverTest;

--- a/language/move-symbol-pool/src/lib.rs
+++ b/language/move-symbol-pool/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! A global, uniqued cache of strings that is never purged. Inspired by

--- a/language/move-symbol-pool/src/pool.rs
+++ b/language/move-symbol-pool/src/pool.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! A pool of uniqued string data akin to a hash set.

--- a/language/move-symbol-pool/src/symbol.rs
+++ b/language/move-symbol-pool/src/symbol.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{pool::Entry, SYMBOL_POOL};

--- a/language/move-symbol-pool/tests/symbol.rs
+++ b/language/move-symbol-pool/tests/symbol.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use move_symbol_pool::Symbol;

--- a/language/move-vm/integration-tests/src/compiler.rs
+++ b/language/move-vm/integration-tests/src/compiler.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::{bail, Result};

--- a/language/move-vm/integration-tests/src/lib.rs
+++ b/language/move-vm/integration-tests/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 #![cfg(test)]

--- a/language/move-vm/integration-tests/src/tests/bad_entry_point_tests.rs
+++ b/language/move-vm/integration-tests/src/tests/bad_entry_point_tests.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::compiler::{as_module, compile_units};

--- a/language/move-vm/integration-tests/src/tests/bad_storage_tests.rs
+++ b/language/move-vm/integration-tests/src/tests/bad_storage_tests.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::compiler::{as_module, as_script, compile_units};

--- a/language/move-vm/integration-tests/src/tests/exec_func_effects_tests.rs
+++ b/language/move-vm/integration-tests/src/tests/exec_func_effects_tests.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use std::convert::TryInto;

--- a/language/move-vm/integration-tests/src/tests/function_arg_tests.rs
+++ b/language/move-vm/integration-tests/src/tests/function_arg_tests.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::compiler::{as_module, compile_units};

--- a/language/move-vm/integration-tests/src/tests/loader_tests.rs
+++ b/language/move-vm/integration-tests/src/tests/loader_tests.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::compiler::compile_modules_in_file;

--- a/language/move-vm/integration-tests/src/tests/mod.rs
+++ b/language/move-vm/integration-tests/src/tests/mod.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 mod bad_entry_point_tests;

--- a/language/move-vm/integration-tests/src/tests/mutated_accounts_tests.rs
+++ b/language/move-vm/integration-tests/src/tests/mutated_accounts_tests.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::compiler::{as_module, compile_units};

--- a/language/move-vm/integration-tests/src/tests/return_value_tests.rs
+++ b/language/move-vm/integration-tests/src/tests/return_value_tests.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::compiler::{as_module, compile_units};

--- a/language/move-vm/runtime/src/data_cache.rs
+++ b/language/move-vm/runtime/src/data_cache.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::loader::Loader;

--- a/language/move-vm/runtime/src/debug.rs
+++ b/language/move-vm/runtime/src/debug.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/language/move-vm/runtime/src/interpreter.rs
+++ b/language/move-vm/runtime/src/interpreter.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/language/move-vm/runtime/src/lib.rs
+++ b/language/move-vm/runtime/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 #![forbid(unsafe_code)]

--- a/language/move-vm/runtime/src/loader.rs
+++ b/language/move-vm/runtime/src/loader.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/language/move-vm/runtime/src/logging.rs
+++ b/language/move-vm/runtime/src/logging.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use move_binary_format::errors::{PartialVMError, VMError};

--- a/language/move-vm/runtime/src/move_vm.rs
+++ b/language/move-vm/runtime/src/move_vm.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use std::sync::Arc;

--- a/language/move-vm/runtime/src/native_extensions.rs
+++ b/language/move-vm/runtime/src/native_extensions.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use better_any::{Tid, TidAble, TidExt};

--- a/language/move-vm/runtime/src/native_functions.rs
+++ b/language/move-vm/runtime/src/native_functions.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/language/move-vm/runtime/src/runtime.rs
+++ b/language/move-vm/runtime/src/runtime.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/language/move-vm/runtime/src/session.rs
+++ b/language/move-vm/runtime/src/session.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/language/move-vm/runtime/src/tracing.rs
+++ b/language/move-vm/runtime/src/tracing.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 #[cfg(any(debug_assertions, feature = "debugging"))]

--- a/language/move-vm/runtime/src/unit_tests/mod.rs
+++ b/language/move-vm/runtime/src/unit_tests/mod.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod vm_arguments_tests;

--- a/language/move-vm/runtime/src/unit_tests/vm_arguments_tests.rs
+++ b/language/move-vm/runtime/src/unit_tests/vm_arguments_tests.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use std::collections::HashMap;

--- a/language/move-vm/test-utils/src/lib.rs
+++ b/language/move-vm/test-utils/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 #![allow(clippy::new_without_default)]

--- a/language/move-vm/test-utils/src/storage.rs
+++ b/language/move-vm/test-utils/src/storage.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 #[allow(unused)]

--- a/language/move-vm/transactional-tests/src/lib.rs
+++ b/language/move-vm/transactional-tests/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 #![forbid(unsafe_code)]

--- a/language/move-vm/transactional-tests/tests/tests.rs
+++ b/language/move-vm/transactional-tests/tests/tests.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 pub const TEST_DIR: &str = "tests";

--- a/language/move-vm/types/src/data_store.rs
+++ b/language/move-vm/types/src/data_store.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/language/move-vm/types/src/gas_schedule.rs
+++ b/language/move-vm/types/src/gas_schedule.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! This module lays out the basic abstract costing schedule for bytecode instructions.

--- a/language/move-vm/types/src/lib.rs
+++ b/language/move-vm/types/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 #![forbid(unsafe_code)]

--- a/language/move-vm/types/src/loaded_data/mod.rs
+++ b/language/move-vm/types/src/loaded_data/mod.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 //! Loaded definition of code data used in runtime.
 //!

--- a/language/move-vm/types/src/loaded_data/runtime_types.rs
+++ b/language/move-vm/types/src/loaded_data/runtime_types.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use move_binary_format::{

--- a/language/move-vm/types/src/natives/function.rs
+++ b/language/move-vm/types/src/natives/function.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! Native Function Support

--- a/language/move-vm/types/src/natives/mod.rs
+++ b/language/move-vm/types/src/natives/mod.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod function;

--- a/language/move-vm/types/src/unit_tests/identifier_prop_tests.rs
+++ b/language/move-vm/types/src/unit_tests/identifier_prop_tests.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use move_binary_format::file_format::CompiledModule;

--- a/language/move-vm/types/src/unit_tests/mod.rs
+++ b/language/move-vm/types/src/unit_tests/mod.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 #[cfg(feature = "fuzzing")]

--- a/language/move-vm/types/src/values/mod.rs
+++ b/language/move-vm/types/src/values/mod.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod values_impl;

--- a/language/move-vm/types/src/values/value_prop_tests.rs
+++ b/language/move-vm/types/src/values/value_prop_tests.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::values::{prop::layout_and_value_strategy, Value};

--- a/language/move-vm/types/src/values/value_tests.rs
+++ b/language/move-vm/types/src/values/value_tests.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::values::*;

--- a/language/move-vm/types/src/values/values_impl.rs
+++ b/language/move-vm/types/src/values/values_impl.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::loaded_data::runtime_types::Type;

--- a/language/testing-infra/module-generation/src/generator.rs
+++ b/language/testing-infra/module-generation/src/generator.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{options::ModuleGeneratorOptions, padding::Pad, utils::random_string};

--- a/language/testing-infra/module-generation/src/lib.rs
+++ b/language/testing-infra/module-generation/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 mod generator;

--- a/language/testing-infra/module-generation/src/options.rs
+++ b/language/testing-infra/module-generation/src/options.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! Defines constants and options that are used for module generation

--- a/language/testing-infra/module-generation/src/padding.rs
+++ b/language/testing-infra/module-generation/src/padding.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{options::ModuleGeneratorOptions, utils::random_string};

--- a/language/testing-infra/module-generation/src/utils.rs
+++ b/language/testing-infra/module-generation/src/utils.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use rand::{distributions::Alphanumeric, rngs::StdRng, Rng};

--- a/language/testing-infra/test-generation/measure-coverage.sh
+++ b/language/testing-infra/test-generation/measure-coverage.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # Copyright (c) The Diem Core Contributors
+# Copyright (c) The Move Contributors
 # SPDX-License-Identifier: Apache-2.0
 
 # Check that the test directory and report path arguments are provided

--- a/language/testing-infra/test-generation/src/abstract_state.rs
+++ b/language/testing-infra/test-generation/src/abstract_state.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{borrow_graph::BorrowGraph, error::VMError};

--- a/language/testing-infra/test-generation/src/borrow_graph.rs
+++ b/language/testing-infra/test-generation/src/borrow_graph.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::abstract_state::Mutability;

--- a/language/testing-infra/test-generation/src/bytecode_generator.rs
+++ b/language/testing-infra/test-generation/src/bytecode_generator.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/language/testing-infra/test-generation/src/config.rs
+++ b/language/testing-infra/test-generation/src/config.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use clap::Parser;

--- a/language/testing-infra/test-generation/src/control_flow_graph.rs
+++ b/language/testing-infra/test-generation/src/control_flow_graph.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::abstract_state::{AbstractValue, BorrowState};

--- a/language/testing-infra/test-generation/src/error.rs
+++ b/language/testing-infra/test-generation/src/error.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use std::fmt;

--- a/language/testing-infra/test-generation/src/lib.rs
+++ b/language/testing-infra/test-generation/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 #![forbid(unsafe_code)]

--- a/language/testing-infra/test-generation/src/main.rs
+++ b/language/testing-infra/test-generation/src/main.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 #![forbid(unsafe_code)]

--- a/language/testing-infra/test-generation/src/summaries.rs
+++ b/language/testing-infra/test-generation/src/summaries.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/language/testing-infra/test-generation/src/transitions.rs
+++ b/language/testing-infra/test-generation/src/transitions.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/language/testing-infra/test-generation/tests/boolean_instructions.rs
+++ b/language/testing-infra/test-generation/tests/boolean_instructions.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 extern crate test_generation;

--- a/language/testing-infra/test-generation/tests/call_graph.rs
+++ b/language/testing-infra/test-generation/tests/call_graph.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 extern crate test_generation;

--- a/language/testing-infra/test-generation/tests/common.rs
+++ b/language/testing-infra/test-generation/tests/common.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 extern crate test_generation;

--- a/language/testing-infra/test-generation/tests/comparison_instructions.rs
+++ b/language/testing-infra/test-generation/tests/comparison_instructions.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 extern crate test_generation;

--- a/language/testing-infra/test-generation/tests/control_flow_instructions.rs
+++ b/language/testing-infra/test-generation/tests/control_flow_instructions.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 extern crate test_generation;

--- a/language/testing-infra/test-generation/tests/generic_instructions.rs
+++ b/language/testing-infra/test-generation/tests/generic_instructions.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 extern crate test_generation;

--- a/language/testing-infra/test-generation/tests/integer_instructions.rs
+++ b/language/testing-infra/test-generation/tests/integer_instructions.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 extern crate test_generation;

--- a/language/testing-infra/test-generation/tests/load_instructions.rs
+++ b/language/testing-infra/test-generation/tests/load_instructions.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 extern crate test_generation;

--- a/language/testing-infra/test-generation/tests/local_instructions.rs
+++ b/language/testing-infra/test-generation/tests/local_instructions.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 extern crate test_generation;

--- a/language/testing-infra/test-generation/tests/reference_instructions.rs
+++ b/language/testing-infra/test-generation/tests/reference_instructions.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 extern crate test_generation;

--- a/language/testing-infra/test-generation/tests/special_instructions.rs
+++ b/language/testing-infra/test-generation/tests/special_instructions.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 extern crate test_generation;

--- a/language/testing-infra/test-generation/tests/struct_instructions.rs
+++ b/language/testing-infra/test-generation/tests/struct_instructions.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 extern crate test_generation;

--- a/language/testing-infra/transactional-test-runner/src/framework.rs
+++ b/language/testing-infra/transactional-test-runner/src/framework.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 #![forbid(unsafe_code)]

--- a/language/testing-infra/transactional-test-runner/src/lib.rs
+++ b/language/testing-infra/transactional-test-runner/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 #![forbid(unsafe_code)]

--- a/language/testing-infra/transactional-test-runner/src/tasks.rs
+++ b/language/testing-infra/transactional-test-runner/src/tasks.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 #![forbid(unsafe_code)]

--- a/language/testing-infra/transactional-test-runner/src/vm_test_harness.rs
+++ b/language/testing-infra/transactional-test-runner/src/vm_test_harness.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{collections::BTreeMap, path::Path};

--- a/language/testing-infra/transactional-test-runner/tests/tests.rs
+++ b/language/testing-infra/transactional-test-runner/tests/tests.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 pub const TEST_DIR: &str = "tests";

--- a/language/tools/move-bytecode-utils/src/dependency_graph.rs
+++ b/language/tools/move-bytecode-utils/src/dependency_graph.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use move_binary_format::{access::ModuleAccess, file_format::CompiledModule};

--- a/language/tools/move-bytecode-utils/src/layout.rs
+++ b/language/tools/move-bytecode-utils/src/layout.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::module_cache::GetModule;

--- a/language/tools/move-bytecode-utils/src/lib.rs
+++ b/language/tools/move-bytecode-utils/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod dependency_graph;

--- a/language/tools/move-bytecode-utils/src/module_cache.rs
+++ b/language/tools/move-bytecode-utils/src/module_cache.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::{anyhow, Result};

--- a/language/tools/move-bytecode-viewer/src/bytecode_viewer.rs
+++ b/language/tools/move-bytecode-viewer/src/bytecode_viewer.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 #![forbid(unsafe_code)]

--- a/language/tools/move-bytecode-viewer/src/interfaces.rs
+++ b/language/tools/move-bytecode-viewer/src/interfaces.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;

--- a/language/tools/move-bytecode-viewer/src/lib.rs
+++ b/language/tools/move-bytecode-viewer/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/language/tools/move-bytecode-viewer/src/main.rs
+++ b/language/tools/move-bytecode-viewer/src/main.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 #![forbid(unsafe_code)]

--- a/language/tools/move-bytecode-viewer/src/source_viewer.rs
+++ b/language/tools/move-bytecode-viewer/src/source_viewer.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 #![forbid(unsafe_code)]

--- a/language/tools/move-bytecode-viewer/src/tui/mod.rs
+++ b/language/tools/move-bytecode-viewer/src/tui/mod.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 #![forbid(unsafe_code)]

--- a/language/tools/move-bytecode-viewer/src/tui/text_builder.rs
+++ b/language/tools/move-bytecode-viewer/src/tui/text_builder.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 #![forbid(unsafe_code)]

--- a/language/tools/move-bytecode-viewer/src/tui/tui_interface.rs
+++ b/language/tools/move-bytecode-viewer/src/tui/tui_interface.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 #![forbid(unsafe_code)]

--- a/language/tools/move-bytecode-viewer/src/viewer.rs
+++ b/language/tools/move-bytecode-viewer/src/viewer.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 #![forbid(unsafe_code)]

--- a/language/tools/move-cli/src/base/commands/check.rs
+++ b/language/tools/move-cli/src/base/commands/check.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use std::collections::BTreeMap;

--- a/language/tools/move-cli/src/base/commands/compile.rs
+++ b/language/tools/move-cli/src/base/commands/compile.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use std::collections::BTreeMap;

--- a/language/tools/move-cli/src/base/commands/mod.rs
+++ b/language/tools/move-cli/src/base/commands/mod.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod check;

--- a/language/tools/move-cli/src/base/mod.rs
+++ b/language/tools/move-cli/src/base/mod.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod commands;

--- a/language/tools/move-cli/src/experimental/cli.rs
+++ b/language/tools/move-cli/src/experimental/cli.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{path::PathBuf, str::FromStr};

--- a/language/tools/move-cli/src/experimental/commands/mod.rs
+++ b/language/tools/move-cli/src/experimental/commands/mod.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod read_writeset_analysis;

--- a/language/tools/move-cli/src/experimental/commands/read_writeset_analysis.rs
+++ b/language/tools/move-cli/src/experimental/commands/read_writeset_analysis.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::sandbox::utils::on_disk_state_view::OnDiskStateView;

--- a/language/tools/move-cli/src/experimental/mod.rs
+++ b/language/tools/move-cli/src/experimental/mod.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod cli;

--- a/language/tools/move-cli/src/lib.rs
+++ b/language/tools/move-cli/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use move_package::BuildConfig;

--- a/language/tools/move-cli/src/main.rs
+++ b/language/tools/move-cli/src/main.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;

--- a/language/tools/move-cli/src/package/cli.rs
+++ b/language/tools/move-cli/src/package/cli.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{

--- a/language/tools/move-cli/src/package/mod.rs
+++ b/language/tools/move-cli/src/package/mod.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod cli;

--- a/language/tools/move-cli/src/package/prover.rs
+++ b/language/tools/move-cli/src/package/prover.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! Support for the prover in the package system.

--- a/language/tools/move-cli/src/sandbox/cli.rs
+++ b/language/tools/move-cli/src/sandbox/cli.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/language/tools/move-cli/src/sandbox/commands/doctor.rs
+++ b/language/tools/move-cli/src/sandbox/commands/doctor.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::sandbox::utils::on_disk_state_view::OnDiskStateView;

--- a/language/tools/move-cli/src/sandbox/commands/generate.rs
+++ b/language/tools/move-cli/src/sandbox/commands/generate.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::sandbox::utils::on_disk_state_view::OnDiskStateView;

--- a/language/tools/move-cli/src/sandbox/commands/mod.rs
+++ b/language/tools/move-cli/src/sandbox/commands/mod.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod doctor;

--- a/language/tools/move-cli/src/sandbox/commands/publish.rs
+++ b/language/tools/move-cli/src/sandbox/commands/publish.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/language/tools/move-cli/src/sandbox/commands/run.rs
+++ b/language/tools/move-cli/src/sandbox/commands/run.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/language/tools/move-cli/src/sandbox/commands/test.rs
+++ b/language/tools/move-cli/src/sandbox/commands/test.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{sandbox::utils::module, DEFAULT_BUILD_DIR, DEFAULT_STORAGE_DIR};

--- a/language/tools/move-cli/src/sandbox/commands/view.rs
+++ b/language/tools/move-cli/src/sandbox/commands/view.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::sandbox::utils::{

--- a/language/tools/move-cli/src/sandbox/mod.rs
+++ b/language/tools/move-cli/src/sandbox/mod.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod cli;

--- a/language/tools/move-cli/src/sandbox/utils/mod.rs
+++ b/language/tools/move-cli/src/sandbox/utils/mod.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::sandbox::utils::on_disk_state_view::OnDiskStateView;

--- a/language/tools/move-cli/src/sandbox/utils/on_disk_state_view.rs
+++ b/language/tools/move-cli/src/sandbox/utils/on_disk_state_view.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{BCS_EXTENSION, DEFAULT_BUILD_DIR, DEFAULT_STORAGE_DIR};

--- a/language/tools/move-cli/src/sandbox/utils/package_context.rs
+++ b/language/tools/move-cli/src/sandbox/utils/package_context.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 use crate::{sandbox::utils::OnDiskStateView, DEFAULT_BUILD_DIR};
 use anyhow::Result;

--- a/language/tools/move-cli/tests/build_testsuite.rs
+++ b/language/tools/move-cli/tests/build_testsuite.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use move_cli::sandbox::commands::test;

--- a/language/tools/move-cli/tests/build_testsuite_evm.rs
+++ b/language/tools/move-cli/tests/build_testsuite_evm.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use move_cli::sandbox::commands::test;

--- a/language/tools/move-cli/tests/cli_tests.rs
+++ b/language/tools/move-cli/tests/cli_tests.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use move_cli::sandbox::commands::test;

--- a/language/tools/move-cli/tests/move_unit_tests_evm.rs
+++ b/language/tools/move-cli/tests/move_unit_tests_evm.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use move_cli::sandbox::commands::test;

--- a/language/tools/move-cli/tests/move_unit_tests_move_vm_and_stackless_vm.rs
+++ b/language/tools/move-cli/tests/move_unit_tests_move_vm_and_stackless_vm.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use move_cli::sandbox::commands::test;

--- a/language/tools/move-cli/tests/sandbox_testsuite.rs
+++ b/language/tools/move-cli/tests/sandbox_testsuite.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use move_cli::sandbox::commands::test;

--- a/language/tools/move-coverage/check_coverage.bash
+++ b/language/tools/move-coverage/check_coverage.bash
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 # Copyright (c) The Diem Core Contributors
+# Copyright (c) The Move Contributors
 # SPDX-License-Identifier: Apache-2.0
 
 TRACE_PATH=$HOME/trace

--- a/language/tools/move-coverage/src/bin/coverage-summaries.rs
+++ b/language/tools/move-coverage/src/bin/coverage-summaries.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 #![forbid(unsafe_code)]

--- a/language/tools/move-coverage/src/bin/move-trace-conversion.rs
+++ b/language/tools/move-coverage/src/bin/move-trace-conversion.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 #![forbid(unsafe_code)]

--- a/language/tools/move-coverage/src/bin/source-coverage.rs
+++ b/language/tools/move-coverage/src/bin/source-coverage.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 #![forbid(unsafe_code)]

--- a/language/tools/move-coverage/src/coverage_map.rs
+++ b/language/tools/move-coverage/src/coverage_map.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 #![forbid(unsafe_code)]

--- a/language/tools/move-coverage/src/lib.rs
+++ b/language/tools/move-coverage/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::summary::ModuleSummary;

--- a/language/tools/move-coverage/src/source_coverage.rs
+++ b/language/tools/move-coverage/src/source_coverage.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 #![forbid(unsafe_code)]

--- a/language/tools/move-coverage/src/summary.rs
+++ b/language/tools/move-coverage/src/summary.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 #![forbid(unsafe_code)]

--- a/language/tools/move-coverage/utils.sh
+++ b/language/tools/move-coverage/utils.sh
@@ -1,4 +1,5 @@
 # Copyright (c) The Diem Core Contributors
+# Copyright (c) The Move Contributors
 # SPDX-License-Identifier: Apache-2.0
 
 alias coverage_update="pkill cargo; cargo run --release --bin move-trace-conversion -- -f $HOME/trace -u trace.mvcov -o trace.mvcov; rm -rf $HOME/trace"

--- a/language/tools/move-disassembler/src/disassembler.rs
+++ b/language/tools/move-disassembler/src/disassembler.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::{bail, format_err, Error, Result};

--- a/language/tools/move-disassembler/src/lib.rs
+++ b/language/tools/move-disassembler/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod disassembler;

--- a/language/tools/move-disassembler/src/main.rs
+++ b/language/tools/move-disassembler/src/main.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 #![forbid(unsafe_code)]

--- a/language/tools/move-explain/src/main.rs
+++ b/language/tools/move-explain/src/main.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use clap::Parser;

--- a/language/tools/move-package/src/compilation/build_plan.rs
+++ b/language/tools/move-package/src/compilation/build_plan.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/language/tools/move-package/src/compilation/compiled_package.rs
+++ b/language/tools/move-package/src/compilation/compiled_package.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/language/tools/move-package/src/compilation/mod.rs
+++ b/language/tools/move-package/src/compilation/mod.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod build_plan;

--- a/language/tools/move-package/src/compilation/model_builder.rs
+++ b/language/tools/move-package/src/compilation/model_builder.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/language/tools/move-package/src/compilation/package_layout.rs
+++ b/language/tools/move-package/src/compilation/package_layout.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use std::path::{Path, PathBuf};

--- a/language/tools/move-package/src/lib.rs
+++ b/language/tools/move-package/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 mod package_lock;

--- a/language/tools/move-package/src/package_lock.rs
+++ b/language/tools/move-package/src/package_lock.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use named_lock::{NamedLock, NamedLockGuard};

--- a/language/tools/move-package/src/resolution/digest.rs
+++ b/language/tools/move-package/src/resolution/digest.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;

--- a/language/tools/move-package/src/resolution/mod.rs
+++ b/language/tools/move-package/src/resolution/mod.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 mod digest;

--- a/language/tools/move-package/src/resolution/resolution_graph.rs
+++ b/language/tools/move-package/src/resolution/resolution_graph.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/language/tools/move-package/src/source_package/layout.rs
+++ b/language/tools/move-package/src/source_package/layout.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use std::path::{Path, PathBuf};

--- a/language/tools/move-package/src/source_package/manifest_parser.rs
+++ b/language/tools/move-package/src/source_package/manifest_parser.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{source_package::parsed_manifest as PM, Architecture};

--- a/language/tools/move-package/src/source_package/mod.rs
+++ b/language/tools/move-package/src/source_package/mod.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod layout;

--- a/language/tools/move-package/src/source_package/parsed_manifest.rs
+++ b/language/tools/move-package/src/source_package/parsed_manifest.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::Architecture;

--- a/language/tools/move-package/tests/package_hash_skips_non_move_files.rs
+++ b/language/tools/move-package/tests/package_hash_skips_non_move_files.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use move_package::BuildConfig;

--- a/language/tools/move-package/tests/test_additional_addresses.rs
+++ b/language/tools/move-package/tests/test_additional_addresses.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use move_core_types::account_address::AccountAddress;

--- a/language/tools/move-package/tests/test_removal_second_compilation.rs
+++ b/language/tools/move-package/tests/test_removal_second_compilation.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use move_package::{compilation::package_layout::CompiledPackageLayout, BuildConfig};

--- a/language/tools/move-package/tests/test_runner.rs
+++ b/language/tools/move-package/tests/test_runner.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use move_command_line_common::testing::{format_diff, read_env_update_baseline, EXP_EXT};

--- a/language/tools/move-package/tests/test_thread_safety.rs
+++ b/language/tools/move-package/tests/test_thread_safety.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use move_package::BuildConfig;

--- a/language/tools/move-resource-viewer/src/fat_type.rs
+++ b/language/tools/move-resource-viewer/src/fat_type.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 //! Loaded representation for runtime types.
 

--- a/language/tools/move-resource-viewer/src/lib.rs
+++ b/language/tools/move-resource-viewer/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/language/tools/move-resource-viewer/src/module_cache.rs
+++ b/language/tools/move-resource-viewer/src/module_cache.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use move_binary_format::CompiledModule;

--- a/language/tools/move-resource-viewer/src/resolver.rs
+++ b/language/tools/move-resource-viewer/src/resolver.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/language/tools/move-unit-test/src/cargo_runner.rs
+++ b/language/tools/move-unit-test/src/cargo_runner.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use move_command_line_common::files::find_filenames;

--- a/language/tools/move-unit-test/src/extensions.rs
+++ b/language/tools/move-unit-test/src/extensions.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //! This module manages native extensions supported by the unit testing framework.

--- a/language/tools/move-unit-test/src/lib.rs
+++ b/language/tools/move-unit-test/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod cargo_runner;

--- a/language/tools/move-unit-test/src/main.rs
+++ b/language/tools/move-unit-test/src/main.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use clap::*;

--- a/language/tools/move-unit-test/src/test_reporter.rs
+++ b/language/tools/move-unit-test/src/test_reporter.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::format_module_id;

--- a/language/tools/move-unit-test/src/test_runner.rs
+++ b/language/tools/move-unit-test/src/test_runner.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/language/tools/move-unit-test/tests/move_unit_test_testsuite.rs
+++ b/language/tools/move-unit-test/tests/move_unit_test_testsuite.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use move_command_line_common::testing::{format_diff, read_env_update_baseline, EXP_EXT};

--- a/language/tools/move-unit-test/tests/test_deps.rs
+++ b/language/tools/move-unit-test/tests/test_deps.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use move_core_types::{

--- a/language/tools/read-write-set/dynamic/src/dynamic_analysis.rs
+++ b/language/tools/read-write-set/dynamic/src/dynamic_analysis.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::{anyhow, bail, Result};

--- a/language/tools/read-write-set/dynamic/src/lib.rs
+++ b/language/tools/read-write-set/dynamic/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 mod dynamic_analysis;

--- a/language/tools/read-write-set/dynamic/src/normalize.rs
+++ b/language/tools/read-write-set/dynamic/src/normalize.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::dynamic_analysis::{

--- a/language/tools/read-write-set/src/lib.rs
+++ b/language/tools/read-write-set/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;

--- a/language/tools/read-write-set/types/src/access.rs
+++ b/language/tools/read-write-set/types/src/access.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use serde::{Deserialize, Serialize};

--- a/language/tools/read-write-set/types/src/lib.rs
+++ b/language/tools/read-write-set/types/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 mod access;

--- a/scripts/cargo_check_dependencies.sh
+++ b/scripts/cargo_check_dependencies.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 # Copyright (c) The Diem Core Contributors
+# Copyright (c) The Move Contributors
 # SPDX-License-Identifier: Apache-2.0
 
 # This script assumes it runs in the same directory as a Cargo.toml file

--- a/scripts/cargo_update_outdated.sh
+++ b/scripts/cargo_update_outdated.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 # Copyright (c) The Diem Core Contributors
+# Copyright (c) The Move Contributors
 # SPDX-License-Identifier: Apache-2.0
 
 # This script modifies local cargo files to reflect compatibility (semver)

--- a/scripts/changed-files.sh
+++ b/scripts/changed-files.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 # Copyright (c) The Diem Core Contributors
+# Copyright (c) The Move Contributors
 # SPDX-License-Identifier: Apache-2.0
 
 set -e

--- a/scripts/dev_setup.sh
+++ b/scripts/dev_setup.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # Copyright (c) The Diem Core Contributors
+# Copyright (c) The Move Contributors
 # SPDX-License-Identifier: Apache-2.0
 # This script sets up the environment for the Move build by installing necessary dependencies.
 #

--- a/scripts/git-checks.sh
+++ b/scripts/git-checks.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # Copyright (c) The Diem Core Contributors
+# Copyright (c) The Move Contributors
 # SPDX-License-Identifier: Apache-2.0
 
 set -e

--- a/scripts/run_quarantined.sh
+++ b/scripts/run_quarantined.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # Copyright (c) The Diem Core Contributors
+# Copyright (c) The Move Contributors
 # SPDX-License-Identifier: Apache-2.0
 
 crate=


### PR DESCRIPTION
- Added 'Move contributors' license to all files
- Files must now have the Move Contributors license header
- Optionally, they can have the Diem Core Contributors header first

## Motivation

- I kept making this mistake on my PRs, so I figured it would be good to update the lint 

## Test Plan

- cargo x lint