### PR TITLE
[move-vm] Fix compatibility issues for new entry modifier

### DIFF
--- a/language/move-binary-format/src/normalized.rs
+++ b/language/move-binary-format/src/normalized.rs
@@ -89,6 +89,7 @@ pub struct Function {
 /// function declarations.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct Module {
+    pub file_format_version: u32,
     pub address: AccountAddress,
     pub name: Identifier,
     pub friends: Vec<ModuleId>,
@@ -118,6 +119,7 @@ impl Module {
             .collect();
 
         Self {
+            file_format_version: m.version(),
             address: *m.address(),
             name: m.name().to_owned(),
             friends,

--- a/language/move-binary-format/src/unit_tests/compatibility_tests.rs
+++ b/language/move-binary-format/src/unit_tests/compatibility_tests.rs
@@ -1,0 +1,134 @@
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use std::convert::TryFrom;
+
+use crate::{compatibility::Compatibility, file_format::*, normalized};
+use move_core_types::{account_address::AccountAddress, identifier::Identifier};
+
+fn mk_module(vis: u8) -> normalized::Module {
+    let (visibility, is_entry) = if vis == Visibility::DEPRECATED_SCRIPT {
+        (Visibility::Public, true)
+    } else {
+        (Visibility::try_from(vis).unwrap(), false)
+    };
+    let m = CompiledModule {
+        version: crate::file_format_common::VERSION_4,
+        module_handles: vec![
+            // only self module
+            ModuleHandle {
+                address: AddressIdentifierIndex(0),
+                name: IdentifierIndex(0),
+            },
+        ],
+        self_module_handle_idx: ModuleHandleIndex(0),
+        identifiers: vec![
+            Identifier::new("M").unwrap(),  // Module name
+            Identifier::new("fn").unwrap(), // Function name
+        ],
+        address_identifiers: vec![
+            AccountAddress::ZERO, // Module address
+        ],
+        function_handles: vec![
+            // fun fn()
+            FunctionHandle {
+                module: ModuleHandleIndex(0),
+                name: IdentifierIndex(1),
+                parameters: SignatureIndex(0),
+                return_: SignatureIndex(0),
+                type_parameters: vec![],
+            },
+        ],
+        function_defs: vec![
+            // public(script) fun fn() { return; }
+            FunctionDefinition {
+                function: FunctionHandleIndex(0),
+                visibility,
+                is_entry,
+                acquires_global_resources: vec![],
+                code: Some(CodeUnit {
+                    locals: SignatureIndex(0),
+                    code: vec![Bytecode::Ret],
+                }),
+            },
+        ],
+        signatures: vec![
+            Signature(vec![]), // void
+        ],
+        struct_defs: vec![],
+        struct_handles: vec![],
+        constant_pool: vec![],
+        metadata: vec![],
+        field_handles: vec![],
+        friend_decls: vec![],
+        struct_def_instantiations: vec![],
+        function_instantiations: vec![],
+        field_instantiations: vec![],
+    };
+    normalized::Module::new(&m)
+}
+
+const NON_COMPATIBLE: Compatibility = Compatibility {
+    struct_and_function_linking: false,
+    struct_layout: true,
+};
+
+const COMPATIBLE: Compatibility = Compatibility {
+    struct_and_function_linking: true,
+    struct_layout: true,
+};
+
+#[test]
+fn deprecated_unchanged_script_visibility() {
+    let script_module = mk_module(Visibility::DEPRECATED_SCRIPT);
+    assert_eq!(
+        Compatibility::check(&script_module, &script_module,),
+        COMPATIBLE
+    );
+}
+
+#[test]
+fn deprecated_remove_script_visibility() {
+    let script_module = mk_module(Visibility::DEPRECATED_SCRIPT);
+    // script -> private, not allowed
+    let private_module = mk_module(Visibility::Private as u8);
+    assert_eq!(
+        Compatibility::check(&script_module, &private_module),
+        NON_COMPATIBLE
+    );
+    // script -> public, not allowed
+    let public_module = mk_module(Visibility::Public as u8);
+    assert_eq!(
+        Compatibility::check(&script_module, &public_module),
+        NON_COMPATIBLE
+    );
+    // script -> friend, not allowed
+    let friend_module = mk_module(Visibility::Friend as u8);
+    assert_eq!(
+        Compatibility::check(&script_module, &friend_module),
+        NON_COMPATIBLE
+    );
+}
+
+#[test]
+fn deprecated_add_script_visibility() {
+    let script_module = mk_module(Visibility::DEPRECATED_SCRIPT);
+    // private -> script, allowed
+    let private_module = mk_module(Visibility::Private as u8);
+    assert_eq!(
+        Compatibility::check(&private_module, &script_module,),
+        COMPATIBLE
+    );
+    // public -> script, not allowed
+    let public_module = mk_module(Visibility::Public as u8);
+    assert_eq!(
+        Compatibility::check(&public_module, &script_module),
+        NON_COMPATIBLE
+    );
+    // friend -> script, not allowed
+    let friend_module = mk_module(Visibility::Friend as u8);
+    assert_eq!(
+        Compatibility::check(&friend_module, &script_module),
+        NON_COMPATIBLE
+    );
+}

--- a/language/move-binary-format/src/unit_tests/mod.rs
+++ b/language/move-binary-format/src/unit_tests/mod.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 mod binary_tests;
+mod compatibility_tests;
 mod deserializer_tests;
 mod number_tests;
 mod signature_token_tests;

--- a/language/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/dependencies_tests.rs
+++ b/language/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/dependencies_tests.rs
@@ -1,0 +1,294 @@
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use move_binary_format::file_format::*;
+use move_bytecode_verifier::dependencies;
+use move_core_types::{
+    account_address::AccountAddress, identifier::Identifier, vm_status::StatusCode,
+};
+
+fn mk_script_function_module() -> CompiledModule {
+    let m = CompiledModule {
+        version: move_binary_format::file_format_common::VERSION_4,
+        module_handles: vec![
+            // only self module
+            ModuleHandle {
+                address: AddressIdentifierIndex(0),
+                name: IdentifierIndex(0),
+            },
+        ],
+        self_module_handle_idx: ModuleHandleIndex(0),
+        identifiers: vec![
+            Identifier::new("M").unwrap(),    // Module name
+            Identifier::new("fn").unwrap(),   // Function name
+            Identifier::new("g_fn").unwrap(), // Generic function name
+        ],
+        address_identifiers: vec![
+            AccountAddress::ZERO, // Module address
+        ],
+        function_handles: vec![
+            // fun fn()
+            FunctionHandle {
+                module: ModuleHandleIndex(0),
+                name: IdentifierIndex(1),
+                parameters: SignatureIndex(0),
+                return_: SignatureIndex(0),
+                type_parameters: vec![],
+            },
+            // fun g_fn<T>()
+            FunctionHandle {
+                module: ModuleHandleIndex(0),
+                name: IdentifierIndex(2),
+                parameters: SignatureIndex(0),
+                return_: SignatureIndex(0),
+                type_parameters: vec![AbilitySet::EMPTY],
+            },
+        ],
+        function_defs: vec![
+            // public(script)  fun fn() { return; }
+            FunctionDefinition {
+                function: FunctionHandleIndex(0),
+                visibility: Visibility::Public,
+                is_entry: true,
+                acquires_global_resources: vec![],
+                code: Some(CodeUnit {
+                    locals: SignatureIndex(0),
+                    code: vec![Bytecode::Ret],
+                }),
+            },
+            // public(script) fun g_fn<T>() { return; }
+            FunctionDefinition {
+                function: FunctionHandleIndex(1),
+                visibility: Visibility::Public,
+                is_entry: true,
+                acquires_global_resources: vec![],
+                code: Some(CodeUnit {
+                    locals: SignatureIndex(0),
+                    code: vec![Bytecode::Ret],
+                }),
+            },
+        ],
+        signatures: vec![
+            Signature(vec![]), // void
+        ],
+        struct_defs: vec![],
+        struct_handles: vec![],
+        constant_pool: vec![],
+        metadata: vec![],
+        field_handles: vec![],
+        friend_decls: vec![],
+        struct_def_instantiations: vec![],
+        function_instantiations: vec![],
+        field_instantiations: vec![],
+    };
+    move_bytecode_verifier::verify_module(&m).unwrap();
+    m
+}
+
+fn mk_invoking_module(use_generic: bool, valid: bool) -> CompiledModule {
+    let call = if use_generic {
+        Bytecode::CallGeneric(FunctionInstantiationIndex(0))
+    } else {
+        Bytecode::Call(FunctionHandleIndex(1))
+    };
+    let m = CompiledModule {
+        version: move_binary_format::file_format_common::VERSION_4,
+        module_handles: vec![
+            // self module
+            ModuleHandle {
+                address: AddressIdentifierIndex(0),
+                name: IdentifierIndex(0),
+            },
+            // other module
+            ModuleHandle {
+                address: AddressIdentifierIndex(0),
+                name: IdentifierIndex(2),
+            },
+        ],
+        self_module_handle_idx: ModuleHandleIndex(0),
+        identifiers: vec![
+            Identifier::new("Test").unwrap(),    // Module name
+            Identifier::new("test_fn").unwrap(), // test name
+            Identifier::new("M").unwrap(),       // Other Module name
+            Identifier::new("fn").unwrap(),      // Other Function name
+            Identifier::new("g_fn").unwrap(),    // Other Generic function name
+        ],
+        address_identifiers: vec![
+            AccountAddress::ZERO, // Module address
+        ],
+        function_handles: vec![
+            // Self::test_fn()
+            FunctionHandle {
+                module: ModuleHandleIndex(0),
+                name: IdentifierIndex(1),
+                parameters: SignatureIndex(0),
+                return_: SignatureIndex(0),
+                type_parameters: vec![],
+            },
+            // 0::M::fn()
+            FunctionHandle {
+                module: ModuleHandleIndex(1),
+                name: IdentifierIndex(3),
+                parameters: SignatureIndex(0),
+                return_: SignatureIndex(0),
+                type_parameters: vec![],
+            },
+            // 0::M::g_fn<T>()
+            FunctionHandle {
+                module: ModuleHandleIndex(1),
+                name: IdentifierIndex(4),
+                parameters: SignatureIndex(0),
+                return_: SignatureIndex(0),
+                type_parameters: vec![AbilitySet::EMPTY],
+            },
+        ],
+        // 0::M::g_fn<u64>()
+        function_instantiations: vec![FunctionInstantiation {
+            handle: FunctionHandleIndex(2),
+            type_parameters: SignatureIndex(1),
+        }],
+        function_defs: vec![
+            // fun fn() { return; }
+            FunctionDefinition {
+                function: FunctionHandleIndex(0),
+                visibility: Visibility::Public,
+                is_entry: valid,
+                acquires_global_resources: vec![],
+                code: Some(CodeUnit {
+                    locals: SignatureIndex(0),
+                    code: vec![call, Bytecode::Ret],
+                }),
+            },
+        ],
+        signatures: vec![
+            Signature(vec![]),                    // void
+            Signature(vec![SignatureToken::U64]), // u64
+        ],
+        struct_defs: vec![],
+        struct_handles: vec![],
+        constant_pool: vec![],
+        metadata: vec![],
+        field_handles: vec![],
+        friend_decls: vec![],
+        struct_def_instantiations: vec![],
+        field_instantiations: vec![],
+    };
+    move_bytecode_verifier::verify_module(&m).unwrap();
+    m
+}
+
+fn mk_invoking_script(use_generic: bool) -> CompiledScript {
+    let call = if use_generic {
+        Bytecode::CallGeneric(FunctionInstantiationIndex(0))
+    } else {
+        Bytecode::Call(FunctionHandleIndex(0))
+    };
+    let s = CompiledScript {
+        version: move_binary_format::file_format_common::VERSION_4,
+        module_handles: vec![
+            // other module
+            ModuleHandle {
+                address: AddressIdentifierIndex(0),
+                name: IdentifierIndex(0),
+            },
+        ],
+        identifiers: vec![
+            Identifier::new("M").unwrap(),    // Other Module name
+            Identifier::new("fn").unwrap(),   // Other Function name
+            Identifier::new("g_fn").unwrap(), // Other Generic function name
+        ],
+        address_identifiers: vec![
+            AccountAddress::ZERO, // Module address
+        ],
+        function_handles: vec![
+            // 0::M::fn()
+            FunctionHandle {
+                module: ModuleHandleIndex(0),
+                name: IdentifierIndex(1),
+                parameters: SignatureIndex(0),
+                return_: SignatureIndex(0),
+                type_parameters: vec![],
+            },
+            // 0::M::g_fn<T>()
+            FunctionHandle {
+                module: ModuleHandleIndex(0),
+                name: IdentifierIndex(2),
+                parameters: SignatureIndex(0),
+                return_: SignatureIndex(0),
+                type_parameters: vec![AbilitySet::EMPTY],
+            },
+        ],
+        // 0::M::g_fn<u64>()
+        function_instantiations: vec![FunctionInstantiation {
+            handle: FunctionHandleIndex(1),
+            type_parameters: SignatureIndex(1),
+        }],
+        type_parameters: vec![],
+        parameters: SignatureIndex(0),
+        code: CodeUnit {
+            locals: SignatureIndex(0),
+            code: vec![call, Bytecode::Ret],
+        },
+        signatures: vec![
+            Signature(vec![]),                    // void
+            Signature(vec![SignatureToken::U64]), // u64
+        ],
+        struct_handles: vec![],
+        constant_pool: vec![],
+        metadata: vec![],
+    };
+    move_bytecode_verifier::verify_script(&s).unwrap();
+    s
+}
+
+#[test]
+
+// tests the deprecated Script visibility logic for < V5
+// tests correct permissible invocation of Script functions
+fn deprecated_script_visibility_checks_valid() {
+    let script_function_module = mk_script_function_module();
+    let deps = &[script_function_module];
+
+    // module uses script functions from script context
+    let is_valid = true;
+    let non_generic_call_mod = mk_invoking_module(false, is_valid);
+    let result = dependencies::verify_module(&non_generic_call_mod, deps);
+    assert!(result.is_ok());
+
+    let generic_call_mod = mk_invoking_module(true, is_valid);
+    let result = dependencies::verify_module(&generic_call_mod, deps);
+    assert!(result.is_ok());
+
+    // script uses script functions
+    let non_generic_call_script = mk_invoking_script(false);
+    let result = dependencies::verify_script(&non_generic_call_script, deps);
+    assert!(result.is_ok());
+
+    let generic_call_script = mk_invoking_script(true);
+    let result = dependencies::verify_script(&generic_call_script, deps);
+    assert!(result.is_ok());
+}
+
+#[test]
+// tests the deprecated Script visibility logic for < V5
+// tests correct non-permissible invocation of Script functions
+fn deprecated_script_visibility_checks_invalid() {
+    let script_function_module = mk_script_function_module();
+    let deps = &[script_function_module];
+
+    // module uses script functions from script context
+    let not_valid = false;
+    let non_generic_call_mod = mk_invoking_module(false, not_valid);
+    let result = dependencies::verify_module(&non_generic_call_mod, deps);
+    assert_eq!(
+        result.unwrap_err().major_status(),
+        StatusCode::CALLED_SCRIPT_VISIBLE_FROM_NON_SCRIPT_VISIBLE,
+    );
+
+    let generic_call_mod = mk_invoking_module(true, not_valid);
+    let result = dependencies::verify_module(&generic_call_mod, deps);
+    assert_eq!(
+        result.unwrap_err().major_status(),
+        StatusCode::CALLED_SCRIPT_VISIBLE_FROM_NON_SCRIPT_VISIBLE,
+    );
+}

--- a/language/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/mod.rs
+++ b/language/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/mod.rs
@@ -7,6 +7,7 @@ pub mod bounds_tests;
 pub mod code_unit_tests;
 pub mod constants_tests;
 pub mod control_flow_tests;
+pub mod dependencies_tests;
 pub mod duplication_tests;
 pub mod generic_ops_tests;
 pub mod multi_pass_tests;

--- a/language/move-bytecode-verifier/src/dependencies.rs
+++ b/language/move-bytecode-verifier/src/dependencies.rs
@@ -560,7 +560,7 @@ fn verify_script_visibility_usage(
                 .at_code_offset(fdef_idx, idx)
                 .with_message(
                     "script-visible functions can only be called from scripts or other \
-                    script-visibile functions"
+                    script-visible functions"
                         .to_string(),
                 ));
             }

--- a/language/move-compiler/src/interface_generator.rs
+++ b/language/move-compiler/src/interface_generator.rs
@@ -220,7 +220,7 @@ fn write_function_def(ctx: &mut Context, fdef: &FunctionDefinition) -> String {
     let return_ = &ctx.module.signature_at(fhandle.return_).0;
     format!(
         "    native {}{}fun {}{}({}){};",
-        write_visibility(fdef.visibility, fdef.is_entry),
+        write_visibility(fdef.visibility),
         if fdef.is_entry { "entry " } else { "" },
         ctx.module.identifier_at(fhandle.name),
         write_fun_type_parameters(&fhandle.type_parameters),
@@ -229,10 +229,9 @@ fn write_function_def(ctx: &mut Context, fdef: &FunctionDefinition) -> String {
     )
 }
 
-fn write_visibility(visibility: Visibility, is_entry: bool) -> String {
+fn write_visibility(visibility: Visibility) -> String {
     match visibility {
         Visibility::Public => "public ",
-        _ if is_entry => panic!("ICE non-public entry functions are not yet supported"),
         Visibility::Friend => "public(friend) ",
         Visibility::Private => "",
     }

--- a/language/move-vm/transactional-tests/tests/module_publishing/republish_module_compatible_add_entry.exp
+++ b/language/move-vm/transactional-tests/tests/module_publishing/republish_module_compatible_add_entry.exp
@@ -1,0 +1,1 @@
+processed 6 tasks

--- a/language/move-vm/transactional-tests/tests/module_publishing/republish_module_compatible_add_entry.mvir
+++ b/language/move-vm/transactional-tests/tests/module_publishing/republish_module_compatible_add_entry.mvir
@@ -1,0 +1,49 @@
+// entry can be added to functions
+
+//# publish
+module 0x42.Priv {
+    foo() {
+    label b0:
+        return;
+    }
+}
+
+//# publish
+module 0x42.Priv {
+    entry foo() {
+    label b0:
+        return;
+    }
+}
+
+//# publish
+module 0x42.Pub {
+    public foo() {
+    label b0:
+        return;
+    }
+}
+
+//# publish
+module 0x42.Pub {
+    public entry foo() {
+    label b0:
+        return;
+    }
+}
+
+//# publish
+module 0x42.Fr {
+    public(friend) foo() {
+    label b0:
+        return;
+    }
+}
+
+//# publish
+module 0x42.Fr {
+    public(friend) entry foo() {
+    label b0:
+        return;
+    }
+}

--- a/language/move-vm/transactional-tests/tests/module_publishing/republish_module_incompatible_entry_removed.exp
+++ b/language/move-vm/transactional-tests/tests/module_publishing/republish_module_incompatible_entry_removed.exp
@@ -1,0 +1,28 @@
+processed 6 tasks
+
+task 1 'publish'. lines 11-17:
+Error: Unable to publish module '00000000000000000000000000000042::Priv'. Got VMError: {
+    major_status: BACKWARD_INCOMPATIBLE_MODULE_UPDATE,
+    sub_status: None,
+    location: undefined,
+    indices: [],
+    offsets: [],
+}
+
+task 3 'publish'. lines 27-33:
+Error: Unable to publish module '00000000000000000000000000000042::Pub'. Got VMError: {
+    major_status: BACKWARD_INCOMPATIBLE_MODULE_UPDATE,
+    sub_status: None,
+    location: undefined,
+    indices: [],
+    offsets: [],
+}
+
+task 5 'publish'. lines 43-49:
+Error: Unable to publish module '00000000000000000000000000000042::Fr'. Got VMError: {
+    major_status: BACKWARD_INCOMPATIBLE_MODULE_UPDATE,
+    sub_status: None,
+    location: undefined,
+    indices: [],
+    offsets: [],
+}

--- a/language/move-vm/transactional-tests/tests/module_publishing/republish_module_incompatible_entry_removed.mvir
+++ b/language/move-vm/transactional-tests/tests/module_publishing/republish_module_incompatible_entry_removed.mvir
@@ -1,0 +1,49 @@
+// entry cannot be removed from functions
+
+//# publish
+module 0x42.Priv {
+    entry foo() {
+    label b0:
+        return;
+    }
+}
+
+//# publish
+module 0x42.Priv {
+    foo() {
+    label b0:
+        return;
+    }
+}
+
+//# publish
+module 0x42.Pub {
+    public entry foo() {
+    label b0:
+        return;
+    }
+}
+
+//# publish
+module 0x42.Pub {
+    public foo() {
+    label b0:
+        return;
+    }
+}
+
+//# publish
+module 0x42.Fr {
+    public(friend) entry foo() {
+    label b0:
+        return;
+    }
+}
+
+//# publish
+module 0x42.Fr {
+    public(friend) foo() {
+    label b0:
+        return;
+    }
+}


### PR DESCRIPTION
- Fix issues where rules were removed for V4

## Motivation

- Preserving these is a pain, but makes upgrades easier
- The changes in #182 made it so you could get inconsistent results on V4 versions of the file format. Where the old software would say no, and the new software would say yes. 

## Test Plan

- Bit of a pain, had to manually construct V4 modules 