### PR TITLE
[move-compiler] Allow 'vector' as a module name

### DIFF
--- a/language/move-compiler/src/parser/syntax.rs
+++ b/language/move-compiler/src/parser/syntax.rs
@@ -884,7 +884,10 @@ fn parse_term(context: &mut Context) -> Result<Exp, Diagnostic> {
             Exp_::Continue
         }
 
-        Tok::Identifier if context.tokens.content() == VECTOR_IDENT => {
+        Tok::Identifier
+            if context.tokens.content() == VECTOR_IDENT
+                && matches!(context.tokens.lookahead(), Ok(Tok::Less | Tok::LBracket)) =>
+        {
             consume_identifier(context.tokens, VECTOR_IDENT)?;
             let vec_end_loc = context.tokens.previous_end_loc();
             let vec_loc = make_loc(context.tokens.file_hash(), start_loc, vec_end_loc);

--- a/language/move-compiler/tests/move_check/expansion/restricted_module_alias_names.exp
+++ b/language/move-compiler/tests/move_check/expansion/restricted_module_alias_names.exp
@@ -1,12 +1,12 @@
 error[E03011]: invalid use of reserved name
-  ┌─ tests/move_check/expansion/restricted_module_alias_names.move:2:20
-  │
-2 │     use 0x42::M as Self;
-  │                    ^^^^ Invalid module alias name 'Self'. 'Self' is restricted and cannot be used to name a module alias
-
-error[E03011]: invalid use of reserved name
   ┌─ tests/move_check/expansion/restricted_module_alias_names.move:3:20
   │
-3 │     use 0x42::M as vector;
-  │                    ^^^^^^ Invalid module alias name 'vector'. 'vector' is restricted and cannot be used to name a module alias
+3 │     use 0x42::M as Self;
+  │                    ^^^^ Invalid module alias name 'Self'. 'Self' is restricted and cannot be used to name a module alias
+
+warning[W09001]: unused alias
+  ┌─ tests/move_check/expansion/restricted_module_alias_names.move:5:20
+  │
+5 │     use 0x42::M as vector;
+  │                    ^^^^^^ Unused 'use' of alias 'vector'. Consider removing it
 

--- a/language/move-compiler/tests/move_check/expansion/restricted_module_alias_names.move
+++ b/language/move-compiler/tests/move_check/expansion/restricted_module_alias_names.move
@@ -1,4 +1,6 @@
 module 0x42::M {
+    // not allowed
     use 0x42::M as Self;
+    // now allowed
     use 0x42::M as vector;
 }

--- a/language/move-compiler/tests/move_check/expansion/restricted_module_names.exp
+++ b/language/move-compiler/tests/move_check/expansion/restricted_module_names.exp
@@ -1,12 +1,6 @@
 error[E03011]: invalid use of reserved name
-  ┌─ tests/move_check/expansion/restricted_module_names.move:1:14
-  │
-1 │ module 0x42::Self {}
-  │              ^^^^ Invalid module name 'Self'. 'Self' is restricted and cannot be used to name a module
-
-error[E03011]: invalid use of reserved name
   ┌─ tests/move_check/expansion/restricted_module_names.move:2:14
   │
-2 │ module 0x42::vector {}
-  │              ^^^^^^ Invalid module name 'vector'. 'vector' is restricted and cannot be used to name a module
+2 │ module 0x42::Self {}
+  │              ^^^^ Invalid module name 'Self'. 'Self' is restricted and cannot be used to name a module
 

--- a/language/move-compiler/tests/move_check/expansion/restricted_module_names.move
+++ b/language/move-compiler/tests/move_check/expansion/restricted_module_names.move
@@ -1,2 +1,4 @@
+// not allowed
 module 0x42::Self {}
+// now allowed
 module 0x42::vector {}


### PR DESCRIPTION
## Motivation

- old rule overly protective. 

## Test Plan

- updated tests