### PR TITLE
[Move] Added support for go-to-type-def

### DIFF
--- a/language/move-analyzer/src/bin/move-analyzer.rs
+++ b/language/move-analyzer/src/bin/move-analyzer.rs
@@ -9,7 +9,7 @@ use lsp_server::{Connection, Message, Notification, Request, Response};
 use lsp_types::{
     notification::Notification as _, request::Request as _, CompletionOptions, Diagnostic,
     HoverProviderCapability, OneOf, SaveOptions, TextDocumentSyncCapability, TextDocumentSyncKind,
-    TextDocumentSyncOptions, WorkDoneProgressOptions,
+    TextDocumentSyncOptions, TypeDefinitionProviderCapability, WorkDoneProgressOptions,
 };
 use std::{
     collections::BTreeMap,
@@ -94,6 +94,9 @@ fn main() {
             },
         }),
         definition_provider: Some(OneOf::Left(symbols::DEFS_AND_REFS_SUPPORT)),
+        type_definition_provider: Some(TypeDefinitionProviderCapability::Simple(
+            symbols::DEFS_AND_REFS_SUPPORT,
+        )),
         references_provider: Some(OneOf::Left(symbols::DEFS_AND_REFS_SUPPORT)),
         ..Default::default()
     })
@@ -194,6 +197,9 @@ fn on_request(context: &Context, request: &Request) {
         lsp_types::request::Completion::METHOD => on_completion_request(context, request),
         lsp_types::request::GotoDefinition::METHOD => {
             symbols::on_go_to_def_request(context, request, &context.symbols.lock().unwrap());
+        }
+        lsp_types::request::GotoTypeDefinition::METHOD => {
+            symbols::on_go_to_type_def_request(context, request, &context.symbols.lock().unwrap());
         }
         lsp_types::request::References::METHOD => {
             symbols::on_references_request(context, request, &context.symbols.lock().unwrap());

--- a/language/move-analyzer/tests/symbols/sources/M1.move
+++ b/language/move-analyzer/tests/symbols/sources/M1.move
@@ -120,4 +120,17 @@ module Symbols::M1 {
         tmp
     }
 
+    fun struct_param(p: SomeOtherStruct): SomeOtherStruct {
+        p
+    }
+
+    fun struct_var(p: bool): SomeOtherStruct {
+        let tmp = M2::some_other_struct(7);
+        if (p) {
+            tmp
+        } else {
+            M2::some_other_struct(42)
+        }
+    }
+
 }


### PR DESCRIPTION
## Motivation

This is another refinement for the recently added (https://github.com/move-language/move/pull/147) symbolication support in the language server. This PR adds the goto-type-def functionality.

The basic idea is to figure out which struct definition corresponds to a given module_id/struct_name pair and include this data with the symbols information for future retrieval. The data needed to find the right data was already being computed - this PR simply takes advantage of its existence.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes
