### PR TITLE
[Move analyzer] Added a more meaningful missing manifest message

### DIFF
--- a/language/move-analyzer/src/symbols.rs
+++ b/language/move-analyzer/src/symbols.rs
@@ -373,9 +373,11 @@ impl SymbolicatorRunner {
                         // cases when developer indeed intended to open a standalone file that was
                         // not meant to compile
                         missing_manifests.insert(starting_path);
-                        if let Err(err) =
-                            sender.send(Err(anyhow!("Unable to find package manifest")))
-                        {
+                        if let Err(err) = sender.send(Err(anyhow!(
+                            "Unable to find package manifest. Make sure that
+                            the source files are located in a sub-directory of a package containing
+                            a Move.toml file. "
+                        ))) {
                             eprintln!("could not pass missing manifest error: {:?}", err);
                         }
                         continue;


### PR DESCRIPTION
## Motivation

A missing manifest message should be more meaningful to allow developers to act on it more easily. 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes
