### PR TITLE
[move-package] Change all yaml files to be TOML

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1172,12 +1172,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31ad93652f40969dead8d4bf897a41e9462095152eb21c56e5830537e41179dd"
 
 [[package]]
-name = "dtoa"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d7ed2934d741c6b37e33e3832298e8850b53fd2d2bea03873375596c7cea4e"
-
-[[package]]
 name = "duct"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2406,8 +2400,8 @@ dependencies = [
  "read-write-set",
  "read-write-set-dynamic",
  "serde 1.0.130",
- "serde_yaml",
  "tempfile",
+ "toml",
  "walkdir",
 ]
 
@@ -2701,7 +2695,6 @@ dependencies = [
  "ptree",
  "regex",
  "serde 1.0.130",
- "serde_yaml",
  "sha2",
  "tempfile",
  "termcolor",
@@ -4470,18 +4463,6 @@ dependencies = [
  "proc-macro2 1.0.28",
  "quote 1.0.9",
  "syn 1.0.74",
-]
-
-[[package]]
-name = "serde_yaml"
-version = "0.8.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15654ed4ab61726bf918a39cb8d98a2e2995b002387807fa6ba58fdf7f59bb23"
-dependencies = [
- "dtoa",
- "linked-hash-map",
- "serde 1.0.130",
- "yaml-rust",
 ]
 
 [[package]]

--- a/language/changes/7-packages.md
+++ b/language/changes/7-packages.md
@@ -287,7 +287,7 @@ a_move_package
 ...
 └── build
     ├── <dep_pkg_name>
-    │   ├── BuildInfo.yaml
+    │   ├── BuildInfo.toml
     │   ├── bytecode_modules
     │   │   └── *.mv
     │   ├── source_maps
@@ -301,7 +301,7 @@ a_move_package
     │       └── *.move
     ...
     └── <dep_pkg_name>
-        ├── BuildInfo.yaml
+        ├── BuildInfo.toml
         ...
         └── sources
 ```

--- a/language/documentation/book/src/packages.md
+++ b/language/documentation/book/src/packages.md
@@ -268,7 +268,7 @@ a_move_package
 ...
 └── build
     ├── <dep_pkg_name>
-    │   ├── BuildInfo.yaml
+    │   ├── BuildInfo.toml
     │   ├── bytecode_modules
     │   │   └── *.mv
     │   ├── source_maps
@@ -282,7 +282,7 @@ a_move_package
     │       └── *.move
     ...
     └── <dep_pkg_name>
-        ├── BuildInfo.yaml
+        ├── BuildInfo.toml
         ...
         └── sources
 ```

--- a/language/tools/move-cli/Cargo.toml
+++ b/language/tools/move-cli/Cargo.toml
@@ -15,7 +15,7 @@ colored = "2.0.0"
 difference = "2.0.0"
 once_cell = "1.7.2"
 serde = { version = "1.0.124", default-features = false }
-serde_yaml = "0.8.17"
+toml = "0.5.8"
 clap = { version = "3.1.8", features = ["derive"] }
 tempfile = "3.2.0"
 walkdir = "2.3.1"

--- a/language/tools/move-cli/src/sandbox/commands/generate.rs
+++ b/language/tools/move-cli/src/sandbox/commands/generate.rs
@@ -35,7 +35,7 @@ pub fn generate_struct_layouts(
                 SerdeLayoutBuilder::new(state)
             };
             layout_builder.build_struct_layout(&struct_tag)?;
-            let layout = serde_yaml::to_string(layout_builder.registry())?;
+            let layout = toml::to_string(layout_builder.registry())?;
             state.save_struct_layouts(&layout)?;
             println!("{}", layout);
         } else {

--- a/language/tools/move-cli/src/sandbox/utils/on_disk_state_view.rs
+++ b/language/tools/move-cli/src/sandbox/utils/on_disk_state_view.rs
@@ -37,7 +37,7 @@ pub const MODULES_DIR: &str = "modules";
 pub const EVENTS_DIR: &str = "events";
 
 /// file under `DEFAULT_BUILD_DIR` where a registry of generated struct layouts are stored
-pub const STRUCT_LAYOUTS_FILE: &str = "struct_layouts.yaml";
+pub const STRUCT_LAYOUTS_FILE: &str = "struct_layouts.toml";
 
 #[derive(Debug)]
 pub struct OnDiskStateView {
@@ -332,7 +332,7 @@ impl OnDiskStateView {
         Ok(fs::write(path, &module_bytes)?)
     }
 
-    /// Save the YAML encoding `layout` on disk under `build_dir/layouts/id`.
+    /// Save the TOML encoding `layout` on disk under `build_dir/layouts/id`.
     pub fn save_struct_layouts(&self, layouts: &str) -> Result<()> {
         let layouts_file = self.struct_layouts_file();
         if !layouts_file.exists() {

--- a/language/tools/move-package/Cargo.toml
+++ b/language/tools/move-package/Cargo.toml
@@ -16,7 +16,6 @@ walkdir = "2.3.1"
 clap = { version = "3.1.8", features = ["derive"] }
 bcs = "0.1.2"
 colored = "2.0.0"
-serde_yaml = "0.8.17"
 tempfile = "3.2.0"
 sha2 = "0.9.3"
 regex = "1.1.9"

--- a/language/tools/move-package/src/compilation/compiled_package.rs
+++ b/language/tools/move-package/src/compilation/compiled_package.rs
@@ -132,7 +132,7 @@ impl OnDiskCompiledPackage {
                 p.parent().unwrap(),
             )
         };
-        let package = serde_yaml::from_slice::<OnDiskPackage>(&buf)?;
+        let package = toml::from_slice::<OnDiskPackage>(&buf)?;
         assert!(build_path.ends_with(CompiledPackageLayout::Root.path()));
         let root_path = build_path.join(package.compiled_package_info.package_name.as_str());
         Ok(Self { root_path, package })
@@ -725,7 +725,7 @@ impl CompiledPackage {
 
         on_disk_package.save_under(
             CompiledPackageLayout::BuildInfo.path(),
-            serde_yaml::to_string(&on_disk_package.package)?.as_bytes(),
+            toml::to_string(&on_disk_package.package)?.as_bytes(),
         )?;
 
         Ok(on_disk_package)


### PR DESCRIPTION
## Motivation

Let's stick with 1 parser for Move.  I picked TOML, since it was the one that was already being manually manipulated for the Move package system.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

yes

## Test Plan

Ran tests, though the solidity ones didn't like me

## Related issue
https://github.com/move-language/move/issues/176