### PR TITLE
[stackless bytecode] fix a bug in VecPack and VecUnpack

### DIFF
--- a/language/move-prover/bytecode/tests/from_move/vector_instructions.exp
+++ b/language/move-prover/bytecode/tests/from_move/vector_instructions.exp
@@ -1,0 +1,113 @@
+============ initial translation from Move ================
+
+[variant baseline]
+public intrinsic fun vector::contains<#0>($t0|v: &vector<#0>, $t1|e: &#0): bool;
+
+
+[variant baseline]
+public intrinsic fun vector::index_of<#0>($t0|v: &vector<#0>, $t1|e: &#0): (bool, u64);
+
+
+[variant baseline]
+public intrinsic fun vector::append<#0>($t0|lhs: &mut vector<#0>, $t1|other: vector<#0>);
+
+
+[variant baseline]
+public native fun vector::borrow<#0>($t0|v: &vector<#0>, $t1|i: u64): &#0;
+
+
+[variant baseline]
+public native fun vector::borrow_mut<#0>($t0|v: &mut vector<#0>, $t1|i: u64): &mut #0;
+
+
+[variant baseline]
+public native fun vector::destroy_empty<#0>($t0|v: vector<#0>);
+
+
+[variant baseline]
+public native fun vector::empty<#0>(): vector<#0>;
+
+
+[variant baseline]
+public intrinsic fun vector::is_empty<#0>($t0|v: &vector<#0>): bool;
+
+
+[variant baseline]
+public native fun vector::length<#0>($t0|v: &vector<#0>): u64;
+
+
+[variant baseline]
+public native fun vector::pop_back<#0>($t0|v: &mut vector<#0>): #0;
+
+
+[variant baseline]
+public native fun vector::push_back<#0>($t0|v: &mut vector<#0>, $t1|e: #0);
+
+
+[variant baseline]
+public intrinsic fun vector::remove<#0>($t0|v: &mut vector<#0>, $t1|i: u64): #0;
+
+
+[variant baseline]
+public intrinsic fun vector::reverse<#0>($t0|v: &mut vector<#0>);
+
+
+[variant baseline]
+public fun vector::singleton<#0>($t0|e: #0): vector<#0> {
+     var $t1|v: vector<#0>
+     var $t2: vector<#0>
+     var $t3: &mut vector<#0>
+     var $t4: #0
+     var $t5: vector<#0>
+  0: $t2 := vector::empty<#0>()
+  1: $t1 := $t2
+  2: $t3 := borrow_local($t1)
+  3: $t4 := move($t0)
+  4: vector::push_back<#0>($t3, $t4)
+  5: $t5 := move($t1)
+  6: return $t5
+}
+
+
+[variant baseline]
+public native fun vector::swap<#0>($t0|v: &mut vector<#0>, $t1|i: u64, $t2|j: u64);
+
+
+[variant baseline]
+public intrinsic fun vector::swap_remove<#0>($t0|v: &mut vector<#0>, $t1|i: u64): #0;
+
+
+[variant baseline]
+fun M::f() {
+     var $t0|len: u64
+     var $t1|v: vector<u8>
+     var $t2: u8
+     var $t3: u8
+     var $t4: vector<u8>
+     var $t5: &mut vector<u8>
+     var $t6: &vector<u8>
+     var $t7: u64
+     var $t8: u64
+     var $t9: u64
+     var $t10: bool
+     var $t11: u64
+  0: $t2 := 0
+  1: $t3 := 0
+  2: $t4 := vector::empty<u8>()
+  3: $t5 := borrow_local($t4)
+  4: vector::push_back<u8>($t5, $t2)
+  5: vector::push_back<u8>($t5, $t3)
+  6: $t1 := $t4
+  7: $t6 := borrow_local($t1)
+  8: $t7 := vector::length<u8>($t6)
+  9: $t0 := $t7
+ 10: $t8 := move($t0)
+ 11: $t9 := 1
+ 12: $t10 := ==($t8, $t9)
+ 13: if ($t10) goto 17 else goto 14
+ 14: label L1
+ 15: $t11 := 0
+ 16: abort($t11)
+ 17: label L0
+ 18: return ()
+}

--- a/language/move-prover/bytecode/tests/from_move/vector_instructions.move
+++ b/language/move-prover/bytecode/tests/from_move/vector_instructions.move
@@ -1,0 +1,16 @@
+// dep: ../../move-stdlib/sources/vector.move
+
+module 0x42::M {
+    use std::vector;
+    const ZERO: u8 = 0;
+
+    fun f() {
+        let v = vector[ZERO, ZERO];
+        let len = vector::length(&v);
+        assert!(len == 1, 0);
+    }
+
+    spec f {
+        aborts_if true;
+    }
+}


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Move Language.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

This PR fixes a bug in stackless bytecode generation of vector bytecode instructions. 

Previously, `VecPack` is translated to:
```rust
let temp = vector::new();
for element in operands {
    vector::push_back(temp, element);
}
``` 
This is buggy because `vector::new()` returns a new vector object but `vector::push_back` takes in a mutable reference to a vector. This PR adds that missing `borrow_mut`:
```rust
let temp = vector::new();
let mut_ref = &mut temp;
for element in operands {
    vector::push_back(mut_ref, element);
}
``` 
Same reasoning applies to `VecUnpack`.
