### PR TITLE
[book] Added book.toml for better GitHub integration

### DIFF
--- a/language/documentation/book/book.toml
+++ b/language/documentation/book/book.toml
@@ -1,0 +1,12 @@
+[book]
+title = "The Move Book"
+description = "Move book maintained by the Move core team."
+authors = ["The Move Contributors"]
+language = "en"
+multilingual = false
+src = "src"
+
+[output.html]
+git-repository-url = "https://github.com/move-language/move"
+git-repository-icon = "fa-github"
+edit-url-template = "https://github.com/move-language/move/edit/main/language/documentation/book/{path}"


### PR DESCRIPTION
Added book.toml for better integration with our GitHub repository.
The GitHub edit button hopefully encourages people to contribute.

Also added structured metadata such as name, description, language and author information.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Move Language.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

GitHub edit button was missing.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes.

## Test Plan

```
cd ./language/documentation/book
mdbook serve --open
```