### PR TITLE
[move-lang] Make control expressions terms. Fix their associativity.

### DIFF
--- a/language/move-compiler/src/parser/syntax.rs
+++ b/language/move-compiler/src/parser/syntax.rs
@@ -883,13 +883,37 @@ fn parse_sequence(context: &mut Context) -> Result<Sequence, Diagnostic> {
 //          | "(" <Exp> ":" <Type> ")"
 //          | "(" <Exp> "as" <Type> ")"
 //          | "{" <Sequence>
+//          | "if" "(" <Exp> ")" <Exp> "else" "{" <Exp> "}"
+//          | "if" "(" <Exp> ")" "{" <Exp> "}"
+//          | "if" "(" <Exp> ")" <Exp> ("else" <Exp>)?
+//          | "while" "(" <Exp> ")" "{" <Exp> "}"
+//          | "while" "(" <Exp> ")" <Exp> (SpecBlock)?
+//          | "loop" <Exp>
+//          | "loop" "{" <Exp> "}"
+//          | "return" "{" <Exp> "}"
+//          | "return" <Exp>?
+//          | "abort" "{" <Exp> "}"
+//          | "abort" <Exp>
 fn parse_term(context: &mut Context) -> Result<Exp, Diagnostic> {
     const VECTOR_IDENT: &str = "vector";
 
     let start_loc = context.tokens.start_loc();
     let term = match context.tokens.peek() {
+        tok if is_control_exp(tok) => {
+            let (control_exp, ends_in_block) = parse_control_exp(context)?;
+            if !ends_in_block || at_end_of_exp(context) {
+                return Ok(control_exp);
+            }
+
+            return parse_binop_exp(context, control_exp, /* min_prec */ 1);
+        }
         Tok::Break => {
             context.tokens.advance()?;
+            if at_start_of_exp(context) {
+                let mut diag = unexpected_token_error(context.tokens, "the end of an expression");
+                diag.add_note("'break' with a value is not yet supported");
+                return Err(diag);
+            }
             Exp_::Break
         }
 
@@ -1010,6 +1034,119 @@ fn parse_term(context: &mut Context) -> Result<Exp, Diagnostic> {
     ))
 }
 
+fn is_control_exp(tok: Tok) -> bool {
+    matches!(
+        tok,
+        Tok::If | Tok::While | Tok::Loop | Tok::Return | Tok::Abort
+    )
+}
+
+// if there is a block, only parse the block, not any subsequent tokens
+// e.g.           if (cond) e1 else { e2 } + 1
+// should be,    (if (cond) e1 else { e2 }) + 1
+// AND NOT,       if (cond) e1 else ({ e2 } + 1)
+// But otherwise, if (cond) e1 else e2 + 1
+// should be,     if (cond) e1 else (e2 + 1)
+fn parse_control_exp(context: &mut Context) -> Result<(Exp, bool), Diagnostic> {
+    fn parse_exp_or_sequence(context: &mut Context) -> Result<(Exp, bool), Diagnostic> {
+        match context.tokens.peek() {
+            Tok::LBrace => {
+                let block_start_loc = context.tokens.start_loc();
+                context.tokens.advance()?; // consume the LBrace
+                let block_ = Exp_::Block(parse_sequence(context)?);
+                let block_end_loc = context.tokens.previous_end_loc();
+                let exp = spanned(
+                    context.tokens.file_hash(),
+                    block_start_loc,
+                    block_end_loc,
+                    block_,
+                );
+                Ok((exp, true))
+            }
+            _ => Ok((parse_exp(context)?, false)),
+        }
+    }
+    let start_loc = context.tokens.start_loc();
+    let (exp_, ends_in_block) = match context.tokens.peek() {
+        Tok::If => {
+            context.tokens.advance()?;
+            consume_token(context.tokens, Tok::LParen)?;
+            let eb = Box::new(parse_exp(context)?);
+            consume_token(context.tokens, Tok::RParen)?;
+            let (et, ends_in_block) = parse_exp_or_sequence(context)?;
+            let (ef, ends_in_block) = if match_token(context.tokens, Tok::Else)? {
+                let (ef, ends_in_block) = parse_exp_or_sequence(context)?;
+                (Some(Box::new(ef)), ends_in_block)
+            } else {
+                (None, ends_in_block)
+            };
+            (Exp_::IfElse(eb, Box::new(et), ef), ends_in_block)
+        }
+        Tok::While => {
+            context.tokens.advance()?;
+            consume_token(context.tokens, Tok::LParen)?;
+            let econd = parse_exp(context)?;
+            consume_token(context.tokens, Tok::RParen)?;
+            let (eloop, ends_in_block) = parse_exp_or_sequence(context)?;
+            let (econd, ends_in_block) = if context.tokens.peek() == Tok::Spec {
+                // Parse a loop invariant. Also validate that only `invariant`
+                // properties are contained in the spec block. This is
+                // transformed into `while ({spec { .. }; cond) body`.
+                let spec = parse_spec_block(vec![], context)?;
+                for member in &spec.value.members {
+                    match member.value {
+                        // Ok
+                        SpecBlockMember_::Condition {
+                            kind: sp!(_, SpecConditionKind_::Invariant(..)),
+                            ..
+                        } => (),
+                        _ => {
+                            return Err(diag!(
+                                Syntax::InvalidSpecBlockMember,
+                                (member.loc, "only 'invariant' allowed here")
+                            ))
+                        }
+                    }
+                }
+                let spec_seq = sp(
+                    spec.loc,
+                    SequenceItem_::Seq(Box::new(sp(spec.loc, Exp_::Spec(spec)))),
+                );
+                let loc = econd.loc;
+                let spec_block = Exp_::Block((vec![], vec![spec_seq], None, Box::new(Some(econd))));
+                (sp(loc, spec_block), true)
+            } else {
+                (econd, ends_in_block)
+            };
+            (Exp_::While(Box::new(econd), Box::new(eloop)), ends_in_block)
+        }
+        Tok::Loop => {
+            context.tokens.advance()?;
+            let (eloop, ends_in_block) = parse_exp_or_sequence(context)?;
+            (Exp_::Loop(Box::new(eloop)), ends_in_block)
+        }
+        Tok::Return => {
+            context.tokens.advance()?;
+            let (e, ends_in_block) = if !at_start_of_exp(context) {
+                (None, false)
+            } else {
+                let (e, ends_in_block) = parse_exp_or_sequence(context)?;
+                (Some(Box::new(e)), ends_in_block)
+            };
+            (Exp_::Return(e), ends_in_block)
+        }
+        Tok::Abort => {
+            context.tokens.advance()?;
+            let (e, ends_in_block) = parse_exp_or_sequence(context)?;
+            (Exp_::Abort(Box::new(e)), ends_in_block)
+        }
+        _ => unreachable!(),
+    };
+    let end_loc = context.tokens.previous_end_loc();
+    let exp = spanned(context.tokens.file_hash(), start_loc, end_loc, exp_);
+    Ok((exp, ends_in_block))
+}
+
 // Parse a pack, call, or other reference to a name:
 //      NameExp =
 //          <NameAccessChain> <OptionalTypeArgs> "{" Comma<ExpField> "}"
@@ -1096,15 +1233,39 @@ fn at_end_of_exp(context: &mut Context) -> bool {
     )
 }
 
+fn at_start_of_exp(context: &mut Context) -> bool {
+    matches!(
+        context.tokens.peek(),
+        // value
+        Tok::NumValue
+            | Tok::NumTypedValue
+            | Tok::ByteStringValue
+            | Tok::Identifier
+            | Tok::AtSign
+            | Tok::Copy
+            | Tok::Move
+            | Tok::False
+            | Tok::True
+            | Tok::Amp
+            | Tok::AmpMut
+            | Tok::Star
+            | Tok::Exclaim
+            | Tok::LParen
+            | Tok::LBrace
+            | Tok::Abort
+            | Tok::Break
+            | Tok::Continue
+            | Tok::If
+            | Tok::Loop
+            | Tok::Return
+            | Tok::While
+    )
+}
+
 // Parse an expression:
 //      Exp =
 //            <LambdaBindList> <Exp>        spec only
 //          | <Quantifier>                  spec only
-//          | "if" "(" <Exp> ")" <Exp> ("else" <Exp>)?
-//          | "while" "(" <Exp> ")" <Exp> (SpecBlock)?
-//          | "loop" <Exp>
-//          | "return" <Exp>?
-//          | "abort" <Exp>
 //          | <BinOpExp>
 //          | <UnaryExp> "=" <Exp>
 fn parse_exp(context: &mut Context) -> Result<Exp, Diagnostic> {
@@ -1116,82 +1277,6 @@ fn parse_exp(context: &mut Context) -> Result<Exp, Diagnostic> {
             Exp_::Lambda(bindings, body)
         }
         Tok::Identifier if is_quant(context) => parse_quant(context)?,
-        Tok::If => {
-            context.tokens.advance()?;
-            consume_token(context.tokens, Tok::LParen)?;
-            let eb = Box::new(parse_exp(context)?);
-            consume_token(context.tokens, Tok::RParen)?;
-            let et = Box::new(parse_exp(context)?);
-            let ef = if match_token(context.tokens, Tok::Else)? {
-                Some(Box::new(parse_exp(context)?))
-            } else {
-                None
-            };
-            Exp_::IfElse(eb, et, ef)
-        }
-        Tok::While => {
-            context.tokens.advance()?;
-            consume_token(context.tokens, Tok::LParen)?;
-            let econd = parse_exp(context)?;
-            consume_token(context.tokens, Tok::RParen)?;
-            let eloop = Box::new(parse_exp(context)?);
-            let econd = if context.tokens.peek() == Tok::Spec {
-                // Parse a loop invariant. Also validate that only `invariant`
-                // properties are contained in the spec block. This is
-                // transformed into `while ({spec { .. }; cond) body`.
-                let spec = parse_spec_block(vec![], context)?;
-                for member in &spec.value.members {
-                    match member.value {
-                        SpecBlockMember_::Condition {
-                            kind: sp!(_, SpecConditionKind_::Invariant(..)),
-                            ..
-                        } => {
-                            // Ok
-                        }
-                        _ => {
-                            return Err(diag!(
-                                Syntax::InvalidSpecBlockMember,
-                                (member.loc, "only 'invariant' allowed here")
-                            ))
-                        }
-                    }
-                }
-                sp(
-                    econd.loc,
-                    Exp_::Block((
-                        vec![],
-                        vec![sp(
-                            spec.loc,
-                            SequenceItem_::Seq(Box::new(sp(spec.loc, Exp_::Spec(spec)))),
-                        )],
-                        None,
-                        Box::new(Some(econd)),
-                    )),
-                )
-            } else {
-                econd
-            };
-            Exp_::While(Box::new(econd), eloop)
-        }
-        Tok::Loop => {
-            context.tokens.advance()?;
-            let eloop = Box::new(parse_exp(context)?);
-            Exp_::Loop(eloop)
-        }
-        Tok::Return => {
-            context.tokens.advance()?;
-            let e = if at_end_of_exp(context) {
-                None
-            } else {
-                Some(Box::new(parse_exp(context)?))
-            };
-            Exp_::Return(e)
-        }
-        Tok::Abort => {
-            context.tokens.advance()?;
-            let e = Box::new(parse_exp(context)?);
-            Exp_::Abort(e)
-        }
         _ => {
             // This could be either an assignment or a binary operator
             // expression.

--- a/language/move-compiler/src/typing/core.rs
+++ b/language/move-compiler/src/typing/core.rs
@@ -1010,6 +1010,10 @@ fn solve_builtin_type_constraint(
         )
     };
     match &t.value {
+        // already failed, ignore
+        UnresolvedError => (),
+        // Will fail later in compiling, either through dead code, or unknown type variable
+        Anything => (),
         Apply(abilities_opt, sp!(_, Builtin(sp!(_, b))), args) if builtin_set.contains(b) => {
             if let Some(abilities) = abilities_opt {
                 assert!(

--- a/language/move-compiler/tests/move_check/parser/break_with_value.exp
+++ b/language/move-compiler/tests/move_check/parser/break_with_value.exp
@@ -1,0 +1,11 @@
+error[E01002]: unexpected token
+  ┌─ tests/move_check/parser/break_with_value.move:3:22
+  │
+3 │         loop { break 0 };
+  │                      ^
+  │                      │
+  │                      Unexpected '0'
+  │                      Expected the end of an expression
+  │
+  = 'break' with a value is not yet supported
+

--- a/language/move-compiler/tests/move_check/parser/break_with_value.move
+++ b/language/move-compiler/tests/move_check/parser/break_with_value.move
@@ -1,0 +1,5 @@
+module 0x42::M {
+    fun t(cond: bool) {
+        loop { break 0 };
+    }
+}

--- a/language/move-compiler/tests/move_check/parser/control_exp_as_term.exp
+++ b/language/move-compiler/tests/move_check/parser/control_exp_as_term.exp
@@ -1,0 +1,36 @@
+warning[W09005]: dead or unreachable code
+  ┌─ tests/move_check/parser/control_exp_as_term.move:7:13
+  │
+7 │         1 + loop {} + 2;
+  │             ^^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
+
+warning[W09005]: dead or unreachable code
+  ┌─ tests/move_check/parser/control_exp_as_term.move:8:13
+  │
+8 │         1 + return + 0;
+  │             ^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
+
+warning[W09005]: dead or unreachable code
+   ┌─ tests/move_check/parser/control_exp_as_term.move:10:14
+   │
+10 │         foo(&if (cond) 0 else 1);
+   │              ^^^^^^^^^^^^^^^^^^ Unreachable code. This statement (and any following statements) will not be executed.
+
+warning[W09005]: dead or unreachable code
+   ┌─ tests/move_check/parser/control_exp_as_term.move:11:14
+   │
+11 │         foo(&loop {});
+   │              ^^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
+
+warning[W09005]: dead or unreachable code
+   ┌─ tests/move_check/parser/control_exp_as_term.move:12:14
+   │
+12 │         foo(&return);
+   │              ^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
+
+warning[W09005]: dead or unreachable code
+   ┌─ tests/move_check/parser/control_exp_as_term.move:13:14
+   │
+13 │         foo(&abort 0);
+   │              ^^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
+

--- a/language/move-compiler/tests/move_check/parser/control_exp_as_term.move
+++ b/language/move-compiler/tests/move_check/parser/control_exp_as_term.move
@@ -1,0 +1,15 @@
+module 0x42::M {
+
+    fun foo(_: &u64) {}
+
+    fun t(cond: bool) {
+        1 + if (cond) 0 else { 1 } + 2;
+        1 + loop {} + 2;
+        1 + return + 0;
+
+        foo(&if (cond) 0 else 1);
+        foo(&loop {});
+        foo(&return);
+        foo(&abort 0);
+    }
+}

--- a/language/move-compiler/tests/move_check/parser/control_exp_associativity.move
+++ b/language/move-compiler/tests/move_check/parser/control_exp_associativity.move
@@ -1,0 +1,10 @@
+// tests that control structures are right associative when not immediately followed by a block
+
+module 0x42::M {
+    fun t(cond: bool) {
+        let _: u64 = 1 + if (cond) 0 else 10 + 10;
+        let _: bool = true || if (cond) false else 10 == 10;
+        let _: bool = if (cond) 10 else { 10 } == 10;
+        let _: u64 = if (cond) 0 else { 10 } + 1;
+    }
+}

--- a/language/move-compiler/tests/move_check/parser/control_exp_associativity_else_after_if_block.exp
+++ b/language/move-compiler/tests/move_check/parser/control_exp_associativity_else_after_if_block.exp
@@ -1,0 +1,9 @@
+error[E01002]: unexpected token
+   ┌─ tests/move_check/parser/control_exp_associativity_else_after_if_block.move:13:28
+   │
+13 │         if (cond) { s1 }.f else s2.f
+   │                            ^^^^
+   │                            │
+   │                            Unexpected 'else'
+   │                            Expected ';'
+

--- a/language/move-compiler/tests/move_check/parser/control_exp_associativity_else_after_if_block.move
+++ b/language/move-compiler/tests/move_check/parser/control_exp_associativity_else_after_if_block.move
@@ -1,0 +1,17 @@
+// tests that control structures are right associative when not immediately followed by a block
+
+module 0x42::M {
+
+    struct S has copy, drop { f: u64 }
+
+    fun t(cond: bool, s1: S, s2: S) {
+        // (if (cond) s1 else s2).f
+        let _: u64 = if (cond) { s1 } else { s2 }.f;
+
+        // (if (cond) s1).f else (s2.f)
+        // so parsing error
+        if (cond) { s1 }.f else s2.f
+
+
+    }
+}

--- a/language/move-compiler/tests/move_check/parser/control_exp_associativity_field_access.move
+++ b/language/move-compiler/tests/move_check/parser/control_exp_associativity_field_access.move
@@ -1,0 +1,16 @@
+// tests that control structures are right associative when not immediately followed by a block
+
+// valid usage with field access
+
+module 0x42::M {
+
+    struct S has copy, drop { f: u64 }
+
+    fun t(cond: bool, s1: S, s2: S) {
+        let _: u64 = if (cond) 0 else s2.f;
+        let _: u64 = if (cond) s1.f else s2.f;
+        let _: u64 = if (cond) s1 else { s2 }.f;
+        let _: u64 = if (cond) { s1 } else { s2 }.f;
+    }
+
+}

--- a/language/move-compiler/tests/move_check/parser/control_exp_associativity_typing_invalid.exp
+++ b/language/move-compiler/tests/move_check/parser/control_exp_associativity_typing_invalid.exp
@@ -1,0 +1,88 @@
+error[E04007]: incompatible types
+   ┌─ tests/move_check/parser/control_exp_associativity_typing_invalid.move:12:9
+   │
+ 7 │     fun bar(): u64 { 0 }
+   │                --- Found: 'u64'. It is not compatible with the other type.
+   ·
+12 │         if (cond) bar() + 1;
+   │         ^^^^^^^^^^^^^^^^^^^
+   │         │
+   │         Incompatible branches
+   │         Found: '()'. It is not compatible with the other type.
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/parser/control_exp_associativity_typing_invalid.move:15:9
+   │
+15 │         if (cond) { foo() } + 1;
+   │         ^^^^^^^^^^^^^^^^^^^
+   │         │
+   │         Invalid argument to '+'
+   │         Found: '()'. But expected: 'u8', 'u64', 'u128'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/parser/control_exp_associativity_typing_invalid.move:15:29
+   │
+15 │         if (cond) { foo() } + 1;
+   │         ------------------- ^ - Found: integer. It is not compatible with the other type.
+   │         │                   │  
+   │         │                   Incompatible arguments to '+'
+   │         Found: '()'. It is not compatible with the other type.
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/parser/control_exp_associativity_typing_invalid.move:15:31
+   │
+15 │         if (cond) { foo() } + 1;
+   │         -------------------   ^ Invalid argument to '+'
+   │         │                      
+   │         Found: '()'. But expected: 'u8', 'u64', 'u128'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/parser/control_exp_associativity_typing_invalid.move:19:22
+   │
+ 7 │     fun bar(): u64 { 0 }
+   │                --- Given: 'u64'
+   ·
+19 │         while (cond) bar() + 2;
+   │                      ^^^^^^^^^
+   │                      │
+   │                      Invalid loop body
+   │                      Expected: '()'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/parser/control_exp_associativity_typing_invalid.move:22:9
+   │
+22 │         while (cond) { foo() } + 2;
+   │         ^^^^^^^^^^^^^^^^^^^^^^
+   │         │
+   │         Invalid argument to '+'
+   │         Found: '()'. But expected: 'u8', 'u64', 'u128'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/parser/control_exp_associativity_typing_invalid.move:22:32
+   │
+22 │         while (cond) { foo() } + 2;
+   │         ---------------------- ^ - Found: integer. It is not compatible with the other type.
+   │         │                      │  
+   │         │                      Incompatible arguments to '+'
+   │         Found: '()'. It is not compatible with the other type.
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_check/parser/control_exp_associativity_typing_invalid.move:22:34
+   │
+22 │         while (cond) { foo() } + 2;
+   │         ----------------------   ^ Invalid argument to '+'
+   │         │                         
+   │         Found: '()'. But expected: 'u8', 'u64', 'u128'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/parser/control_exp_associativity_typing_invalid.move:26:14
+   │
+ 7 │     fun bar(): u64 { 0 }
+   │                --- Given: 'u64'
+   ·
+26 │         loop bar() + 2;
+   │              ^^^^^^^^^
+   │              │
+   │              Invalid loop body
+   │              Expected: '()'
+

--- a/language/move-compiler/tests/move_check/parser/control_exp_associativity_typing_invalid.move
+++ b/language/move-compiler/tests/move_check/parser/control_exp_associativity_typing_invalid.move
@@ -1,0 +1,29 @@
+// tests that control structures are right associative when not immediately followed by a block
+
+// these cases do not type check
+
+module 0x42::M {
+    fun foo() {}
+    fun bar(): u64 { 0 }
+
+    fun t(cond: bool) {
+        // if (cond) (bar() + 1);
+        // so error about incompatible branches
+        if (cond) bar() + 1;
+        // (if (cond) bar()) + 1;
+        // so error about wrong argument to +
+        if (cond) { foo() } + 1;
+
+        // while (cond) (bar() + 1);
+        // so error about invalid loop body type
+        while (cond) bar() + 2;
+        // (while (cond) foo()) + 2
+        // so error about wrong argument to +
+        while (cond) { foo() } + 2;
+
+        // loop (bar() + 1);
+        // so error about invalid loop body type
+        loop bar() + 2;
+        // loop { foo() } + 2; would type check
+    }
+}

--- a/language/move-compiler/tests/move_check/parser/control_exp_associativity_unreachable_code.exp
+++ b/language/move-compiler/tests/move_check/parser/control_exp_associativity_unreachable_code.exp
@@ -1,0 +1,72 @@
+warning[W09002]: unused variable
+  ┌─ tests/move_check/parser/control_exp_associativity_unreachable_code.move:9:11
+  │
+9 │     fun t(cond: bool): u64 {
+  │           ^^^^ Unused parameter 'cond'. Consider removing or prefixing with an underscore: '_cond'
+
+warning[W09005]: dead or unreachable code
+   ┌─ tests/move_check/parser/control_exp_associativity_unreachable_code.move:11:13
+   │
+11 │         1 + loop { foo() } + 2;
+   │             ^^^^^^^^^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
+
+warning[W09005]: dead or unreachable code
+   ┌─ tests/move_check/parser/control_exp_associativity_unreachable_code.move:12:13
+   │
+12 │         1 + loop foo();
+   │             ^^^^^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
+
+warning[W09005]: dead or unreachable code
+   ┌─ tests/move_check/parser/control_exp_associativity_unreachable_code.move:12:18
+   │
+12 │         1 + loop foo();
+   │                  ^^^^^ Unreachable code. This statement (and any following statements) will not be executed.
+
+warning[W09005]: dead or unreachable code
+   ┌─ tests/move_check/parser/control_exp_associativity_unreachable_code.move:13:9
+   │
+13 │         loop { foo() } + 1;
+   │         ^^^^^^^^^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
+
+warning[W09005]: dead or unreachable code
+   ┌─ tests/move_check/parser/control_exp_associativity_unreachable_code.move:13:16
+   │
+13 │         loop { foo() } + 1;
+   │                ^^^^^ Unreachable code. This statement (and any following statements) will not be executed.
+
+warning[W09005]: dead or unreachable code
+   ┌─ tests/move_check/parser/control_exp_associativity_unreachable_code.move:17:9
+   │
+17 │         return { 1 + 2 };
+   │         ^^^^^^^^^^^^^^^^ Unreachable code. This statement (and any following statements) will not be executed.
+
+warning[W09005]: dead or unreachable code
+   ┌─ tests/move_check/parser/control_exp_associativity_unreachable_code.move:18:9
+   │
+18 │         return { 1 } && false;
+   │         ^^^^^^^^^^^^ Unreachable code. This statement (and any following statements) will not be executed.
+
+warning[W09005]: dead or unreachable code
+   ┌─ tests/move_check/parser/control_exp_associativity_unreachable_code.move:18:9
+   │
+18 │         return { 1 } && false;
+   │         ^^^^^^^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
+
+warning[W09005]: dead or unreachable code
+   ┌─ tests/move_check/parser/control_exp_associativity_unreachable_code.move:22:9
+   │
+22 │         abort { 1 + 2 };
+   │         ^^^^^^^^^^^^^^^ Unreachable code. This statement (and any following statements) will not be executed.
+
+warning[W09005]: dead or unreachable code
+   ┌─ tests/move_check/parser/control_exp_associativity_unreachable_code.move:23:9
+   │
+23 │         abort { 1 } && false;
+   │         ^^^^^^^^^^^ Unreachable code. This statement (and any following statements) will not be executed.
+
+warning[W09005]: dead or unreachable code
+   ┌─ tests/move_check/parser/control_exp_associativity_unreachable_code.move:23:9
+   │
+23 │         abort { 1 } && false;
+   │         ^^^^^^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
+

--- a/language/move-compiler/tests/move_check/parser/control_exp_associativity_unreachable_code.move
+++ b/language/move-compiler/tests/move_check/parser/control_exp_associativity_unreachable_code.move
@@ -1,0 +1,27 @@
+// tests that control structures are right associative when not immediately followed by a block
+
+// these cases type check, but have dead code
+
+module 0x42::M {
+    fun foo() {}
+    fun bar(): u64 { 0 }
+
+    fun t(cond: bool): u64 {
+        // loop
+        1 + loop { foo() } + 2;
+        1 + loop foo();
+        loop { foo() } + 1;
+
+        // return
+        return 1 + 2;
+        return { 1 + 2 };
+        return { 1 } && false;
+
+        // abort
+        abort 1 + 2;
+        abort { 1 + 2 };
+        abort { 1 } && false;
+
+        0
+    }
+}

--- a/language/move-compiler/tests/move_check/parser/return_in_binop.exp
+++ b/language/move-compiler/tests/move_check/parser/return_in_binop.exp
@@ -1,0 +1,96 @@
+warning[W09005]: dead or unreachable code
+  ┌─ tests/move_check/parser/return_in_binop.move:3:9
+  │
+3 │         return >> 0;
+  │         ^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
+
+warning[W09005]: dead or unreachable code
+  ┌─ tests/move_check/parser/return_in_binop.move:4:9
+  │
+4 │         return << 0;
+  │         ^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
+
+warning[W09005]: dead or unreachable code
+  ┌─ tests/move_check/parser/return_in_binop.move:5:9
+  │
+5 │         return || false;
+  │         ^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
+
+warning[W09005]: dead or unreachable code
+  ┌─ tests/move_check/parser/return_in_binop.move:6:9
+  │
+6 │         return && false;
+  │         ^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
+
+warning[W09005]: dead or unreachable code
+  ┌─ tests/move_check/parser/return_in_binop.move:7:9
+  │
+7 │         return + 0;
+  │         ^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
+
+warning[W09005]: dead or unreachable code
+  ┌─ tests/move_check/parser/return_in_binop.move:8:9
+  │
+8 │         return - 0;
+  │         ^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
+
+warning[W09005]: dead or unreachable code
+  ┌─ tests/move_check/parser/return_in_binop.move:9:9
+  │
+9 │         return % 0;
+  │         ^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
+
+warning[W09005]: dead or unreachable code
+   ┌─ tests/move_check/parser/return_in_binop.move:10:9
+   │
+10 │         return / 1;
+   │         ^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
+
+warning[W09005]: dead or unreachable code
+   ┌─ tests/move_check/parser/return_in_binop.move:11:9
+   │
+11 │         return < 0;
+   │         ^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
+
+warning[W09005]: dead or unreachable code
+   ┌─ tests/move_check/parser/return_in_binop.move:12:9
+   │
+12 │         return > 0;
+   │         ^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
+
+warning[W09005]: dead or unreachable code
+   ┌─ tests/move_check/parser/return_in_binop.move:13:9
+   │
+13 │         return <= 0;
+   │         ^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
+
+warning[W09005]: dead or unreachable code
+   ┌─ tests/move_check/parser/return_in_binop.move:14:9
+   │
+14 │         return == 0;
+   │         ^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
+
+warning[W09005]: dead or unreachable code
+   ┌─ tests/move_check/parser/return_in_binop.move:15:9
+   │
+15 │         return >= 0;
+   │         ^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
+
+warning[W09005]: dead or unreachable code
+   ┌─ tests/move_check/parser/return_in_binop.move:16:9
+   │
+16 │         return != 0;
+   │         ^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
+
+warning[W09005]: dead or unreachable code
+   ┌─ tests/move_check/parser/return_in_binop.move:17:9
+   │
+17 │         return | 0;
+   │         ^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
+
+warning[W09005]: dead or unreachable code
+   ┌─ tests/move_check/parser/return_in_binop.move:18:9
+   │
+18 │         return ^ 0;
+   │         ^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
+

--- a/language/move-compiler/tests/move_check/parser/return_in_binop.move
+++ b/language/move-compiler/tests/move_check/parser/return_in_binop.move
@@ -1,0 +1,20 @@
+module 0x42::M {
+    fun t() {
+        return >> 0;
+        return << 0;
+        return || false;
+        return && false;
+        return + 0;
+        return - 0;
+        return % 0;
+        return / 1;
+        return < 0;
+        return > 0;
+        return <= 0;
+        return == 0;
+        return >= 0;
+        return != 0;
+        return | 0;
+        return ^ 0;
+    }
+}

--- a/language/move-compiler/tests/move_check/typing/binary_add_invalid.exp
+++ b/language/move-compiler/tests/move_check/typing/binary_add_invalid.exp
@@ -128,15 +128,6 @@ error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_add_invalid.move:15:9
    │
 15 │         1 + false + @0x0 + 0;
-   │         ^^^^^^^^^
-   │         │ │
-   │         │ Found: '_'. But expected: 'u8', 'u64', 'u128'
-   │         Invalid argument to '+'
-
-error[E04003]: built-in operation not supported
-   ┌─ tests/move_check/typing/binary_add_invalid.move:15:9
-   │
-15 │         1 + false + @0x0 + 0;
    │         ^^^^^^^^^^^^^^^^
    │         │           │
    │         │           Found: 'address'. But expected: 'u8', 'u64', 'u128'
@@ -150,14 +141,6 @@ error[E04007]: incompatible types
    │         │ │  
    │         │ Incompatible arguments to '+'
    │         Found: integer. It is not compatible with the other type.
-
-error[E04003]: built-in operation not supported
-   ┌─ tests/move_check/typing/binary_add_invalid.move:15:21
-   │
-15 │         1 + false + @0x0 + 0;
-   │           -         ^^^^ Invalid argument to '+'
-   │           │          
-   │           Found: '_'. But expected: 'u8', 'u64', 'u128'
 
 error[E04007]: incompatible types
    ┌─ tests/move_check/typing/binary_add_invalid.move:15:26

--- a/language/move-compiler/tests/move_check/typing/binary_bit_and_invalid.exp
+++ b/language/move-compiler/tests/move_check/typing/binary_bit_and_invalid.exp
@@ -128,15 +128,6 @@ error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_bit_and_invalid.move:15:9
    │
 15 │         1 & false & @0x0 & 0;
-   │         ^^^^^^^^^
-   │         │ │
-   │         │ Found: '_'. But expected: 'u8', 'u64', 'u128'
-   │         Invalid argument to '&'
-
-error[E04003]: built-in operation not supported
-   ┌─ tests/move_check/typing/binary_bit_and_invalid.move:15:9
-   │
-15 │         1 & false & @0x0 & 0;
    │         ^^^^^^^^^^^^^^^^
    │         │           │
    │         │           Found: 'address'. But expected: 'u8', 'u64', 'u128'
@@ -150,14 +141,6 @@ error[E04007]: incompatible types
    │         │ │  
    │         │ Incompatible arguments to '&'
    │         Found: integer. It is not compatible with the other type.
-
-error[E04003]: built-in operation not supported
-   ┌─ tests/move_check/typing/binary_bit_and_invalid.move:15:21
-   │
-15 │         1 & false & @0x0 & 0;
-   │           -         ^^^^ Invalid argument to '&'
-   │           │          
-   │           Found: '_'. But expected: 'u8', 'u64', 'u128'
 
 error[E04007]: incompatible types
    ┌─ tests/move_check/typing/binary_bit_and_invalid.move:15:26

--- a/language/move-compiler/tests/move_check/typing/binary_bit_or_invalid.exp
+++ b/language/move-compiler/tests/move_check/typing/binary_bit_or_invalid.exp
@@ -128,15 +128,6 @@ error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_bit_or_invalid.move:15:9
    │
 15 │         1 | false | @0x0 | 0;
-   │         ^^^^^^^^^
-   │         │ │
-   │         │ Found: '_'. But expected: 'u8', 'u64', 'u128'
-   │         Invalid argument to '|'
-
-error[E04003]: built-in operation not supported
-   ┌─ tests/move_check/typing/binary_bit_or_invalid.move:15:9
-   │
-15 │         1 | false | @0x0 | 0;
    │         ^^^^^^^^^^^^^^^^
    │         │           │
    │         │           Found: 'address'. But expected: 'u8', 'u64', 'u128'
@@ -150,14 +141,6 @@ error[E04007]: incompatible types
    │         │ │  
    │         │ Incompatible arguments to '|'
    │         Found: integer. It is not compatible with the other type.
-
-error[E04003]: built-in operation not supported
-   ┌─ tests/move_check/typing/binary_bit_or_invalid.move:15:21
-   │
-15 │         1 | false | @0x0 | 0;
-   │           -         ^^^^ Invalid argument to '|'
-   │           │          
-   │           Found: '_'. But expected: 'u8', 'u64', 'u128'
 
 error[E04007]: incompatible types
    ┌─ tests/move_check/typing/binary_bit_or_invalid.move:15:26

--- a/language/move-compiler/tests/move_check/typing/binary_bit_xor_invalid.exp
+++ b/language/move-compiler/tests/move_check/typing/binary_bit_xor_invalid.exp
@@ -128,15 +128,6 @@ error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_bit_xor_invalid.move:15:9
    │
 15 │         1 ^ false ^ @0x0 ^ 0;
-   │         ^^^^^^^^^
-   │         │ │
-   │         │ Found: '_'. But expected: 'u8', 'u64', 'u128'
-   │         Invalid argument to '^'
-
-error[E04003]: built-in operation not supported
-   ┌─ tests/move_check/typing/binary_bit_xor_invalid.move:15:9
-   │
-15 │         1 ^ false ^ @0x0 ^ 0;
    │         ^^^^^^^^^^^^^^^^
    │         │           │
    │         │           Found: 'address'. But expected: 'u8', 'u64', 'u128'
@@ -150,14 +141,6 @@ error[E04007]: incompatible types
    │         │ │  
    │         │ Incompatible arguments to '^'
    │         Found: integer. It is not compatible with the other type.
-
-error[E04003]: built-in operation not supported
-   ┌─ tests/move_check/typing/binary_bit_xor_invalid.move:15:21
-   │
-15 │         1 ^ false ^ @0x0 ^ 0;
-   │           -         ^^^^ Invalid argument to '^'
-   │           │          
-   │           Found: '_'. But expected: 'u8', 'u64', 'u128'
 
 error[E04007]: incompatible types
    ┌─ tests/move_check/typing/binary_bit_xor_invalid.move:15:26

--- a/language/move-compiler/tests/move_check/typing/binary_div_invalid.exp
+++ b/language/move-compiler/tests/move_check/typing/binary_div_invalid.exp
@@ -128,15 +128,6 @@ error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_div_invalid.move:15:9
    │
 15 │         1 / false / @0x0 / 0;
-   │         ^^^^^^^^^
-   │         │ │
-   │         │ Found: '_'. But expected: 'u8', 'u64', 'u128'
-   │         Invalid argument to '/'
-
-error[E04003]: built-in operation not supported
-   ┌─ tests/move_check/typing/binary_div_invalid.move:15:9
-   │
-15 │         1 / false / @0x0 / 0;
    │         ^^^^^^^^^^^^^^^^
    │         │           │
    │         │           Found: 'address'. But expected: 'u8', 'u64', 'u128'
@@ -150,14 +141,6 @@ error[E04007]: incompatible types
    │         │ │  
    │         │ Incompatible arguments to '/'
    │         Found: integer. It is not compatible with the other type.
-
-error[E04003]: built-in operation not supported
-   ┌─ tests/move_check/typing/binary_div_invalid.move:15:21
-   │
-15 │         1 / false / @0x0 / 0;
-   │           -         ^^^^ Invalid argument to '/'
-   │           │          
-   │           Found: '_'. But expected: 'u8', 'u64', 'u128'
 
 error[E04007]: incompatible types
    ┌─ tests/move_check/typing/binary_div_invalid.move:15:26

--- a/language/move-compiler/tests/move_check/typing/binary_mod_invalid.exp
+++ b/language/move-compiler/tests/move_check/typing/binary_mod_invalid.exp
@@ -128,15 +128,6 @@ error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_mod_invalid.move:15:9
    │
 15 │         1 % false % @0x0 % 0;
-   │         ^^^^^^^^^
-   │         │ │
-   │         │ Found: '_'. But expected: 'u8', 'u64', 'u128'
-   │         Invalid argument to '%'
-
-error[E04003]: built-in operation not supported
-   ┌─ tests/move_check/typing/binary_mod_invalid.move:15:9
-   │
-15 │         1 % false % @0x0 % 0;
    │         ^^^^^^^^^^^^^^^^
    │         │           │
    │         │           Found: 'address'. But expected: 'u8', 'u64', 'u128'
@@ -150,14 +141,6 @@ error[E04007]: incompatible types
    │         │ │  
    │         │ Incompatible arguments to '%'
    │         Found: integer. It is not compatible with the other type.
-
-error[E04003]: built-in operation not supported
-   ┌─ tests/move_check/typing/binary_mod_invalid.move:15:21
-   │
-15 │         1 % false % @0x0 % 0;
-   │           -         ^^^^ Invalid argument to '%'
-   │           │          
-   │           Found: '_'. But expected: 'u8', 'u64', 'u128'
 
 error[E04007]: incompatible types
    ┌─ tests/move_check/typing/binary_mod_invalid.move:15:26

--- a/language/move-compiler/tests/move_check/typing/binary_mul_invalid.exp
+++ b/language/move-compiler/tests/move_check/typing/binary_mul_invalid.exp
@@ -128,15 +128,6 @@ error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_mul_invalid.move:15:9
    │
 15 │         1 * false * @0x0 * 0;
-   │         ^^^^^^^^^
-   │         │ │
-   │         │ Found: '_'. But expected: 'u8', 'u64', 'u128'
-   │         Invalid argument to '*'
-
-error[E04003]: built-in operation not supported
-   ┌─ tests/move_check/typing/binary_mul_invalid.move:15:9
-   │
-15 │         1 * false * @0x0 * 0;
    │         ^^^^^^^^^^^^^^^^
    │         │           │
    │         │           Found: 'address'. But expected: 'u8', 'u64', 'u128'
@@ -150,14 +141,6 @@ error[E04007]: incompatible types
    │         │ │  
    │         │ Incompatible arguments to '*'
    │         Found: integer. It is not compatible with the other type.
-
-error[E04003]: built-in operation not supported
-   ┌─ tests/move_check/typing/binary_mul_invalid.move:15:21
-   │
-15 │         1 * false * @0x0 * 0;
-   │           -         ^^^^ Invalid argument to '*'
-   │           │          
-   │           Found: '_'. But expected: 'u8', 'u64', 'u128'
 
 error[E04007]: incompatible types
    ┌─ tests/move_check/typing/binary_mul_invalid.move:15:26

--- a/language/move-compiler/tests/move_check/typing/binary_sub_invalid.exp
+++ b/language/move-compiler/tests/move_check/typing/binary_sub_invalid.exp
@@ -128,15 +128,6 @@ error[E04003]: built-in operation not supported
    ┌─ tests/move_check/typing/binary_sub_invalid.move:15:9
    │
 15 │         1 - false - @0x0 - 0;
-   │         ^^^^^^^^^
-   │         │ │
-   │         │ Found: '_'. But expected: 'u8', 'u64', 'u128'
-   │         Invalid argument to '-'
-
-error[E04003]: built-in operation not supported
-   ┌─ tests/move_check/typing/binary_sub_invalid.move:15:9
-   │
-15 │         1 - false - @0x0 - 0;
    │         ^^^^^^^^^^^^^^^^
    │         │           │
    │         │           Found: 'address'. But expected: 'u8', 'u64', 'u128'
@@ -150,14 +141,6 @@ error[E04007]: incompatible types
    │         │ │  
    │         │ Incompatible arguments to '-'
    │         Found: integer. It is not compatible with the other type.
-
-error[E04003]: built-in operation not supported
-   ┌─ tests/move_check/typing/binary_sub_invalid.move:15:21
-   │
-15 │         1 - false - @0x0 - 0;
-   │           -         ^^^^ Invalid argument to '-'
-   │           │          
-   │           Found: '_'. But expected: 'u8', 'u64', 'u128'
 
 error[E04007]: incompatible types
    ┌─ tests/move_check/typing/binary_sub_invalid.move:15:26

--- a/language/move-compiler/transactional-tests/tests/parser/control_exp_associativity.exp
+++ b/language/move-compiler/transactional-tests/tests/parser/control_exp_associativity.exp
@@ -1,0 +1,4 @@
+processed 2 tasks
+
+task 1 'run'. lines 24-24:
+return values: 42

--- a/language/move-compiler/transactional-tests/tests/parser/control_exp_associativity.move
+++ b/language/move-compiler/transactional-tests/tests/parser/control_exp_associativity.move
@@ -1,0 +1,24 @@
+//# publish
+module 0x42::M {
+    fun t(): u64 {
+        // 1 + (if (false) 0 else (10 + 10))
+        let x = 1 + if (false) 0 else 10 + 10;
+        assert!(x == 21, 0);
+        // true && (if (false) false else (10 == 10))
+        let x = true && if (false) false else 10 == 10;
+        assert!(x, 0);
+        // (if (false) 0 else 10 ) == 10
+        let x = if (false) 0 else { 10 } == 10;
+        assert!(x, 0);
+        // (if (true) 0 else 10) + 1
+        let x = if (true) 0 else { 10 } + 1;
+        assert!(x == 1, 0);
+        // if (true) 0 else (10 + 1)
+        let x = if (true) 0 else ({ 10 }) + 1;
+        assert!(x == 0, 0);
+        42
+    }
+
+}
+
+//# run 0x42::M::t

--- a/language/move-compiler/transactional-tests/tests/parser/return_not_binary.exp
+++ b/language/move-compiler/transactional-tests/tests/parser/return_not_binary.exp
@@ -1,0 +1,7 @@
+processed 3 tasks
+
+task 1 'run'. lines 18-18:
+return values: 0
+
+task 2 'run'. lines 20-20:
+return values: 0

--- a/language/move-compiler/transactional-tests/tests/parser/return_not_binary.move
+++ b/language/move-compiler/transactional-tests/tests/parser/return_not_binary.move
@@ -1,0 +1,20 @@
+// Test returning expressions, that if parsed differently, could be binary operators,
+// where the left argument would be the 'return'
+
+//# publish
+module 0x42::M {
+    struct S { f: u64}
+
+    fun t1(u: &u64): u64 {
+        if (true) return * u;
+        0
+    }
+
+    fun t2(s: &S): &u64 {
+        if (true) return & s.f else & s.f
+    }
+}
+
+//# run 0x42::M::t1 --args 0
+
+//# run 0x42::M::t2 --args 0


### PR DESCRIPTION
- Made control expressions terms to fix cases where they did not behave like other expressions
- Allowed blocks to switch their associativity
  - Before this PR, control expressions (`if`, `else`, `loop`, `while`, `return`, and `abort`) were always right associative. 
  - After this PR, control expressions only consume the next block if there is one. Otherwise, they continue their right associative behavior. 
  - It is a bit funky to describe, but I think the examples make sense
    - and it mostly matches the behavior with if/else and begin/end in OCaml (and similar constructs in other ML languages)
- Fixed some issues with return's value not being parsed correctly

## Motivation

- Fixing an issue @awelc found. `if (cond) { s1 } else { s2 }.f` looks like it should be parsed as `(if (cond) s1 else s2).f` but it was actually being parsed as `if (cond) s1 else (s2.f)`

## Test Plan

- many new tests