### PR TITLE
[move-ir] De-tokenize primitive types

### DIFF
--- a/language/move-ir-compiler/move-ir-to-bytecode/syntax/src/lexer.rs
+++ b/language/move-ir-compiler/move-ir-to-bytecode/syntax/src/lexer.rs
@@ -50,10 +50,8 @@ pub enum Tok {
     /// Aborts if in the spec language
     AbortsIf,
     Acquires,
-    Address,
     As,
     Assert,
-    Bool,
     BorrowGlobal,
     BorrowGlobalMut,
     Copy,
@@ -91,15 +89,10 @@ pub enum Tok {
     SpecReturn,
     /// Return statement in the Move language
     Return,
-    Signer,
     Struct,
     SucceedsIf,
     Synthetic,
     True,
-    U8,
-    U64,
-    U128,
-    Vector,
     VecPack(u64),
     VecLen,
     VecImmBorrow,
@@ -268,7 +261,6 @@ impl<'input> Lexer<'input> {
                             }
                         }
                         Some('<') => match name {
-                            "vector" => (Tok::Vector, len),
                             "vec_len" => (Tok::VecLen, len),
                             "vec_imm_borrow" => (Tok::VecImmBorrow, len),
                             "vec_mut_borrow" => (Tok::VecMutBorrow, len),
@@ -454,9 +446,7 @@ fn get_name_token(name: &str) -> Tok {
         "abort" => Tok::Abort,
         "aborts_if" => Tok::AbortsIf,
         "acquires" => Tok::Acquires,
-        "address" => Tok::Address,
         "as" => Tok::As,
-        "bool" => Tok::Bool,
         "copy" => Tok::Copy,
         "ensures" => Tok::Ensures,
         "false" => Tok::False,
@@ -483,14 +473,10 @@ fn get_name_token(name: &str) -> Tok {
         "RET" => Tok::SpecReturn,
         "return" => Tok::Return,
         "script" => Tok::Script,
-        "signer" => Tok::Signer,
         "struct" => Tok::Struct,
         "succeeds_if" => Tok::SucceedsIf,
         "synthetic" => Tok::Synthetic,
         "true" => Tok::True,
-        "u8" => Tok::U8,
-        "u64" => Tok::U64,
-        "u128" => Tok::U128,
         _ => Tok::NameValue,
     }
 }

--- a/language/move-ir-compiler/move-ir-to-bytecode/syntax/src/syntax.rs
+++ b/language/move-ir-compiler/move-ir-to-bytecode/syntax/src/syntax.rs
@@ -1187,33 +1187,32 @@ fn parse_ability(tokens: &mut Lexer) -> Result<(Ability, Loc), ParseError<Loc, a
 
 fn parse_type(tokens: &mut Lexer) -> Result<Type, ParseError<Loc, anyhow::Error>> {
     let t = match tokens.peek() {
-        Tok::Address => {
+        Tok::NameValue if matches!(tokens.content(), "address") => {
             tokens.advance()?;
             Type::Address
         }
-        Tok::Signer => {
-            tokens.advance()?;
-            Type::Signer
-        }
-        Tok::U8 => {
+        Tok::NameValue if matches!(tokens.content(), "u8") => {
             tokens.advance()?;
             Type::U8
         }
-        Tok::U64 => {
+        Tok::NameValue if matches!(tokens.content(), "u64") => {
             tokens.advance()?;
             Type::U64
         }
-        Tok::U128 => {
+        Tok::NameValue if matches!(tokens.content(), "u128") => {
             tokens.advance()?;
             Type::U128
         }
-        Tok::Bool => {
+        Tok::NameValue if matches!(tokens.content(), "bool") => {
             tokens.advance()?;
             Type::Bool
         }
-        Tok::Vector => {
+        Tok::NameValue if matches!(tokens.content(), "signer") => {
             tokens.advance()?;
-            consume_token(tokens, Tok::Less)?;
+            Type::Signer
+        }
+        Tok::NameBeginTyValue if matches!(tokens.content(), "vector<") => {
+            tokens.advance()?;
             let ty = parse_type(tokens)?;
             adjust_token(tokens, &[Tok::Greater])?;
             consume_token(tokens, Tok::Greater)?;

--- a/language/move-ir-compiler/transactional-tests/tests/parsing/keywords.mvir
+++ b/language/move-ir-compiler/transactional-tests/tests/parsing/keywords.mvir
@@ -1,6 +1,6 @@
 //# print-bytecode
-// `signer` is a keyword so it cannot be used as a parameter name.
-main(signer: address) {
+// `label` is a keyword so it cannot be used as a parameter name.
+main(label: address) {
 label b0:
     return;
 }


### PR DESCRIPTION
- primitive type names are no longer tokens. They use the name token like other identifiers

## Test Plan

- internal change