### PR TITLE
[move-stdlib] Fix vector tests

### DIFF
--- a/language/move-stdlib/tests/VectorTests.move
+++ b/language/move-stdlib/tests/VectorTests.move
@@ -89,7 +89,6 @@ module Std::VectorTests {
         }
     }
 
-    /* TODO: renable
     #[test]
     #[expected_failure(abort_code = 1)]
     fun borrow_out_of_range() {
@@ -97,7 +96,6 @@ module Std::VectorTests {
         V::push_back(&mut v, 7);
         V::borrow(&v, 1);
     }
-    */
 
     #[test]
     fun vector_contains() {
@@ -134,7 +132,6 @@ module Std::VectorTests {
         V::destroy_empty(v);
     }
 
-    /* FIXME: re-enable
     #[test]
     #[expected_failure(abort_code = 3)]
     fun destroy_non_empty() {
@@ -142,7 +139,6 @@ module Std::VectorTests {
         V::push_back(&mut v, 42);
         V::destroy_empty(v);
     }
-    */
 
     #[test]
     fun get_set_work() {
@@ -157,14 +153,12 @@ module Std::VectorTests {
         assert!(*V::borrow(&vec, 0) == 17, 0);
     }
 
-    /* FIXME: re-enable
     #[test]
     #[expected_failure(abort_code = 2)]
     fun pop_out_of_range() {
         let v = V::empty<u64>();
         V::pop_back(&mut v);
     }
-    */
 
     #[test]
     fun swap_different_indices() {
@@ -304,16 +298,13 @@ module Std::VectorTests {
         assert!(*V::borrow(&v, 0) == 2, 6);
     }
 
-    /* FIXME: re-enable
     #[test]
     #[expected_failure(abort_code = 1)]
     fun swap_empty() {
         let v = V::empty<u64>();
         V::swap(&mut v, 0, 0);
     }
-    */
 
-    /* FIXME: re-enable
     #[test]
     #[expected_failure(abort_code = 1)]
     fun swap_out_of_range() {
@@ -326,7 +317,6 @@ module Std::VectorTests {
 
         V::swap(&mut v, 1, 10);
     }
-    */
 
     #[test]
     #[expected_failure(abort_code = 0)]
@@ -386,7 +376,6 @@ module Std::VectorTests {
         assert!(*V::borrow(&v, 2) == 2, 9);
     }
 
-    /* FIXME: re-enable
     #[test]
     #[expected_failure(abort_code = 1)]
     fun swap_remove_out_of_range() {
@@ -394,7 +383,6 @@ module Std::VectorTests {
         V::push_back(&mut v, 0);
         V::swap_remove(&mut v, 1);
     }
-    */
 
     #[test]
     fun push_back_and_borrow() {

--- a/language/tools/move-unit-test/src/test_runner.rs
+++ b/language/tools/move-unit-test/src/test_runner.rs
@@ -483,7 +483,10 @@ impl SharedTestingConfig {
                     // Expected the test the abort with a specific `code`, and it did abort with
                     // that abort code
                     (Some(ExpectedFailure::ExpectedWithCode(code)), Some(other_code))
-                        if err.major_status() == StatusCode::ABORTED && *code == other_code =>
+                        if matches!(
+                            err.major_status(),
+                            StatusCode::ABORTED | StatusCode::VECTOR_OPERATION_ERROR
+                        ) && *code == other_code =>
                     {
                         output.pass(function_name);
                         stats.test_success(test_run_info, test_plan);

--- a/language/tools/move-unit-test/tests/test_sources/native_abort.exp
+++ b/language/tools/move-unit-test/tests/test_sources/native_abort.exp
@@ -1,24 +1,11 @@
 Running Move unit tests
-[ FAIL    ] 0x1::A::native_abort_good_right_code
+[ PASS    ] 0x1::A::native_abort_good_right_code
 [ FAIL    ] 0x1::A::native_abort_good_wrong_code
 [ FAIL    ] 0x1::A::native_abort_unexpected_abort
 
 Test failures:
 
 Failures in 0x1::A:
-
-┌── native_abort_good_right_code ──────
-│ error[E11001]: test failure
-│    ┌─ native_abort.move:18:9
-│    │
-│ 17 │     fun native_abort_good_right_code() {
-│    │         ---------------------------- In this function in 0x1::A
-│ 18 │         Vector::borrow(&Vector::empty<u64>(), 1);
-│    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Test did not abort with expected code. Expected test to abort with 1 but instead it aborted with 1 here
-│ 
-│ 
-└──────────────────
-
 
 ┌── native_abort_good_wrong_code ──────
 │ error[E11001]: test failure
@@ -45,4 +32,4 @@ Failures in 0x1::A:
 │ 
 └──────────────────
 
-Test result: FAILED. Total tests: 3; passed: 0; failed: 3
+Test result: FAILED. Total tests: 3; passed: 1; failed: 2


### PR DESCRIPTION
- Fixed vector tests failing, re-enabled tests
- The tests exited with VECTOR_OPERATION_ERROR instead of ABORTED
- We should be able to specify the difference in the future

## Motivation

#124

## Test Plan

- re-enabled tests