### PR TITLE
[Move analyzer] Changed the max address length limit

### DIFF
--- a/language/move-analyzer/Cargo.toml
+++ b/language/move-analyzer/Cargo.toml
@@ -26,3 +26,8 @@ move-compiler = { path = "../move-compiler" }
 move-ir-types = { path = "../move-ir/types" }
 move-package = { path = "../tools/move-package" }
 move-symbol-pool = { path = "../move-symbol-pool" }
+
+[features]
+default = ["address32"]
+address20 = ["move-compiler/address20"]
+address32 = ["move-compiler/address32"]

--- a/language/move-analyzer/Cargo.toml
+++ b/language/move-analyzer/Cargo.toml
@@ -28,6 +28,5 @@ move-package = { path = "../tools/move-package" }
 move-symbol-pool = { path = "../move-symbol-pool" }
 
 [features]
-default = ["address32"]
 address20 = ["move-compiler/address20"]
 address32 = ["move-compiler/address32"]

--- a/language/move-compiler/Cargo.toml
+++ b/language/move-compiler/Cargo.toml
@@ -39,3 +39,7 @@ datatest-stable = "0.1.1"
 [[test]]
 name = "move_check_testsuite"
 harness = false
+
+[features]
+address20 = ["move-core-types/address20"]
+address32 = ["move-core-types/address32"]


### PR DESCRIPTION
## Motivation

Max length of the address in core Move is 16 bytes but this is not true for other Move applications where this length can be as long as 32 bytes. This PR modifies Move analyzer (and Move analyzer only) to use longer max length to avoid compilation errors for Move uses outside of Move core. 

The max length is by default set to 32 bytes, but build-time options (via Cargo features) have been provided to either set it to core Move default (by resetting the default features of the Move analyzer) or by choosing 20 (or 32) bytes via selecting a specific Cargo feature.

EDIT:

It seems like defaulting to 32. bytes is not going to work without a more major restructuring of core Move code (as the feature the propagates to tests etc.), and this does not seem worthwhile at this point. A simpler option is to update the installation instructions after this PR lands.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes
