### PR TITLE
[language server] Added support for passing compilation errors back to the IDE

### DIFF
--- a/language/move-analyzer/src/bin/move-analyzer.rs
+++ b/language/move-analyzer/src/bin/move-analyzer.rs
@@ -2,6 +2,7 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use anyhow::Result;
 use clap::Parser;
 use crossbeam::channel::{bounded, select};
 use lsp_server::{Connection, Message, Notification, Request, Response};
@@ -106,7 +107,7 @@ fn main() {
     let initialize_params: lsp_types::InitializeParams =
         serde_json::from_value(client_response).expect("could not deserialize client capabilities");
 
-    let (diag_sender, diag_receiver) = bounded::<BTreeMap<Symbol, Vec<Diagnostic>>>(0);
+    let (diag_sender, diag_receiver) = bounded::<Result<BTreeMap<Symbol, Vec<Diagnostic>>>>(0);
     let mut symbolicator_runner = symbols::SymbolicatorRunner::idle();
     if symbols::DEFS_AND_REFS_SUPPORT {
         if let Some(uri) = initialize_params.root_uri {
@@ -116,22 +117,47 @@ fn main() {
         }
     };
 
+    let mut missing_manifest_reported = false;
     loop {
         select! {
             recv(diag_receiver) -> message => {
                 match message {
-                    Ok(diags) => {
-                        for (k, v) in diags {
-                            let url = Url::from_file_path(Path::new(&k.to_string())).unwrap();
-                            let params = lsp_types::PublishDiagnosticsParams::new(url, v, None);
-                            let notification = Notification::new(lsp_types::notification::PublishDiagnostics::METHOD.to_string(), params);
-                            if let Err(err) = context
-                                .connection
-                                .sender
-                                .send(lsp_server::Message::Notification(notification)) {
-                                    eprintln!("could not send completion response: {:?}", err);
+                    Ok(result) => {
+                        match result {
+                            Ok(diags) => {
+                                for (k, v) in diags {
+                                    let url = Url::from_file_path(Path::new(&k.to_string())).unwrap();
+                                    let params = lsp_types::PublishDiagnosticsParams::new(url, v, None);
+                                    let notification = Notification::new(lsp_types::notification::PublishDiagnostics::METHOD.to_string(), params);
+                                    if let Err(err) = context
+                                        .connection
+                                        .sender
+                                        .send(lsp_server::Message::Notification(notification)) {
+                                            eprintln!("could not send diagnostics response: {:?}", err);
+                                        };
                                 }
-
+                            },
+                            Err(err) => {
+                                let typ = lsp_types::MessageType::Error;
+                                let message = format!("{err}");
+                                let missing_manifest = message.starts_with("Unable to find package manifest");
+                                if !missing_manifest || !missing_manifest_reported {
+                                    // report missing manifest only once to avoid re-generating
+                                    // user-visible error in cases when the developer decides to
+                                    // keep editing a file that does not belong to a packages
+                                    let params = lsp_types::ShowMessageParams { typ, message };
+                                    let notification = Notification::new(lsp_types::notification::ShowMessage::METHOD.to_string(), params);
+                                    if let Err(err) = context
+                                        .connection
+                                        .sender
+                                        .send(lsp_server::Message::Notification(notification)) {
+                                            eprintln!("could not send compiler error response: {:?}", err);
+                                        };
+                                }
+                                if missing_manifest {
+                                    missing_manifest_reported = true;
+                                }
+                            },
                         }
                     },
                     Err(error) => eprintln!("symbolicator message error: {:?}", error),

--- a/language/move-analyzer/src/symbols.rs
+++ b/language/move-analyzer/src/symbols.rs
@@ -86,7 +86,7 @@ use move_symbol_pool::Symbol;
 
 /// Enabling/disabling the language server reporting readiness to support go-to-def and
 /// go-to-references to the IDE.
-pub const DEFS_AND_REFS_SUPPORT: bool = false;
+pub const DEFS_AND_REFS_SUPPORT: bool = true;
 
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Copy)]
 /// Location of a definition's identifier


### PR DESCRIPTION
## Motivation

One more refinement of recently added support for more advanced language server features (https://github.com/move-language/move/pull/147). This PR is about passing "fatal" compilation errors (i.e., those that do not result in generating diagnostics for the source code) back to IDE so that it's more explicit why more advanced features (i.e., those relying on successful compilation) may not work as expected.

Enabled advanced functionality in the server to simplify deployment, but it's not meant for wider consumption yet as it requires the extension to be re-published for the new functionality to work.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes
