### PR TITLE
[cli] refactor logging setup out of run_move_prover

### DIFF
--- a/language/tools/move-cli/src/base/prove.rs
+++ b/language/tools/move-cli/src/base/prove.rs
@@ -63,6 +63,11 @@ impl Prove {
         }
         args.extend(opts.iter().cloned());
         let options = move_prover::cli::Options::create_from_args(&args)?;
+        if for_test {
+            options.setup_logging_for_test();
+        } else {
+            options.setup_logging();
+        }
 
         run_move_prover(config, &rerooted_path, &target_filter, for_test, options)
     }
@@ -183,9 +188,6 @@ pub fn run_move_prover(
     let mut error_writer = StandardStream::stderr(ColorChoice::Auto);
     if for_test {
         options.set_quiet();
-        options.setup_logging_for_test();
-    } else {
-        options.setup_logging();
     }
     let now = Instant::now();
     let model = config.move_model_for_package(


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Move Language.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Now that `move_cli::base::run_move_prover` is used by multiple chain-specific CLIs as a library function, logging setup should be moved out of the function. Since each chain-specific CLI may use different logging scheme. This PR doesn't change how the core Move CLI behaves.