### PR TITLE
[Move analyzer] Added support for computing first symbol info synchronously

### DIFF
--- a/language/move-analyzer/src/bin/move-analyzer.rs
+++ b/language/move-analyzer/src/bin/move-analyzer.rs
@@ -53,6 +53,12 @@ fn main() {
         files: VirtualFileSystem::default(),
         symbols: Arc::new(Mutex::new(symbols::Symbolicator::empty_symbols())),
     };
+
+    let (id, client_response) = context
+        .connection
+        .initialize_start()
+        .expect("could not start connection initialization");
+
     let capabilities = serde_json::to_value(lsp_types::ServerCapabilities {
         // The server receives notifications from the client as users open, close,
         // and modify documents.
@@ -102,17 +108,41 @@ fn main() {
     })
     .expect("could not serialize server capabilities");
 
-    context
-        .connection
-        .initialize(capabilities)
-        .expect("could not initialize the connection");
-
     let (diag_sender, diag_receiver) = bounded::<Result<BTreeMap<Symbol, Vec<Diagnostic>>>>(0);
     let mut symbolicator_runner = symbols::SymbolicatorRunner::idle();
     if symbols::DEFS_AND_REFS_SUPPORT {
+        let initialize_params: lsp_types::InitializeParams =
+            serde_json::from_value(client_response)
+                .expect("could not deserialize client capabilities");
+
         symbolicator_runner =
             symbols::SymbolicatorRunner::new(context.symbols.clone(), diag_sender);
+
+        // If initialization information from the client contains a path to the directory being
+        // opened, try to initialize symbols before sending response to the client.D o not bother
+        // with diagnostics as they will be recomputed whenever the first source file is opened. The
+        // main reason for this is to enable unit tests that rely on the symbolication information
+        // to be available right after the client is initialized.
+        if let Some(uri) = initialize_params.root_uri {
+            if let Some(p) = symbols::SymbolicatorRunner::root_dir(Path::new(uri.path())) {
+                if let Ok((Some(new_symbols), _)) = symbols::Symbolicator::get_symbols(p.as_path())
+                {
+                    let mut old_symbols = context.symbols.lock().unwrap();
+                    (*old_symbols).merge(new_symbols);
+                }
+            }
+        }
     };
+
+    context
+        .connection
+        .initialize_finish(
+            id,
+            serde_json::json!({
+                "capabilities": capabilities,
+            }),
+        )
+        .expect("could not finish connection initialization");
 
     loop {
         select! {

--- a/language/move-analyzer/src/bin/move-analyzer.rs
+++ b/language/move-analyzer/src/bin/move-analyzer.rs
@@ -119,7 +119,7 @@ fn main() {
             symbols::SymbolicatorRunner::new(context.symbols.clone(), diag_sender);
 
         // If initialization information from the client contains a path to the directory being
-        // opened, try to initialize symbols before sending response to the client.D o not bother
+        // opened, try to initialize symbols before sending response to the client. Do not bother
         // with diagnostics as they will be recomputed whenever the first source file is opened. The
         // main reason for this is to enable unit tests that rely on the symbolication information
         // to be available right after the client is initialized.

--- a/language/move-analyzer/src/symbols.rs
+++ b/language/move-analyzer/src/symbols.rs
@@ -433,8 +433,8 @@ impl SymbolicatorRunner {
         cvar.notify_one();
     }
 
-    /// Finds manifest file in a subdirectory of a Move source file passed as argument
-    fn root_dir(starting_path: &Path) -> Option<PathBuf> {
+    /// Finds manifest file in a (sub)directory of the starting path passed as argument
+    pub fn root_dir(starting_path: &Path) -> Option<PathBuf> {
         let mut current_path_opt = Some(starting_path);
         while current_path_opt.is_some() {
             let current_path = current_path_opt.unwrap();
@@ -525,7 +525,7 @@ impl UseDefMap {
 }
 
 impl Symbols {
-    fn merge(&mut self, other: Self) {
+    pub fn merge(&mut self, other: Self) {
         for (k, v) in other.references {
             self.references
                 .entry(k)


### PR DESCRIPTION
## Motivation

The goal of this PR is to enable unit tests that require symbolication information to be available to the IDE client right away, that is right after a connection with the language server is successfully established. Otherwise, we either need to use hard-coded delays (which is arguably not the prettiest nor most reliable approach) or create a more elaborate synchronization mechanism (which is otherwise unnecessary and may affect server responsiveness). 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes

