### PR TITLE
Trim errmap doc strings

### DIFF
--- a/language/move-prover/move-errmapgen/src/errmapgen.rs
+++ b/language/move-prover/move-errmapgen/src/errmapgen.rs
@@ -89,7 +89,7 @@ impl<'env> ErrmapGen<'env> {
                 error_category,
                 ErrorDescription {
                     code_name: name.to_string(),
-                    code_description: named_constant.get_doc().to_string(),
+                    code_description: named_constant.get_doc().trim().to_string(),
                 },
             )?
         }
@@ -110,7 +110,7 @@ impl<'env> ErrmapGen<'env> {
                     abort_code,
                     ErrorDescription {
                         code_name: name.to_string(),
-                        code_description: named_constant.get_doc().to_string(),
+                        code_description: named_constant.get_doc().trim().to_string(),
                     },
                 )?
             }


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Move Language.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Errmap strings have extra leading spaces in them.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes

## Test Plan

N/A
