### PR TITLE
[Move analyzer] Updated package info & clap usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2286,7 +2286,7 @@ dependencies = [
 
 [[package]]
 name = "move-analyzer"
-version = "0.0.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "clap 3.1.8",

--- a/language/move-analyzer/Cargo.toml
+++ b/language/move-analyzer/Cargo.toml
@@ -1,10 +1,9 @@
 [package]
 name = "move-analyzer"
-version = "0.0.0"
+version = "1.0.0"
 authors = ["Diem Association <opensource@diem.com>"]
 description = "A language server for Move"
-repository = "https://github.com/diem/diem"
-homepage = "https://diem.com"
+repository = "https://github.com/move-language/move"
 license = "Apache-2.0"
 publish = false
 edition = "2018"

--- a/language/move-analyzer/src/bin/move-analyzer.rs
+++ b/language/move-analyzer/src/bin/move-analyzer.rs
@@ -28,7 +28,7 @@ use move_symbol_pool::Symbol;
 use url::Url;
 
 #[derive(Parser)]
-#[clap(author, version = "1.0.0", about)]
+#[clap(author, version, about)]
 struct Options {}
 
 fn main() {


### PR DESCRIPTION
While `move-analyzer --version` reports `1.0.0`, the package itself is at version `0.0.0`. This is because version information is hardcoded to the `clap()` usage, and the `Cargo.toml` package manifest is out-of-date.

Updated `Cargo.toml` information: dropping Diem mentions and setting a proper version. `Clap()` usage was also changed to idiomatic one as per 9225b84aa ("Idiomatic "clap" usage (implements --version switch for tools) (#81)", 2022-05-02)

(Also tried to replace the author, but changing it doesn't pass the linter, so need to have another PR for changing the linting rule and all the mentions in every `Cargo.toml`, since that would be logically a different kind of change)

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Move Language.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

There is a discrepancy between the package version, and version reported by `move-analyzer --version`. This was fixed by updating `Cargo.toml` and `clap()` usage accordingly. Also outdated information was updated/removed.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes.

## Test Plan
```
cargo install --path language/move-analyzer --version 1.0.0 move-analyzer
target/release/move-analyzer --version
```

Also, installing the previous `0.0.0` should fail:
```
cargo install --path language/move-analyzer --version 0.0.0 move-analyzer
```