### PR TITLE
[disassembler] fix bug in function signature disassembly

### DIFF
--- a/language/move-ir-compiler/transactional-tests/tests/bytecode-generation/declarations/function.exp
+++ b/language/move-ir-compiler/transactional-tests/tests/bytecode-generation/declarations/function.exp
@@ -7,7 +7,7 @@ struct Coin {
 	value: u64
 }
 
-public value(loc0: &Coin): u64 {
+public value(Arg0: &Coin): u64 {
 B0:
 	0: MoveLoc[0](Arg0: &Coin)
 	1: ImmBorrowField[0](Coin.value: u64)
@@ -16,7 +16,7 @@ B0:
 	4: ReadRef
 	5: Ret
 }
-public deposit(loc0: &mut Coin, loc1: Coin) {
+public deposit(Arg0: &mut Coin, Arg1: Coin) {
 L0:	loc2: &Coin
 L1:	loc3: u64
 L2:	loc4: u64

--- a/language/move-ir-compiler/transactional-tests/tests/bytecode-generation/expressions/borrow.exp
+++ b/language/move-ir-compiler/transactional-tests/tests/bytecode-generation/expressions/borrow.exp
@@ -46,7 +46,7 @@ struct T {
 	u: u64
 }
 
-f(loc0: &T) {
+f(Arg0: &T) {
 B0:
 	0: MoveLoc[0](Arg0: &T)
 	1: ImmBorrowField[0](T.u: u64)
@@ -55,7 +55,7 @@ B0:
 	4: Pop
 	5: Ret
 }
-g(loc0: &mut T) {
+g(Arg0: &mut T) {
 B0:
 	0: MoveLoc[0](Arg0: &mut T)
 	1: ImmBorrowField[0](T.u: u64)
@@ -64,7 +64,7 @@ B0:
 	4: Pop
 	5: Ret
 }
-public h(loc0: &mut T) {
+public h(Arg0: &mut T) {
 B0:
 	0: MoveLoc[0](Arg0: &mut T)
 	1: MutBorrowField[0](T.u: u64)
@@ -82,7 +82,7 @@ struct T<Ty0> {
 	u: Ty0
 }
 
-f(loc0: &T<u64>) {
+f(Arg0: &T<u64>) {
 B0:
 	0: MoveLoc[0](Arg0: &T<u64>)
 	1: ImmBorrowFieldGeneric[0](T.u: Ty0)
@@ -91,7 +91,7 @@ B0:
 	4: Pop
 	5: Ret
 }
-g(loc0: &mut T<u128>) {
+g(Arg0: &mut T<u128>) {
 B0:
 	0: MoveLoc[0](Arg0: &mut T<u128>)
 	1: ImmBorrowFieldGeneric[1](T.u: Ty0)

--- a/language/move-ir-compiler/transactional-tests/tests/bytecode-generation/expressions/borrow_mut.exp
+++ b/language/move-ir-compiler/transactional-tests/tests/bytecode-generation/expressions/borrow_mut.exp
@@ -27,7 +27,7 @@ struct FooCoin {
 	value: u64
 }
 
-public borrow_mut_field(loc0: &mut FooCoin) {
+public borrow_mut_field(Arg0: &mut FooCoin) {
 B0:
 	0: MoveLoc[0](Arg0: &mut FooCoin)
 	1: MutBorrowField[0](FooCoin.value: u64)
@@ -45,7 +45,7 @@ struct FooCoin<Ty0> {
 	value: u64
 }
 
-public borrow_mut_field(loc0: &mut FooCoin<address>) {
+public borrow_mut_field(Arg0: &mut FooCoin<address>) {
 B0:
 	0: MoveLoc[0](Arg0: &mut FooCoin<address>)
 	1: MutBorrowFieldGeneric[0](FooCoin.value: u64)

--- a/language/move-ir-compiler/transactional-tests/tests/bytecode-generation/expressions/builtins/borrow_global.exp
+++ b/language/move-ir-compiler/transactional-tests/tests/bytecode-generation/expressions/builtins/borrow_global.exp
@@ -7,7 +7,7 @@ struct T has key {
 	b: bool
 }
 
-f(loc0: signer) {
+f(Arg0: signer) {
 B0:
 	0: ImmBorrowLoc[0](Arg0: signer)
 	1: Call[1](address_of(&signer): address)

--- a/language/move-ir-compiler/transactional-tests/tests/bytecode-generation/expressions/builtins/borrow_global_mut.exp
+++ b/language/move-ir-compiler/transactional-tests/tests/bytecode-generation/expressions/builtins/borrow_global_mut.exp
@@ -7,7 +7,7 @@ struct T has key {
 	b: bool
 }
 
-f(loc0: signer) {
+f(Arg0: signer) {
 B0:
 	0: ImmBorrowLoc[0](Arg0: signer)
 	1: Call[1](address_of(&signer): address)

--- a/language/move-ir-compiler/transactional-tests/tests/bytecode-generation/expressions/builtins/move_to.exp
+++ b/language/move-ir-compiler/transactional-tests/tests/bytecode-generation/expressions/builtins/move_to.exp
@@ -13,7 +13,7 @@ B0:
 	1: Pack[0](T)
 	2: Ret
 }
-f() {
+f(Arg0: signer) {
 B0:
 	0: ImmBorrowLoc[0](Arg0: signer)
 	1: Call[0](new(): T)

--- a/language/tools/move-cli/tests/sandbox_tests/module_publish_view/args.exp
+++ b/language/tools/move-cli/tests/sandbox_tests/module_publish_view/args.exp
@@ -9,7 +9,7 @@ struct S {
 	i: u64
 }
 
-public foo(): S {
+public foo(Arg0: u64): S {
 B0:
 	0: MoveLoc[0](Arg0: u64)
 	1: Pack[0](S)

--- a/language/tools/move-cli/tests/sandbox_tests/package_basics/args.exp
+++ b/language/tools/move-cli/tests/sandbox_tests/package_basics/args.exp
@@ -53,7 +53,7 @@ Command `package coverage bytecode --module AModule`:
 module 1.AModule {
 
 
-public double_except_three(): u64 {
+public double_except_three(x: u64): u64 {
 B0:
 [6]	0: CopyLoc[0](x: u64)
 [6]	1: LdU64(3)
@@ -75,49 +75,49 @@ Command `package disassemble --package MoveStdlib --name Errors`:
 module 1.Errors {
 
 
-public already_published(): u64 {
+public already_published(reason: u64): u64 {
 B0:
 	0: LdAddr[0](U8: [6])
 	1: MoveLoc[0](reason: u64)
 	2: Call[6](make(u8, u64): u64)
 	3: Ret
 }
-public custom(): u64 {
+public custom(reason: u64): u64 {
 B0:
 	0: LdAddr[1](U8: [255])
 	1: MoveLoc[0](reason: u64)
 	2: Call[6](make(u8, u64): u64)
 	3: Ret
 }
-public internal(): u64 {
+public internal(reason: u64): u64 {
 B0:
 	0: LdAddr[2](U8: [10])
 	1: MoveLoc[0](reason: u64)
 	2: Call[6](make(u8, u64): u64)
 	3: Ret
 }
-public invalid_argument(): u64 {
+public invalid_argument(reason: u64): u64 {
 B0:
 	0: LdAddr[3](U8: [7])
 	1: MoveLoc[0](reason: u64)
 	2: Call[6](make(u8, u64): u64)
 	3: Ret
 }
-public invalid_state(): u64 {
+public invalid_state(reason: u64): u64 {
 B0:
 	0: LdAddr[4](U8: [1])
 	1: MoveLoc[0](reason: u64)
 	2: Call[6](make(u8, u64): u64)
 	3: Ret
 }
-public limit_exceeded(): u64 {
+public limit_exceeded(reason: u64): u64 {
 B0:
 	0: LdAddr[5](U8: [8])
 	1: MoveLoc[0](reason: u64)
 	2: Call[6](make(u8, u64): u64)
 	3: Ret
 }
-make(): u64 {
+make(category: u8, reason: u64): u64 {
 B0:
 	0: MoveLoc[0](category: u8)
 	1: CastU64
@@ -127,28 +127,28 @@ B0:
 	5: Add
 	6: Ret
 }
-public not_published(): u64 {
+public not_published(reason: u64): u64 {
 B0:
 	0: LdAddr[6](U8: [5])
 	1: MoveLoc[0](reason: u64)
 	2: Call[6](make(u8, u64): u64)
 	3: Ret
 }
-public requires_address(): u64 {
+public requires_address(reason: u64): u64 {
 B0:
 	0: LdAddr[7](U8: [2])
 	1: MoveLoc[0](reason: u64)
 	2: Call[6](make(u8, u64): u64)
 	3: Ret
 }
-public requires_capability(): u64 {
+public requires_capability(reason: u64): u64 {
 B0:
 	0: LdAddr[8](U8: [4])
 	1: MoveLoc[0](reason: u64)
 	2: Call[6](make(u8, u64): u64)
 	3: Ret
 }
-public requires_role(): u64 {
+public requires_role(reason: u64): u64 {
 B0:
 	0: LdAddr[9](U8: [3])
 	1: MoveLoc[0](reason: u64)

--- a/language/tools/move-disassembler/src/disassembler.rs
+++ b/language/tools/move-disassembler/src/disassembler.rs
@@ -984,6 +984,13 @@ impl<'a> Disassembler<'a> {
         parameters: SignatureIndex,
         code: Option<&CodeUnit>,
     ) -> Result<String> {
+        debug_assert_eq!(
+            function_source_map.parameters.len(),
+            self.source_mapper.bytecode.signature_at(parameters).len(),
+            "Arity mismatch between function source map and bytecode for function {}",
+            name
+        );
+
         let visibility_modifier = match function {
             Some(function) => match function.0.visibility {
                 Visibility::Private => {
@@ -1015,7 +1022,7 @@ impl<'a> Disassembler<'a> {
             .signature_at(parameters)
             .0
             .iter()
-            .zip(function_source_map.locals.iter())
+            .zip(function_source_map.parameters.iter())
             .map(|(tok, (name, _))| {
                 Ok(format!(
                     "{}: {}",


### PR DESCRIPTION
The function disassembler was looking at the local types, but it should have been looking at the parameter types. Fixed the bug, previously wrong expected value tests show that the fix works. Also added assertion to ensure that a source/bytecode function signature mismatch can't cause the same problem.