### PR TITLE
[quick fix] Add help for updated expected output files

### DIFF
--- a/language/move-command-line-common/src/testing.rs
+++ b/language/move-command-line-common/src/testing.rs
@@ -23,6 +23,17 @@ pub fn read_env_update_baseline() -> bool {
     read_bool_env_var(UPDATE_BASELINE) || read_bool_env_var(UPBL) || read_bool_env_var(UB)
 }
 
+pub fn add_update_baseline_fix(s: impl AsRef<str>) -> String {
+    format!(
+        "{}\n\
+        Run with `env {}=1` (or `env {}=1`) to save the current output as \
+        the new expected output",
+        s.as_ref(),
+        UB,
+        UPDATE_BASELINE
+    )
+}
+
 pub fn format_diff(expected: impl AsRef<str>, actual: impl AsRef<str>) -> String {
     use difference::*;
 

--- a/language/move-compiler/tests/move_check_testsuite.rs
+++ b/language/move-compiler/tests/move_check_testsuite.rs
@@ -4,7 +4,7 @@
 
 use move_command_line_common::{
     env::read_bool_env_var,
-    testing::{format_diff, read_env_update_baseline, EXP_EXT, OUT_EXT},
+    testing::{add_update_baseline_fix, format_diff, read_env_update_baseline, EXP_EXT, OUT_EXT},
 };
 use move_compiler::{
     compiled_unit::AnnotatedCompiledUnit,
@@ -126,14 +126,14 @@ fn run_test(path: &Path, exp_path: &Path, out_path: &Path, flags: Flags) -> anyh
                 "Expected success. Unexpected diagnostics:\n{}",
                 rendered_diags
             );
-            anyhow::bail!(msg)
+            anyhow::bail!(add_update_baseline_fix(msg))
         }
         (false, true) => {
             let msg = format!(
                 "Unexpected success. Expected diagnostics:\n{}",
                 fs::read_to_string(exp_path)?
             );
-            anyhow::bail!(msg)
+            anyhow::bail!(add_update_baseline_fix(msg))
         }
         (true, true) => {
             let expected_diags = fs::read_to_string(exp_path)?;
@@ -142,7 +142,7 @@ fn run_test(path: &Path, exp_path: &Path, out_path: &Path, flags: Flags) -> anyh
                     "Expected diagnostics differ from actual diagnostics:\n{}",
                     format_diff(expected_diags, rendered_diags),
                 );
-                anyhow::bail!(msg)
+                anyhow::bail!(add_update_baseline_fix(msg))
             } else {
                 Ok(())
             }

--- a/language/testing-infra/transactional-test-runner/src/framework.rs
+++ b/language/testing-infra/transactional-test-runner/src/framework.rs
@@ -19,7 +19,7 @@ use move_command_line_common::{
     address::ParsedAddress,
     env::read_bool_env_var,
     files::{MOVE_EXTENSION, MOVE_IR_EXTENSION},
-    testing::{format_diff, read_env_update_baseline, EXP_EXT},
+    testing::{add_update_baseline_fix, format_diff, read_env_update_baseline, EXP_EXT},
     types::ParsedType,
     values::{ParsableValue, ParsedValue},
 };
@@ -748,7 +748,7 @@ fn handle_expected_output(test_path: &Path, output: impl AsRef<str>) -> Result<(
             "Expected errors differ from actual errors:\n{}",
             format_diff(expected_output, output),
         );
-        anyhow::bail!(msg)
+        anyhow::bail!(add_update_baseline_fix(msg))
     } else {
         Ok(())
     }

--- a/language/tools/move-cli/src/sandbox/commands/test.rs
+++ b/language/tools/move-cli/src/sandbox/commands/test.rs
@@ -7,7 +7,7 @@ use crate::{sandbox::utils::module, DEFAULT_BUILD_DIR, DEFAULT_STORAGE_DIR};
 use move_command_line_common::{
     env::read_bool_env_var,
     files::{find_filenames, path_to_string},
-    testing::{format_diff, read_env_update_baseline, EXP_EXT},
+    testing::{add_update_baseline_fix, format_diff, read_env_update_baseline, EXP_EXT},
 };
 use move_compiler::command_line::COLOR_MODE_ENV_VAR;
 use move_coverage::coverage_map::{CoverageMap, ExecCoverageMapWithModules};
@@ -336,10 +336,11 @@ pub fn run_one(
 
     let expected_output = fs::read_to_string(exp_path).unwrap_or_else(|_| "".to_string());
     if expected_output != output {
-        anyhow::bail!(
+        let msg = format!(
             "Expected output differs from actual output:\n{}",
             format_diff(expected_output, output)
-        )
+        );
+        anyhow::bail!(add_update_baseline_fix(msg))
     } else {
         Ok(cov_info)
     }

--- a/language/tools/move-package/tests/test_runner.rs
+++ b/language/tools/move-package/tests/test_runner.rs
@@ -104,12 +104,12 @@ pub fn run_test(path: &Path) -> datatest_stable::Result<()> {
     if exp_exists {
         let expected = fs::read_to_string(&exp_path)?;
         if expected != output {
-            return Err(anyhow::format_err!(
+            let msg = format!(
                 "Expected outputs differ for {:?}:\n{}",
                 exp_path,
                 format_diff(expected, output)
-            )
-            .into());
+            );
+            anyhow::bail!(add_update_baseline_fix(msg))
         }
     } else {
         return Err(anyhow::format_err!(

--- a/language/tools/move-package/tests/test_runner.rs
+++ b/language/tools/move-package/tests/test_runner.rs
@@ -2,7 +2,9 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use move_command_line_common::testing::{format_diff, read_env_update_baseline, EXP_EXT};
+use move_command_line_common::testing::{
+    add_update_baseline_fix, format_diff, read_env_update_baseline, EXP_EXT,
+};
 use move_package::{
     compilation::{build_plan::BuildPlan, model_builder::ModelBuilder},
     resolution::resolution_graph as RG,
@@ -109,7 +111,7 @@ pub fn run_test(path: &Path) -> datatest_stable::Result<()> {
                 exp_path,
                 format_diff(expected, output)
             );
-            anyhow::bail!(add_update_baseline_fix(msg))
+            return Err(anyhow::format_err!(add_update_baseline_fix(msg)).into());
         }
     } else {
         return Err(anyhow::format_err!(

--- a/language/tools/move-unit-test/tests/move_unit_test_testsuite.rs
+++ b/language/tools/move-unit-test/tests/move_unit_test_testsuite.rs
@@ -107,18 +107,16 @@ fn run_test_impl(path: &Path) -> anyhow::Result<()> {
         if exp_exists {
             let expected = fs::read_to_string(&exp_path)?;
             if expected != cleaned_output {
-                anyhow::bail!(
+                let msg = format!(
                     "Expected outputs differ for {:?}:\n{}",
                     exp_path,
                     format_diff(expected, cleaned_output)
                 );
+                anyhow::bail!(add_update_baseline_fix(msg));
             }
         } else {
-            anyhow::bail!(
-                "No expected output found for {:?}.\
-                    You probably want to rerun with `env UPDATE_BASELINE=1`",
-                path
-            );
+            let msg = format!("No expected output found for {:?}", path);
+            anyhow::bail!(add_update_baseline_fix(msg));
         }
     }
 

--- a/language/tools/move-unit-test/tests/move_unit_test_testsuite.rs
+++ b/language/tools/move-unit-test/tests/move_unit_test_testsuite.rs
@@ -2,7 +2,9 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use move_command_line_common::testing::{format_diff, read_env_update_baseline, EXP_EXT};
+use move_command_line_common::testing::{
+    add_update_baseline_fix, format_diff, read_env_update_baseline, EXP_EXT,
+};
 use move_unit_test::{self, UnitTestingConfig};
 use regex::RegexBuilder;
 use std::{


### PR DESCRIPTION
- Added help message for all tests but the prover
  - The provers test logic is a bit more custom
  - And I think it already has a message

## Motivation

- @bmwill was rightfully confused 
- We have had some confusion on new contributors too 

## Test Plan

Example
```
running 1 tests
test move_check_testsuite::parser/function_visibility_script.move ... FAILED
Error: Expected success. Unexpected diagnostics:
error[E01002]: unexpected token
  ┌─ tests/move_check/parser/function_visibility_script.move:4:23
  │
4 │     public ( script ) fuun h() {}
  │                       ^^^^
  │                       │
  │                       Unexpected 'fuun'
  │                       Expected a module member: 'spec', 'use', 'friend', 'const', 'fun', or 'struct'


Run with `env UB=1` (or `env UPDATE_BASELINE=1`) to save the current output as the new expected output

failures:
    move_check_testsuite::parser/function_visibility_script.move
```