### PR TITLE
[vm] Allow module publishing skipping compatability checks.

### DIFF
--- a/language/move-vm/runtime/src/runtime.rs
+++ b/language/move-vm/runtime/src/runtime.rs
@@ -75,6 +75,7 @@ impl VMRuntime {
         sender: AccountAddress,
         data_store: &mut impl DataStore,
         _gas_status: &mut GasStatus,
+        compat_check: bool,
     ) -> VMResult<()> {
         // deserialize the modules. Perform bounds check. After this indexes can be
         // used with the `[]` operator
@@ -114,7 +115,7 @@ impl VMRuntime {
         // changing the bytecode format to include an `is_upgradable` flag in the CompiledModule.
         for module in &compiled_modules {
             let module_id = module.self_id();
-            if data_store.exists_module(&module_id)? {
+            if data_store.exists_module(&module_id)? && compat_check {
                 let old_module_ref = self.loader.load_module(&module_id, data_store)?;
                 let old_module = old_module_ref.module();
                 let old_m = normalized::Module::new(old_module);

--- a/language/move-vm/runtime/src/session.rs
+++ b/language/move-vm/runtime/src/session.rs
@@ -178,6 +178,9 @@ impl<'r, 'l, S: MoveResolver> Session<'r, 'l, S> {
     ///
     /// In case an invariant violation occurs, the whole Session should be considered corrupted and
     /// one shall not proceed with effect generation.
+    ///
+    /// This operation performs compatibility checks if a module is replaced. See also
+    /// `move_binary_format::compatibility`.
     pub fn publish_module_bundle(
         &mut self,
         modules: Vec<Vec<u8>>,
@@ -185,7 +188,18 @@ impl<'r, 'l, S: MoveResolver> Session<'r, 'l, S> {
         gas_status: &mut GasStatus,
     ) -> VMResult<()> {
         self.runtime
-            .publish_module_bundle(modules, sender, &mut self.data_cache, gas_status)
+            .publish_module_bundle(modules, sender, &mut self.data_cache, gas_status, true)
+    }
+
+    /// Same like `publish_module_bundle` but relaxes compatibility checks.
+    pub fn publish_module_bundle_relax_compatibility(
+        &mut self,
+        modules: Vec<Vec<u8>>,
+        sender: AccountAddress,
+        gas_status: &mut GasStatus,
+    ) -> VMResult<()> {
+        self.runtime
+            .publish_module_bundle(modules, sender, &mut self.data_cache, gas_status, false)
     }
 
     pub fn num_mutated_accounts(&self, sender: &AccountAddress) -> u64 {


### PR DESCRIPTION
By default module publishing checks for downwards compatibility of a module when it is re-published. This PR adds a new entry point which allows to relax this check if desired.

