### PR TITLE
[fix] handle multi root workspaces in ide

### DIFF
--- a/language/move-analyzer/editors/code/.vscode/extensions.json
+++ b/language/move-analyzer/editors/code/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+    // See http://go.microsoft.com/fwlink/?LinkId=827846
+    // for the documentation about the extensions.json format
+    "recommendations": [
+        "dbaeumer.vscode-eslint"
+    ]
+}

--- a/language/move-analyzer/editors/code/.vscode/launch.json
+++ b/language/move-analyzer/editors/code/.vscode/launch.json
@@ -1,0 +1,36 @@
+// A launch configuration that compiles the extension and then opens it inside a new window
+// Use IntelliSense to learn about possible attributes.
+// Hover to view descriptions of existing attributes.
+// For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Run Extension",
+            "type": "extensionHost",
+            "request": "launch",
+            "args": [
+                "--extensionDevelopmentPath=${workspaceFolder}"
+            ],
+            "outFiles": [
+                "${workspaceFolder}/out/src/**/*.js"
+            ],
+            "preLaunchTask": "${defaultBuildTask}",
+            "sourceMaps": true
+        },
+        {
+            "name": "Extension Tests",
+            "type": "extensionHost",
+            "request": "launch",
+            "args": [
+                "--extensionDevelopmentPath=${workspaceFolder}",
+                "--extensionTestsPath=${workspaceFolder}/out/test/index"
+            ],
+            "outFiles": [
+                "${workspaceFolder}/out/test/**/*.js"
+            ],
+            "preLaunchTask": "${defaultBuildTask}",
+            "sourceMaps": true
+        }
+    ]
+}

--- a/language/move-analyzer/editors/code/.vscode/settings.json
+++ b/language/move-analyzer/editors/code/.vscode/settings.json
@@ -1,0 +1,11 @@
+// Place your settings in this file to overwrite default and user settings.
+{
+    "files.exclude": {
+        "out": false // set this to true to hide the "out" folder with the compiled JS files
+    },
+    "search.exclude": {
+        "out": true // set this to false to include "out" folder in search results
+    },
+    // Turn off tsc task auto detection since we have the necessary tasks as npm scripts
+    "typescript.tsc.autoDetect": "off"
+}

--- a/language/move-analyzer/editors/code/.vscode/tasks.json
+++ b/language/move-analyzer/editors/code/.vscode/tasks.json
@@ -1,0 +1,20 @@
+// See https://go.microsoft.com/fwlink/?LinkId=733558
+// for the documentation about the tasks.json format
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "type": "npm",
+            "script": "watch",
+            "problemMatcher": "$tsc-watch",
+            "isBackground": true,
+            "presentation": {
+                "reveal": "never"
+            },
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
+        }
+    ]
+}

--- a/language/move-analyzer/src/context.rs
+++ b/language/move-analyzer/src/context.rs
@@ -5,6 +5,7 @@
 use crate::{symbols::Symbols, vfs::VirtualFileSystem};
 use lsp_server::Connection;
 use std::sync::{Arc, Mutex};
+use std::collections::HashMap;
 
 /// The context within which the language server is running.
 pub struct Context {
@@ -13,5 +14,5 @@ pub struct Context {
     /// The files that the language server is providing information about.
     pub files: VirtualFileSystem,
     /// Symbolication information
-    pub symbols: Arc<Mutex<Symbols>>,
+    pub symbols: Arc<Mutex<HashMap<String, Symbols>>>,
 }


### PR DESCRIPTION
## Motivation

Fixes https://github.com/MystenLabs/sui/issues/2234

The main idea to fix the issue is from two perspective

1. previously, we only symbolicating the root directory of our open workspace https://github.com/move-language/move/blob/main/language/move-analyzer/src/bin/move-analyzer.rs#L112-L117, so for the multi root workspaces, the root workspace is not always a valid move workspace (does not contain a `Move.toml`). in order to fix that, we need to list all the valid move workspaces from sub directories including the root directory and symbolicate them all.
2. in previous symbolicating process, if we symbolicate multiple move workspaces simultaneously, it will always store the last symbolicating result https://github.com/move-language/move/blob/main/language/move-analyzer/src/symbols.rs#L244-L249 and overwrite all the other symbolicating result, it will cause that we can always use `go-to-def` and `find-reference` for only one workspace among multi root workspaces case. in the fix, it introduces a global mapping to store symbolicating result for each move workspace and everything work like a charm then.

## Test Plan

have tested with https://github.com/MystenLabs/sui/tree/main/sui_programmability/examples manually, but dont get a clear idea for creating integrating tests for this feature, we only have unit tests for symbolicating right now.