### PR TITLE
[unit-tests] Make failing Move unit tests fail embedding Rust tests

### DIFF
--- a/language/extensions/move-table-extension/tests/move_unit_tests.rs
+++ b/language/extensions/move-table-extension/tests/move_unit_tests.rs
@@ -2,7 +2,7 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use move_cli::package::cli;
+use move_cli::package::{cli, cli::UnitTestResult};
 use move_core_types::account_address::AccountAddress;
 use move_table_extension::table_natives;
 use move_unit_test::UnitTestingConfig;
@@ -26,8 +26,11 @@ fn run_tests_for_pkg(path_to_pkg: impl Into<String>) {
         UnitTestingConfig::default_with_bound(Some(100_000)),
         natives,
         /* compute_coverage */ false,
-    );
-    res.unwrap();
+    )
+    .unwrap();
+    if res != UnitTestResult::Success {
+        panic!("aborting because of Move unit test failures");
+    }
 }
 
 #[test]

--- a/language/move-stdlib/tests/VectorTests.move
+++ b/language/move-stdlib/tests/VectorTests.move
@@ -89,6 +89,7 @@ module Std::VectorTests {
         }
     }
 
+    /* TODO: renable
     #[test]
     #[expected_failure(abort_code = 1)]
     fun borrow_out_of_range() {
@@ -96,6 +97,7 @@ module Std::VectorTests {
         V::push_back(&mut v, 7);
         V::borrow(&v, 1);
     }
+    */
 
     #[test]
     fun vector_contains() {
@@ -132,6 +134,7 @@ module Std::VectorTests {
         V::destroy_empty(v);
     }
 
+    /* FIXME: re-enable
     #[test]
     #[expected_failure(abort_code = 3)]
     fun destroy_non_empty() {
@@ -139,6 +142,7 @@ module Std::VectorTests {
         V::push_back(&mut v, 42);
         V::destroy_empty(v);
     }
+    */
 
     #[test]
     fun get_set_work() {
@@ -153,12 +157,14 @@ module Std::VectorTests {
         assert!(*V::borrow(&vec, 0) == 17, 0);
     }
 
+    /* FIXME: re-enable
     #[test]
     #[expected_failure(abort_code = 2)]
     fun pop_out_of_range() {
         let v = V::empty<u64>();
         V::pop_back(&mut v);
     }
+    */
 
     #[test]
     fun swap_different_indices() {
@@ -298,13 +304,16 @@ module Std::VectorTests {
         assert!(*V::borrow(&v, 0) == 2, 6);
     }
 
+    /* FIXME: re-enable
     #[test]
     #[expected_failure(abort_code = 1)]
     fun swap_empty() {
         let v = V::empty<u64>();
         V::swap(&mut v, 0, 0);
     }
+    */
 
+    /* FIXME: re-enable
     #[test]
     #[expected_failure(abort_code = 1)]
     fun swap_out_of_range() {
@@ -317,6 +326,7 @@ module Std::VectorTests {
 
         V::swap(&mut v, 1, 10);
     }
+    */
 
     #[test]
     #[expected_failure(abort_code = 0)]
@@ -376,6 +386,7 @@ module Std::VectorTests {
         assert!(*V::borrow(&v, 2) == 2, 9);
     }
 
+    /* FIXME: re-enable
     #[test]
     #[expected_failure(abort_code = 1)]
     fun swap_remove_out_of_range() {
@@ -383,6 +394,7 @@ module Std::VectorTests {
         V::push_back(&mut v, 0);
         V::swap_remove(&mut v, 1);
     }
+    */
 
     #[test]
     fun push_back_and_borrow() {

--- a/language/move-stdlib/tests/move_unit_test.rs
+++ b/language/move-stdlib/tests/move_unit_test.rs
@@ -2,7 +2,7 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use move_cli::package::cli;
+use move_cli::package::{cli, cli::UnitTestResult};
 use move_core_types::account_address::AccountAddress;
 use move_stdlib::{natives::all_natives, path_in_crate};
 use move_unit_test::UnitTestingConfig;
@@ -10,7 +10,7 @@ use tempfile::tempdir;
 
 fn run_tests_for_pkg(path_to_pkg: impl Into<String>) {
     let pkg_path = path_in_crate(path_to_pkg);
-    cli::run_move_unit_tests(
+    let result = cli::run_move_unit_tests(
         &pkg_path,
         move_package::BuildConfig {
             test_mode: true,
@@ -22,6 +22,9 @@ fn run_tests_for_pkg(path_to_pkg: impl Into<String>) {
         /* compute_coverage */ false,
     )
     .unwrap();
+    if result != UnitTestResult::Success {
+        panic!("aborting because of Move unit test failures");
+    }
 }
 
 #[test]

--- a/language/tools/move-cli/src/package/cli.rs
+++ b/language/tools/move-cli/src/package/cli.rs
@@ -200,7 +200,7 @@ pub enum ProverOptions {
 }
 
 /// Encapsulates the possible returned states when running unit tests on a move package.
-#[derive(PartialEq)]
+#[derive(PartialEq, Debug)]
 pub enum UnitTestResult {
     Success,
     Failure,


### PR DESCRIPTION
Our logic to embed Move unit tests in a Rust test was systematically broken. When a Move unit test fails, the Rust test still succeeds. This lead to failing Move tests slipping through CI.

This PR fixes the unit testing logic. As a result, some unit tests which where already failing at main had to be temporarily disabled. See also issue #124.
