### PR TITLE
fix the wrong logic in VMStatus::status_code()

### DIFF
--- a/language/move-core/types/src/unit_tests/mod.rs
+++ b/language/move-core/types/src/unit_tests/mod.rs
@@ -5,3 +5,4 @@
 mod identifier_test;
 mod language_storage_test;
 mod value_test;
+mod vm_status_test;

--- a/language/move-core/types/src/unit_tests/vm_status_test.rs
+++ b/language/move-core/types/src/unit_tests/vm_status_test.rs
@@ -1,0 +1,14 @@
+// Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    vm_status::{VMStatus, StatusCode},
+};
+
+#[test]
+fn test_stats_code() {
+    let vm_status = VMStatus::Error(StatusCode::OUT_OF_GAS);
+    let code = vm_status.status_code();
+    assert_eq!(code, StatusCode::OUT_OF_GAS);
+}

--- a/language/move-core/types/src/vm_status.rs
+++ b/language/move-core/types/src/vm_status.rs
@@ -130,7 +130,7 @@ impl VMStatus {
                 let code = *code;
                 debug_assert!(code != StatusCode::EXECUTED);
                 debug_assert!(code != StatusCode::ABORTED);
-                debug_assert!(code.status_type() != StatusType::Execution);
+                debug_assert!(code.status_type() == StatusType::Execution);
                 code
             }
         }


### PR DESCRIPTION
fix the wrong logic in VMStatus::status_code()

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Move Language.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

(Write your answer here.)

## Test Plan

unit test case is attached
