### PR TITLE
[move-prover] print new values of havocked variables in error trace (…

### DIFF
--- a/language/move-prover/boogie-backend/src/boogie_wrapper.rs
+++ b/language/move-prover/boogie-backend/src/boogie_wrapper.rs
@@ -97,6 +97,7 @@ pub enum TraceEntry {
     Exp(NodeId, ModelValue),
     SubExp(NodeId, ModelValue),
     GlobalMem(NodeId, ModelValue),
+    InfoLine(String),
 }
 
 // Error message matching
@@ -385,6 +386,10 @@ impl<'env> BoogieWrapper<'env> {
                             }
                         }
                     }
+                    InfoLine(info_line) => {
+                        // information that should be displayed to the user
+                        display.push(format!("    {}", info_line));
+                    }
                     _ => {}
                 }
             }
@@ -649,6 +654,10 @@ impl<'env> BoogieWrapper<'env> {
                 let value = self.extract_value(value)?;
                 Ok(TraceEntry::GlobalMem(node_id, value))
             }
+            "info" => match value {
+                Some(info_line) => Ok(TraceEntry::InfoLine(info_line.trim().to_string())),
+                None => Ok(TraceEntry::InfoLine("".to_string())),
+            },
             _ => Err(ModelParseError::new(&format!(
                 "unrecognized augmented trace entry `{}`",
                 name

--- a/language/move-prover/boogie-backend/src/bytecode_translator.rs
+++ b/language/move-prover/boogie-backend/src/bytecode_translator.rs
@@ -728,7 +728,17 @@ impl<'env> FunctionTranslator<'env> {
 
         // Print debug comments.
         if let Some(comment) = fun_target.get_debug_comment(attr_id) {
-            emitln!(writer, "// {}", comment);
+            if comment.starts_with("info: ") {
+                // if the comment is annotated with "info: ", it should be displayed to the user
+                emitln!(
+                    writer,
+                    "assume {{:print \"${}(){}\"}} true;",
+                    &comment[..4],
+                    &comment[4..]
+                );
+            } else {
+                emitln!(writer, "// {}", comment);
+            }
         }
 
         // Track location for execution traces.

--- a/language/move-prover/bytecode/src/debug_instrumentation.rs
+++ b/language/move-prover/bytecode/src/debug_instrumentation.rs
@@ -93,7 +93,7 @@ impl FunctionTargetProcessor for DebugInstrumenter {
                     for idx in affected_variables {
                         // Only emit this for user declared locals, not for ones introduced
                         // by stack elimination.
-                        if idx < fun_env.get_local_count() {
+                        if !fun_env.is_temporary(idx) {
                             builder.emit_with(|id| {
                                 Call(id, vec![], Operation::TraceLocal(idx), vec![idx], None)
                             });

--- a/language/move-prover/tests/sources/functional/aborts_if.exp
+++ b/language/move-prover/tests/sources/functional/aborts_if.exp
@@ -63,7 +63,6 @@ error: function does not abort under this condition
     =     at tests/sources/functional/aborts_if.move:145: abort_at_2_or_3_spec_incorrect
     =         x = <redacted>
     =     at tests/sources/functional/aborts_if.move:146: abort_at_2_or_3_spec_incorrect
-    =         <redacted> = <redacted>
     =     at tests/sources/functional/aborts_if.move:147: abort_at_2_or_3_spec_incorrect
     =     at tests/sources/functional/aborts_if.move:151: abort_at_2_or_3_spec_incorrect (spec)
 
@@ -82,8 +81,6 @@ error: abort not covered by any of the `aborts_if` clauses
     =     at tests/sources/functional/aborts_if.move:154: abort_at_2_or_3_strict_incorrect
     =         x = <redacted>
     =     at tests/sources/functional/aborts_if.move:155: abort_at_2_or_3_strict_incorrect
-    =         <redacted> = <redacted>
-    =     at tests/sources/functional/aborts_if.move:155: abort_at_2_or_3_strict_incorrect
     =         ABORTED
 
 error: abort not covered by any of the `aborts_if` clauses
@@ -101,8 +98,6 @@ error: abort not covered by any of the `aborts_if` clauses
     │
     =     at tests/sources/functional/aborts_if.move:136: abort_at_2_or_3_total_incorrect
     =         x = <redacted>
-    =     at tests/sources/functional/aborts_if.move:137: abort_at_2_or_3_total_incorrect
-    =         <redacted> = <redacted>
     =     at tests/sources/functional/aborts_if.move:137: abort_at_2_or_3_total_incorrect
     =         ABORTED
 

--- a/language/move-prover/tests/sources/functional/choice.cvc5_exp
+++ b/language/move-prover/tests/sources/functional/choice.cvc5_exp
@@ -51,7 +51,6 @@ error: post-condition does not hold
    =     at tests/sources/functional/choice.move:16: simple_incorrect
    =         b = <redacted>
    =     at tests/sources/functional/choice.move:17: simple_incorrect
-   =         <redacted> = <redacted>
    =         result = <redacted>
    =     at tests/sources/functional/choice.move:18: simple_incorrect
    =     at tests/sources/functional/choice.move:22: simple_incorrect (spec)

--- a/language/move-prover/tests/sources/functional/choice.exp
+++ b/language/move-prover/tests/sources/functional/choice.exp
@@ -51,7 +51,6 @@ error: post-condition does not hold
    =     at tests/sources/functional/choice.move:16: simple_incorrect
    =         b = <redacted>
    =     at tests/sources/functional/choice.move:17: simple_incorrect
-   =         <redacted> = <redacted>
    =         result = <redacted>
    =     at tests/sources/functional/choice.move:18: simple_incorrect
    =     at tests/sources/functional/choice.move:22: simple_incorrect (spec)

--- a/language/move-prover/tests/sources/functional/invariants.exp
+++ b/language/move-prover/tests/sources/functional/invariants.exp
@@ -49,7 +49,6 @@ error: data invariant does not hold
     =     at tests/sources/functional/invariants.move:143
     =     at tests/sources/functional/invariants.move:158: lifetime_invalid_S_branching
     =         a = <redacted>
-    =         <redacted> = <redacted>
     =         x_ref = <redacted>
     =     at tests/sources/functional/invariants.move:160: lifetime_invalid_S_branching
     =     at tests/sources/functional/invariants.move:143

--- a/language/move-prover/tests/sources/functional/loops.exp
+++ b/language/move-prover/tests/sources/functional/loops.exp
@@ -14,6 +14,9 @@ error: abort not covered by any of the `aborts_if` clauses
    =     at tests/sources/functional/loops.move:77: iter10_abort_incorrect
    =         i = <redacted>
    =     at tests/sources/functional/loops.move:79: iter10_abort_incorrect
+   =     enter loop, variable(s) i havocked and reassigned
+   =         i = <redacted>
+   =     loop invariant holds at current state
    =     at tests/sources/functional/loops.move:80: iter10_abort_incorrect
    =     at tests/sources/functional/loops.move:78: iter10_abort_incorrect
    =     at tests/sources/functional/loops.move:82: iter10_abort_incorrect
@@ -28,6 +31,8 @@ error: unknown assertion failed
     =     at tests/sources/functional/loops.move:233: iter10_assert_instead_of_invariant
     =         i = <redacted>
     =     at tests/sources/functional/loops.move:235: iter10_assert_instead_of_invariant
+    =     enter loop, variable(s) i havocked and reassigned
+    =         i = <redacted>
 
 error: function does not abort under this condition
    ┌─ tests/sources/functional/loops.move:58:9
@@ -38,6 +43,9 @@ error: function does not abort under this condition
    =     at tests/sources/functional/loops.move:48: iter10_no_abort_incorrect
    =         i = <redacted>
    =     at tests/sources/functional/loops.move:50: iter10_no_abort_incorrect
+   =     enter loop, variable(s) i havocked and reassigned
+   =         i = <redacted>
+   =     loop invariant holds at current state
    =     at tests/sources/functional/loops.move:51: iter10_no_abort_incorrect
    =     at tests/sources/functional/loops.move:49: iter10_no_abort_incorrect
    =     at tests/sources/functional/loops.move:58: iter10_no_abort_incorrect (spec)
@@ -67,6 +75,9 @@ error: induction case of the loop invariant does not hold
     =         x = <redacted>
     =     at tests/sources/functional/loops.move:222: loop_invariant_induction_invalid
     =     at tests/sources/functional/loops.move:223: loop_invariant_induction_invalid
+    =     enter loop, variable(s) x havocked and reassigned
+    =         x = <redacted>
+    =     loop invariant holds at current state
     =     at tests/sources/functional/loops.move:225: loop_invariant_induction_invalid
     =     at tests/sources/functional/loops.move:221: loop_invariant_induction_invalid
     =         x = <redacted>
@@ -84,6 +95,10 @@ error: induction case of the loop invariant does not hold
     =     at tests/sources/functional/loops.move:185: loop_with_two_back_edges_incorrect
     =     at tests/sources/functional/loops.move:188: loop_with_two_back_edges_incorrect
     =     at tests/sources/functional/loops.move:189: loop_with_two_back_edges_incorrect
+    =     enter loop, variable(s) x, y havocked and reassigned
+    =         x = <redacted>
+    =         y = <redacted>
+    =     loop invariant holds at current state
     =     at tests/sources/functional/loops.move:191: loop_with_two_back_edges_incorrect
     =         y = <redacted>
     =     at tests/sources/functional/loops.move:193: loop_with_two_back_edges_incorrect
@@ -100,6 +115,9 @@ error: base case of the loop invariant does not hold
     =         y = <redacted>
     =     at tests/sources/functional/loops.move:140: nested_loop_inner_invariant_incorrect
     =     at tests/sources/functional/loops.move:143: nested_loop_inner_invariant_incorrect
+    =     enter loop, variable(s) x, y havocked and reassigned
+    =         x = <redacted>
+    =         y = <redacted>
     =     at tests/sources/functional/loops.move:144: nested_loop_inner_invariant_incorrect
     =     at tests/sources/functional/loops.move:145: nested_loop_inner_invariant_incorrect
 
@@ -114,8 +132,14 @@ error: induction case of the loop invariant does not hold
     =         y = <redacted>
     =     at tests/sources/functional/loops.move:140: nested_loop_inner_invariant_incorrect
     =     at tests/sources/functional/loops.move:143: nested_loop_inner_invariant_incorrect
+    =     enter loop, variable(s) x, y havocked and reassigned
+    =         x = <redacted>
+    =         y = <redacted>
     =     at tests/sources/functional/loops.move:144: nested_loop_inner_invariant_incorrect
     =     at tests/sources/functional/loops.move:145: nested_loop_inner_invariant_incorrect
+    =     enter loop, variable(s) y havocked and reassigned
+    =         y = <redacted>
+    =     loop invariant holds at current state
     =     at tests/sources/functional/loops.move:147: nested_loop_inner_invariant_incorrect
     =         y = <redacted>
     =     at tests/sources/functional/loops.move:145: nested_loop_inner_invariant_incorrect
@@ -132,6 +156,12 @@ error: induction case of the loop invariant does not hold
     =     at tests/sources/functional/loops.move:115: nested_loop_outer_invariant_incorrect
     =     at tests/sources/functional/loops.move:118: nested_loop_outer_invariant_incorrect
     =     at tests/sources/functional/loops.move:119: nested_loop_outer_invariant_incorrect
+    =     enter loop, variable(s) x, y havocked and reassigned
+    =         x = <redacted>
+    =         y = <redacted>
+    =     loop invariant holds at current state
     =     at tests/sources/functional/loops.move:122: nested_loop_outer_invariant_incorrect
+    =     enter loop, variable(s) y havocked and reassigned
+    =         y = <redacted>
     =         x = <redacted>
     =     at tests/sources/functional/loops.move:119: nested_loop_outer_invariant_incorrect

--- a/language/move-prover/tests/sources/functional/loops_with_memory_ops.exp
+++ b/language/move-prover/tests/sources/functional/loops_with_memory_ops.exp
@@ -25,12 +25,24 @@ error: unknown assertion failed
    =     at tests/sources/functional/loops_with_memory_ops.move:68: nested_loop2
    =     at tests/sources/functional/loops_with_memory_ops.move:69: nested_loop2
    =     at tests/sources/functional/loops_with_memory_ops.move:70: nested_loop2
+   =     enter loop, variable(s) a, b, i, x, y havocked and reassigned
+   =         a = <redacted>
+   =         b = <redacted>
+   =         i = <redacted>
+   =         x = <redacted>
+   =         y = <redacted>
+   =     loop invariant holds at current state
    =     at tests/sources/functional/loops_with_memory_ops.move:67: nested_loop2
    =     at tests/sources/functional/loops_with_memory_ops.move:68: nested_loop2
    =     at tests/sources/functional/loops_with_memory_ops.move:69: nested_loop2
    =     at tests/sources/functional/loops_with_memory_ops.move:70: nested_loop2
    =     at tests/sources/functional/loops_with_memory_ops.move:73: nested_loop2
+   =     enter loop, variable(s) x, y havocked and reassigned
+   =         x = <redacted>
+   =         y = <redacted>
    =     at tests/sources/functional/loops_with_memory_ops.move:74: nested_loop2
+   =     enter loop, variable(s) y havocked and reassigned
+   =         y = <redacted>
    =         b = <redacted>
    =         a = <redacted>
    =     at tests/sources/functional/loops_with_memory_ops.move:85: nested_loop2
@@ -64,12 +76,24 @@ error: induction case of the loop invariant does not hold
    =     at tests/sources/functional/loops_with_memory_ops.move:68: nested_loop2
    =     at tests/sources/functional/loops_with_memory_ops.move:69: nested_loop2
    =     at tests/sources/functional/loops_with_memory_ops.move:70: nested_loop2
+   =     enter loop, variable(s) a, b, i, x, y havocked and reassigned
+   =         a = <redacted>
+   =         b = <redacted>
+   =         i = <redacted>
+   =         x = <redacted>
+   =         y = <redacted>
+   =     loop invariant holds at current state
    =     at tests/sources/functional/loops_with_memory_ops.move:67: nested_loop2
    =     at tests/sources/functional/loops_with_memory_ops.move:68: nested_loop2
    =     at tests/sources/functional/loops_with_memory_ops.move:69: nested_loop2
    =     at tests/sources/functional/loops_with_memory_ops.move:70: nested_loop2
    =     at tests/sources/functional/loops_with_memory_ops.move:73: nested_loop2
+   =     enter loop, variable(s) x, y havocked and reassigned
+   =         x = <redacted>
+   =         y = <redacted>
    =     at tests/sources/functional/loops_with_memory_ops.move:74: nested_loop2
+   =     enter loop, variable(s) y havocked and reassigned
+   =         y = <redacted>
    =         b = <redacted>
    =         a = <redacted>
    =     at tests/sources/functional/loops_with_memory_ops.move:85: nested_loop2

--- a/language/move-prover/tests/sources/functional/macro_verification.exp
+++ b/language/move-prover/tests/sources/functional/macro_verification.exp
@@ -22,7 +22,11 @@ error: post-condition does not hold
    =         `invariant forall j in 0..i: v[j] == old(v)[j] + 1;` = <redacted>
    =     at tests/sources/functional/macro_verification.move:26: foreach
    =         `invariant forall j in i..len(v): v[j] == old(v)[j];` = <redacted>
+   =     enter loop, variable(s) v, i havocked and reassigned
+   =         v = <redacted>
+   =         i = <redacted>
    =         `invariant forall j in i..len(v): v[j] == old(v)[j];` = <redacted>
+   =     loop invariant holds at current state
    =     at tests/sources/functional/macro_verification.move:23: foreach
    =         `invariant i >= 0 && i <= len(v);` = <redacted>
    =     at tests/sources/functional/macro_verification.move:24: foreach
@@ -62,7 +66,11 @@ error: post-condition does not hold
    =         `invariant i >= 0 && i <= len(v);` = <redacted>
    =     at tests/sources/functional/macro_verification.move:50: reduce
    =         `invariant sum == spec_sum(v, i);` = <redacted>
+   =     enter loop, variable(s) i, sum havocked and reassigned
+   =         i = <redacted>
+   =         sum = <redacted>
    =         `invariant sum == spec_sum(v, i);` = <redacted>
+   =     loop invariant holds at current state
    =     at tests/sources/functional/macro_verification.move:49: reduce
    =         `invariant i >= 0 && i <= len(v);` = <redacted>
    =     at tests/sources/functional/macro_verification.move:50: reduce
@@ -108,6 +116,10 @@ error: post-condition does not hold
    =     at tests/sources/functional/macro_verification.move:48: reduce
    =     at tests/sources/functional/macro_verification.move:49: reduce
    =     at tests/sources/functional/macro_verification.move:50: reduce
+   =     enter loop, variable(s) i, sum havocked and reassigned
+   =         i = <redacted>
+   =         sum = <redacted>
+   =     loop invariant holds at current state
    =     at tests/sources/functional/macro_verification.move:49: reduce
    =     at tests/sources/functional/macro_verification.move:50: reduce
    =     at tests/sources/functional/macro_verification.move:43: reduce

--- a/language/move-prover/tests/sources/functional/mut_ref.exp
+++ b/language/move-prover/tests/sources/functional/mut_ref.exp
@@ -34,7 +34,6 @@ error: data invariant does not hold
   =         b = <redacted>
   =         x = <redacted>
   =     at tests/sources/functional/mut_ref.move:91: return_ref_different_path_vec2
-  =         <redacted> = <redacted>
   =         result = <redacted>
   =         x = <redacted>
   =         x = <redacted>


### PR DESCRIPTION
…#213)(#214)

When doing loop analysis, insert trace_local instructions for havocked user-declared locals. This shows the implicitly reassigned values to the user. Also show "enter loop" and "loop invariant holds" info to the user. This fixes issue #213.

Remove temporary variables introduced by the compiler from the error trace. This fixes issue #214.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Move Language.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

When a loop invariant does not hold, the current error message shown to the user is incomplete and hard to understand (see #213, #214).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes.

## Test Plan

cargo test --release
