### PR TITLE
[move-prover] Fixed hyper edge ordering problem

### DIFF
--- a/language/move-prover/bytecode/src/borrow_analysis.rs
+++ b/language/move-prover/bytecode/src/borrow_analysis.rs
@@ -214,7 +214,7 @@ impl BorrowInfo {
                 self.borrows_from
                     .entry(dst.clone())
                     .or_default()
-                    .insert((src.clone(), edge.clone()));
+                    .insert((src.clone(), edge.clone().reverse()));
             }
         }
     }
@@ -260,7 +260,7 @@ impl BorrowInfo {
     ) {
         for (dest, edge) in outgoing.iter() {
             let mut path = prefix.to_owned();
-            path.extend(edge.flatten().into_iter().cloned());
+            path.extend(edge.clone().reverse().flatten().into_iter().cloned());
             if let Some(succs) = ret_info.borrows_from.get(dest) {
                 self.construct_hyper_edges(leaf, ret_info, path, succs);
             } else {
@@ -268,7 +268,6 @@ impl BorrowInfo {
                 let edge = if path.len() == 1 {
                     path.pop().unwrap()
                 } else {
-                    path.reverse();
                     BorrowEdge::Hyper(path)
                 };
                 self.borrowed_by
@@ -308,7 +307,7 @@ impl BorrowInfo {
                         self.add_edge(
                             actual_in_node.clone(),
                             out_node.clone(),
-                            edge.instantiate(callee_targs),
+                            edge.instantiate(callee_targs).reverse(),
                         );
                         self.moved_nodes.insert(actual_in_node);
                     }

--- a/language/move-prover/bytecode/src/stackless_bytecode.rs
+++ b/language/move-prover/bytecode/src/stackless_bytecode.rs
@@ -295,6 +295,16 @@ impl BorrowEdge {
         }
     }
 
+    pub fn reverse(self) -> BorrowEdge {
+        if let BorrowEdge::Hyper(edges) = self {
+            let mut new_edges: Vec<BorrowEdge> = edges.to_vec();
+            new_edges.reverse();
+            BorrowEdge::Hyper(new_edges)
+        } else {
+            self
+        }
+    }
+
     pub fn instantiate(&self, params: &[Type]) -> Self {
         match self {
             Self::Field(qid, offset) => Self::Field(qid.instantiate_ref(params), *offset),

--- a/language/move-prover/bytecode/src/stackless_bytecode.rs
+++ b/language/move-prover/bytecode/src/stackless_bytecode.rs
@@ -1206,7 +1206,7 @@ impl<'a> std::fmt::Display for BorrowEdgeDisplay<'a> {
                     field_type.display(&tctx),
                 )
             }
-            Index => write!(f, "[]BLAH"),
+            Index => write!(f, "[]"),
             Direct => write!(f, "@"),
             Hyper(es) => {
                 write!(

--- a/language/move-prover/bytecode/src/stackless_bytecode.rs
+++ b/language/move-prover/bytecode/src/stackless_bytecode.rs
@@ -1196,7 +1196,7 @@ impl<'a> std::fmt::Display for BorrowEdgeDisplay<'a> {
                     field_type.display(&tctx),
                 )
             }
-            Index => write!(f, "[]"),
+            Index => write!(f, "[]BLAH"),
             Direct => write!(f, "@"),
             Hyper(es) => {
                 write!(


### PR DESCRIPTION
## Motivation

This is an attempt to fix the Move prover problem reported and analyzed in https://github.com/move-language/move/issues/270

Please note that the bytecode translator changes are failing - due to changes that have been made expected result no longer matches the expected output - if the solution is correct we should update expected output.

Admittedly this solution has been crated "by feel" rather than by a super-deep knowledge of the borrow analyzer, but perhaps even if it's not 100% correct, it will inspire a proper solution.

Some observations:
1. It seems to me that hyper edges in `borrowed_by` and `borrowed_from` sets should be reverted, which is currently not the case (hence edge revert operation in `consolidate`).
2. The failure in the bytecode translator for the example in the related issue (https://github.com/move-language/move/issues/270) is due to a hyper edge in the `borrowed_from` set being in the wrong order, which means that considering the bullet above, it's the `borrowed_from` set should keep the "correct" (from the bytecode translator's perspective) order
3. The final bit is that in constructing function annotation (in `summarize` and then `construct_hyper_edges`) we use `borrowed_from` edge ("correct" order) to construct a `borrowed_by` edge (incorrect order), so we have to reverse the hyper edge (but not any edge as before).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes

## Test Plan

I don't think we have Boogie backend tests, but with this PR in the test exposing the bug (added in https://github.com/move-language/move/pull/284) no longer crashes the prover.