### PR TITLE
[async-move] Allow passing extensions to async move vm.

### DIFF
--- a/language/extensions/async/move-async-vm/src/async_vm.rs
+++ b/language/extensions/async/move-async-vm/src/async_vm.rs
@@ -78,7 +78,23 @@ impl AsyncVM {
         virtual_time: u128,
         move_resolver: &'r mut S,
     ) -> AsyncSession<'r, 'l, S> {
-        let extensions = make_extensions(for_actor, virtual_time, true);
+        self.new_session_with_extensions(
+            for_actor,
+            virtual_time,
+            move_resolver,
+            NativeContextExtensions::default(),
+        )
+    }
+
+    /// Creates a new session.
+    pub fn new_session_with_extensions<'r, 'l, S: MoveResolver>(
+        &'l self,
+        for_actor: AccountAddress,
+        virtual_time: u128,
+        move_resolver: &'r mut S,
+        ext: NativeContextExtensions<'r>,
+    ) -> AsyncSession<'r, 'l, S> {
+        let extensions = make_extensions(ext, for_actor, virtual_time, true);
         AsyncSession {
             vm: self,
             vm_session: self
@@ -329,12 +345,12 @@ impl<'r, 'l, S: MoveResolver> AsyncSession<'r, 'l, S> {
     }
 }
 
-fn make_extensions<'a>(
+fn make_extensions(
+    mut exts: NativeContextExtensions,
     actor_addr: AccountAddress,
     virtual_time: u128,
     in_initializer: bool,
-) -> NativeContextExtensions<'a> {
-    let mut exts = NativeContextExtensions::default();
+) -> NativeContextExtensions {
     exts.add(AsyncExtension {
         current_actor: actor_addr,
         sent: vec![],


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Move Language.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation
Add an api for async move vm to allow an extension.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

`cargo check`