### PR TITLE
[Move] Fixed symbolication of modules stored in the same file

### DIFF
--- a/language/move-analyzer/tests/symbols/sources/M4.move
+++ b/language/move-analyzer/tests/symbols/sources/M4.move
@@ -49,7 +49,10 @@ module Symbols::M4 {
         tmp
     }
 
+}
 
+module Symbols::M5 {
 
+    const SOME_CONST: u64 = 7;
 
 }


### PR DESCRIPTION
## Motivation

Symbolication support for the language server incorrectly assumed that each module is stored in a separate file. This PR fixes this problem.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes
