### PR TITLE
[Prover] Make the `move-table-extension` package lowercase

### DIFF
--- a/language/extensions/move-table-extension/Move.toml
+++ b/language/extensions/move-table-extension/Move.toml
@@ -3,12 +3,11 @@ name = "MoveTableExtension"
 version = "1.0.0"
 
 [addresses]
-std = "_"
-Extensions = "_"
+extensions = "_"
 
 [dev-addresses]
 std = "0x1"
-Extensions = "0x2"
+extensions = "0x2"
 
 [dependencies]
 MoveStdlib = { local = "../../move-stdlib" }

--- a/language/extensions/move-table-extension/README.md
+++ b/language/extensions/move-table-extension/README.md
@@ -15,7 +15,7 @@ use move_vm_runtime::native_functions::NativeContextExtensions;
 fn run() {
     let resource_resolver = unimplemented!(); // a resource resolver the adapter provides
     let txn_hash = unimplemented!(); // a unique hash for table creation for this transaction
-    let table_resolver = unimplemented!(); // a remote table resover the adapter provides
+    let table_resolver = unimplemented!(); // a remote table resolver the adapter provides
     let std_addr = unimplemented!(); // address where to deploy the std lib
     let extension_addr = unimplemented!(); // address where to deploy the table extension
 

--- a/language/extensions/move-table-extension/sources/Table.move
+++ b/language/extensions/move-table-extension/sources/Table.move
@@ -1,5 +1,5 @@
 /// Type of large-scale storage tables.
-module Extensions::Table {
+module extensions::table {
     use std::errors;
 
     // TODO: native code should not use reasons to signal logical type of error. Instead,

--- a/language/extensions/move-table-extension/sources/Table.spec.move
+++ b/language/extensions/move-table-extension/sources/Table.spec.move
@@ -1,5 +1,5 @@
 /// Specifications of the `Table` module.
-spec Extensions::Table {
+spec extensions::table {
 
     // Make most of the public API intrinsic. Those functions have custom specifications in the prover.
 

--- a/language/extensions/move-table-extension/src/lib.rs
+++ b/language/extensions/move-table-extension/src/lib.rs
@@ -322,14 +322,14 @@ pub fn table_natives(table_addr: AccountAddress) -> NativeFunctionTable {
     native_functions::make_table(
         table_addr,
         &[
-            ("Table", "new_table_handle", native_new_table_handle),
-            ("Table", "add_box", native_add_box),
-            ("Table", "borrow_box", native_borrow_box),
-            ("Table", "borrow_box_mut", native_borrow_box),
-            ("Table", "remove_box", native_remove_box),
-            ("Table", "contains_box", native_contains_box),
-            ("Table", "destroy_empty_box", native_destroy_empty_box),
-            ("Table", "drop_unchecked_box", native_drop_unchecked_box),
+            ("table", "new_table_handle", native_new_table_handle),
+            ("table", "add_box", native_add_box),
+            ("table", "borrow_box", native_borrow_box),
+            ("table", "borrow_box_mut", native_borrow_box),
+            ("table", "remove_box", native_remove_box),
+            ("table", "contains_box", native_contains_box),
+            ("table", "destroy_empty_box", native_destroy_empty_box),
+            ("table", "drop_unchecked_box", native_drop_unchecked_box),
         ],
     )
 }

--- a/language/extensions/move-table-extension/tests/table_tests.move
+++ b/language/extensions/move-table-extension/tests/table_tests.move
@@ -1,7 +1,7 @@
 #[test_only]
-module Extensions::TableTests {
+module extensions::table_tests {
     use std::vector;
-    use Extensions::Table as T;
+    use extensions::table as T;
 
     struct S<phantom K: copy + drop, phantom V> has key {
         t: T::Table<K, V>

--- a/language/move-model/src/well_known.rs
+++ b/language/move-model/src/well_known.rs
@@ -8,6 +8,6 @@
 //! declarations. It can be extended on the go.
 
 pub const VECTOR_BORROW_MUT: &str = "vector::borrow_mut";
-pub const TABLE_BORROW_MUT: &str = "Table::borrow_mut";
+pub const TABLE_BORROW_MUT: &str = "table::borrow_mut";
 pub const EVENT_EMIT_EVENT: &str = "event::emit_event";
-pub const TABLE_TABLE: &str = "Table::Table";
+pub const TABLE_TABLE: &str = "table::Table";

--- a/language/move-prover/boogie-backend/src/prelude/native.bpl
+++ b/language/move-prover/boogie-backend/src/prelude/native.bpl
@@ -242,32 +242,32 @@ function $IsValid'table{{S}}'(t: {{Self}}): bool {
     (forall i: int:: ContainsTable(t, i) ==> $IsValid{{SV}}(GetTable(t, i)))
 }
 
-procedure {:inline 2} {{Ext}}_Table_new{{S}}() returns (v: {{Self}}) {
+procedure {:inline 2} {{Ext}}_table_new{{S}}() returns (v: {{Self}}) {
     v := EmptyTable();
 }
 
-procedure {:inline 2} {{Ext}}_Table_destroy_empty{{S}}(t: {{Self}}) {
+procedure {:inline 2} {{Ext}}_table_destroy_empty{{S}}(t: {{Self}}) {
     if (LenTable(t) != 0) {
         call $Abort($StdError(1/*INVALID_STATE*/, 102/*ENOT_EMPTY*/));
     }
 }
 
-procedure {:inline 2} {{Ext}}_Table_drop_unchecked{{S}}(t: {{Self}}) {
+procedure {:inline 2} {{Ext}}_table_drop_unchecked{{S}}(t: {{Self}}) {
 }
 
-procedure {:inline 2} {{Ext}}_Table_length{{S}}(t: ({{Self}})) returns (l: int) {
+procedure {:inline 2} {{Ext}}_table_length{{S}}(t: ({{Self}})) returns (l: int) {
     l := LenTable(t);
 }
 
-procedure {:inline 2} {{Ext}}_Table_empty{{S}}(t: ({{Self}})) returns (r: bool) {
+procedure {:inline 2} {{Ext}}_table_empty{{S}}(t: ({{Self}})) returns (r: bool) {
     r := LenTable(t) == 0;
 }
 
-procedure {:inline 2} {{Ext}}_Table_contains{{S}}(t: ({{Self}}), k: {{K}}) returns (r: bool) {
+procedure {:inline 2} {{Ext}}_table_contains{{S}}(t: ({{Self}}), k: {{K}}) returns (r: bool) {
     r := ContainsTable(t, {{ENC}}(k));
 }
 
-procedure {:inline 2} {{Ext}}_Table_add{{S}}(m: $Mutation ({{Self}}), k: {{K}}, v: {{V}}) returns (m': $Mutation({{Self}})) {
+procedure {:inline 2} {{Ext}}_table_add{{S}}(m: $Mutation ({{Self}}), k: {{K}}, v: {{V}}) returns (m': $Mutation({{Self}})) {
     var enc_k: int;
     var t: {{Self}};
     enc_k := {{ENC}}(k);
@@ -279,7 +279,7 @@ procedure {:inline 2} {{Ext}}_Table_add{{S}}(m: $Mutation ({{Self}}), k: {{K}}, 
     }
 }
 
-procedure {:inline 2} {{Ext}}_Table_remove{{S}}(m: $Mutation ({{Self}}), k: {{K}})
+procedure {:inline 2} {{Ext}}_table_remove{{S}}(m: $Mutation ({{Self}}), k: {{K}})
 returns (v: {{V}}, m': $Mutation({{Self}})) {
     var enc_k: int;
     var t: {{Self}};
@@ -293,7 +293,7 @@ returns (v: {{V}}, m': $Mutation({{Self}})) {
     }
 }
 
-procedure {:inline 2} {{Ext}}_Table_borrow{{S}}(t: {{Self}}, k: {{K}}) returns (v: {{V}}) {
+procedure {:inline 2} {{Ext}}_table_borrow{{S}}(t: {{Self}}, k: {{K}}) returns (v: {{V}}) {
     var enc_k: int;
     enc_k := {{ENC}}(k);
     if (!ContainsTable(t, enc_k)) {
@@ -303,7 +303,7 @@ procedure {:inline 2} {{Ext}}_Table_borrow{{S}}(t: {{Self}}, k: {{K}}) returns (
     }
 }
 
-procedure {:inline 2} {{Ext}}_Table_borrow_mut{{S}}(m: $Mutation ({{Self}}), k: {{K}})
+procedure {:inline 2} {{Ext}}_table_borrow_mut{{S}}(m: $Mutation ({{Self}}), k: {{K}})
 returns (dst: $Mutation ({{V}}), m': $Mutation ({{Self}})) {
     var enc_k: int;
     var t: {{Self}};
@@ -317,28 +317,28 @@ returns (dst: $Mutation ({{V}}), m': $Mutation ({{Self}})) {
     }
 }
 
-function {:inline} {{Ext}}_Table_spec_table{{S}}(): {{Self}} {
+function {:inline} {{Ext}}_table_spec_table{{S}}(): {{Self}} {
     EmptyTable()
 }
 
-function {:inline} {{Ext}}_Table_spec_len{{S}}(t: {{Self}}): int {
+function {:inline} {{Ext}}_table_spec_len{{S}}(t: {{Self}}): int {
     LenTable(t)
 }
 
-function {:inline} {{Ext}}_Table_spec_contains{{S}}(t: {{Self}}, k: {{K}}): bool {
+function {:inline} {{Ext}}_table_spec_contains{{S}}(t: {{Self}}, k: {{K}}): bool {
     ContainsTable(t, {{ENC}}(k))
 }
 
 
-function {:inline} {{Ext}}_Table_spec_add{{S}}(t: {{Self}}, k: {{K}}, v: {{V}}): {{Self}} {
+function {:inline} {{Ext}}_table_spec_add{{S}}(t: {{Self}}, k: {{K}}, v: {{V}}): {{Self}} {
     AddTable(t, {{ENC}}(k), v)
 }
 
-function {:inline} {{Ext}}_Table_spec_remove{{S}}(t: {{Self}}, k: {{K}}): {{Self}} {
+function {:inline} {{Ext}}_table_spec_remove{{S}}(t: {{Self}}, k: {{K}}): {{Self}} {
     RemoveTable(t, {{ENC}}(k))
 }
 
-function {:inline} {{Ext}}_Table_spec_get{{S}}(t: {{Self}}, k: {{K}}): {{V}} {
+function {:inline} {{Ext}}_table_spec_get{{S}}(t: {{Self}}, k: {{K}}): {{V}} {
     GetTable(t, {{ENC}}(k))
 }
 

--- a/language/move-prover/tests/sources/functional/verify_table.move
+++ b/language/move-prover/tests/sources/functional/verify_table.move
@@ -1,15 +1,15 @@
 // This file verifies the intrinsic Table implementation.
 module 0x42::VerifyTable {
-    use Extensions::Table::{Self, Table};
-    use Extensions::Table::{spec_get, spec_len, spec_contains};
+    use extensions::table::{Self, Table};
+    use extensions::table::{spec_get, spec_len, spec_contains};
 
     // TODO: test precise aborts behavior of all table functions
 
     fun add(): Table<u8, u64> {
-        let t = Table::new<u8, u64>();
-        Table::add(&mut t, 1, 2);
-        Table::add(&mut t, 2, 3);
-        Table::add(&mut t, 3, 4);
+        let t = table::new<u8, u64>();
+        table::add(&mut t, 1, 2);
+        table::add(&mut t, 2, 3);
+        table::add(&mut t, 3, 4);
         t
     }
     spec add {
@@ -21,10 +21,10 @@ module 0x42::VerifyTable {
     }
 
     fun add_fail(): Table<u8, u64> {
-        let t = Table::new<u8, u64>();
-        Table::add(&mut t, 1, 2);
-        Table::add(&mut t, 2, 3);
-        Table::add(&mut t, 3, 4);
+        let t = table::new<u8, u64>();
+        table::add(&mut t, 1, 2);
+        table::add(&mut t, 2, 3);
+        table::add(&mut t, 3, 4);
         t
     }
     spec add_fail {
@@ -32,9 +32,9 @@ module 0x42::VerifyTable {
     }
 
     fun add_fail_exists(k1: u8, k2: u8): Table<u8, u64> {
-        let t = Table::new<u8, u64>();
-        Table::add(&mut t, k1, 2);
-        Table::add(&mut t, k2, 3);
+        let t = table::new<u8, u64>();
+        table::add(&mut t, k1, 2);
+        table::add(&mut t, k2, 3);
         t
     }
     spec add_fail_exists {
@@ -43,7 +43,7 @@ module 0x42::VerifyTable {
 
     fun remove(): Table<u8, u64> {
         let t = add();
-        Table::remove(&mut t, 2);
+        table::remove(&mut t, 2);
         t
     }
     spec remove {
@@ -54,10 +54,10 @@ module 0x42::VerifyTable {
     }
 
     fun contains_and_length(): (bool, bool, u64, Table<u8, u64>) {
-        let t = Table::new<u8, u64>();
-        Table::add(&mut t, 1, 2);
-        Table::add(&mut t, 2, 3);
-        (Table::contains(&t, 1), Table::contains(&t, 3), Table::length(&t), t)
+        let t = table::new<u8, u64>();
+        table::add(&mut t, 1, 2);
+        table::add(&mut t, 2, 3);
+        (table::contains(&t, 1), table::contains(&t, 3), table::length(&t), t)
     }
     spec contains_and_length {
         ensures result_1 == true;
@@ -66,9 +66,9 @@ module 0x42::VerifyTable {
     }
 
     fun borrow(): (u64, Table<u8, u64>) {
-        let t = Table::new<u8, u64>();
-        Table::add(&mut t, 1, 2);
-        let r = Table::borrow(&t, 1);
+        let t = table::new<u8, u64>();
+        table::add(&mut t, 1, 2);
+        let r = table::borrow(&t, 1);
         (*r, t)
     }
     spec borrow {
@@ -78,10 +78,10 @@ module 0x42::VerifyTable {
     }
 
     fun borrow_mut(): Table<u8, u64> {
-        let t = Table::new<u8, u64>();
-        Table::add(&mut t, 1, 2);
-        Table::add(&mut t, 2, 3);
-        let r = Table::borrow_mut(&mut t, 1);
+        let t = table::new<u8, u64>();
+        table::add(&mut t, 1, 2);
+        table::add(&mut t, 2, 3);
+        let r = table::borrow_mut(&mut t, 1);
         *r = 4;
         t
     }
@@ -104,9 +104,9 @@ module 0x42::VerifyTable {
     }
 
     fun make_R(): R {
-        let t = Table::new<Key, u64>();
-        Table::add(&mut t, Key{v: vector[1, 2]}, 22);
-        Table::add(&mut t, Key{v: vector[2, 3]}, 23);
+        let t = table::new<Key, u64>();
+        table::add(&mut t, Key{v: vector[1, 2]}, 22);
+        table::add(&mut t, Key{v: vector[2, 3]}, 23);
         R{t}
     }
 
@@ -136,7 +136,7 @@ module 0x42::VerifyTable {
 
     fun borrow_mut_R(): R {
         let r = make_R();
-        let x = Table::borrow_mut(&mut r.t, Key{v: vector[1, 2]});
+        let x = table::borrow_mut(&mut r.t, Key{v: vector[1, 2]});
         *x = *x * 2;
         r
     }

--- a/language/move-prover/tests/testsuite.rs
+++ b/language/move-prover/tests/testsuite.rs
@@ -207,7 +207,7 @@ fn get_flags_and_baseline(
     flags.push("--named-addresses=std=0x1".to_string());
 
     // Add flag assigning an address to stdlib extensions.
-    flags.push("--named-addresses=Extensions=0x2".to_string());
+    flags.push("--named-addresses=extensions=0x2".to_string());
 
     // Add flags specific to the feature.
     flags.extend(feature.flags.iter().map(|f| f.to_string()));


### PR DESCRIPTION
This PR "lowercased" the `move-table-extension` package, and updated Prover accordingly.

## Motivation

To make the `move-table-extension` package lowercase

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

yes

## Test Plan

cargo test
