### PR TITLE
[move-analyzer] Improve support for Move doc comments

### DIFF
--- a/language/move-analyzer/editors/code/src/context.ts
+++ b/language/move-analyzer/editors/code/src/context.ts
@@ -59,23 +59,23 @@ export class Context {
      * [2]: https://github.com/rust-lang/vscode-rust/blob/660b412701fe2ea62fad180c40ee4f8a60571c61/src/extension.ts#L287:L287
      */
     configureLanguage(): void {
-      const disposable = vscode.languages.setLanguageConfiguration('move', {
-        onEnterRules: [
-          {
-            // Doc single-line comment
-            // e.g. ///|
-            beforeText: /^\s*\/{3}.*$/,
-            action: { indentAction: IndentAction.None, appendText: '/// ' },
-          },
-          {
-            // Parent doc single-line comment
-            // e.g. //!|
-            beforeText: /^\s*\/{2}!.*$/,
-            action: { indentAction: IndentAction.None, appendText: '//! ' },
-          },
-        ],
-      });
-      this.extensionContext.subscriptions.push(disposable);
+        const disposable = vscode.languages.setLanguageConfiguration('move', {
+            onEnterRules: [
+                {
+                    // Doc single-line comment
+                    // e.g. ///|
+                    beforeText: /^\s*\/{3}.*$/,
+                    action: { indentAction: IndentAction.None, appendText: '/// ' },
+                },
+                {
+                    // Parent doc single-line comment
+                    // e.g. //!|
+                    beforeText: /^\s*\/{2}!.*$/,
+                    action: { indentAction: IndentAction.None, appendText: '//! ' },
+                },
+            ],
+        });
+        this.extensionContext.subscriptions.push(disposable);
     }
 
     /**

--- a/language/move-analyzer/editors/code/src/context.ts
+++ b/language/move-analyzer/editors/code/src/context.ts
@@ -7,6 +7,7 @@ import * as vscode from 'vscode';
 import * as lc from 'vscode-languageclient';
 import { log } from './log';
 import { sync as commandExistsSync } from 'command-exists';
+import { IndentAction } from 'vscode';
 
 /** Information passed along to each VS Code command defined by this extension. */
 export class Context {
@@ -46,6 +47,35 @@ export class Context {
             return com;
         });
         this.extensionContext.subscriptions.push(disposable);
+    }
+
+    /**
+     * Sets up additional language configuration that's impossible to do via a
+     * separate language-configuration.json file. See [1] for more information.
+     *
+     * This code originates from [2](vscode-rust).
+     *
+     * [1]: https://github.com/Microsoft/vscode/issues/11514#issuecomment-244707076
+     * [2]: https://github.com/rust-lang/vscode-rust/blob/660b412701fe2ea62fad180c40ee4f8a60571c61/src/extension.ts#L287:L287
+     */
+    configureLanguage(): void {
+      const disposable = vscode.languages.setLanguageConfiguration('move', {
+        onEnterRules: [
+          {
+            // Doc single-line comment
+            // e.g. ///|
+            beforeText: /^\s*\/{3}.*$/,
+            action: { indentAction: IndentAction.None, appendText: '/// ' },
+          },
+          {
+            // Parent doc single-line comment
+            // e.g. //!|
+            beforeText: /^\s*\/{2}!.*$/,
+            action: { indentAction: IndentAction.None, appendText: '//! ' },
+          },
+        ],
+      });
+      this.extensionContext.subscriptions.push(disposable);
     }
 
     /**

--- a/language/move-analyzer/editors/code/src/main.ts
+++ b/language/move-analyzer/editors/code/src/main.ts
@@ -62,6 +62,9 @@ export function activate(extensionContext: Readonly<vscode.ExtensionContext>): v
     // Register handlers for VS Code commands that the user explicitly issues.
     context.registerCommand('serverVersion', serverVersion);
 
+    // Configure other language features.
+    context.configureLanguage();
+
     // All other utilities provided by this extension occur via the language server.
     context.startClient();
 }


### PR DESCRIPTION
## Motivation

Annoying to write doc strings

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes

## Test Plan

Ran the extension locally