### PR TITLE
[async-move] Return extension context in async move execution api.

### DIFF
--- a/language/extensions/async/move-async-vm/src/async_vm.rs
+++ b/language/extensions/async/move-async-vm/src/async_vm.rs
@@ -134,12 +134,12 @@ pub struct AsyncSession<'r, 'l, S> {
 pub type Message = (AccountAddress, u64, Vec<Vec<u8>>);
 
 /// A structure to represent success for the execution of an async session operation.
-#[derive(Debug, Clone)]
-pub struct AsyncSuccess {
+pub struct AsyncSuccess<'r> {
     pub change_set: ChangeSet,
     pub events: Vec<Event>,
     pub messages: Vec<Message>,
     pub gas_used: u64,
+    pub ext: NativeContextExtensions<'r>,
 }
 
 /// A structure to represent failure for the execution of an async session operation.
@@ -150,7 +150,7 @@ pub struct AsyncError {
 }
 
 /// Result type for operations of an AsyncSession.
-pub type AsyncResult = Result<AsyncSuccess, AsyncError>;
+pub type AsyncResult<'r> = Result<AsyncSuccess<'r>, AsyncError>;
 
 impl<'r, 'l, S: MoveResolver> AsyncSession<'r, 'l, S> {
     /// Get the underlying Move VM session.
@@ -166,7 +166,7 @@ impl<'r, 'l, S: MoveResolver> AsyncSession<'r, 'l, S> {
         module_id: &ModuleId,
         actor_addr: AccountAddress,
         gas_status: &mut GasStatus,
-    ) -> AsyncResult {
+    ) -> AsyncResult<'r> {
         let actor = self
             .vm
             .actor_metadata
@@ -235,6 +235,7 @@ impl<'r, 'l, S: MoveResolver> AsyncSession<'r, 'l, S> {
                         events,
                         messages: async_ext.sent,
                         gas_used,
+                        ext: native_extensions,
                     })
                 }
             }
@@ -251,7 +252,7 @@ impl<'r, 'l, S: MoveResolver> AsyncSession<'r, 'l, S> {
         message_hash: u64,
         mut args: Vec<Vec<u8>>,
         gas_status: &mut GasStatus,
-    ) -> AsyncResult {
+    ) -> AsyncResult<'r> {
         // Resolve actor and function which handles the message.
         let (module_id, handler_id) =
             self.vm.message_table.get(&message_hash).ok_or_else(|| {
@@ -327,6 +328,7 @@ impl<'r, 'l, S: MoveResolver> AsyncSession<'r, 'l, S> {
                         events,
                         messages: async_ext.sent,
                         gas_used,
+                        ext: native_extensions,
                     })
                 }
             }
@@ -405,13 +407,14 @@ impl Display for AsyncError {
 
 impl Error for AsyncError {}
 
-impl Display for AsyncSuccess {
+impl<'r> Display for AsyncSuccess<'r> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         let AsyncSuccess {
             change_set,
             events,
             messages,
             gas_used,
+            ext: _,
         } = self;
         write!(f, "change_set: {:?}", change_set)?;
         write!(f, ", events: {:?}", events)?;

--- a/language/extensions/async/move-async-vm/tests/testsuite.rs
+++ b/language/extensions/async/move-async-vm/tests/testsuite.rs
@@ -97,12 +97,12 @@ impl Harness {
                 addr.short_str_lossless(),
                 actor.short_str_lossless()
             ));
-            let result = {
+            {
                 let mut proxy = HarnessProxy { harness: self };
                 let session = self.vm.new_session(addr, 0, &mut proxy);
-                session.new_actor(&actor, addr, &mut gas)
+                let result = session.new_actor(&actor, addr, &mut gas);
+                self.handle_result(&mut mailbox, result);
             };
-            self.handle_result(&mut mailbox, result);
 
             // Put a start message for this actor into the mailbox.
             let entry_point_id = Identifier::from_str("start")?;


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Move Language.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Return the native context in async move's api for better composibility. The goal here is to integrate table extension to async move and the current api is not capable of doing that as native context gets consumed.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?
Yes

## Test Plan

`cargo test`