### PR TITLE
[move-prover] fix hyper-edge constructor in borrow analysis

### DIFF
--- a/language/move-prover/bytecode/src/borrow_analysis.rs
+++ b/language/move-prover/bytecode/src/borrow_analysis.rs
@@ -260,7 +260,7 @@ impl BorrowInfo {
     ) {
         for (dest, edge) in outgoing.iter() {
             let mut path = prefix.to_owned();
-            path.extend(edge.flatten().into_iter().cloned());
+            path.push(edge.clone());
             if let Some(succs) = ret_info.borrows_from.get(dest) {
                 self.construct_hyper_edges(leaf, ret_info, path, succs);
             } else {
@@ -269,7 +269,13 @@ impl BorrowInfo {
                     path.pop().unwrap()
                 } else {
                     path.reverse();
-                    BorrowEdge::Hyper(path)
+                    let flattened = path
+                        .iter()
+                        .map(|e| e.flatten().into_iter())
+                        .flatten()
+                        .cloned()
+                        .collect();
+                    BorrowEdge::Hyper(flattened)
                 };
                 self.borrowed_by
                     .entry(dest.clone())

--- a/language/move-prover/bytecode/tests/borrow/function_call.exp
+++ b/language/move-prover/bytecode/tests/borrow/function_call.exp
@@ -262,27 +262,27 @@ fun MultiLayerCalling::outer($t0|has_vector: &mut MultiLayerCalling::HasVector) 
   0: $t2 := MultiLayerCalling::mid($t0)
      # live_nodes: Reference($t0), Reference($t2)
      # moved_nodes: Reference($t0)
-     # borrowed_by: Reference($t0) -> {([]/.v (vector<MultiLayerCalling::HasAnotherVector>), Reference($t2))}
-     # borrows_from: Reference($t2) -> {([]/.v (vector<MultiLayerCalling::HasAnotherVector>), Reference($t0))}
+     # borrowed_by: Reference($t0) -> {(.v (vector<MultiLayerCalling::HasAnotherVector>)/[], Reference($t2))}
+     # borrows_from: Reference($t2) -> {(.v (vector<MultiLayerCalling::HasAnotherVector>)/[], Reference($t0))}
   1: $t3 := borrow_field<MultiLayerCalling::HasAnotherVector>.v($t2)
      # live_nodes: Reference($t0), Reference($t3)
      # moved_nodes: Reference($t0)
-     # borrowed_by: Reference($t0) -> {([]/.v (vector<MultiLayerCalling::HasAnotherVector>), Reference($t2))}, Reference($t2) -> {(.v (vector<u8>), Reference($t3))}
-     # borrows_from: Reference($t2) -> {([]/.v (vector<MultiLayerCalling::HasAnotherVector>), Reference($t0))}, Reference($t3) -> {(.v (vector<u8>), Reference($t2))}
+     # borrowed_by: Reference($t0) -> {(.v (vector<MultiLayerCalling::HasAnotherVector>)/[], Reference($t2))}, Reference($t2) -> {(.v (vector<u8>), Reference($t3))}
+     # borrows_from: Reference($t2) -> {(.v (vector<MultiLayerCalling::HasAnotherVector>)/[], Reference($t0))}, Reference($t3) -> {(.v (vector<u8>), Reference($t2))}
   2: $t4 := 42
      # live_nodes: Reference($t0), Reference($t3)
      # moved_nodes: Reference($t0)
-     # borrowed_by: Reference($t0) -> {([]/.v (vector<MultiLayerCalling::HasAnotherVector>), Reference($t2))}, Reference($t2) -> {(.v (vector<u8>), Reference($t3))}
-     # borrows_from: Reference($t2) -> {([]/.v (vector<MultiLayerCalling::HasAnotherVector>), Reference($t0))}, Reference($t3) -> {(.v (vector<u8>), Reference($t2))}
+     # borrowed_by: Reference($t0) -> {(.v (vector<MultiLayerCalling::HasAnotherVector>)/[], Reference($t2))}, Reference($t2) -> {(.v (vector<u8>), Reference($t3))}
+     # borrows_from: Reference($t2) -> {(.v (vector<MultiLayerCalling::HasAnotherVector>)/[], Reference($t0))}, Reference($t3) -> {(.v (vector<u8>), Reference($t2))}
   3: vector::push_back<u8>($t3, $t4)
      # live_nodes: Reference($t0)
      # moved_nodes: Reference($t0)
-     # borrowed_by: Reference($t0) -> {([]/.v (vector<MultiLayerCalling::HasAnotherVector>), Reference($t2))}, Reference($t2) -> {(.v (vector<u8>), Reference($t3))}
-     # borrows_from: Reference($t2) -> {([]/.v (vector<MultiLayerCalling::HasAnotherVector>), Reference($t0))}, Reference($t3) -> {(.v (vector<u8>), Reference($t2))}
+     # borrowed_by: Reference($t0) -> {(.v (vector<MultiLayerCalling::HasAnotherVector>)/[], Reference($t2))}, Reference($t2) -> {(.v (vector<u8>), Reference($t3))}
+     # borrows_from: Reference($t2) -> {(.v (vector<MultiLayerCalling::HasAnotherVector>)/[], Reference($t0))}, Reference($t3) -> {(.v (vector<u8>), Reference($t2))}
   4: trace_local[has_vector]($t0)
      # moved_nodes: Reference($t0)
-     # borrowed_by: Reference($t0) -> {([]/.v (vector<MultiLayerCalling::HasAnotherVector>), Reference($t2))}, Reference($t2) -> {(.v (vector<u8>), Reference($t3))}
-     # borrows_from: Reference($t2) -> {([]/.v (vector<MultiLayerCalling::HasAnotherVector>), Reference($t0))}, Reference($t3) -> {(.v (vector<u8>), Reference($t2))}
+     # borrowed_by: Reference($t0) -> {(.v (vector<MultiLayerCalling::HasAnotherVector>)/[], Reference($t2))}, Reference($t2) -> {(.v (vector<u8>), Reference($t3))}
+     # borrows_from: Reference($t2) -> {(.v (vector<MultiLayerCalling::HasAnotherVector>)/[], Reference($t0))}, Reference($t3) -> {(.v (vector<u8>), Reference($t2))}
   5: return ()
 }
 
@@ -299,5 +299,5 @@ borrowed_by: Reference($t0) -> {(.v (vector<MultiLayerCalling::HasAnotherVector>
 borrows_from: Return(0) -> {(.v (vector<MultiLayerCalling::HasAnotherVector>)/[], Reference($t0))}
 
 fun MultiLayerCalling::mid[baseline]
-borrowed_by: Reference($t0) -> {([]/.v (vector<MultiLayerCalling::HasAnotherVector>), Return(0))}
-borrows_from: Return(0) -> {([]/.v (vector<MultiLayerCalling::HasAnotherVector>), Reference($t0))}
+borrowed_by: Reference($t0) -> {(.v (vector<MultiLayerCalling::HasAnotherVector>)/[], Return(0))}
+borrows_from: Return(0) -> {(.v (vector<MultiLayerCalling::HasAnotherVector>)/[], Reference($t0))}


### PR DESCRIPTION
This commit fixes issue #270 where the edge ordering are reversed in a
hyper-edge when that hyper-edge is inlined to construct a borrow graph.

In Move Prover, hyper-edges are used to summarize the borrow-relation
between function arguments and function return values:

In the example in #270, given

```move
fun inner(has_vector: &mut HasVector): &mut HasAnotherVector {
    vector::borrow_mut(&mut has_vector.v, 7)
}
```

The `inner` function will yield a hyper-edge:
```
return_ref --borrows_from--> { arg: has_vector, edge: Hyper(.v/[]) }
```

Now, this hyper-edge will be further used to derive the borrow-relation
for the `mid` function:

```
fun mid(has_vector: &mut HasVector): &mut HasAnotherVector {
    inner(has_vector)
}
```

The expected summary for `mid` is
```
return_ref --borrows_from--> { arg: has_vector, edge: Hyper(.v/[]) }
```

However, due to the bug, the summary becomes:
```
return_ref --borrows_from--> { arg: has_vector, edge: Hyper([]/.v) }
                                                            ^^^^^
                                                            // reversed
```
which causes the crash found in #270.

This commit fixes this bug. In summary, the fix is: when constructing
hyper-edges, reverse the edges first before flattening all the edges.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Move Language.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

As above

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes

## Test Plan

Unit tests