### PR TITLE
[docker] Added Dockerfile for the Move CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,21 @@ Move is a programming language for writing safe smart contracts originally devel
 
 This repository is the official home of the Move virtual machine, bytecode verifier, compiler, prover, package manager, and book. For Move code examples and papers, check out [awesome-move](https://github.com/MystenLabs/awesome-move).
 
+## Quickstart
+
+### Build the [Docker](https://www.docker.com/community/open-source/) Image for the Command Line Tool
+
+```
+docker build -t move/cli -f docker/move-cli/Dockerfile .
+```
+
+### Build a Test Project
+
+```
+cd ./language/documentation/tutorial/step_1/BasicCoin
+docker run -v `pwd`:/project move/cli package build
+```
+
 ## Community
 
 * Join us on the [Move Discord](https://discord.gg/vTepKPdF).

--- a/docker/move-cli/Dockerfile
+++ b/docker/move-cli/Dockerfile
@@ -1,0 +1,41 @@
+FROM debian:buster-20211011@sha256:f9182ead292f45165f4a851e5ff98ea0800e172ccedce7d17764ffaae5ed4d6e
+
+VOLUME /project
+WORKDIR /project
+
+ADD . /move/
+
+#Needed for sccache to function, and to work around home dir being blatted.
+ENV CARGO_HOME "/opt/cargo"
+ENV RUSTUP_HOME "/opt/rustup"
+
+ENV DOTNET_ROOT "/opt/dotnet"
+ENV Z3_EXE "/opt/bin/z3"
+ENV CVC5_EXE "/opt/bin/cvc5"
+ENV BOOGIE_EXE "/opt/dotnet/tools/boogie"
+ENV SOLC_EXE "/opt/bin/solc"
+ENV PATH "/opt/cargo/bin:/usr/lib/golang/bin:/opt/bin:${DOTNET_ROOT}:${DOTNET_ROOT}/tools:$PATH"
+
+# Batch mode and all operations tooling
+RUN mkdir -p /github/home && \
+    mkdir -p /opt/cargo/ && \
+    mkdir -p /opt/git/ && \
+    /move/scripts/dev_setup.sh -t -b -p -y -d -n && \
+    apt-get install -y git && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Compile a small rust tool?  But we already have in dev_setup (sccache/grcov)...?
+# Test that all commands we need are installed and on the PATH
+RUN [ -x "$(set -x; command -v rustup)" ] \
+    && [ -x "$(set -x; command -v cargo)" ] \
+    && [ -x "$(set -x; command -v solc)" ] \
+    && [ -x "$(set -x; command -v z3)" ] \
+    && [ -x "$(set -x; command -v "$BOOGIE_EXE")" ] \
+    && [ -x "$(set -x; xargs rustup which cargo --toolchain < /move/rust-toolchain )" ] \
+    && [ -x "$(set -x; command -v clang)" ] \
+    && [ -x "$(set -x; command -v npm)" ]
+
+RUN cd /move; cargo build -p move-cli
+
+ENTRYPOINT ["/move/target/debug/move"]


### PR DESCRIPTION
Added Dockerfile for Move command-line interface for getting started
easier. This Dockerfile is based on the CI image found in docker/.

Also added building instructions to README.

## Motivation

Providing an easier way to get started with Move.

This Dockerfile can later be used with automated packaging solutions, such as Docker Hub.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#pull-requests)?

Yes (going to fix the link anchor :laughing: ).

## Test Plan

```
docker build -t move/cli -f docker/move-cli/Dockerfile .
cd ./language/documentation/tutorial/step_1/BasicCoin
docker run -v `pwd`:/project move/cli package build
```