### PR TITLE
move-bytecode-verifier: remove the Clone bound for the error type in …

### DIFF
--- a/language/move-bytecode-verifier/src/absint.rs
+++ b/language/move-bytecode-verifier/src/absint.rs
@@ -50,7 +50,7 @@ pub type InvariantMap<State, AnalysisError> =
 /// Auxiliary data can be stored in self.
 pub trait TransferFunctions {
     type State: AbstractDomain;
-    type AnalysisError: Clone;
+    type AnalysisError;
 
     /// Execute local@instr found at index local@index in the current basic block from pre-state
     /// local@pre.


### PR DESCRIPTION
…the TransferFunctions trait

Error types generally do not implement clone.