### PR TITLE
[chore] Updated Rust packages to pass the Cargo audit

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -20,8 +20,9 @@ jobs:
         # List of ignored RUSTSEC
         # 1. RUSTSEC-2021-0073 - Not impacted.
         # 2. RUSTSEC-2021-0072 - Not impacted.
+        # 3. RUSTSEC-2020-0071 - Not impacted (chronotope/chrono#578).
         run: |
-          cargo audit --color never --ignore RUSTSEC-2021-0073 --ignore RUSTSEC-2021-0072 > $AUDIT_SUMMARY_FILE
+          cargo audit --color never --ignore RUSTSEC-2021-0073 --ignore RUSTSEC-2021-0072 --ignore RUSTSEC-2020-0071 > $AUDIT_SUMMARY_FILE
       - name: set issue body content
         if: ${{ failure() }}
         env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -508,12 +508,24 @@ dependencies = [
 
 [[package]]
 name = "chrono-tz"
-version = "0.5.3"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2554a3155fec064362507487171dcc4edc3df60cb10f3a1fb10ed8094822b120"
+checksum = "58549f1842da3080ce63002102d5bc954c7bc843d4f47818e642abdc36253552"
 dependencies = [
  "chrono",
+ "chrono-tz-build",
+ "phf",
+]
+
+[[package]]
+name = "chrono-tz-build"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db058d493fb2f65f41861bfed7e3fe6335264a9f0f92710cab5bdf01fef09069"
+dependencies = [
  "parse-zoneinfo",
+ "phf",
+ "phf_codegen",
 ]
 
 [[package]]
@@ -802,7 +814,7 @@ dependencies = [
  "bitflags",
  "crossterm_winapi 0.8.0",
  "libc",
- "mio",
+ "mio 0.7.13",
  "parking_lot 0.11.1",
  "signal-hook",
  "signal-hook-mio",
@@ -818,7 +830,7 @@ dependencies = [
  "bitflags",
  "crossterm_winapi 0.9.0",
  "libc",
- "mio",
+ "mio 0.7.13",
  "parking_lot 0.11.1",
  "signal-hook",
  "signal-hook-mio",
@@ -2099,9 +2111,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.112"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b03d17f364a3a042d5e5d46b053bbbf82c92c9430c592dd4c064dc6ee997125"
+checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
 
 [[package]]
 name = "linked-hash-map"
@@ -2120,9 +2132,9 @@ dependencies = [
 
 [[package]]
 name = "lock_api"
-version = "0.4.4"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0382880606dff6d15c9476c416d18690b72742aa7b605bb6dd6ec9030fbf07eb"
+checksum = "88943dd7ef4a2e5a4bfa2753aaab3013e34ce2533d1996fb18ef591e315e2b3b"
 dependencies = [
  "scopeguard",
 ]
@@ -2209,6 +2221,18 @@ dependencies = [
  "miow",
  "ntapi",
  "winapi",
+]
+
+[[package]]
+name = "mio"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57ee1c23c7c63b0c9250c339ffdc69255f110b298b901b9f6c82547b7b87caaf"
+dependencies = [
+ "libc",
+ "log",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "windows-sys",
 ]
 
 [[package]]
@@ -3495,8 +3519,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d7744ac029df22dca6284efe4e898991d28e3085c706c972bcd7da4a27a15eb"
 dependencies = [
  "instant",
- "lock_api 0.4.4",
+ "lock_api 0.4.6",
  "parking_lot_core 0.8.3",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+dependencies = [
+ "lock_api 0.4.6",
+ "parking_lot_core 0.9.3",
 ]
 
 [[package]]
@@ -3525,6 +3559,19 @@ dependencies = [
  "redox_syscall 0.2.10",
  "smallvec",
  "winapi",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09a279cbf25cb0757810394fbc1e359949b59e348145c643a939a525692e6929"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "redox_syscall 0.2.10",
+ "smallvec",
+ "windows-sys",
 ]
 
 [[package]]
@@ -3618,6 +3665,45 @@ checksum = "4a13a2fa9d0b63e5f22328828741e523766fff0ee9e779316902290dff3f824f"
 dependencies = [
  "fixedbitset 0.4.0",
  "indexmap",
+]
+
+[[package]]
+name = "phf"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabbf1ead8a5bcbc20f5f8b939ee3f5b0f6f281b6ad3468b84656b658b455259"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb1c3a8bc4dd4e5cfce29b44ffc14bedd2ee294559a294e2a4d4c9e9a6a13cd"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6"
+dependencies = [
+ "phf_shared",
+ "rand 0.8.4",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
+dependencies = [
+ "siphasher",
+ "uncased",
 ]
 
 [[package]]
@@ -4602,7 +4688,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29fd5867f1c4f2c5be079aee7a2adf1152ebb04a4bc4d341f504b7dece607ed4"
 dependencies = [
  "libc",
- "mio",
+ "mio 0.7.13",
  "signal-hook",
 ]
 
@@ -4631,6 +4717,12 @@ dependencies = [
  "log",
  "termcolor",
 ]
+
+[[package]]
+name = "siphasher"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
 
 [[package]]
 name = "sized-chunks"
@@ -4673,6 +4765,16 @@ dependencies = [
  "num 0.3.1",
  "pomelo",
  "structopt 0.3.25",
+]
+
+[[package]]
+name = "socket2"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66d72b759436ae32898a2af0a14218dbf55efde3feeb170eb623637db85ee1e0"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -4857,9 +4959,9 @@ dependencies = [
 
 [[package]]
 name = "tera"
-version = "1.7.1"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2617ab2fb1de8587a988a761692e59895438bebf404725d4f2123251f60bf23e"
+checksum = "7c9783d6ff395ae80cf17ed9a25360e7ba37742a79fa8fddabb073c5c7c8856d"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -4959,9 +5061,9 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
+checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
 dependencies = [
  "once_cell",
 ]
@@ -5022,29 +5124,29 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.9.0"
+version = "1.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b7b349f11a7047e6d1276853e612d152f5e8a352c61917887cc2169e2366b4c"
+checksum = "c51a52ed6686dd62c320f9b89299e9dfb46f730c7a48e635c19f21d116cb1439"
 dependencies = [
- "autocfg",
  "bytes",
  "libc",
  "memchr",
- "mio",
+ "mio 0.8.4",
  "num_cpus",
  "once_cell",
- "parking_lot 0.11.1",
+ "parking_lot 0.12.1",
  "pin-project-lite",
  "signal-hook-registry",
+ "socket2",
  "tokio-macros",
  "winapi",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "1.3.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54473be61f4ebe4efd09cec9bd5d16fa51d70ea0192213d754d2d500457db110"
+checksum = "9724f9a975fb987ef7a3cd9be0350edcbe130698af5b8f7a631e23d42d052484"
 dependencies = [
  "proc-macro2 1.0.28",
  "quote 1.0.9",
@@ -5086,11 +5188,12 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.21"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f4ed65637b8390770814083d20756f87bfa2c21bf2f110babdc5438351746e4"
+checksum = "7b7358be39f2f274f322d2aaed611acc57f382e8eb1e5b48cb9ae30933495ce7"
 dependencies = [
- "lazy_static 1.4.0",
+ "once_cell",
+ "valuable",
 ]
 
 [[package]]
@@ -5106,13 +5209,13 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.3"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "245da694cc7fc4729f3f418b304cb57789f1bed2a78c575407ab8a23f53cb4d3"
+checksum = "60db860322da191b40952ad9affe65ea23e7dd6a5c442c2c42865810c6ab8e6b"
 dependencies = [
  "ansi_term 0.12.1",
- "lazy_static 1.4.0",
  "matchers",
+ "once_cell",
  "regex",
  "sharded-slab",
  "smallvec",
@@ -5197,6 +5300,15 @@ dependencies = [
  "crunchy",
  "hex",
  "static_assertions",
+]
+
+[[package]]
+name = "uncased"
+version = "0.9.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09b01702b0fd0b3fadcf98e098780badda8742d4f4a7676615cad90e8ac73622"
+dependencies = [
+ "version_check",
 ]
 
 [[package]]
@@ -5327,6 +5439,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "936e4b492acfd135421d8dca4b1aa80a7bfc26e702ef3af710e0752684df5372"
 
 [[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+
+[[package]]
 name = "variant_count"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5400,6 +5518,12 @@ name = "wasi"
 version = "0.10.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
@@ -5501,6 +5625,49 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
+dependencies = [
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
 
 [[package]]
 name = "wyz"

--- a/devtools/x/Cargo.toml
+++ b/devtools/x/Cargo.toml
@@ -23,7 +23,7 @@ env_logger = "0.8.3"
 log = "0.4.14"
 chrono = "0.4.19"
 globset = "0.4.6"
-regex = "1.4.3"
+regex = "1.5.5"
 rayon = "1.5.0"
 nextest-config = { git = "https://github.com/diem/diem-devtools", rev = "f99a204e3d3f8e503d51d7df42e55c8282b59154" }
 nextest-runner = { git = "https://github.com/diem/diem-devtools", rev = "f99a204e3d3f8e503d51d7df42e55c8282b59154" }

--- a/language/move-compiler/Cargo.toml
+++ b/language/move-compiler/Cargo.toml
@@ -11,7 +11,7 @@ license = "Apache-2.0"
 anyhow = "1.0.52"
 codespan-reporting = "0.11.1"
 hex = "0.4.3"
-regex = "1.4.3"
+regex = "1.5.5"
 clap = { version = "3.1.8", features = ["derive"] }
 difference = "2.0.0"
 petgraph = "0.5.1"

--- a/language/move-core/types/Cargo.toml
+++ b/language/move-core/types/Cargo.toml
@@ -24,7 +24,7 @@ serde_bytes = "0.11.5"
 [dev-dependencies]
 proptest = "1.0.0"
 proptest-derive = "0.3.0"
-regex = "1.4.3"
+regex = "1.5.5"
 serde_json = "1.0.64"
 
 [features]

--- a/language/move-model/Cargo.toml
+++ b/language/move-model/Cargo.toml
@@ -26,7 +26,7 @@ itertools = "0.10.0"
 log = "0.4.14"
 num = "0.4.0"
 once_cell = "1.7.2"
-regex = "1.4.3"
+regex = "1.5.5"
 anyhow = "1.0.52"
 serde = { version = "1.0.124", features = ["derive"] }
 

--- a/language/move-prover/Cargo.toml
+++ b/language/move-prover/Cargo.toml
@@ -38,7 +38,7 @@ serde = { version = "1.0.124", features = ["derive"] }
 serde_json = "1.0.64"
 simplelog = "0.9.0"
 once_cell = "1.7.2"
-tokio = { version = "1.8.1", features = ["full"] }
+tokio = { version = "1.18.2", features = ["full"] }
 toml = "0.5.8"
 
 [dev-dependencies]

--- a/language/move-prover/boogie-backend/Cargo.toml
+++ b/language/move-prover/boogie-backend/Cargo.toml
@@ -22,10 +22,10 @@ serde_json = "1.0.64"
 anyhow = "1.0.52"
 once_cell = "1.7.2"
 pretty = "0.10.0"
-regex = "1.4.3"
+regex = "1.5.5"
 rand = "0.8.3"
 futures = "0.3.12"
-tera = "1.7.1"
-tokio = { version = "1.8.1", features = ["full"] }
+tera = "1.16.0"
+tokio = { version = "1.18.2", features = ["full"] }
 codespan = "0.11.1"
 codespan-reporting = "0.11.1"

--- a/language/move-prover/move-docgen/Cargo.toml
+++ b/language/move-prover/move-docgen/Cargo.toml
@@ -17,7 +17,7 @@ codespan-reporting = "0.11.1"
 itertools = "0.10.0"
 log = "0.4.14"
 num = "0.4.0"
-regex = "1.4.3"
+regex = "1.5.5"
 anyhow = "1.0.52"
 serde = { version = "1.0.124", features = ["derive"] }
 once_cell = "1.7.2"

--- a/language/move-prover/test-utils/Cargo.toml
+++ b/language/move-prover/test-utils/Cargo.toml
@@ -9,5 +9,5 @@ license = "Apache-2.0"
 [dependencies]
 prettydiff = "0.4.0"
 anyhow = "1.0.52"
-regex = "1.4.3"
+regex = "1.5.5"
 move-command-line-common = { path = "../../move-command-line-common" }

--- a/language/testing-infra/test-generation/Cargo.toml
+++ b/language/testing-infra/test-generation/Cargo.toml
@@ -18,7 +18,7 @@ hex = "0.4.3"
 getrandom = "0.2.2"
 crossbeam-channel = "0.5.0"
 tracing = "0.1.26"
-tracing-subscriber = { version = "0.3.3", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }
 once_cell = "1.7.2"
 
 move-bytecode-verifier = { path = "../../move-bytecode-verifier" }

--- a/language/tools/move-bytecode-viewer/Cargo.toml
+++ b/language/tools/move-bytecode-viewer/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 [dependencies]
 clap = { version = "3.1.8", features = ["derive"] }
 anyhow = "1.0.52"
-regex = "1.1.9"
+regex = "1.5.5"
 tui = "0.17.0"
 crossterm = "0.21"
 

--- a/language/tools/move-unit-test/Cargo.toml
+++ b/language/tools/move-unit-test/Cargo.toml
@@ -16,7 +16,7 @@ clap = { version = "3.1.8", features = ["derive"] }
 codespan-reporting = "0.11.1"
 colored = "2.0.0"
 rayon = "1.5.0"
-regex = "1.1.9"
+regex = "1.5.5"
 once_cell = "1.7.2"
 itertools = "0.10.1"
 


### PR DESCRIPTION
Updated Rust packages in order to pass the `cargo audit`.

`time` is not updated. Instead the security advisory `RUSTSEC-2020-0071` should be ignored, since it does not affect `chrono`, our only dependency using it.

Took cue from Diem's commit: [f416e383e](https://github.com/diem/diem/commit/f416e383e08826d0eee42bd433e4f2ef4fd764e9) ("fix rustsec vulnerabilities", 2022-06-22).

Original Diem PR: diem/diem#10306
Chrono not affected: chronotope/chrono#578

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Move Language.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

`cargo audit` didn't pass. Updated packages accordingly and modified the daily CI to ignore an advisory not related to us.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes.

## Test Plan

CI tests.