### PR TITLE
[move-prover] Removed broken and outdated links

### DIFF
--- a/language/move-prover/tests/README.md
+++ b/language/move-prover/tests/README.md
@@ -97,17 +97,6 @@ MVP_TEST_INCONSISTENCY=1 cargo test -p move-prover
 
 ## Code coverage
 
-Analyzing the test coverage of the diem repo is regularly done in CI, and the result updates the online report at
-
-* https://ci-artifacts.diem.com/coverage/unit-coverage/latest/index.html
-* https://codecov.io/gh/diem/diem (reports significantly less coverage due to panic unwinding being considered a branch)
-
-Note that this report is based on the the coverage test when the environment variable `BOOGIE_EXE`
-is not set. So, the coverage result may not be as accurate as expected because all verifications with Boogie/Z3 are
-skipped during the test.
-
 To run the coverage test locally, one can use `cargo xtest html-cov-dir="/some/dir"`. Keep in mind what is compiled and
 run when targeting a single crate is not the same as is run/built with multiple crates due to cargo's feature
 unification.
-
-For any questions regarding code coverage, please use the Cadiem slack channel "#code_coverage".


### PR DESCRIPTION
CI coverage service at ci-artifacts.diem.com recently started returning 403, breaking the broken link checker.

Also the code coverage report at codecov.io hasn't been updated in over a year, so removing that too.

Removed most of the chapter as outdated, leaving only mentions to local code coverage analysis.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Move Language.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

CI broken link checker failed because of... ...well, a broken link.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes.

## Test Plan

If this PR's CI tests pass, then this change is tested and verified.
