### PR TITLE
[stdlib] Bump the version of stdlib to `0.1.1`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2862,7 +2862,7 @@ dependencies = [
 
 [[package]]
 name = "move-stdlib"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "dir-diff",

--- a/language/move-stdlib/Cargo.toml
+++ b/language/move-stdlib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "move-stdlib"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2018"
 authors = ["Diem Association <opensource@diem.com>"]
 description = "Diem stdlib"


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Move Language.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Increment the version number of stdlib to `0.1.1`. This is needed because in a recent change to stdlib, the name of some move files are changed from upper case to lower case. This could incur some unexpected issues on some file systems that don't distinguish between upper case and lower case. Bumping the version will fix this issue partially: for those who uses cargo to bring in dependency, the file path will contain the new `0.1.1` version and would thus be able to distinguish between `move-stdlib-0.1.0/docs/BCS.md` and `move-stdlib-0.1.1/docs/bcs.md`, whereas in the previous case it is not possible for the system to distinguish between `move-stdlib-0.1.0/docs/BCS.md` and `move-stdlib-0.1.0/docs/bcs.md`.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes

## Test Plan

N/A
