### PR TITLE
[language server] Async symbolication on file saves

### DIFF
--- a/language/move-analyzer/src/bin/move-analyzer.rs
+++ b/language/move-analyzer/src/bin/move-analyzer.rs
@@ -110,7 +110,9 @@ fn main() {
     loop {
         match context.connection.receiver.recv() {
             Ok(message) => match message {
-                Message::Request(request) => on_request(&context, &request, &symbols),
+                Message::Request(request) => {
+                    on_request(&context, &request, &context.symbols.lock().unwrap())
+                }
                 Message::Response(response) => on_response(&context, &response),
                 Message::Notification(notification) => {
                     match notification.method.as_str() {

--- a/language/move-analyzer/src/bin/move-analyzer.rs
+++ b/language/move-analyzer/src/bin/move-analyzer.rs
@@ -110,9 +110,7 @@ fn main() {
     loop {
         match context.connection.receiver.recv() {
             Ok(message) => match message {
-                Message::Request(request) => {
-                    on_request(&context, &request, &context.symbols.lock().unwrap())
-                }
+                Message::Request(request) => on_request(&context, &request),
                 Message::Response(response) => on_response(&context, &response),
                 Message::Notification(notification) => {
                     match notification.method.as_str() {
@@ -138,7 +136,7 @@ fn main() {
     eprintln!("Shut down language server '{}'.", exe);
 }
 
-fn on_request(context: &Context, request: &Request, symbols: &symbols::Symbols) {
+fn on_request(context: &Context, request: &Request) {
     match request.method.as_str() {
         lsp_types::request::Completion::METHOD => on_completion_request(context, request),
         lsp_types::request::GotoDefinition::METHOD => {

--- a/language/move-analyzer/src/context.rs
+++ b/language/move-analyzer/src/context.rs
@@ -2,8 +2,9 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::vfs::VirtualFileSystem;
+use crate::{symbols::Symbols, vfs::VirtualFileSystem};
 use lsp_server::Connection;
+use std::sync::{Arc, Mutex};
 
 /// The context within which the language server is running.
 pub struct Context {
@@ -11,4 +12,6 @@ pub struct Context {
     pub connection: Connection,
     /// The files that the language server is providing information about.
     pub files: VirtualFileSystem,
+    /// Symbolication information
+    pub symbols: Arc<Mutex<Symbols>>,
 }

--- a/language/move-analyzer/src/symbols.rs
+++ b/language/move-analyzer/src/symbols.rs
@@ -47,34 +47,24 @@
 //! matching uses to a definition in the innermost scope.
 
 use crate::context::Context;
-use anyhow::Result;
+use anyhow::{bail, Result};
 use codespan_reporting::files::{Files, SimpleFiles};
-<<<<<<< HEAD
 use im::ordmap::OrdMap;
-=======
->>>>>>> 8a48fe92a (Added async symbolication on file saves)
 use lsp_server::{Request, RequestId};
 use lsp_types::{GotoDefinitionParams, Location, Position, Range, ReferenceParams};
 use std::{
     cmp,
-<<<<<<< HEAD
     collections::{BTreeMap, BTreeSet},
-    fs,
-    path::{Path, PathBuf},
-=======
-    collections::{BTreeMap, BTreeSet, VecDeque},
     fs,
     path::{Path, PathBuf},
     sync::{Arc, Condvar, Mutex},
     thread,
->>>>>>> 8a48fe92a (Added async symbolication on file saves)
 };
 use tempfile::tempdir;
 use url::Url;
 
 use move_command_line_common::files::FileHash;
 use move_compiler::{
-    diagnostics,
     expansion::ast::{Fields, ModuleIdent, ModuleIdent_},
     naming::ast::{StructDefinition, StructFields, TParam, Type, TypeName_, Type_},
     parser::ast::StructName,
@@ -91,11 +81,7 @@ use move_symbol_pool::Symbol;
 
 /// Enabling/disabling the language server reporting readiness to support go-to-def and
 /// go-to-references to the IDE.
-<<<<<<< HEAD
 pub const DEFS_AND_REFS_SUPPORT: bool = false;
-=======
-pub const DEFS_AND_REFS_SUPPORT: bool = true;
->>>>>>> 8a48fe92a (Added async symbolication on file saves)
 
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Copy)]
 /// Location of a definition's identifier
@@ -157,12 +143,6 @@ struct ModuleDefs {
     functions: BTreeMap<Symbol, Position>,
 }
 
-<<<<<<< HEAD
-=======
-/// Holds information about local definitions in a given scope
-type Scope = BTreeMap<Symbol, DefLoc>;
-
->>>>>>> 8a48fe92a (Added async symbolication on file saves)
 /// Data used during symbolication
 pub struct Symbolicator {
     /// Outermost definitions in a module (structs, consts, functions)
@@ -171,25 +151,17 @@ pub struct Symbolicator {
     files: SimpleFiles<Symbol, String>,
     /// A mapping from file hashes to file IDs (used to obtain source file locations)
     file_id_mapping: BTreeMap<FileHash, usize>,
-<<<<<<< HEAD
     /// Contains type params where relevant (e.g. when processing function definition)
     type_params: BTreeMap<Symbol, DefLoc>,
-=======
-    /// Scope to contain type params where relevant (e.g. when processing function definition)
-    type_params: Scope,
->>>>>>> 8a48fe92a (Added async symbolication on file saves)
     /// Current processed module (always set before module processing starts)
     current_mod: Option<ModuleIdent_>,
 }
 
-<<<<<<< HEAD
-=======
 /// Maps a line number to a list of use-def pairs on a given line (use-def set is sorted by
 /// col_start)
 #[derive(Debug)]
 struct UseDefMap(BTreeMap<u32, BTreeSet<UseDef>>);
 
->>>>>>> 8a48fe92a (Added async symbolication on file saves)
 /// Result of the symbolication process
 pub struct Symbols {
     /// A map from def locations to all the references (uses)
@@ -202,8 +174,6 @@ pub struct Symbols {
     file_name_mapping: BTreeMap<FileHash, Symbol>,
 }
 
-<<<<<<< HEAD
-=======
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Copy)]
 enum RunnerState {
     Run,
@@ -289,7 +259,6 @@ impl SymbolicatorRunner {
     }
 }
 
->>>>>>> 8a48fe92a (Added async symbolication on file saves)
 impl UseDef {
     fn new(
         references: &mut BTreeMap<DefLoc, BTreeSet<UseLoc>>,
@@ -341,14 +310,6 @@ impl PartialEq for UseDef {
     }
 }
 
-<<<<<<< HEAD
-/// Maps a line number to a list of use-def pairs on a given line (use-def set is sorted by
-/// col_start)
-#[derive(Debug)]
-struct UseDefMap(BTreeMap<u32, BTreeSet<UseDef>>);
-
-=======
->>>>>>> 8a48fe92a (Added async symbolication on file saves)
 impl UseDefMap {
     fn new() -> Self {
         Self(BTreeMap::new())
@@ -389,34 +350,31 @@ impl Symbolicator {
         }
 
         let build_plan = BuildPlan::create(resolution_graph)?;
-<<<<<<< HEAD
         let mut typed_ast = None;
-=======
-        let mut typed_ast = vec![];
->>>>>>> 8a48fe92a (Added async symbolication on file saves)
         build_plan.compile_with_driver(&mut std::io::sink(), |compiler| {
-            let (files, comments_and_compiler_res) = compiler.run::<PASS_TYPING>().unwrap();
-            let (_, compiler) =
-                diagnostics::unwrap_or_report_diagnostics(&files, comments_and_compiler_res);
+            eprintln!("compiling to typed AST");
+            let (files, compilation_result) = compiler.run::<PASS_TYPING>().unwrap();
+            eprintln!("compiled to typed AST");
+            let (_, compiler) = match compilation_result {
+                Ok(v) => v,
+                Err(_) => bail!("typed AST compilation failed"),
+            };
+            eprintln!("reported typed AST diagnostics");
             let (compiler, typed_program) = compiler.into_ast();
-<<<<<<< HEAD
             typed_ast = Some(typed_program.clone());
-=======
-            typed_ast.push(typed_program.clone());
->>>>>>> 8a48fe92a (Added async symbolication on file saves)
+            eprintln!("compiling to bytecode");
             let compilation_result = compiler.at_typing(typed_program).build();
-
-            let (units, _) = diagnostics::unwrap_or_report_diagnostics(&files, compilation_result);
+            eprintln!("compiled to bytecode");
+            let (units, _) = match compilation_result {
+                Ok(v) => v,
+                Err(_) => bail!("bytecode compilation failed"),
+            };
+            eprintln!("reported bytecode diagnostics");
             Ok((files, units))
         })?;
 
-<<<<<<< HEAD
         debug_assert!(typed_ast.is_some());
         let modules = &typed_ast.unwrap().modules;
-=======
-        debug_assert!(typed_ast.len() == 1);
-        let modules = &typed_ast.get(0).unwrap().modules;
->>>>>>> 8a48fe92a (Added async symbolication on file saves)
 
         let mut mod_outer_defs = BTreeMap::new();
         let mut references = BTreeMap::new();
@@ -449,13 +407,8 @@ impl Symbolicator {
             mod_outer_defs,
             files,
             file_id_mapping,
-<<<<<<< HEAD
             type_params: BTreeMap::new(),
             current_mod: None,
-=======
-            type_params: Scope::new(),
-            current_mod: Option::None,
->>>>>>> 8a48fe92a (Added async symbolication on file saves)
         };
 
         for (_, module_ident, module_def) in modules {
@@ -639,11 +592,7 @@ impl Symbolicator {
         use_defs: &mut UseDefMap,
     ) {
         // create scope designated to contain type parameters (if any)
-<<<<<<< HEAD
         let mut tp_scope = BTreeMap::new();
-=======
-        let mut tp_scope = Scope::new();
->>>>>>> 8a48fe92a (Added async symbolication on file saves)
         for stp in &struct_def.type_parameters {
             self.add_type_param(&stp.param, &mut tp_scope, references, use_defs);
         }
@@ -663,27 +612,15 @@ impl Symbolicator {
         use_defs: &mut UseDefMap,
     ) {
         // create scope designated to contain type parameters (if any)
-<<<<<<< HEAD
         let mut tp_scope = BTreeMap::new();
-=======
-        let mut tp_scope = Scope::new();
->>>>>>> 8a48fe92a (Added async symbolication on file saves)
         for tp in &fun.signature.type_parameters {
             self.add_type_param(tp, &mut tp_scope, references, use_defs);
         }
         self.type_params = tp_scope;
 
-<<<<<<< HEAD
         // scope for the main function scope (for parameters and
         // function body)
         let mut scope = OrdMap::new();
-=======
-        let mut scope_stack = VecDeque::new();
-        // scope for the main function scope (for parameters and
-        // function body)
-        let fn_scope = Scope::new();
-        scope_stack.push_front(fn_scope);
->>>>>>> 8a48fe92a (Added async symbolication on file saves)
 
         for (pname, ptype) in &fun.signature.parameters {
             self.add_type_id_use_def(ptype, references, use_defs);
@@ -692,11 +629,7 @@ impl Symbolicator {
             self.add_def(
                 &pname.loc(),
                 &pname.value(),
-<<<<<<< HEAD
                 &mut scope,
-=======
-                &mut scope_stack,
->>>>>>> 8a48fe92a (Added async symbolication on file saves)
                 references,
                 use_defs,
             );
@@ -705,35 +638,14 @@ impl Symbolicator {
         match &fun.body.value {
             FunctionBody_::Defined(sequence) => {
                 for seq_item in sequence {
-<<<<<<< HEAD
                     self.seq_item_symbols(&mut scope, seq_item, references, use_defs);
-=======
-                    self.seq_item_symbols(&mut scope_stack, seq_item, references, use_defs);
->>>>>>> 8a48fe92a (Added async symbolication on file saves)
                 }
             }
             FunctionBody_::Native => (),
         }
 
-<<<<<<< HEAD
         // process return types
         self.add_type_id_use_def(&fun.signature.return_type, references, use_defs);
-=======
-        // pop the main function scope
-        scope_stack.pop_front();
-        debug_assert!(scope_stack.is_empty());
-
-        // after processing the function body, create a scope to process return types
-        let ret_scope = Scope::new();
-        scope_stack.push_front(ret_scope);
-
-        self.add_type_id_use_def(&fun.signature.return_type, references, use_defs);
-
-        // pop the return parameters scope
-        scope_stack.pop_front();
-        debug_assert!(scope_stack.is_empty());
-
->>>>>>> 8a48fe92a (Added async symbolication on file saves)
         // process optional "acquires" clause
         for name in fun.acquires.keys() {
             self.add_struct_use_def(
@@ -771,46 +683,28 @@ impl Symbolicator {
     /// Get symbols for a sequence representing function body
     fn seq_item_symbols(
         &self,
-<<<<<<< HEAD
         scope: &mut OrdMap<Symbol, DefLoc>,
-=======
-        scope_stack: &mut VecDeque<Scope>,
->>>>>>> 8a48fe92a (Added async symbolication on file saves)
         seq_item: &SequenceItem,
         references: &mut BTreeMap<DefLoc, BTreeSet<UseLoc>>,
         use_defs: &mut UseDefMap,
     ) {
         use SequenceItem_ as I;
         match &seq_item.value {
-<<<<<<< HEAD
             I::Seq(e) => self.exp_symbols(e, scope, references, use_defs),
             I::Declare(lvalues) => {
                 self.lvalue_list_symbols(true, lvalues, scope, references, use_defs)
-=======
-            I::Seq(e) => self.exp_symbols(e, scope_stack, references, use_defs),
-            I::Declare(lvalues) => {
-                self.lvalue_list_symbols(true, lvalues, scope_stack, references, use_defs)
->>>>>>> 8a48fe92a (Added async symbolication on file saves)
             }
             I::Bind(lvalues, opt_types, e) => {
                 // process RHS first to avoid accidentally binding its identifiers to LHS (which now
                 // will be put into the current scope only after RHS is processed)
-<<<<<<< HEAD
                 self.exp_symbols(e, scope, references, use_defs);
-=======
-                self.exp_symbols(e, scope_stack, references, use_defs);
->>>>>>> 8a48fe92a (Added async symbolication on file saves)
                 for opt_t in opt_types {
                     match opt_t {
                         Some(t) => self.add_type_id_use_def(t, references, use_defs),
                         None => (),
                     }
                 }
-<<<<<<< HEAD
                 self.lvalue_list_symbols(true, lvalues, scope, references, use_defs);
-=======
-                self.lvalue_list_symbols(true, lvalues, scope_stack, references, use_defs);
->>>>>>> 8a48fe92a (Added async symbolication on file saves)
             }
         }
     }
@@ -820,20 +714,12 @@ impl Symbolicator {
         &self,
         define: bool,
         lvalues: &LValueList,
-<<<<<<< HEAD
         scope: &mut OrdMap<Symbol, DefLoc>,
-=======
-        scope_stack: &mut VecDeque<Scope>,
->>>>>>> 8a48fe92a (Added async symbolication on file saves)
         references: &mut BTreeMap<DefLoc, BTreeSet<UseLoc>>,
         use_defs: &mut UseDefMap,
     ) {
         for lval in &lvalues.value {
-<<<<<<< HEAD
             self.lvalue_symbols(define, lval, scope, references, use_defs);
-=======
-            self.lvalue_symbols(define, lval, scope_stack, references, use_defs);
->>>>>>> 8a48fe92a (Added async symbolication on file saves)
         }
     }
 
@@ -842,32 +728,16 @@ impl Symbolicator {
         &self,
         define: bool,
         lval: &LValue,
-<<<<<<< HEAD
         scope: &mut OrdMap<Symbol, DefLoc>,
-=======
-        scope_stack: &mut VecDeque<Scope>,
->>>>>>> 8a48fe92a (Added async symbolication on file saves)
         references: &mut BTreeMap<DefLoc, BTreeSet<UseLoc>>,
         use_defs: &mut UseDefMap,
     ) {
         match &lval.value {
             LValue_::Var(var, _) => {
                 if define {
-<<<<<<< HEAD
                     self.add_def(&var.loc(), &var.value(), scope, references, use_defs);
                 } else {
                     self.add_local_use_def(&var.value(), &var.loc(), references, scope, use_defs)
-=======
-                    self.add_def(&var.loc(), &var.value(), scope_stack, references, use_defs);
-                } else {
-                    self.add_local_use_def(
-                        &var.value(),
-                        &var.loc(),
-                        references,
-                        scope_stack,
-                        use_defs,
-                    )
->>>>>>> 8a48fe92a (Added async symbolication on file saves)
                 }
             }
             LValue_::Unpack(ident, name, tparams, fields) => {
@@ -877,11 +747,7 @@ impl Symbolicator {
                     name,
                     tparams,
                     fields,
-<<<<<<< HEAD
                     scope,
-=======
-                    scope_stack,
->>>>>>> 8a48fe92a (Added async symbolication on file saves)
                     references,
                     use_defs,
                 );
@@ -893,11 +759,7 @@ impl Symbolicator {
                     name,
                     tparams,
                     fields,
-<<<<<<< HEAD
                     scope,
-=======
-                    scope_stack,
->>>>>>> 8a48fe92a (Added async symbolication on file saves)
                     references,
                     use_defs,
                 );
@@ -914,11 +776,7 @@ impl Symbolicator {
         name: &StructName,
         tparams: &Vec<Type>,
         fields: &Fields<(Type, LValue)>,
-<<<<<<< HEAD
         scope: &mut OrdMap<Symbol, DefLoc>,
-=======
-        scope_stack: &mut VecDeque<Scope>,
->>>>>>> 8a48fe92a (Added async symbolication on file saves)
         references: &mut BTreeMap<DefLoc, BTreeSet<UseLoc>>,
         use_defs: &mut UseDefMap,
     ) {
@@ -928,11 +786,7 @@ impl Symbolicator {
             // add use of the field name
             self.add_field_use_def(ident, &name.value(), fname, &fpos, references, use_defs);
             // add definition or use of a variable used for struct field unpacking
-<<<<<<< HEAD
             self.lvalue_symbols(define, lvalue, scope, references, use_defs);
-=======
-            self.lvalue_symbols(define, lvalue, scope_stack, references, use_defs);
->>>>>>> 8a48fe92a (Added async symbolication on file saves)
         }
         // add type params
         for t in tparams {
@@ -944,11 +798,7 @@ impl Symbolicator {
     fn exp_symbols(
         &self,
         exp: &Exp,
-<<<<<<< HEAD
         scope: &mut OrdMap<Symbol, DefLoc>,
-=======
-        scope_stack: &mut VecDeque<Scope>,
->>>>>>> 8a48fe92a (Added async symbolication on file saves)
         references: &mut BTreeMap<DefLoc, BTreeSet<UseLoc>>,
         use_defs: &mut UseDefMap,
     ) {
@@ -957,23 +807,12 @@ impl Symbolicator {
             E::Move {
                 from_user: _,
                 var: v,
-<<<<<<< HEAD
             } => self.add_local_use_def(&v.value(), &v.loc(), references, scope, use_defs),
             E::Copy {
                 from_user: _,
                 var: v,
             } => self.add_local_use_def(&v.value(), &v.loc(), references, scope, use_defs),
             E::Use(v) => self.add_local_use_def(&v.value(), &v.loc(), references, scope, use_defs),
-=======
-            } => self.add_local_use_def(&v.value(), &v.loc(), references, scope_stack, use_defs),
-            E::Copy {
-                from_user: _,
-                var: v,
-            } => self.add_local_use_def(&v.value(), &v.loc(), references, scope_stack, use_defs),
-            E::Use(v) => {
-                self.add_local_use_def(&v.value(), &v.loc(), references, scope_stack, use_defs)
-            }
->>>>>>> 8a48fe92a (Added async symbolication on file saves)
             E::Constant(mod_ident_opt, name) => self.add_const_use_def(
                 mod_ident_opt,
                 &name.value(),
@@ -981,13 +820,7 @@ impl Symbolicator {
                 references,
                 use_defs,
             ),
-<<<<<<< HEAD
             E::ModuleCall(mod_call) => self.mod_call_symbols(mod_call, scope, references, use_defs),
-=======
-            E::ModuleCall(mod_call) => {
-                self.mod_call_symbols(mod_call, scope_stack, references, use_defs)
-            }
->>>>>>> 8a48fe92a (Added async symbolication on file saves)
             E::Builtin(builtin_fun, exp) => {
                 use BuiltinFunction_ as BF;
                 match &builtin_fun.value {
@@ -998,7 +831,6 @@ impl Symbolicator {
                     BF::Freeze(t) => self.add_type_id_use_def(t, references, use_defs),
                     _ => (),
                 }
-<<<<<<< HEAD
                 self.exp_symbols(exp, scope, references, use_defs);
             }
             E::Vector(_, _, t, exp) => {
@@ -1026,43 +858,12 @@ impl Symbolicator {
             }
             E::Assign(lvalues, opt_types, e) => {
                 self.lvalue_list_symbols(false, lvalues, scope, references, use_defs);
-=======
-                self.exp_symbols(exp, scope_stack, references, use_defs);
-            }
-            E::Vector(_, _, t, exp) => {
-                self.add_type_id_use_def(t, references, use_defs);
-                self.exp_symbols(exp, scope_stack, references, use_defs);
-            }
-            E::IfElse(cond, t, f) => {
-                self.exp_symbols(cond, scope_stack, references, use_defs);
-                self.exp_symbols(t, scope_stack, references, use_defs);
-                self.exp_symbols(f, scope_stack, references, use_defs);
-            }
-            E::While(cond, body) => {
-                self.exp_symbols(cond, scope_stack, references, use_defs);
-                self.exp_symbols(body, scope_stack, references, use_defs);
-            }
-            E::Loop { has_break: _, body } => {
-                self.exp_symbols(body, scope_stack, references, use_defs);
-            }
-            E::Block(sequence) => {
-                // a block is a new var scope
-                scope_stack.push_front(Scope::new());
-                for seq_item in sequence {
-                    self.seq_item_symbols(scope_stack, seq_item, references, use_defs);
-                }
-                scope_stack.pop_front();
-            }
-            E::Assign(lvalues, opt_types, e) => {
-                self.lvalue_list_symbols(false, lvalues, scope_stack, references, use_defs);
->>>>>>> 8a48fe92a (Added async symbolication on file saves)
                 for opt_t in opt_types {
                     match opt_t {
                         Some(t) => self.add_type_id_use_def(t, references, use_defs),
                         None => (),
                     }
                 }
-<<<<<<< HEAD
                 self.exp_symbols(e, scope, references, use_defs);
             }
             E::Mutate(lhs, rhs) => {
@@ -1084,29 +885,6 @@ impl Symbolicator {
             E::BinopExp(lhs, _, _, rhs) => {
                 self.exp_symbols(lhs, scope, references, use_defs);
                 self.exp_symbols(rhs, scope, references, use_defs);
-=======
-                self.exp_symbols(e, scope_stack, references, use_defs);
-            }
-            E::Mutate(lhs, rhs) => {
-                self.exp_symbols(lhs, scope_stack, references, use_defs);
-                self.exp_symbols(rhs, scope_stack, references, use_defs);
-            }
-            E::Return(exp) => {
-                self.exp_symbols(exp, scope_stack, references, use_defs);
-            }
-            E::Abort(exp) => {
-                self.exp_symbols(exp, scope_stack, references, use_defs);
-            }
-            E::Dereference(exp) => {
-                self.exp_symbols(exp, scope_stack, references, use_defs);
-            }
-            E::UnaryExp(_, exp) => {
-                self.exp_symbols(exp, scope_stack, references, use_defs);
-            }
-            E::BinopExp(lhs, _, _, rhs) => {
-                self.exp_symbols(lhs, scope_stack, references, use_defs);
-                self.exp_symbols(rhs, scope_stack, references, use_defs);
->>>>>>> 8a48fe92a (Added async symbolication on file saves)
             }
             E::Pack(ident, name, tparams, fields) => {
                 self.pack_symbols(
@@ -1114,11 +892,7 @@ impl Symbolicator {
                     name,
                     tparams,
                     fields,
-<<<<<<< HEAD
                     scope,
-=======
-                    scope_stack,
->>>>>>> 8a48fe92a (Added async symbolication on file saves)
                     references,
                     use_defs,
                 );
@@ -1131,19 +905,11 @@ impl Symbolicator {
                         ExpListItem::Single(e, _) => e,
                         ExpListItem::Splat(_, e, _) => e,
                     };
-<<<<<<< HEAD
                     self.exp_symbols(exp, scope, references, use_defs);
                 }
             }
             E::Borrow(_, exp, field) => {
                 self.exp_symbols(exp, scope, references, use_defs);
-=======
-                    self.exp_symbols(exp, scope_stack, references, use_defs);
-                }
-            }
-            E::Borrow(_, exp, field) => {
-                self.exp_symbols(exp, scope_stack, references, use_defs);
->>>>>>> 8a48fe92a (Added async symbolication on file saves)
                 // get expression type to match fname to a struct def
                 self.add_field_type_use_def(
                     &exp.ty,
@@ -1154,7 +920,6 @@ impl Symbolicator {
                 );
             }
             E::TempBorrow(_, exp) => {
-<<<<<<< HEAD
                 self.exp_symbols(exp, scope, references, use_defs);
             }
             E::BorrowLocal(_, var) => {
@@ -1166,19 +931,6 @@ impl Symbolicator {
             }
             E::Annotate(exp, t) => {
                 self.exp_symbols(exp, scope, references, use_defs);
-=======
-                self.exp_symbols(exp, scope_stack, references, use_defs);
-            }
-            E::BorrowLocal(_, var) => {
-                self.add_local_use_def(&var.value(), &var.loc(), references, scope_stack, use_defs)
-            }
-            E::Cast(exp, t) => {
-                self.exp_symbols(exp, scope_stack, references, use_defs);
-                self.add_type_id_use_def(t, references, use_defs);
-            }
-            E::Annotate(exp, t) => {
-                self.exp_symbols(exp, scope_stack, references, use_defs);
->>>>>>> 8a48fe92a (Added async symbolication on file saves)
                 self.add_type_id_use_def(t, references, use_defs);
             }
 
@@ -1216,11 +968,7 @@ impl Symbolicator {
     fn mod_call_symbols(
         &self,
         mod_call: &ModuleCall,
-<<<<<<< HEAD
         scope: &mut OrdMap<Symbol, DefLoc>,
-=======
-        scope_stack: &mut VecDeque<Scope>,
->>>>>>> 8a48fe92a (Added async symbolication on file saves)
         references: &mut BTreeMap<DefLoc, BTreeSet<UseLoc>>,
         use_defs: &mut UseDefMap,
     ) {
@@ -1240,11 +988,7 @@ impl Symbolicator {
         }
 
         // handle arguments
-<<<<<<< HEAD
         self.exp_symbols(&mod_call.arguments, scope, references, use_defs);
-=======
-        self.exp_symbols(&mod_call.arguments, scope_stack, references, use_defs);
->>>>>>> 8a48fe92a (Added async symbolication on file saves)
     }
 
     /// Get symbols for the pack expression
@@ -1254,11 +998,7 @@ impl Symbolicator {
         name: &StructName,
         tparams: &Vec<Type>,
         fields: &Fields<(Type, Exp)>,
-<<<<<<< HEAD
         scope: &mut OrdMap<Symbol, DefLoc>,
-=======
-        scope_stack: &mut VecDeque<Scope>,
->>>>>>> 8a48fe92a (Added async symbolication on file saves)
         references: &mut BTreeMap<DefLoc, BTreeSet<UseLoc>>,
         use_defs: &mut UseDefMap,
     ) {
@@ -1268,11 +1008,7 @@ impl Symbolicator {
             // add use of the field name
             self.add_field_use_def(ident, &name.value(), fname, &fpos, references, use_defs);
             // add field initialization expression
-<<<<<<< HEAD
             self.exp_symbols(init_exp, scope, references, use_defs);
-=======
-            self.exp_symbols(init_exp, scope_stack, references, use_defs);
->>>>>>> 8a48fe92a (Added async symbolication on file saves)
         }
         // add type params
         for t in tparams {
@@ -1286,11 +1022,7 @@ impl Symbolicator {
     fn add_type_param(
         &mut self,
         tp: &TParam,
-<<<<<<< HEAD
         tp_scope: &mut BTreeMap<Symbol, DefLoc>,
-=======
-        tp_scope: &mut Scope,
->>>>>>> 8a48fe92a (Added async symbolication on file saves)
         references: &mut BTreeMap<DefLoc, BTreeSet<UseLoc>>,
         use_defs: &mut UseDefMap,
     ) {
@@ -1534,11 +1266,7 @@ impl Symbolicator {
         &self,
         pos: &Loc,
         name: &Symbol,
-<<<<<<< HEAD
         scope: &mut OrdMap<Symbol, DefLoc>,
-=======
-        scope_stack: &mut VecDeque<Scope>,
->>>>>>> 8a48fe92a (Added async symbolication on file saves)
         references: &mut BTreeMap<DefLoc, BTreeSet<UseLoc>>,
         use_defs: &mut UseDefMap,
     ) {
@@ -1548,18 +1276,10 @@ impl Symbolicator {
                     fhash: pos.file_hash(),
                     start: name_start,
                 };
-<<<<<<< HEAD
-=======
-                let mut scope = scope_stack.pop_front().unwrap(); // scope stack guaranteed non-empty
->>>>>>> 8a48fe92a (Added async symbolication on file saves)
                 scope.insert(*name, def_loc);
                 // in other languages only one definition is allowed per scope but in move an (and
                 // in rust) a variable can be re-defined in the same scope replacing the previous
                 // definition
-<<<<<<< HEAD
-=======
-                scope_stack.push_front(scope);
->>>>>>> 8a48fe92a (Added async symbolication on file saves)
 
                 // enter self-definition for def name
                 use_defs.insert(
@@ -1587,11 +1307,7 @@ impl Symbolicator {
         use_name: &Symbol,
         use_pos: &Loc,
         references: &mut BTreeMap<DefLoc, BTreeSet<UseLoc>>,
-<<<<<<< HEAD
         scope: &OrdMap<Symbol, DefLoc>,
-=======
-        scope_stack: &VecDeque<Scope>,
->>>>>>> 8a48fe92a (Added async symbolication on file saves)
         use_defs: &mut UseDefMap,
     ) {
         let name_start = match Self::get_start_loc(use_pos, &self.files, &self.file_id_mapping) {
@@ -1602,7 +1318,6 @@ impl Symbolicator {
             }
         };
 
-<<<<<<< HEAD
         if let Some(def_loc) = scope.get(use_name) {
             use_defs.insert(
                 name_start.line,
@@ -1618,25 +1333,6 @@ impl Symbolicator {
         } else {
             debug_assert!(false);
         }
-=======
-        for s in scope_stack {
-            if let Some(def_loc) = s.get(use_name) {
-                use_defs.insert(
-                    name_start.line,
-                    UseDef::new(
-                        references,
-                        use_pos.file_hash(),
-                        name_start,
-                        def_loc.fhash,
-                        def_loc.start,
-                        use_name,
-                    ),
-                );
-                return;
-            }
-        }
-        debug_assert!(false);
->>>>>>> 8a48fe92a (Added async symbolication on file saves)
     }
 }
 
@@ -1740,11 +1436,7 @@ pub fn on_use_request(
     id: RequestId,
     use_def_action: impl Fn(&UseDef) -> Option<serde_json::Value>,
 ) {
-<<<<<<< HEAD
     let mut result = None;
-=======
-    let mut result = Option::<serde_json::Value>::None;
->>>>>>> 8a48fe92a (Added async symbolication on file saves)
 
     let mut use_def_found = false;
     if let Some(mod_ident) = symbols.mod_ident_map.get(&PathBuf::from(use_fpath)) {

--- a/language/move-analyzer/src/vfs.rs
+++ b/language/move-analyzer/src/vfs.rs
@@ -16,6 +16,8 @@ use lsp_types::{
     DidOpenTextDocumentParams, DidSaveTextDocumentParams,
 };
 
+use crate::symbols;
+
 /// A mapping from identifiers (file names, potentially, but not necessarily) to their contents.
 #[derive(Debug, Default)]
 pub struct VirtualFileSystem {
@@ -49,6 +51,7 @@ impl VirtualFileSystem {
 /// Updates the given virtual file system based on the text document sync notification that was sent.
 pub fn on_text_document_sync_notification(
     files: &mut VirtualFileSystem,
+    symbolicator_runner: &symbols::SymbolicatorRunner,
     notification: &Notification,
 ) {
     match notification.method.as_str() {
@@ -78,6 +81,7 @@ pub fn on_text_document_sync_notification(
                 parameters.text_document.uri.path(),
                 &parameters.text.unwrap(),
             );
+            symbolicator_runner.run();
         }
         lsp_types::notification::DidCloseTextDocument::METHOD => {
             let parameters =


### PR DESCRIPTION
## Motivation

This is a refinement for the recently added (https://github.com/move-language/move/pull/147) symbolication support in the language server. The purpose of the original PR (https://github.com/move-language/move/pull/147) was to introduce (and test) the symbolication algorithm itself.

The goal of this PR is to move the needle in terms of user experience - in the original PR, symbolication was triggered only once at the language server start. In this PR we trigger symbolication asynchronously (in a separate thread) each time a file is saved so that the most recent information about symbols is available to the IDE.

One reason to use only a single symbolicator thread is to throttle the number of times symbolication (which is relatively expensive) is triggered. At this point it's not a big issue as it's triggered of file save operation, but could become one when we manage to get the compiler operate on in-memory files, and when we will be triggering symbolication on cadence closer to key strokes than to file saves.


### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes
