### PR TITLE
[ethereum_abi_annotator] Implement an adapter to convert between ethe…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,6 +78,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "739f4a8db6605981345c5654f3a85b056ce52f37a39d34da03f25bf2151ea16e"
 
 [[package]]
+name = "ahash"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43bb833f0bf979d8475d38fbf09ed3b8a55e1885fe93ad3f93239fc6a4f17b98"
+dependencies = [
+ "getrandom 0.2.2",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1779,6 +1790,9 @@ name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+dependencies = [
+ "ahash 0.7.4",
+]
 
 [[package]]
 name = "heck"
@@ -2129,6 +2143,15 @@ checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
  "cfg-if 1.0.0",
  "serde 1.0.130",
+]
+
+[[package]]
+name = "lru"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c84e6fe5655adc6ce00787cf7dcaf8dc4f998a0565d23eafc207a8b08ca3349a"
+dependencies = [
+ "hashbrown 0.11.2",
 ]
 
 [[package]]
@@ -2562,6 +2585,22 @@ dependencies = [
  "ethabi",
  "once_cell",
  "regex",
+ "serde 1.0.130",
+ "serde_json",
+]
+
+[[package]]
+name = "move-ethereum-annotator"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "ethabi",
+ "ethereum-types 0.13.1",
+ "lru",
+ "move-binary-format",
+ "move-core-types",
+ "move-ethereum-abi",
+ "move-vm-runtime",
  "serde 1.0.130",
  "serde_json",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "language/evm/exec-utils",
     "language/evm/extract-ethereum-abi",
     "language/evm/move-ethereum-abi",
+    "language/evm/move-ethereum-annotator",
     "language/evm/move-to-yul",
     "language/extensions/async/move-async-vm",
     "language/extensions/move-table-extension",

--- a/language/evm/move-ethereum-abi/src/abi_signature_type.rs
+++ b/language/evm/move-ethereum-abi/src/abi_signature_type.rs
@@ -4,7 +4,10 @@
 
 // This file defines JSON-ABI types.
 
+use anyhow::anyhow;
+use ethabi::{Event, Function};
 use serde::{Deserialize, Serialize};
+use std::convert::TryFrom;
 
 #[derive(Serialize, Deserialize)]
 pub struct ABIJsonArg {
@@ -29,4 +32,28 @@ pub struct ABIJsonSignature {
     pub state_mutability: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub anonymous: Option<bool>,
+}
+
+impl TryFrom<&ABIJsonSignature> for Function {
+    type Error = anyhow::Error;
+
+    fn try_from(abi: &ABIJsonSignature) -> Result<Function, anyhow::Error> {
+        serde_json::from_str(
+            &serde_json::to_string_pretty(abi)
+                .map_err(|err| anyhow!("Malformed abi: {:?}", err))?,
+        )
+        .map_err(|err| anyhow!("Unable to decode into ethabi::Function: {:?}", err))
+    }
+}
+
+impl TryFrom<&ABIJsonSignature> for Event {
+    type Error = anyhow::Error;
+
+    fn try_from(abi: &ABIJsonSignature) -> Result<Event, anyhow::Error> {
+        serde_json::from_str(
+            &serde_json::to_string_pretty(abi)
+                .map_err(|err| anyhow!("Malformed abi: {:?}", err))?,
+        )
+        .map_err(|err| anyhow!("Unable to decode into ethabi::Function: {:?}", err))
+    }
 }

--- a/language/evm/move-ethereum-annotator/Cargo.toml
+++ b/language/evm/move-ethereum-annotator/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "move-ethereum-annotator"
+version = "0.1.0"
+authors = ["Diem Association <opensource@diem.com>"]
+description = "Annotating Move values by their corresponding ethereum abi."
+publish = false
+edition = "2018"
+license = "Apache-2.0"
+
+[dependencies]
+# external dependencies
+serde = { version = "1.0.124", features = ["derive"] }
+serde_json = "1.0.64"
+move-ethereum-abi = { path = "../move-ethereum-abi" }
+move-core-types = { path = "../../move-core/types" }
+anyhow = "1.0.52"
+ethabi = "17.0.0"
+ethereum-types = "0.13.1"
+move-binary-format = { path = "../../move-binary-format" }
+move-vm-runtime = { path = "../../move-vm/runtime" }
+lru = "0.7.6"
+
+[lib]
+doctest = false
+
+[features]
+address20 = []
+address32 = []
+default = []

--- a/language/evm/move-ethereum-annotator/src/events.rs
+++ b/language/evm/move-ethereum-annotator/src/events.rs
@@ -1,0 +1,95 @@
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    util::{convert_move_value, ModuleCache},
+    LRU_CACHE_SIZE,
+};
+use anyhow::{anyhow, bail, Result};
+use ethabi::{encode, RawLog};
+use ethereum_types::H256;
+use lru::LruCache;
+use move_core_types::value::MoveValue;
+use move_core_types::{
+    effects::Event, language_storage::TypeTag, resolver::MoveResolver, value::MoveTypeLayout,
+};
+use move_vm_runtime::move_vm::MoveVM;
+
+pub struct MoveEventAnnotator<R: MoveResolver> {
+    resolver: R,
+    abi_cache: ModuleCache<R>,
+    layout_cache: LruCache<TypeTag, MoveTypeLayout>,
+}
+
+impl<R: MoveResolver + Clone> MoveEventAnnotator<R> {
+    pub fn new(resolver: R) -> Self {
+        Self {
+            resolver: resolver.clone(),
+            abi_cache: ModuleCache::new(resolver),
+            layout_cache: LruCache::new(LRU_CACHE_SIZE),
+        }
+    }
+
+    pub fn annotate_move_event(&mut self, event: Event) -> Result<RawLog> {
+        let struct_tag = {
+            use TypeTag::*;
+            match &event.2 {
+                Struct(s) => s,
+                Bool | U8 | U64 | U128 | Address | Signer | Vector(_) => {
+                    bail!("Unsupported primitive types")
+                }
+            }
+        };
+
+        let move_value = {
+            if !self.layout_cache.contains(&event.2) {
+                let move_vm = MoveVM::new(vec![].into_iter()).unwrap();
+                let layout = move_vm
+                    .new_session(&self.resolver)
+                    .get_type_layout(&event.2)
+                    .map_err(|err| {
+                        anyhow!("Failed to get layout from type {:?}: {:?}", event.2, err)
+                    })?;
+                self.layout_cache.push(event.2.clone(), layout);
+            }
+            MoveValue::simple_deserialize(
+                event.0.as_slice(),
+                self.layout_cache.get(&event.2).unwrap(),
+            )
+            .map_err(|err| anyhow!("Failed to deserialize move value from events: {:?}", err))?
+        };
+
+        let event_abi = self.abi_cache.get_event(struct_tag)?;
+
+        let tokens = {
+            use MoveValue::*;
+            match move_value {
+                Struct(s) => s
+                    .fields()
+                    .iter()
+                    .map(convert_move_value)
+                    .collect::<Vec<_>>(),
+                U128(_) | U8(_) | U64(_) | Address(_) | Signer(_) | Bool(_) | Vector(_) => {
+                    bail!("Unsupported primitive types")
+                }
+            }
+        };
+
+        if tokens.len() != event_abi.inputs.len() {
+            bail!("Event argument length mismatch")
+        }
+
+        let mut topics = vec![];
+
+        for (token, param) in tokens.iter().zip(event_abi.inputs.iter()) {
+            if param.indexed {
+                topics.push(H256::from_slice(encode(&[token.clone()]).as_slice()));
+            }
+        }
+
+        Ok(RawLog {
+            data: encode(tokens.as_slice()),
+            topics,
+        })
+    }
+}

--- a/language/evm/move-ethereum-annotator/src/functions.rs
+++ b/language/evm/move-ethereum-annotator/src/functions.rs
@@ -1,0 +1,55 @@
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::util::{convert_rlp_value, ModuleCache};
+use anyhow::{anyhow, bail, Result};
+use move_core_types::{
+    identifier::Identifier, language_storage::ModuleId, resolver::ModuleResolver,
+};
+
+pub struct FunctionCallAnnotator<R: ModuleResolver>(ModuleCache<R>);
+
+pub struct MoveCall {
+    pub module_id: ModuleId,
+    pub function_name: Identifier,
+    pub data: Vec<Vec<u8>>,
+}
+
+impl<R: ModuleResolver> FunctionCallAnnotator<R> {
+    pub fn new(resolver: R) -> Self {
+        Self(ModuleCache::new(resolver))
+    }
+
+    pub fn annotate_eth_call(
+        &mut self,
+        module_id: &ModuleId,
+        call_data: &[u8],
+    ) -> Result<MoveCall> {
+        if call_data.len() < 4 {
+            bail!("Call data needs at least 4 bytes for the selector")
+        }
+
+        let mut selector: [u8; 4] = [0; 4];
+        selector.copy_from_slice(&call_data[0..4]);
+
+        let (function_name, func_sig) = self.0.get_function(module_id, selector)?;
+
+        let tokens = func_sig
+            .decode_input(&call_data[4..])
+            .map_err(|err| anyhow!("Failed to decode from ethereum input: {:?}", err))?;
+
+        let mut data = vec![];
+        for token in tokens {
+            let move_value = convert_rlp_value(&token)?
+                .simple_serialize()
+                .ok_or_else(|| anyhow!("Failed to serialize Move value"))?;
+            data.push(move_value);
+        }
+
+        Ok(MoveCall {
+            module_id: module_id.clone(),
+            function_name,
+            data,
+        })
+    }
+}

--- a/language/evm/move-ethereum-annotator/src/lib.rs
+++ b/language/evm/move-ethereum-annotator/src/lib.rs
@@ -1,0 +1,12 @@
+// Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+mod events;
+mod functions;
+mod util;
+
+pub use events::MoveEventAnnotator;
+pub use functions::{MoveCall, FunctionCallAnnotator};
+
+const LRU_CACHE_SIZE: usize = 1_000;

--- a/language/evm/move-ethereum-annotator/src/lib.rs
+++ b/language/evm/move-ethereum-annotator/src/lib.rs
@@ -7,6 +7,6 @@ mod functions;
 mod util;
 
 pub use events::MoveEventAnnotator;
-pub use functions::{MoveCall, FunctionCallAnnotator};
+pub use functions::{FunctionCallAnnotator, MoveCall};
 
 const LRU_CACHE_SIZE: usize = 1_000;

--- a/language/evm/move-ethereum-annotator/src/util.rs
+++ b/language/evm/move-ethereum-annotator/src/util.rs
@@ -1,0 +1,180 @@
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::LRU_CACHE_SIZE;
+use anyhow::{anyhow, bail, Result};
+use ethabi::{Event, Function, Token};
+use ethereum_types::U256;
+use lru::LruCache;
+use move_binary_format::CompiledModule;
+use move_core_types::{
+    account_address::AccountAddress,
+    identifier::Identifier,
+    language_storage::{ModuleId, StructTag},
+    resolver::ModuleResolver,
+    value::MoveValue,
+};
+use move_ethereum_abi::abi_move_type::{ABIMoveSignature, ABI_ETHER_MOVE_KEY};
+use std::{collections::HashMap, convert::TryFrom, str::FromStr};
+
+pub(crate) struct ModuleCache<R: ModuleResolver> {
+    resolver: R,
+    cache: LruCache<ModuleId, CacheEntry>,
+    // TODO: Review the selector map's value type. Will function name be sufficient here or could there be hash collision issues?
+    selector_cache: LruCache<[u8; 4], String>,
+}
+
+struct CacheEntry {
+    function_table: HashMap<String, Function>,
+    event_table: HashMap<String, Event>,
+}
+
+impl CacheEntry {
+    pub fn new(abi: &ABIMoveSignature) -> Result<Self> {
+        let mut function_table = HashMap::new();
+        for (func_name, sig) in abi.func_map.iter() {
+            function_table.insert(func_name.clone(), Function::try_from(sig)?);
+        }
+
+        let mut event_table = HashMap::new();
+        for (event_name, sig) in abi.func_map.iter() {
+            event_table.insert(event_name.clone(), Event::try_from(sig)?);
+        }
+
+        Ok(CacheEntry {
+            function_table,
+            event_table,
+        })
+    }
+}
+
+impl<R: ModuleResolver> ModuleCache<R> {
+    pub fn new(resolver: R) -> Self {
+        Self {
+            resolver,
+            cache: LruCache::new(LRU_CACHE_SIZE),
+            selector_cache: LruCache::new(LRU_CACHE_SIZE),
+        }
+    }
+
+    // TODO: Revisit whether to return `Result<Option<&Event>>` instead of a single result.
+    pub fn get_event(&mut self, tag: &StructTag) -> Result<&Event> {
+        let module_id = tag.module_id();
+        if !self.cache.contains(&module_id) {
+            self.fetch_module(&module_id)?;
+        };
+        self.cache
+            .get(&module_id)
+            .unwrap()
+            .event_table
+            .get(tag.name.as_str())
+            .ok_or_else(|| anyhow!("Event name doesn't exist"))
+    }
+
+    pub fn get_function(
+        &mut self,
+        module_id: &ModuleId,
+        function_hash: [u8; 4],
+    ) -> Result<(Identifier, &Function)> {
+        if !self.cache.contains(module_id) || !self.selector_cache.contains(&function_hash) {
+            self.fetch_module(module_id)?;
+        };
+        let entry = self.cache.get(module_id).unwrap();
+        let func_name = self
+            .selector_cache
+            .get(&function_hash)
+            .ok_or_else(|| anyhow!("Selector doesn't exist"))?;
+
+        Ok((
+            Identifier::from_str(func_name.as_str())
+                .map_err(|_| anyhow!("Malformed function name"))?,
+            entry
+                .function_table
+                .get(func_name.as_str())
+                .ok_or_else(|| anyhow!("Function name doesn't exist"))?,
+        ))
+    }
+
+    fn fetch_module(&mut self, module_id: &ModuleId) -> Result<()> {
+        let module_bytes = self
+            .resolver
+            .get_module(module_id)
+            .map_err(|err| anyhow!("Failed to get module: {:?}", err))?
+            .ok_or_else(|| anyhow!("Module not found for: {:?}", module_id))?;
+        let module = CompiledModule::deserialize(module_bytes.as_slice()).map_err(|err| {
+            anyhow!(
+                "Failed to deserialize from bytes for module {:?}: {:?}",
+                module_id,
+                err
+            )
+        })?;
+        let metadata = module
+            .metadata
+            .iter()
+            .find(|metadata| &metadata.key == ABI_ETHER_MOVE_KEY.as_bytes())
+            .ok_or_else(|| anyhow!("Target module doesn't have ethereum abi metadata"))?;
+        let module_abi: ABIMoveSignature =
+            serde_json::from_slice(&metadata.value).map_err(|err| {
+                anyhow!(
+                    "Failed to read ethereum abi for module {:?}: {:?}",
+                    module_id,
+                    err
+                )
+            })?;
+
+        let cache_entry = CacheEntry::new(&module_abi)?;
+        for (func_name, func) in cache_entry.function_table.iter() {
+            self.selector_cache
+                .push(func.short_signature(), func_name.clone());
+        }
+        self.cache.push(module_id.clone(), cache_entry);
+        Ok(())
+    }
+}
+
+pub(crate) fn convert_move_value(v: &MoveValue) -> Token {
+    match v {
+        MoveValue::U8(u) => Token::Uint(U256::from(*u)),
+        MoveValue::U64(u) => Token::Uint(U256::from(*u)),
+        MoveValue::U128(u) => Token::Uint(U256::from(*u)),
+        MoveValue::Bool(b) => Token::Bool(*b),
+        // Move address are converted as U256 as ethereum will encode all U128, U160, U256 as U256 in encoding process.
+        MoveValue::Address(a) => Token::Uint(U256::from(a.as_slice())),
+        MoveValue::Vector(values) => Token::Array(values.iter().map(convert_move_value).collect()),
+        MoveValue::Struct(s) => {
+            Token::FixedArray(s.fields().iter().map(convert_move_value).collect())
+        }
+        MoveValue::Signer(a) => Token::Uint(U256::from(a.as_slice())),
+    }
+}
+
+pub(crate) fn convert_rlp_value(t: &Token) -> Result<MoveValue> {
+    Ok(match t {
+        Token::Address(addr) => MoveValue::Address(
+            if cfg!(feature = "address20") {
+                AccountAddress::from_bytes(addr.as_fixed_bytes())
+            } else if cfg!(feature = "address32") {
+                let mut slice = [0_u8; 32];
+                // Fill the top bytes with zero
+                slice[13..32].copy_from_slice(addr.as_bytes());
+                AccountAddress::from_bytes(slice)
+            } else {
+                // Only take the bottom 16 bytes for Move.
+                AccountAddress::from_bytes(&addr.as_bytes()[5..20])
+            }
+            .unwrap(),
+        ),
+        Token::Array(tokens) => MoveValue::Vector(
+            tokens
+                .iter()
+                .map(convert_rlp_value)
+                .collect::<Result<Vec<_>>>()?,
+        ),
+        Token::Bool(b) => MoveValue::Bool(*b),
+        Token::Bytes(b) => MoveValue::vector_u8(b.to_vec()),
+        Token::FixedBytes(b) => MoveValue::vector_u8(b.to_vec()),
+        Token::String(s) => MoveValue::vector_u8(s.clone().into_bytes()),
+        Token::Uint(u) => MoveValue::U128(u.as_u128()),
+        Token::FixedArray(_) | Token::Int(_) | Token::Tuple(_) => bail!("Unsupported types"),
+    })
+}


### PR DESCRIPTION
…reum encoded data and move encoded data.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Move Language.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Implement an adapter to allow interacting with Move world with ethereum style api. There are two major components:
1. An event annotator. The goal here is to convert the event emitted by MoveVM into log format used in the ethereum ecosystem, including both the encoding and the topic hash.
2. A call data annotator. The goal is to convert an eth call data into parameters into invokations into MoveVM's session and also a function to encode the Move value into ethereum's encoding.

I'll add an example later on how to use those apis. The apis needs a lot more tuning on error propagation. This PR just serves as a proof of concept for now.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes

## Test Plan

Will add an example demonstrating how the annotator should work.
