### PR TITLE
[move-cli] sandbox publishing with multiple modules and optionally, all modules in a package

### DIFF
--- a/language/tools/move-cli/src/sandbox/cli.rs
+++ b/language/tools/move-cli/src/sandbox/cli.rs
@@ -39,6 +39,10 @@ pub enum SandboxCommand {
         /// modules in all its dependencies.
         #[clap(long = "with-deps")]
         with_deps: bool,
+        /// If set, all modules at once as a bundle. The default is to publish
+        /// modules sequentially.
+        #[clap(long = "bundle")]
+        bundle: bool,
         /// Manually specify the publishing order of modules.
         #[clap(
             long = "override-ordering",
@@ -188,6 +192,7 @@ impl SandboxCommand {
                 no_republish,
                 ignore_breaking_changes,
                 with_deps,
+                bundle,
                 override_ordering,
             } => {
                 let context =
@@ -201,6 +206,7 @@ impl SandboxCommand {
                     *no_republish,
                     *ignore_breaking_changes,
                     *with_deps,
+                    *bundle,
                     override_ordering.as_ref().map(|o| o.as_slice()),
                     move_args.verbose,
                 )

--- a/language/tools/move-cli/src/sandbox/cli.rs
+++ b/language/tools/move-cli/src/sandbox/cli.rs
@@ -35,6 +35,10 @@ pub enum SandboxCommand {
         /// Set this flag to ignore breaking changes checks and publish anyway.
         #[clap(long = "ignore-breaking-changes")]
         ignore_breaking_changes: bool,
+        /// If set, publish not only the modules in this package but also
+        /// modules in all its dependencies.
+        #[clap(long = "with-deps")]
+        with_deps: bool,
         /// Manually specify the publishing order of modules.
         #[clap(
             long = "override-ordering",
@@ -183,6 +187,7 @@ impl SandboxCommand {
             SandboxCommand::Publish {
                 no_republish,
                 ignore_breaking_changes,
+                with_deps,
                 override_ordering,
             } => {
                 let context =
@@ -195,6 +200,7 @@ impl SandboxCommand {
                     context.package(),
                     *no_republish,
                     *ignore_breaking_changes,
+                    *with_deps,
                     override_ordering.as_ref().map(|o| o.as_slice()),
                     move_args.verbose,
                 )

--- a/language/tools/move-cli/src/sandbox/commands/publish.rs
+++ b/language/tools/move-cli/src/sandbox/commands/publish.rs
@@ -115,13 +115,9 @@ pub fn publish(
                     let res =
                         session.publish_module_bundle(module_bytes_vec, sender, &mut gas_status);
                     if let Err(err) = res {
-                        if modules_to_publish.len() == 1 {
-                            explain_publish_error(err, state, modules_to_publish[0])?;
-                        } else {
-                            // TODO (mengxu): explain publish errors in multi-module publishing
-                            println!("Invalid multi-module publishing: {}", err);
-                            has_error = true;
-                        }
+                        // TODO (mengxu): explain publish errors in multi-module publishing
+                        println!("Invalid multi-module publishing: {}", err);
+                        has_error = true;
                     }
                 }
             }

--- a/language/tools/move-cli/tests/sandbox_tests/cyclic_multi_module_publish/args.exp
+++ b/language/tools/move-cli/tests/sandbox_tests/cyclic_multi_module_publish/args.exp
@@ -1,8 +1,8 @@
-Command `-p p1 sandbox publish --override-ordering A --override-ordering B -v`:
+Command `-p p1 sandbox publish --bundle --override-ordering A --override-ordering B -v`:
 Found 2 modules
 Publishing a new module 00000000000000000000000000000003::A (wrote 82 bytes)
 Publishing a new module 00000000000000000000000000000003::B (wrote 93 bytes)
 Wrote 175 bytes of module ID's and code
-Command `-p p2 sandbox publish --override-ordering A --override-ordering C -v`:
+Command `-p p2 sandbox publish --bundle --override-ordering A --override-ordering C -v`:
 Found 3 modules
 Invalid multi-module publishing: VMError with status INVALID_FRIEND_DECL_WITH_MODULES_IN_DEPENDENCIES at location Module ModuleId { address: 00000000000000000000000000000003, name: Identifier("C") } and message At least one module, 00000000000000000000000000000003::A, appears in both the dependency set and the friend set

--- a/language/tools/move-cli/tests/sandbox_tests/cyclic_multi_module_publish/args.txt
+++ b/language/tools/move-cli/tests/sandbox_tests/cyclic_multi_module_publish/args.txt
@@ -1,2 +1,2 @@
--p p1 sandbox publish --override-ordering A --override-ordering B -v
--p p2 sandbox publish --override-ordering A --override-ordering C -v
+-p p1 sandbox publish --bundle --override-ordering A --override-ordering B -v
+-p p2 sandbox publish --bundle --override-ordering A --override-ordering C -v

--- a/language/tools/move-cli/tests/sandbox_tests/multi_module_publish/args.exp
+++ b/language/tools/move-cli/tests/sandbox_tests/multi_module_publish/args.exp
@@ -1,13 +1,13 @@
-Command `sandbox publish --override-ordering A -v`:
+Command `sandbox publish --bundle --override-ordering A -v`:
 Found 2 modules
 Invalid multi-module publishing: VMError with status LINKER_ERROR at location UNDEFINED and message Cannot find ModuleId { address: 00000000000000000000000000000002, name: Identifier("B") } in data cache
-Command `sandbox publish --override-ordering B -v`:
+Command `sandbox publish --bundle --override-ordering B -v`:
 Found 2 modules
 Invalid multi-module publishing: VMError with status LINKER_ERROR at location UNDEFINED and message Cannot find ModuleId { address: 00000000000000000000000000000002, name: Identifier("A") } in data cache
-Command `sandbox publish --override-ordering B --override-ordering A -v`:
+Command `sandbox publish --bundle --override-ordering B --override-ordering A -v`:
 Found 2 modules
 Invalid multi-module publishing: VMError with status LINKER_ERROR at location UNDEFINED and message Cannot find ModuleId { address: 00000000000000000000000000000002, name: Identifier("A") } in data cache
-Command `sandbox publish --override-ordering A --override-ordering B -v`:
+Command `sandbox publish --bundle --override-ordering A --override-ordering B -v`:
 Found 2 modules
 Publishing a new module 00000000000000000000000000000002::A (wrote 89 bytes)
 Publishing a new module 00000000000000000000000000000002::B (wrote 97 bytes)

--- a/language/tools/move-cli/tests/sandbox_tests/multi_module_publish/args.txt
+++ b/language/tools/move-cli/tests/sandbox_tests/multi_module_publish/args.txt
@@ -1,14 +1,14 @@
 # expect failure as A friends B and B is missing in the bundle
-sandbox publish --override-ordering A -v
+sandbox publish --bundle --override-ordering A -v
 
 # expect failure as B depends on A and A is missing in the bundle
-sandbox publish --override-ordering B -v
+sandbox publish --bundle --override-ordering B -v
 
 # expect failure as B depends on A but A appears after B in the bundle
-sandbox publish --override-ordering B --override-ordering A -v
+sandbox publish --bundle --override-ordering B --override-ordering A -v
 
 # expect success: this is the correct order of publishing A and B
 # with friend relationship
-sandbox publish --override-ordering A --override-ordering B -v
+sandbox publish --bundle --override-ordering A --override-ordering B -v
 sandbox view storage/0x00000000000000000000000000000002/modules/A.mv
 sandbox view storage/0x00000000000000000000000000000002/modules/B.mv


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Move Language.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

This PR contains two changes to the `move-cli sandbox publish` interface:

**Commit 1**: [move-cli] add --with-deps option to the publish command

The default scenario is to publish the modules within the package only,
excluding the modules compiled from its dependency packages. This
`--with-deps` flag, when set, will allow modules in the deps packages
to be published as well, together with the package root modules.

**Commit 2**: [move-cli] allow multi-module publishing in Move CLI with --bundle

The current default mode of publishing in Move CLI is sequential,
i.e., one-module-at-a-time. This means that modules that are cyclic
dependent cannot be published all at once (e.g., the DPN in the
documentation/examples directory).

To show this issue, run:
```
cd language/documentation/examples/diem-framework/move-packages/DPN
cargo run -p df-cli -- sandbox publish
```
An error message of "unexpected LINK_ERROR" will appear.

This commit fixes this issue and allows all modules in the package to be
published at once by specifying the `--bundle` flag, as in
`sandbox publish --bundle`.

The whole DPN can be published with
```
cargo run -p df-cli --sandbox publish --bundle
```

Two move-cli sandbox tests on multiple-module publishing are updated with the `--bundle` flag accordingly.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes

## Test Plan

- CI
- Manual test on the DPN example
```
cd language/documentation/examples/diem-framework/move-packages/DPN

cargo run -p df-cli -- -v sandbox publish
// expect, found 41 modules, but runs into LINK_ERROR
 
cargo run -p df-cli -- -v sandbox publish --with-deps
// expect, found 60 modules, but runs into LINK_ERROR

cargo run -p df-cli -- -v sandbox publish --bundle
// expect, found 41 modules, no error

cargo run -p df-cli -- -v sandbox publish --bundle --with-deps
// expect, found 60 modules, no error, stdlib re-published
```