### PR TITLE
[stdlib] add function to convert option to vector

### DIFF
--- a/language/move-stdlib/docs/Option.md
+++ b/language/move-stdlib/docs/Option.md
@@ -24,6 +24,7 @@ This module defines the Option type and its methods to represent and handle an o
 -  [Function `destroy_with_default`](#0x1_Option_destroy_with_default)
 -  [Function `destroy_some`](#0x1_Option_destroy_some)
 -  [Function `destroy_none`](#0x1_Option_destroy_none)
+-  [Function `to_vec`](#0x1_Option_to_vec)
 -  [Module Specification](#@Module_Specification_1)
     -  [Helper Schema](#@Helper_Schema_2)
 
@@ -799,6 +800,47 @@ Aborts if <code>t</code> holds a value
 
 <pre><code><b>pragma</b> opaque;
 <b>aborts_if</b> <a href="Option.md#0x1_Option_is_some">is_some</a>(t) <b>with</b> <a href="Errors.md#0x1_Errors_INVALID_ARGUMENT">Errors::INVALID_ARGUMENT</a>;
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_Option_to_vec"></a>
+
+## Function `to_vec`
+
+Convert <code>t</code> into a vector of length 1 if it is <code>Some</code>,
+and an empty vector otherwise
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="Option.md#0x1_Option_to_vec">to_vec</a>&lt;Element&gt;(t: <a href="Option.md#0x1_Option_Option">Option::Option</a>&lt;Element&gt;): vector&lt;Element&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="Option.md#0x1_Option_to_vec">to_vec</a>&lt;Element&gt;(t: <a href="Option.md#0x1_Option">Option</a>&lt;Element&gt;): vector&lt;Element&gt; {
+    <b>let</b> <a href="Option.md#0x1_Option">Option</a> { vec } = t;
+    vec
+}
+</code></pre>
+
+
+
+</details>
+
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>pragma</b> opaque;
+<b>aborts_if</b> <b>false</b>;
+<b>ensures</b> result == t.vec;
 </code></pre>
 
 

--- a/language/move-stdlib/sources/Option.move
+++ b/language/move-stdlib/sources/Option.move
@@ -233,6 +233,18 @@ module Std::Option {
         aborts_if is_some(t) with Errors::INVALID_ARGUMENT;
     }
 
+    /// Convert `t` into a vector of length 1 if it is `Some`,
+    /// and an empty vector otherwise
+    public fun to_vec<Element>(t: Option<Element>): vector<Element> {
+        let Option { vec } = t;
+        vec
+    }
+    spec to_vec {
+        pragma opaque;
+        aborts_if false;
+        ensures result == t.vec;
+    }
+
     spec module {} // switch documentation context back to module level
 
     spec module {

--- a/language/move-stdlib/tests/OptionTests.move
+++ b/language/move-stdlib/tests/OptionTests.move
@@ -1,7 +1,7 @@
 #[test_only]
 module Std::OptionTests {
     use Std::Option;
-
+    use Std::Vector;
 
     #[test]
     fun option_none_is_none() {
@@ -152,5 +152,19 @@ module Std::OptionTests {
     #[expected_failure(abort_code = 7)]
     fun destroy_none_some() {
         Option::destroy_none(Option::some<u64>(0));
+    }
+
+    #[test]
+    fun into_vec_some() {
+        let v = Option::to_vec(Option::some<u64>(0));
+        assert!(Vector::length(&v) == 1, 0);
+        let x = Vector::pop_back(&mut v);
+        assert!(x == 0, 1);
+    }
+
+    #[test]
+    fun into_vec_none() {
+        let v: vector<u64> = Option::to_vec(Option::none());
+        assert!(Vector::is_empty(&v), 0);
     }
 }


### PR DESCRIPTION
This is a useful thing to do in some cases, and is very painful to implement outside of the `Option` module.