### PR TITLE
Aw/missing manifest fix

### DIFF
--- a/language/move-analyzer/src/bin/move-analyzer.rs
+++ b/language/move-analyzer/src/bin/move-analyzer.rs
@@ -115,9 +115,6 @@ fn main() {
     if symbols::DEFS_AND_REFS_SUPPORT {
         symbolicator_runner =
             symbols::SymbolicatorRunner::new(context.symbols.clone(), diag_sender);
-        if let Some(uri) = initialize_params.root_uri {
-            symbolicator_runner.run(uri.path());
-        }
     };
 
     loop {

--- a/language/move-analyzer/src/symbols.rs
+++ b/language/move-analyzer/src/symbols.rs
@@ -431,6 +431,7 @@ impl SymbolicatorRunner {
         cvar.notify_one();
     }
 
+    /// Finds manifest file in a subdirectory of a Move source file passed as argument
     fn root_dir(starting_path: &Path) -> Option<PathBuf> {
         eprintln!("Looking for manifest file");
         let mut current_path_opt = Some(starting_path);

--- a/language/move-analyzer/src/symbols.rs
+++ b/language/move-analyzer/src/symbols.rs
@@ -432,15 +432,19 @@ impl SymbolicatorRunner {
     }
 
     fn root_dir(starting_path: &Path) -> Option<PathBuf> {
+        eprintln!("Looking for manifest file");
         let mut current_path_opt = Some(starting_path);
         while current_path_opt.is_some() {
             let current_path = current_path_opt.unwrap();
+            eprintln!("Current manifest file search path: {:?}", current_path);
             let manifest_path = current_path.join("Move.toml");
             if manifest_path.is_file() {
+                eprintln!("Found manifest file path: {:?}", current_path);
                 return Some(current_path.to_path_buf());
             }
             current_path_opt = current_path.parent();
         }
+        eprintln!("Did not find manifest file path");
         None
     }
 }


### PR DESCRIPTION
## Motivation

This PR modifies the time when a manifest file is being located by the language server. Previously finding manifest file was attempted at upon two different events:
- when the first root directory was opened in the IDE
- when a Move source file was opened in the IDE

The first one is not only redundant (as opening a directory without opening a Move source file is basically a no-op) but also may lead to a confusion - for example if a user opens a root directory of a repo containing multiple Move packages/projects, they will get an error as the manifest file in this case will not be found in a parent directory of the repository root (and even if some manifest file is found, it will be most likely an incorrect one). This very problem was reported by @emmazzz 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes
