### PR TITLE
[Move analyzer] Added support for building and running on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1190,6 +1190,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "453440c271cf5577fd2a40e4942540cb7d0d2f85e27c8d07dd0023c925a67541"
+
+[[package]]
 name = "ed25519"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2261,6 +2267,7 @@ dependencies = [
  "clap 3.1.8",
  "codespan-reporting",
  "crossbeam",
+ "dunce",
  "im",
  "lsp-server",
  "lsp-types",

--- a/language/move-analyzer/Cargo.toml
+++ b/language/move-analyzer/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0.52"
 codespan-reporting = "0.11.1"
+dunce = "1.0.2"
 im = "15.1.0"
 lsp-server = "0.5.1"
 lsp-types = "0.90.1"

--- a/language/move-analyzer/src/bin/move-analyzer.rs
+++ b/language/move-analyzer/src/bin/move-analyzer.rs
@@ -124,7 +124,7 @@ fn main() {
         // main reason for this is to enable unit tests that rely on the symbolication information
         // to be available right after the client is initialized.
         if let Some(uri) = initialize_params.root_uri {
-            if let Some(p) = symbols::SymbolicatorRunner::root_dir(Path::new(uri.path())) {
+            if let Some(p) = symbols::SymbolicatorRunner::root_dir(&uri.to_file_path().unwrap()) {
                 if let Ok((Some(new_symbols), _)) = symbols::Symbolicator::get_symbols(p.as_path())
                 {
                     let mut old_symbols = context.symbols.lock().unwrap();

--- a/language/move-analyzer/src/completion.rs
+++ b/language/move-analyzer/src/completion.rs
@@ -127,10 +127,18 @@ pub fn on_completion_request(context: &Context, request: &Request) {
     let parameters = serde_json::from_value::<CompletionParams>(request.params.clone())
         .expect("could not deserialize completion request");
 
-    let path = parameters.text_document_position.text_document.uri.to_file_path().unwrap();
+    let path = parameters
+        .text_document_position
+        .text_document
+        .uri
+        .to_file_path()
+        .unwrap();
     let buffer = context.files.get(&path);
     if buffer.is_none() {
-        eprintln!("Could not read '{:?}' when handling completion request", path);
+        eprintln!(
+            "Could not read '{:?}' when handling completion request",
+            path
+        );
     }
 
     // The completion items we provide depend upon where the user's cursor is positioned.

--- a/language/move-analyzer/src/completion.rs
+++ b/language/move-analyzer/src/completion.rs
@@ -127,10 +127,10 @@ pub fn on_completion_request(context: &Context, request: &Request) {
     let parameters = serde_json::from_value::<CompletionParams>(request.params.clone())
         .expect("could not deserialize completion request");
 
-    let path = parameters.text_document_position.text_document.uri.path();
-    let buffer = context.files.get(path);
+    let path = parameters.text_document_position.text_document.uri.to_file_path().unwrap();
+    let buffer = context.files.get(&path);
     if buffer.is_none() {
-        eprintln!("Could not read '{}' when handling completion request", path);
+        eprintln!("Could not read '{:?}' when handling completion request", path);
     }
 
     // The completion items we provide depend upon where the user's cursor is positioned.

--- a/language/move-analyzer/src/symbols.rs
+++ b/language/move-analyzer/src/symbols.rs
@@ -334,9 +334,7 @@ impl SymbolicatorRunner {
         let runner = SymbolicatorRunner { mtx_cvar };
 
         thread::Builder::new()
-            // building Move code requires a larger stack size on Windows (16MB has been chosen
-            // rather arbitrarily)
-            .stack_size(16 * 1024 * 1024)
+            .stack_size(16 * 1024 * 1024) // building Move code requires a larger stack size on Windows
             .spawn(move || {
                 let (mtx, cvar) = &*thread_mtx_cvar;
                 // Locations opened in the IDE (files or directories) for which manifest file is missing

--- a/language/move-analyzer/src/symbols.rs
+++ b/language/move-analyzer/src/symbols.rs
@@ -334,87 +334,90 @@ impl SymbolicatorRunner {
         let runner = SymbolicatorRunner { mtx_cvar };
 
         thread::Builder::new()
-            .stack_size(16 * 1024 * 1024) // building Move code requires a larger stack size on Windows
+            // building Move code requires a larger stack size on Windows (16MB has been chosen
+            // rather arbitrarily)
+            .stack_size(16 * 1024 * 1024)
             .spawn(move || {
-            let (mtx, cvar) = &*thread_mtx_cvar;
-            // Locations opened in the IDE (files or directories) for which manifest file is missing
-            let mut missing_manifests = BTreeSet::new();
-            // infinite loop to wait for symbolication requests
-            eprintln!("starting symbolicator runner loop");
-            loop {
-                let starting_path_opt = {
-                    // hold the lock only as long as it takes to get the data, rather than through
-                    // the whole symbolication process (hence a separate scope here)
-                    let mut symbolicate = mtx.lock().unwrap();
-                    match symbolicate.clone() {
-                        RunnerState::Quit => break,
-                        RunnerState::Run(root_dir) => {
-                            *symbolicate = RunnerState::Wait;
-                            Some(root_dir)
-                        }
-                        RunnerState::Wait => {
-                            // wait for next request
-                            symbolicate = cvar.wait(symbolicate).unwrap();
-                            match symbolicate.clone() {
-                                RunnerState::Quit => break,
-                                RunnerState::Run(root_dir) => {
-                                    *symbolicate = RunnerState::Wait;
-                                    Some(root_dir)
+                let (mtx, cvar) = &*thread_mtx_cvar;
+                // Locations opened in the IDE (files or directories) for which manifest file is missing
+                let mut missing_manifests = BTreeSet::new();
+                // infinite loop to wait for symbolication requests
+                eprintln!("starting symbolicator runner loop");
+                loop {
+                    let starting_path_opt = {
+                        // hold the lock only as long as it takes to get the data, rather than through
+                        // the whole symbolication process (hence a separate scope here)
+                        let mut symbolicate = mtx.lock().unwrap();
+                        match symbolicate.clone() {
+                            RunnerState::Quit => break,
+                            RunnerState::Run(root_dir) => {
+                                *symbolicate = RunnerState::Wait;
+                                Some(root_dir)
+                            }
+                            RunnerState::Wait => {
+                                // wait for next request
+                                symbolicate = cvar.wait(symbolicate).unwrap();
+                                match symbolicate.clone() {
+                                    RunnerState::Quit => break,
+                                    RunnerState::Run(root_dir) => {
+                                        *symbolicate = RunnerState::Wait;
+                                        Some(root_dir)
+                                    }
+                                    RunnerState::Wait => None,
                                 }
-                                RunnerState::Wait => None,
                             }
                         }
-                    }
-                };
-                if let Some(starting_path) = starting_path_opt {
-                    let root_dir = Self::root_dir(&starting_path);
-                    if root_dir.is_none() && !missing_manifests.contains(&starting_path) {
-                        eprintln!("reporting missing manifest");
+                    };
+                    if let Some(starting_path) = starting_path_opt {
+                        let root_dir = Self::root_dir(&starting_path);
+                        if root_dir.is_none() && !missing_manifests.contains(&starting_path) {
+                            eprintln!("reporting missing manifest");
 
-                        // report missing manifest file only once to avoid cluttering IDE's UI in
-                        // cases when developer indeed intended to open a standalone file that was
-                        // not meant to compile
-                        missing_manifests.insert(starting_path);
-                        if let Err(err) = sender.send(Err(anyhow!(
-                            "Unable to find package manifest. Make sure that
+                            // report missing manifest file only once to avoid cluttering IDE's UI in
+                            // cases when developer indeed intended to open a standalone file that was
+                            // not meant to compile
+                            missing_manifests.insert(starting_path);
+                            if let Err(err) = sender.send(Err(anyhow!(
+                                "Unable to find package manifest. Make sure that
                             the source files are located in a sub-directory of a package containing
                             a Move.toml file. "
-                        ))) {
-                            eprintln!("could not pass missing manifest error: {:?}", err);
-                        }
-                        continue;
-                    }
-                    eprintln!("symbolication started");
-                    match Symbolicator::get_symbols(root_dir.unwrap().as_path()) {
-                        Ok((symbols_opt, lsp_diagnostics)) => {
-                            eprintln!("symbolication finished");
-                            if let Some(new_symbols) = symbols_opt {
-                                // merge the new symbols with the old ones to support a
-                                // (potentially) new project/package that symbolication information
-                                // was built for
-                                //
-                                // TODO: we may consider "unloading" symbolication information when
-                                // files/directories are being closed but as with other performance
-                                // optimizations (e.g. incrementalizatino of the vfs), let's wait
-                                // until we know we actually need it
-                                let mut old_symbols = symbols.lock().unwrap();
-                                (*old_symbols).merge(new_symbols);
+                            ))) {
+                                eprintln!("could not pass missing manifest error: {:?}", err);
                             }
-                            // set/reset (previous) diagnostics
-                            if let Err(err) = sender.send(Ok(lsp_diagnostics)) {
-                                eprintln!("could not pass diagnostics: {:?}", err);
-                            }
+                            continue;
                         }
-                        Err(err) => {
-                            eprintln!("symbolication failed: {:?}", err);
-                            if let Err(err) = sender.send(Err(err)) {
-                                eprintln!("could not pass compiler error: {:?}", err);
+                        eprintln!("symbolication started");
+                        match Symbolicator::get_symbols(root_dir.unwrap().as_path()) {
+                            Ok((symbols_opt, lsp_diagnostics)) => {
+                                eprintln!("symbolication finished");
+                                if let Some(new_symbols) = symbols_opt {
+                                    // merge the new symbols with the old ones to support a
+                                    // (potentially) new project/package that symbolication information
+                                    // was built for
+                                    //
+                                    // TODO: we may consider "unloading" symbolication information when
+                                    // files/directories are being closed but as with other performance
+                                    // optimizations (e.g. incrementalizatino of the vfs), let's wait
+                                    // until we know we actually need it
+                                    let mut old_symbols = symbols.lock().unwrap();
+                                    (*old_symbols).merge(new_symbols);
+                                }
+                                // set/reset (previous) diagnostics
+                                if let Err(err) = sender.send(Ok(lsp_diagnostics)) {
+                                    eprintln!("could not pass diagnostics: {:?}", err);
+                                }
+                            }
+                            Err(err) => {
+                                eprintln!("symbolication failed: {:?}", err);
+                                if let Err(err) = sender.send(Err(err)) {
+                                    eprintln!("could not pass compiler error: {:?}", err);
+                                }
                             }
                         }
                     }
                 }
-            }
-        }).unwrap();
+            })
+            .unwrap();
 
         runner
     }

--- a/language/move-analyzer/src/vfs.rs
+++ b/language/move-analyzer/src/vfs.rs
@@ -10,13 +10,13 @@
 //! basically just a mapping from file identifier (this could be the file's path were it to be
 //! saved) to its textual contents.
 
+use crate::symbols;
 use lsp_server::Notification;
 use lsp_types::{
     notification::Notification as _, DidChangeTextDocumentParams, DidCloseTextDocumentParams,
     DidOpenTextDocumentParams, DidSaveTextDocumentParams,
 };
 use std::path::PathBuf;
-use crate::symbols;
 
 /// A mapping from identifiers (file names, potentially, but not necessarily) to their contents.
 #[derive(Debug, Default)]
@@ -38,8 +38,7 @@ impl VirtualFileSystem {
     /// 'vfs' module that is capable of doing just that, but it is not published on crates.io. If
     /// we could help get it published, we could use it here.
     pub fn update(&mut self, identifier: PathBuf, content: &str) {
-        self.files
-            .insert(identifier, content.to_string());
+        self.files.insert(identifier, content.to_string());
     }
 
     /// Removes the buffer and its identifier from the system.


### PR DESCRIPTION
## Motivation

This PR adds additional support for the Move analyzer to correctly build and run on Windows. In particular the "standard" version of path canonicalization produces non-standard output on Windows (so called UNC format).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes
