### PR TITLE
[Move] Make compilation kill the process on failure/warning optional

### DIFF
--- a/language/benchmarks/src/move_vm.rs
+++ b/language/benchmarks/src/move_vm.rs
@@ -41,7 +41,7 @@ fn compile_modules() -> Vec<CompiledModule> {
         vec![],
         move_stdlib::move_stdlib_named_addresses(),
     )
-    .build_and_report()
+    .build_and_report(true)
     .expect("Error compiling...");
     compiled_units
         .into_iter()

--- a/language/move-compiler/src/bin/move-build.rs
+++ b/language/move-compiler/src/bin/move-build.rs
@@ -83,7 +83,7 @@ pub fn main() -> anyhow::Result<()> {
         move_compiler::Compiler::from_files(source_files, dependencies, named_addr_map)
             .set_interface_files_dir(interface_files_dir)
             .set_flags(flags)
-            .build_and_report()?;
+            .build_and_report(true)?;
     move_compiler::output_compiled_units(
         bytecode_version,
         emit_source_map,

--- a/language/move-vm/integration-tests/src/compiler.rs
+++ b/language/move-vm/integration-tests/src/compiler.rs
@@ -22,7 +22,7 @@ pub fn compile_units(s: &str) -> Result<Vec<AnnotatedCompiledUnit>> {
         vec![],
         move_stdlib::move_stdlib_named_addresses(),
     )
-    .build_and_report()?;
+    .build_and_report(true)?;
 
     dir.close()?;
 
@@ -44,7 +44,7 @@ pub fn compile_modules_in_file(path: &Path) -> Result<Vec<CompiledModule>> {
         vec![],
         std::collections::BTreeMap::<String, _>::new(),
     )
-    .build_and_report()?;
+    .build_and_report(true)?;
 
     expect_modules(units).collect()
 }

--- a/language/testing-infra/test-generation/src/lib.rs
+++ b/language/testing-infra/test-generation/src/lib.rs
@@ -60,7 +60,7 @@ static STORAGE_WITH_MOVE_STDLIB: Lazy<InMemoryStorage> = Lazy::new(|| {
         vec![],
         move_stdlib::move_stdlib_named_addresses(),
     )
-    .build_and_report()
+    .build_and_report(true)
     .unwrap();
     let compiled_modules = compiled_units.into_iter().map(|unit| match unit {
         AnnotatedCompiledUnit::Module(annot_module) => annot_module.named_module.module,

--- a/language/testing-infra/transactional-test-runner/src/vm_test_harness.rs
+++ b/language/testing-infra/transactional-test-runner/src/vm_test_harness.rs
@@ -329,7 +329,7 @@ static PRECOMPILED_MOVE_STDLIB: Lazy<FullyCompiledProgram> = Lazy::new(|| {
         Ok(stdlib) => stdlib,
         Err((files, errors)) => {
             eprintln!("!!!Standard library failed to compile!!!");
-            move_compiler::diagnostics::report_diagnostics(&files, errors)
+            move_compiler::diagnostics::report_diagnostics(&files, errors, true)
         }
     }
 });
@@ -345,11 +345,11 @@ static MOVE_STDLIB_COMPILED: Lazy<Vec<CompiledModule>> = Lazy::new(|| {
     match units_res {
         Err(diags) => {
             eprintln!("!!!Standard library failed to compile!!!");
-            move_compiler::diagnostics::report_diagnostics(&files, diags)
+            move_compiler::diagnostics::report_diagnostics(&files, diags, true)
         }
         Ok((_, warnings)) if !warnings.is_empty() => {
             eprintln!("!!!Standard library failed to compile!!!");
-            move_compiler::diagnostics::report_diagnostics(&files, warnings)
+            move_compiler::diagnostics::report_diagnostics(&files, warnings, true)
         }
         Ok((units, _warnings)) => units
             .into_iter()

--- a/language/testing-infra/transactional-test-runner/src/vm_test_harness.rs
+++ b/language/testing-infra/transactional-test-runner/src/vm_test_harness.rs
@@ -329,7 +329,11 @@ static PRECOMPILED_MOVE_STDLIB: Lazy<FullyCompiledProgram> = Lazy::new(|| {
         Ok(stdlib) => stdlib,
         Err((files, errors)) => {
             eprintln!("!!!Standard library failed to compile!!!");
-            move_compiler::diagnostics::report_diagnostics(&files, errors, true)
+            move_compiler::diagnostics::report_diagnostics(&files, errors, true);
+            // this will never be reached as report_diagnostics will actually already exit the
+            // process, but there is no way to figure this out statically anymore as it's controlled
+            // by the last argument to this function
+            std::process::exit(1);
         }
     }
 });
@@ -345,11 +349,17 @@ static MOVE_STDLIB_COMPILED: Lazy<Vec<CompiledModule>> = Lazy::new(|| {
     match units_res {
         Err(diags) => {
             eprintln!("!!!Standard library failed to compile!!!");
-            move_compiler::diagnostics::report_diagnostics(&files, diags, true)
+            move_compiler::diagnostics::report_diagnostics(&files, diags, true);
+            // see comment in PRECOMPILED_MOVE_STDLIB initializer for why this should never be
+            // reached
+            std::process::exit(1);
         }
         Ok((_, warnings)) if !warnings.is_empty() => {
             eprintln!("!!!Standard library failed to compile!!!");
-            move_compiler::diagnostics::report_diagnostics(&files, warnings, true)
+            move_compiler::diagnostics::report_diagnostics(&files, warnings, true);
+            // see comment in PRECOMPILED_MOVE_STDLIB initializer for why this should never be
+            // reached
+            std::process::exit(1);
         }
         Ok((units, _warnings)) => units
             .into_iter()

--- a/language/tools/move-cli/src/base/commands/compile.rs
+++ b/language/tools/move-cli/src/base/commands/compile.rs
@@ -24,7 +24,7 @@ pub fn compile(
     let (files, compiled_units) =
         Compiler::from_files(sources, interface_files, named_address_mapping)
             .set_flags(Flags::empty().set_sources_shadow_deps(sources_shadow_deps))
-            .build_and_report()?;
+            .build_and_report(true)?;
     move_compiler::output_compiled_units(
         get_bytecode_version_from_env(),
         emit_source_map,

--- a/language/tools/move-cli/src/package/cli.rs
+++ b/language/tools/move-cli/src/package/cli.rs
@@ -501,18 +501,32 @@ pub fn run_move_unit_tests(
     // control back to the Move package system.
     build_plan.compile_with_driver(&mut std::io::stdout(), |compiler| {
         let (files, comments_and_compiler_res) = compiler.run::<PASS_CFGIR>().unwrap();
-        let (_, compiler) =
-            diagnostics::unwrap_or_report_diagnostics(&files, comments_and_compiler_res);
+        let (_, compiler) = match diagnostics::result_or_report_diagnostics(
+            &files,
+            comments_and_compiler_res,
+            true,
+        ) {
+            Some(v) => v,
+            // this will never be reached as result_or_report_diagnostics will actually already exit
+            // the process, but there is no way to figure this out statically anymore as it's
+            // controlled by the last argument to this function
+            None => std::process::exit(1),
+        };
         let (mut compiler, cfgir) = compiler.into_ast();
         let compilation_env = compiler.compilation_env();
         let built_test_plan = construct_test_plan(compilation_env, Some(root_package), &cfgir);
         if let Err(diags) = compilation_env.check_diags_at_or_above_severity(Severity::Warning) {
-            diagnostics::report_diagnostics(&files, diags);
+            diagnostics::report_diagnostics(&files, diags, true);
         }
 
         let compilation_result = compiler.at_cfgir(cfgir).build();
 
-        let (units, _) = diagnostics::unwrap_or_report_diagnostics(&files, compilation_result);
+        let (units, _) =
+            match diagnostics::result_or_report_diagnostics(&files, compilation_result, true) {
+                Some(v) => v,
+                // see comment earlier in this function for why this should never be reached
+                None => std::process::exit(1),
+            };
         test_plan = Some((built_test_plan, files.clone(), units.clone()));
         Ok((files, units))
     })?;

--- a/language/tools/move-cli/src/sandbox/utils/mod.rs
+++ b/language/tools/move-cli/src/sandbox/utils/mod.rs
@@ -434,7 +434,7 @@ pub(crate) fn explain_publish_error(
                     }
                 }
             }
-            report_diagnostics(&files, diags)
+            report_diagnostics(&files, diags, true)
         }
         VMStatus::Error(status_code) => {
             println!("Publishing failed with unexpected error {:?}", status_code)

--- a/language/tools/move-package/src/compilation/build_plan.rs
+++ b/language/tools/move-package/src/compilation/build_plan.rs
@@ -98,8 +98,8 @@ impl BuildPlan {
         })
     }
 
-    pub fn compile<W: Write>(&self, writer: &mut W) -> Result<CompiledPackage> {
-        self.compile_with_driver(writer, |compiler| compiler.build_and_report())
+    pub fn compile<W: Write>(&self, writer: &mut W, should_exit: bool) -> Result<CompiledPackage> {
+        self.compile_with_driver(writer, |compiler| compiler.build_and_report(should_exit))
     }
 
     pub fn compile_with_driver<W: Write>(

--- a/language/tools/move-package/src/lib.rs
+++ b/language/tools/move-package/src/lib.rs
@@ -154,9 +154,20 @@ pub struct ModelConfig {
 impl BuildConfig {
     /// Compile the package at `path` or the containing Move package.
     pub fn compile_package<W: Write>(self, path: &Path, writer: &mut W) -> Result<CompiledPackage> {
+        self.compile_package_process_exit(path, writer, true)
+    }
+
+    /// Compile the package at `path` or the containing Move package, with the compilation process
+    /// exiting on failure/warning or not depending on the value of the should_exit argument.
+    pub fn compile_package_process_exit<W: Write>(
+        self,
+        path: &Path,
+        writer: &mut W,
+        should_exit: bool,
+    ) -> Result<CompiledPackage> {
         let resolved_graph = self.resolution_graph_for_package(path)?;
         let mutx = PackageLock::lock();
-        let ret = BuildPlan::create(resolved_graph)?.compile(writer);
+        let ret = BuildPlan::create(resolved_graph)?.compile(writer, should_exit);
         mutx.unlock();
         ret
     }

--- a/language/tools/move-package/tests/test_runner.rs
+++ b/language/tools/move-package/tests/test_runner.rs
@@ -61,7 +61,7 @@ pub fn run_test(path: &Path) -> datatest_stable::Result<()> {
                 .into())
             }
             (true, _) => match BuildPlan::create(resolved_package)
-                .and_then(|bp| bp.compile(&mut Vec::new()))
+                .and_then(|bp| bp.compile(&mut Vec::new(), true))
             {
                 Ok(mut pkg) => {
                     pkg.compiled_package_info.source_digest =


### PR DESCRIPTION
## Motivation

At this point, building a package containing either errors or just warnings results in the whole process being killed, which makes it impossible for adapters to choose to publish modules with warnings only. This PR addresses the problem by making  process exiting upon encountering failure/warning optional.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes

