### PR TITLE
[move-cli] Added "docgen" command

### DIFF
--- a/language/tools/move-cli/src/base/docgen.rs
+++ b/language/tools/move-cli/src/base/docgen.rs
@@ -1,0 +1,48 @@
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::base::prove::{Prove, ProverOptions};
+use clap::*;
+use move_package::BuildConfig;
+use std::path::PathBuf;
+
+/// Generating javadoc style documentation for packages using the Move Prover
+#[derive(Parser)]
+#[clap(name = "docgen")]
+pub struct Docgen {
+    /// Do not print out other than errors
+    #[clap(long = "quiet", short = 'q')]
+    pub quiet: bool,
+    /// A template for documentation generation.
+    #[clap(long = "template", short = 't', value_name = "FILE")]
+    pub template: Option<String>,
+}
+
+impl Docgen {
+    /// Simply calling the Move Prover with "--docgen"
+    /// Forwarding `--docgen-template` and setting `--verbose` to `error` if applicable
+    pub fn execute(self, path: Option<PathBuf>, config: BuildConfig) -> anyhow::Result<()> {
+        let mut options_list = vec!["--docgen".to_string()];
+
+        if self.quiet {
+            options_list.push("--verbose".to_string());
+            options_list.push("error".to_string());
+        }
+        if self.template.is_some() {
+            options_list.push("--docgen-template".to_string());
+            options_list.push(self.template.unwrap());
+        }
+
+        let options = Some(ProverOptions::Options(options_list));
+
+        Prove::execute(
+            Prove {
+                target_filter: None,
+                for_test: false,
+                options,
+            },
+            path,
+            config,
+        )
+    }
+}

--- a/language/tools/move-cli/src/base/mod.rs
+++ b/language/tools/move-cli/src/base/mod.rs
@@ -4,6 +4,7 @@
 pub mod build;
 pub mod coverage;
 pub mod disassemble;
+pub mod docgen;
 pub mod errmap;
 pub mod info;
 pub mod new;

--- a/language/tools/move-cli/src/lib.rs
+++ b/language/tools/move-cli/src/lib.rs
@@ -3,8 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use base::{
-    build::Build, coverage::Coverage, disassemble::Disassemble, errmap::Errmap, info::Info,
-    new::New, prove::Prove, test::Test,
+    build::Build, coverage::Coverage, disassemble::Disassemble, docgen::Docgen, errmap::Errmap,
+    info::Info, new::New, prove::Prove, test::Test,
 };
 use move_package::BuildConfig;
 
@@ -65,6 +65,7 @@ pub enum Command {
     Build(Build),
     Coverage(Coverage),
     Disassemble(Disassemble),
+    Docgen(Docgen),
     Errmap(Errmap),
     Info(Info),
     New(New),
@@ -103,6 +104,7 @@ pub fn run_cli(
         Command::Build(c) => c.execute(move_args.package_path, move_args.build_config),
         Command::Coverage(c) => c.execute(move_args.package_path, move_args.build_config),
         Command::Disassemble(c) => c.execute(move_args.package_path, move_args.build_config),
+        Command::Docgen(c) => c.execute(move_args.package_path, move_args.build_config),
         Command::Errmap(c) => c.execute(move_args.package_path, move_args.build_config),
         Command::Info(c) => c.execute(move_args.package_path, move_args.build_config),
         Command::New(c) => c.execute_with_defaults(move_args.package_path),

--- a/language/tools/move-cli/tests/build_tests/simple_build_with_docs/args.exp
+++ b/language/tools/move-cli/tests/build_tests/simple_build_with_docs/args.exp
@@ -1,0 +1,9 @@
+Command `new --path . Foo`:
+Command `build`:
+INCLUDING DEPENDENCY MoveStdlib
+BUILDING Foo
+Command `docgen --quiet --template template.md`:
+External Command `grep documentation doc/Foo.md`:
+Test documentation comment
+External Command `cat doc/template.md`:
+This is a test template

--- a/language/tools/move-cli/tests/build_tests/simple_build_with_docs/args.txt
+++ b/language/tools/move-cli/tests/build_tests/simple_build_with_docs/args.txt
@@ -1,0 +1,5 @@
+new --path . Foo
+build
+docgen --quiet --template template.md
+> grep documentation doc/Foo.md
+> cat doc/template.md

--- a/language/tools/move-cli/tests/build_tests/simple_build_with_docs/sources/Foo.move
+++ b/language/tools/move-cli/tests/build_tests/simple_build_with_docs/sources/Foo.move
@@ -1,0 +1,5 @@
+module 0x1::Foo {
+    /// Test documentation comment
+    public fun foo() {
+    }
+}

--- a/language/tools/move-cli/tests/build_tests/simple_build_with_docs/template.md
+++ b/language/tools/move-cli/tests/build_tests/simple_build_with_docs/template.md
@@ -1,0 +1,1 @@
+This is a test template


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Move Language.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->
Move Prover's `--docgen` switch is not currently exposed to the user, so added a top level command `docgen` to do the trick.

Move Prover is also mentioned in the description, so the user knows they must have a working Move Prover setup in order to use this feature.

Also added a smoketest for the `docgen` command so it would not break because of a regression. A non-existent subcommand `smoketest` is intentionally used so the output has as little variable output as possible.

## Motivation

Move Prover's `--docgen` switch is not currently exposed to the user, so added a top level command `docgen` to do the trick.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes.

## Test Plan

In addition to the smoke test (`cargo test -p move-cli`) you can test the actual documentation generation by running:
```
cargo build -p move-cli
./target/debug/move --path ./language/documentation/tutorial/step_8/BasicCoin docgen
```

You should get something like:

```
[INFO] generating documentation
[INFO] Module `0xcafe::BasicCoin` in file `doc/BasicCoin.md` will be generated
[INFO] 0.148s checking, 0.075s generating
```

And then you should have the final generated markdown documentation at `./language/documentation/tutorial/step_8/BasicCoin/doc/BasicCoin.md`.

(In order to use the docgen you must have a working Move Prover, verify this by running `./target/debug/move --path ./language/documentation/tutorial/step_8/BasicCoin prove`)