### PR TITLE
[move-lang] Fix ControlFlowGraph trait

### DIFF
--- a/language/move-binary-format/src/control_flow_graph.rs
+++ b/language/move-binary-format/src/control_flow_graph.rs
@@ -23,7 +23,8 @@ pub trait ControlFlowGraph {
     /// Successors of the block ID in the bytecode vector
     fn successors(&self, block_id: BlockId) -> &Vec<BlockId>;
 
-    fn next_block(&self, block_id: BlockId) -> Option<CodeOffset>;
+    /// Return the next block in traversal order
+    fn next_block(&self, block_id: BlockId) -> Option<BlockId>;
 
     /// Iterator over the indexes of instructions in this block
     fn instr_indexes(&self, block_id: BlockId) -> Box<dyn Iterator<Item = CodeOffset>>;


### PR DESCRIPTION
Fix the signature of `next_block` and add documentation.
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Move Language.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

The `next_block` method returns the block id of the next block to traverse. The current return type however is `CodeOffset`, which is rather confusing.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes.

## Test Plan

Since `pub type BlockId = CodeOffset;`, this change won't affect execution.
