### PR TITLE
[move-prover] add all touched addresses for quantifiers

### DIFF
--- a/language/move-prover/interpreter-testsuite/tests/concrete_check/property/arithmetics.exp
+++ b/language/move-prover/interpreter-testsuite/tests/concrete_check/property/arithmetics.exp
@@ -8,7 +8,7 @@ Test failures:
 Failures in 0x2::A:
 
 ┌── check_arithmetics_div0 ──────
-│ error: failed to evaluate expression
+│ error: failed to evaluate expression: unexpected error code
 │    ┌─ tests/concrete_check/property/arithmetics.move:17:20
 │    │
 │ 17 │             assert 5 / 0 == 1;
@@ -19,7 +19,7 @@ Failures in 0x2::A:
 
 
 ┌── check_arithmetics_mod0 ──────
-│ error: failed to evaluate expression
+│ error: failed to evaluate expression: unexpected error code
 │    ┌─ tests/concrete_check/property/arithmetics.move:24:20
 │    │
 │ 24 │             assert 5 % 0 == 1;

--- a/language/move-prover/interpreter-testsuite/tests/concrete_check/property/global_basics.exp
+++ b/language/move-prover/interpreter-testsuite/tests/concrete_check/property/global_basics.exp
@@ -7,7 +7,7 @@ Test failures:
 Failures in 0x2::A:
 
 ┌── check_global_basics_fail ──────
-│ error: failed to evaluate expression
+│ error: failed to evaluate expression: unexpected error code
 │    ┌─ tests/concrete_check/property/global_basics.move:28:20
 │    │
 │ 28 │             assert global<R>(a).f2 == 42;

--- a/language/move-prover/interpreter-testsuite/tests/concrete_check/quantifier.exp
+++ b/language/move-prover/interpreter-testsuite/tests/concrete_check/quantifier.exp
@@ -8,41 +8,41 @@ Test failures:
 Failures in 0x2::A:
 
 ┌── init_vector_failure ──────
-│ error: failed to evaluate expression: failed to enumerate non-address type domain
+│ error: failed to evaluate expression: enumeration of a non-address type domain is not supported
 │    ┌─ tests/concrete_check/quantifier.move:43:27
 │    │
-│ 43 │         ensures exists i: u64 where (i == len(result)-1): result[i] == 1;
+│ 43 │         ensures exists i: u64 where (i == len(result) - 1): result[i] == 1;
 │    │                           ^^^
 │
-│ error: property does not hold
+│ error: failed to evaluate expression: unexpected error code
 │    ┌─ tests/concrete_check/quantifier.move:43:17
 │    │
-│ 43 │         ensures exists i: u64 where (i == len(result)-1): result[i] == 1;
-│    │                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+│ 43 │         ensures exists i: u64 where (i == len(result) - 1): result[i] == 1;
+│    │                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 │
-│ error: failed to evaluate expression: failed to enumerate non-address type domain
+│ error: failed to evaluate expression: enumeration of a non-address type domain is not supported
 │    ┌─ tests/concrete_check/quantifier.move:44:27
 │    │
-│ 44 │         ensures exists i: u64: (i == len(result)-1) ==> result[i] == 1;
+│ 44 │         ensures exists i: u64: (i == len(result) - 1) ==> result[i] == 1;
 │    │                           ^^^
 │
-│ error: property does not hold
+│ error: failed to evaluate expression: unexpected error code
 │    ┌─ tests/concrete_check/quantifier.move:44:17
 │    │
-│ 44 │         ensures exists i: u64: (i == len(result)-1) ==> result[i] == 1;
-│    │                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+│ 44 │         ensures exists i: u64: (i == len(result) - 1) ==> result[i] == 1;
+│    │                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 │
-│ error: failed to evaluate expression: failed to enumerate non-address type domain
+│ error: failed to evaluate expression: enumeration of a non-address type domain is not supported
 │    ┌─ tests/concrete_check/quantifier.move:45:27
 │    │
-│ 45 │         ensures exists i: u64 : result[i] == 1;
+│ 45 │         ensures exists i: u64: result[i] == 1;
 │    │                           ^^^
 │
-│ error: property does not hold
+│ error: failed to evaluate expression: unexpected error code
 │    ┌─ tests/concrete_check/quantifier.move:45:17
 │    │
-│ 45 │         ensures exists i: u64 : result[i] == 1;
-│    │                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+│ 45 │         ensures exists i: u64: result[i] == 1;
+│    │                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 │
 │
 └──────────────────

--- a/language/move-prover/interpreter-testsuite/tests/concrete_check/quantifier.move
+++ b/language/move-prover/interpreter-testsuite/tests/concrete_check/quantifier.move
@@ -40,8 +40,8 @@ module 0x2::A {
     }
 
     spec init_vector_failure {
-        ensures exists i: u64 where (i == len(result)-1): result[i] == 1;
-        ensures exists i: u64: (i == len(result)-1) ==> result[i] == 1;
-        ensures exists i: u64 : result[i] == 1;
+        ensures exists i: u64 where (i == len(result) - 1): result[i] == 1;
+        ensures exists i: u64: (i == len(result) - 1) ==> result[i] == 1;
+        ensures exists i: u64: result[i] == 1;
     }
 }

--- a/language/move-prover/interpreter/src/concrete/evaluator.rs
+++ b/language/move-prover/interpreter/src/concrete/evaluator.rs
@@ -134,7 +134,7 @@ impl<'env> Evaluator<'env> {
                 if err == BigInt::zero() {
                     return;
                 }
-                self.record_evaluation_failure(exp, err);
+                self.record_evaluation_failure(exp, "unexpected error code");
             }
         }
     }
@@ -599,7 +599,7 @@ impl<'env> Evaluator<'env> {
             }
             // case: type domain
             ExpData::Call(node_id, Operation::TypeDomain, _) => match env.get_node_type(*node_id) {
-                MTy::Type::TypeDomain(ty) => self.unroll_type_domain(&ty),
+                MTy::Type::TypeDomain(ty) => self.unroll_type_domain(&ty, exp)?,
                 _ => unreachable!(),
             },
             // case: resource domain
@@ -1143,7 +1143,7 @@ impl<'env> Evaluator<'env> {
             None => {
                 match self
                     .global_state
-                    .get_resource(Some(true), addr, struct_inst)
+                    .get_resource_for_spec(Some(true), addr, struct_inst)
                 {
                     None => {
                         return Err(Self::eval_failure_code());
@@ -1244,15 +1244,22 @@ impl<'env> Evaluator<'env> {
         Ok(range)
     }
 
-    fn unroll_type_domain(&self, ty: &MTy::Type) -> Vec<BaseValue> {
+    fn unroll_type_domain(&self, ty: &MTy::Type, exp: &Exp) -> EvalResult<Vec<BaseValue>> {
         match ty {
-            MTy::Type::Primitive(MTy::PrimitiveType::Address) => self
+            MTy::Type::Primitive(MTy::PrimitiveType::Address) => Ok(self
                 .eval_state
                 .all_addresses()
                 .into_iter()
+                .chain(self.global_state.get_touched_addresses().iter().copied())
                 .map(BaseValue::Address)
-                .collect(),
-            _ => unreachable!(),
+                .collect()),
+            _ => {
+                self.record_evaluation_failure(
+                    exp,
+                    "enumeration of a non-address type domain is not supported",
+                );
+                Err(Self::eval_failure_code())
+            }
         }
     }
 
@@ -1268,10 +1275,10 @@ impl<'env> Evaluator<'env> {
     // utilities
     //
 
-    fn record_evaluation_failure(&self, exp: &Exp, _err: BigInt) {
+    fn record_evaluation_failure(&self, exp: &Exp, msg: &str) {
         let env = self.target.global_env();
         let loc = env.get_node_loc(exp.node_id());
-        env.error(&loc, "failed to evaluate expression");
+        env.error(&loc, &format!("failed to evaluate expression: {}", msg));
     }
 
     fn record_checking_failure(&self, exp: &Exp) {

--- a/language/move-prover/interpreter/src/concrete/player.rs
+++ b/language/move-prover/interpreter/src/concrete/player.rs
@@ -1100,7 +1100,7 @@ impl<'env> FunctionContext<'env> {
         let env = self.target.global_env();
         let inst = convert_model_struct_type(env, module_id, struct_id, ty_args, &self.ty_args);
         let addr = op_addr.into_address();
-        match global_state.get_resource(None, addr, inst) {
+        match global_state.get_resource_for_code(None, addr, inst) {
             None => Err(self.sys_abort(StatusCode::MISSING_DATA)),
             Some(object) => Ok(object),
         }
@@ -1118,7 +1118,7 @@ impl<'env> FunctionContext<'env> {
         let env = self.target.global_env();
         let inst = convert_model_struct_type(env, module_id, struct_id, ty_args, &self.ty_args);
         let addr = op_addr.into_address();
-        match global_state.get_resource(Some(is_mut), addr, inst) {
+        match global_state.get_resource_for_code(Some(is_mut), addr, inst) {
             None => Err(self.sys_abort(StatusCode::MISSING_DATA)),
             Some(object) => Ok(object),
         }


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Move Language.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

- Record all the addresses touched by bytecode in a set and use it when unrolling address domain when determining the range of quantifiers
- Instead of aborting at `unreachable`, log error message on the console when the range is non-address type

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes.

## Test Plan

New unit tests added for the changes, which is covered in CI already.