### PR TITLE
[Move] Added Move analyzer's support for multi-root workspaces

### DIFF
--- a/language/move-analyzer/src/bin/move-analyzer.rs
+++ b/language/move-analyzer/src/bin/move-analyzer.rs
@@ -113,14 +113,13 @@ fn main() {
     let (diag_sender, diag_receiver) = bounded::<Result<BTreeMap<Symbol, Vec<Diagnostic>>>>(0);
     let mut symbolicator_runner = symbols::SymbolicatorRunner::idle();
     if symbols::DEFS_AND_REFS_SUPPORT {
+        symbolicator_runner =
+            symbols::SymbolicatorRunner::new(context.symbols.clone(), diag_sender);
         if let Some(uri) = initialize_params.root_uri {
-            symbolicator_runner =
-                symbols::SymbolicatorRunner::new(context.symbols.clone(), diag_sender);
-            symbolicator_runner.run(uri.to_file_path().ok());
+            symbolicator_runner.run(uri.path());
         }
     };
 
-    let mut missing_manifest_reported = false;
     loop {
         select! {
             recv(diag_receiver) -> message => {
@@ -143,23 +142,17 @@ fn main() {
                             Err(err) => {
                                 let typ = lsp_types::MessageType::Error;
                                 let message = format!("{err}");
-                                let missing_manifest = message.starts_with("Unable to find package manifest");
-                                if !missing_manifest || !missing_manifest_reported {
                                     // report missing manifest only once to avoid re-generating
                                     // user-visible error in cases when the developer decides to
                                     // keep editing a file that does not belong to a packages
                                     let params = lsp_types::ShowMessageParams { typ, message };
-                                    let notification = Notification::new(lsp_types::notification::ShowMessage::METHOD.to_string(), params);
-                                    if let Err(err) = context
-                                        .connection
-                                        .sender
-                                        .send(lsp_server::Message::Notification(notification)) {
-                                            eprintln!("could not send compiler error response: {:?}", err);
-                                        };
-                                }
-                                if missing_manifest {
-                                    missing_manifest_reported = true;
-                                }
+                                let notification = Notification::new(lsp_types::notification::ShowMessage::METHOD.to_string(), params);
+                                if let Err(err) = context
+                                    .connection
+                                    .sender
+                                    .send(lsp_server::Message::Notification(notification)) {
+                                        eprintln!("could not send compiler error response: {:?}", err);
+                                    };
                             },
                         }
                     },

--- a/language/move-analyzer/src/bin/move-analyzer.rs
+++ b/language/move-analyzer/src/bin/move-analyzer.rs
@@ -115,8 +115,8 @@ fn main() {
     if symbols::DEFS_AND_REFS_SUPPORT {
         if let Some(uri) = initialize_params.root_uri {
             symbolicator_runner =
-                symbols::SymbolicatorRunner::new(&uri, context.symbols.clone(), diag_sender);
-            symbolicator_runner.run();
+                symbols::SymbolicatorRunner::new(context.symbols.clone(), diag_sender);
+            symbolicator_runner.run(uri.to_file_path().ok());
         }
     };
 

--- a/language/move-analyzer/src/symbols.rs
+++ b/language/move-analyzer/src/symbols.rs
@@ -523,7 +523,12 @@ impl UseDefMap {
 
 impl Symbols {
     fn merge(&mut self, other: Self) {
-        self.references.extend(other.references);
+        for (k, v) in other.references {
+            self.references
+                .entry(k)
+                .or_insert_with(BTreeSet::new)
+                .extend(v);
+        }
         self.file_use_defs.extend(other.file_use_defs);
         self.file_name_mapping.extend(other.file_name_mapping);
     }

--- a/language/move-analyzer/src/vfs.rs
+++ b/language/move-analyzer/src/vfs.rs
@@ -15,7 +15,6 @@ use lsp_types::{
     notification::Notification as _, DidChangeTextDocumentParams, DidCloseTextDocumentParams,
     DidOpenTextDocumentParams, DidSaveTextDocumentParams,
 };
-use std::path::{Path, PathBuf};
 
 use crate::symbols;
 
@@ -65,7 +64,7 @@ pub fn on_text_document_sync_notification(
                 parameters.text_document.uri.path(),
                 &parameters.text_document.text,
             );
-            symbolicator_runner.run(root_dir(parameters.text_document.uri.path()));
+            symbolicator_runner.run(parameters.text_document.uri.path());
         }
         lsp_types::notification::DidChangeTextDocument::METHOD => {
             let parameters =
@@ -84,7 +83,7 @@ pub fn on_text_document_sync_notification(
                 parameters.text_document.uri.path(),
                 &parameters.text.unwrap(),
             );
-            symbolicator_runner.run(root_dir(parameters.text_document.uri.path()));
+            symbolicator_runner.run(parameters.text_document.uri.path());
         }
         lsp_types::notification::DidCloseTextDocument::METHOD => {
             let parameters =
@@ -95,21 +94,4 @@ pub fn on_text_document_sync_notification(
         _ => eprintln!("invalid notification '{}'", notification.method),
     }
     eprintln!("text document notification handled");
-}
-
-/// Returns a path to a directory containing Move.toml file corresponding to the Move source file
-/// passed as argument or None if no such directory can be found.
-/// is located.
-fn root_dir(move_file_path: &str) -> Option<PathBuf> {
-    let p = Path::new(move_file_path);
-    let mut parent_opt = p.parent();
-    while parent_opt.is_some() {
-        let parent_path = parent_opt.unwrap();
-        let manifest_path = parent_path.join("Move.toml");
-        if manifest_path.is_file() {
-            return Some(manifest_path);
-        }
-        parent_opt = parent_path.parent();
-    }
-    None
 }


### PR DESCRIPTION
## Motivation

This is another language server enhancement, this time related to supporting multi-root workspaces. This PR not only adds support for opening multiple directories within a workspace but also adds support for manifest file searching in case a single Move source file is open. 

The implementation is fairly straightforward - instead of replacing existing symbolication information, augment it with additional symbols coming from additional files/directories being opened.

This PR also implements discovery of manifest files in case a Move source file is opened rather than a package directory. Previously, if the former has happened, the new features would not be available as the language server did not know where to find Move.toml file needed for compilation.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes
