### PR TITLE
[github] Fixed the link anchor to CONTRIBUTING.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,7 +8,7 @@ The project is undergoing daily changes. Pull Requests will be reviewed and resp
 
 (Write your motivation for proposed changes here.)
 
-### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#pull-requests)?
+### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?
 
 (Write your answer here.)
 


### PR DESCRIPTION
Anchor "#pull-requests" does not exist anymore in CONTRIBUTING.md.
Changed the link in the PR Template  to point to "#developer-workflow"
which does exists, and contains basically the same stuff
"#pull-requests" used to contain.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Move Language.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

The ["Developer Workflow"](https://github.com/move-language/move/blob/8625c747b35050f42cd30e94984d88b602ca004a/CONTRIBUTING.md#developer-workflow) chapter contains the same stuff ["Pull Requests"](https://github.com/move-language/move/blob/5e034dde19a5320d7e2bdc9da25114e816b4454d/CONTRIBUTING.md#pull-requests) chapter used to contain.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#pull-requests)?

Yes :wink: 

## Test Plan

Documentational: no testing needed (checked the link with a browser, though).