### PR TITLE
[github] Automatically generate the Book

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -272,3 +272,26 @@ jobs:
         run: |
           cd ./language/documentation/tutorial/step_1/BasicCoin
           docker run -v `pwd`:/project move/cli build
+
+  generate-documentation:
+    name: Generate the Move Book using mdBook
+    runs-on: ubuntu-20.04
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup mdBook
+        uses: peaceiris/actions-mdbook@v1
+        with:
+          mdbook-version: '0.4.10'
+          # mdbook-version: 'latest'
+
+      - run: mdbook build language/documentation/book
+
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        if: ${{ github.ref == 'refs/heads/main' }}
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./language/documentation/book/book

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: ci-test
+name: ci
 
 on:
   push:
@@ -21,7 +21,7 @@ jobs:
         name: determine changes
         uses: diem/actions/changes@faadd16607b77dfa2231a8f366883e01717b3225
         with:
-          workflow-file: ci-test.yml
+          workflow-file: ci.yml
           github-token: ${{secrets.GITHUB_TOKEN}}
       - id: any-changes-found
         name: determine if there are any files listed in the CHANGES_CHANGED_FILE_OUTPUTFILE.


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Move Language.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

 * **Adding book generation:** now generating the Move Book automatically. Last time the gh-pages branch was updated was December 2021. Gh-pages is the branch served online. The book is generated and pushed to the gh-pages only when the PR lands to main. For PRs themselves, only plain generation takes place in order to spot errors.

 * **Renamed ci-test.yml to ci.yml:** nowadays these tasks are more than just CI tests, they manage a wide variety of tests and generation tasks, implementing continuous integration in general.

## Motivation

The Move Book wasn't generated automatically to the `gh-pages` branch in order to be served at https://move-language.github.io/move/.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

(Write your answer here.)

## Test Plan

Test PR: https://github.com/villesundell/move/pull/2