### PR TITLE
[github] Naive CI test for the CLI Docker image

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -258,3 +258,17 @@ jobs:
           # Don't look in git or target dirs. Don't check png, bib, tex, js, or shell files
           # We allow links to be redirects, allow duplicates, and we also allow Too Many Requests (429) errors
           find . -not \( -path "./.git*" -prune \) -not \( -path "./target" -prune \) -type f -not -name "*.png" -not -name "*.sh" -not -name "*.bib" -not -name "*.tex" -not -name "*.js" | while read arg; do awesome_bot --allow-redirect --allow-dupe --allow 429 --skip-save-results $arg; done
+
+  build-move-cli-docker-image:
+    name: Build Docker image for the Move CLI
+    runs-on: ubuntu-latest
+    needs:
+      - prepare
+    steps:
+      - uses: actions/checkout@v2.4.0
+      - name: Build Dockerfile
+        run: "docker build -t move/cli -f docker/move-cli/Dockerfile ."
+      - name: Build BasicCoin Move module
+        run: |
+          cd ./language/documentation/tutorial/step_1/BasicCoin
+          docker run -v `pwd`:/project move/cli package build


### PR DESCRIPTION
## Motivation

For now, testing the Move CLI Docker image by building it and the BasicCoin Move module.

We should add more detailed tests later, for testing various parts of Move CLI.

The Dockerfile for the Move CLI was added here: 6941dce2f ("[docker] Added Dockerfile for the Move CLI", 2022-05-12)

(Style note: intentionally used double quotes for the `run` command. `run` is utilized throughout the file with, and without quotes. To me it seems that double quotes are used with complicated commands with multiple arguments, so using double quotes in this case as well.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes.

## Test Plan

Tested in this test PR: https://github.com/villesundell/move/pull/1 (The last test in the list, all checks passed).