### PR TITLE
[move-prover] write-back following the whole ancestor tree

### DIFF
--- a/language/move-prover/bytecode/src/borrow_analysis.rs
+++ b/language/move-prover/bytecode/src/borrow_analysis.rs
@@ -21,11 +21,7 @@ use move_model::{
     ty::Type,
     well_known::{TABLE_BORROW_MUT, VECTOR_BORROW_MUT},
 };
-use std::{
-    borrow::BorrowMut,
-    collections::{BTreeMap, BTreeSet},
-    fmt,
-};
+use std::{borrow::BorrowMut, collections::BTreeMap, fmt};
 
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Default)]
 pub struct BorrowInfo {
@@ -44,44 +40,29 @@ pub struct BorrowInfo {
     borrows_from: MapDomain<BorrowNode, SetDomain<(BorrowNode, BorrowEdge)>>,
 }
 
+/// Represents a write-back from a source node to a destination node with the associated edge
+#[derive(Debug, Clone)]
+pub struct WriteBackAction {
+    pub src: BorrowNode,
+    pub dst: BorrowNode,
+    pub edge: BorrowEdge,
+}
+
 impl BorrowInfo {
     /// Gets the children of this node.
-    pub fn get_children(&self, node: &BorrowNode) -> Vec<&BorrowNode> {
+    fn get_children(&self, node: &BorrowNode) -> Vec<&BorrowNode> {
         self.borrowed_by
             .get(node)
             .map(|s| s.iter().map(|(n, _)| n).collect_vec())
-            .unwrap_or_else(Vec::new)
+            .unwrap_or_default()
     }
 
-    /// Gets the parents of this node.
-    pub fn get_parents(&self, node: &BorrowNode) -> Vec<&BorrowNode> {
+    /// Gets the parents (together with the edges) of this node.
+    fn get_incoming(&self, node: &BorrowNode) -> Vec<(&BorrowNode, &BorrowEdge)> {
         self.borrows_from
             .get(node)
-            .map(|s| s.iter().map(|(n, _)| n).collect_vec())
-            .unwrap_or_else(Vec::new)
-    }
-
-    /// Gets incoming edges (together with sources) of this node.
-    pub fn get_incoming(&self, node: &BorrowNode) -> SetDomain<(BorrowNode, BorrowEdge)> {
-        self.borrows_from.get(node).cloned().unwrap_or_default()
-    }
-
-    /// Returns true if this node is conditional, that is, it borrows from multiple parents,
-    /// or has a transient child which is conditional.
-    pub fn is_conditional(&self, node: &BorrowNode) -> bool {
-        if let Some(parents) = self.borrows_from.get(node) {
-            // If there are more than one parent for this node, it is
-            // conditional.
-            if parents.len() > 1 {
-                return true;
-            }
-        }
-        if let Some(childs) = self.borrowed_by.get(node) {
-            // Otherwise we look for a child that is conditional.
-            childs.iter().any(|(c, _)| self.is_conditional(c))
-        } else {
-            false
-        }
+            .map(|s| s.iter().map(|(n, e)| (n, e)).collect_vec())
+            .unwrap_or_default()
     }
 
     /// Checks whether a node is in use. A node is used if it is in the live_nodes set
@@ -96,44 +77,74 @@ impl BorrowInfo {
         }
     }
 
-    /// Checks whether this is a moved node.
-    pub fn is_moved(&self, node: &BorrowNode) -> bool {
-        self.moved_nodes.contains(node)
-    }
-
     /// Returns nodes which are dying from this to the next state. This includes those which
     /// are directly dying plus those from which they borrow. Returns nodes in child-first order.
-    pub fn dying_nodes(&self, next: &BorrowInfo) -> Vec<BorrowNode> {
-        let mut visited = BTreeSet::new();
+    pub fn dying_nodes(&self, next: &BorrowInfo) -> Vec<(BorrowNode, Vec<Vec<WriteBackAction>>)> {
         let mut result = vec![];
         for dying in self.live_nodes.difference(&next.live_nodes) {
-            // Collect ancestors, but exclude those which are still in use. Some nodes may be
-            // dying regards direct usage in instructions, but they may still be ancestors of
-            // living nodes (this is what `is_in_use` checks for).
-            if !next.is_in_use(dying) {
-                self.collect_ancestors(&mut visited, &mut result, dying, &|n| !next.is_in_use(n));
+            if next.is_in_use(dying) {
+                continue;
             }
+
+            // Collect ancestors trees until reaching an ancestor that is still in use.
+            let dying_trees = self.collect_dying_ancestor_trees(dying, next);
+            result.push((dying.clone(), dying_trees));
         }
         result
     }
 
-    /// Collects this node and ancestors, inserting them in child-first order into the
-    /// given vector. Ancestors are only added if they fulfill the predicate.
-    fn collect_ancestors<P>(
+    /// Start from this node and follow-up the borrow chain until reaching a live/in-use ancestor.
+    /// Collect possible paths (from this node to a live ancestor) and return them in the DFS order.
+    fn collect_dying_ancestor_trees(
         &self,
-        visited: &mut BTreeSet<BorrowNode>,
-        order: &mut Vec<BorrowNode>,
         node: &BorrowNode,
-        cond: &P,
-    ) where
-        P: Fn(&BorrowNode) -> bool,
-    {
-        if visited.insert(node.clone()) {
-            order.push(node.clone());
-            for parent in self.get_parents(node) {
-                if cond(parent) {
-                    self.collect_ancestors(visited, order, parent, cond);
+        next: &BorrowInfo,
+    ) -> Vec<Vec<WriteBackAction>> {
+        let mut trees = vec![];
+        self.collect_dying_ancestor_trees_recursive(node, next, vec![], &mut trees);
+        trees
+    }
+
+    fn collect_dying_ancestor_trees_recursive(
+        &self,
+        node: &BorrowNode,
+        next: &BorrowInfo,
+        order: Vec<WriteBackAction>,
+        trees: &mut Vec<Vec<WriteBackAction>>,
+    ) {
+        match node {
+            BorrowNode::LocalRoot(..) | BorrowNode::GlobalRoot(..) => {
+                trees.push(order);
+            }
+            BorrowNode::Reference(..) => {
+                if next.is_in_use(node) {
+                    // stop at a live reference
+                    trees.push(order);
+                } else {
+                    let incoming = self.get_incoming(node);
+                    if incoming.is_empty() {
+                        // when the borrow reference node has no incoming edges, it means that this
+                        // reference is a function argument.
+                        trees.push(order);
+                    } else {
+                        // when there are incoming edges, this borrow occurs within the body
+                        // of this function and this node need to be further traced upwards.
+                        for (parent, edge) in incoming {
+                            let mut appended = order.clone();
+                            appended.push(WriteBackAction {
+                                src: node.clone(),
+                                dst: parent.clone(),
+                                edge: edge.clone(),
+                            });
+                            self.collect_dying_ancestor_trees_recursive(
+                                parent, next, appended, trees,
+                            );
+                        }
+                    }
                 }
+            }
+            BorrowNode::ReturnPlaceholder(..) => {
+                unreachable!("placeholder node type is not expected here");
             }
         }
     }

--- a/language/move-prover/tests/sources/functional/conditional_write_back.move
+++ b/language/move-prover/tests/sources/functional/conditional_write_back.move
@@ -1,0 +1,99 @@
+module 0x42::Test {
+    struct S {
+        x: u64,
+        y: u64,
+    }
+
+    struct T has key {
+        x: u64,
+    }
+
+    struct R has key {
+        x: u64,
+    }
+
+    public fun diff_field(cond: bool): S {
+        let s = S { x: 0, y: 0  };
+
+        let f = if (cond) {
+            &mut s.x
+        } else {
+            &mut s.y
+        };
+        *f = 1;
+
+        s
+    }
+    spec diff_field {
+        ensures cond ==> (result.x == 1 && result.y == 0);
+        ensures (!cond) ==> (result.x == 0 && result.y == 1);
+    }
+
+    public fun diff_address(cond: bool, a1: address, a2: address) acquires T {
+        let x = if (cond) {
+            let t1 = borrow_global_mut<T>(a1);
+            &mut t1.x
+        } else {
+            let t2 = borrow_global_mut<T>(a2);
+            &mut t2.x
+        };
+        *x = 0;
+    }
+    spec diff_address {
+        aborts_if cond && !exists<T>(a1);
+        aborts_if !cond && !exists<T>(a2);
+        ensures if (cond) global<T>(a1).x == 0 else global<T>(a2).x == 0;
+    }
+
+    public fun diff_location(cond: bool, a: address, l: &mut T) acquires T {
+        let x = if (cond) {
+            let t1 = borrow_global_mut<T>(a);
+            &mut t1.x
+        } else {
+            let t2 = l;
+            &mut t2.x
+        };
+        *x = 0;
+    }
+    spec diff_location {
+        aborts_if cond && !exists<T>(a);
+        ensures if (cond) global<T>(a).x == 0 else l.x == 0;
+    }
+
+    public fun diff_resource(cond: bool, a: address) acquires T, R {
+        let x = if (cond) {
+            let t1 = borrow_global_mut<T>(a);
+            &mut t1.x
+        } else {
+            let t2 = borrow_global_mut<R>(a);
+            &mut t2.x
+        };
+        *x = 0;
+    }
+    spec diff_resource {
+        aborts_if cond && !exists<T>(a);
+        aborts_if !cond && !exists<R>(a);
+        ensures if (cond) global<T>(a).x == 0 else global<R>(a).x == 0;
+    }
+
+    struct V<T: store> has key {
+        x: u64,
+        y: T,
+    }
+
+    public fun diff_resource_generic<A: store, B: store>(cond: bool, a: address) acquires V {
+        let x = if (cond) {
+            let t1 = borrow_global_mut<V<A>>(a);
+            &mut t1.x
+        } else {
+            let t2 = borrow_global_mut<V<B>>(a);
+            &mut t2.x
+        };
+        *x = 0;
+    }
+    spec diff_resource_generic {
+        aborts_if cond && !exists<V<A>>(a);
+        aborts_if !cond && !exists<V<B>>(a);
+        ensures if (cond) global<V<A>>(a).x == 0 else global<V<B>>(a).x == 0;
+    }
+}

--- a/language/move-prover/tests/sources/functional/invariants.exp
+++ b/language/move-prover/tests/sources/functional/invariants.exp
@@ -53,7 +53,6 @@ error: data invariant does not hold
     =         x_ref = <redacted>
     =     at tests/sources/functional/invariants.move:160: lifetime_invalid_S_branching
     =     at tests/sources/functional/invariants.move:163: lifetime_invalid_S_branching
-    =     at tests/sources/functional/invariants.move:143
+    =     at <internal>:1
     =     at tests/sources/functional/invariants.move:163: lifetime_invalid_S_branching
-    =         a = <redacted>
     =     at tests/sources/functional/invariants.move:150


### PR DESCRIPTION
The current memory model in Move Prover has a flaw in writing back
dying references, as identified in issue https://github.com/move-language/move/issues/299.

The gist of the flaw is this:
we can only write-back a reference on code paths where it is guaranteed
to be defined. Otherwise in the prover's point of view, the write-back
may cause arbitrary value to be written back to the parent `Mutation`
value and cause unexpected verification failures.

As a side note, this is also visible in the concrete executor of the
spec + move (i.e., the stackless VM).

The solution, as implemented in this commit, is to ravamp the way
write-backs are done.

In summary, the solution is to write-back the dying references according
to DFS paths instead of BFS layers.

Taking the example in https://github.com/move-language/move/issues/299:

The borrow graph looks like this:

```
     --borrows_from--> t7 --borrows_from--> Global(t1)
t3 --|
     --borrows_from--> t8 --borrows_from--> Global(t2)
```

And the old approach is to write-back according to BFS layers,
i.e., t3, then t7 and t8, which yields the following psudo-code.

```
if IsParent[t7](t3) {
    WriteBack[t7](t3);
}

if IsParent[t8](t3) {
    WriteBack[t8](t3);
}

// both t7 and t8 are not always defined when code reaches here
WriteBack[Global](t7);
WriteBack[Global](t8);
```

The correct behavior should be DFS paths, i.e.:

```
if IsParent[t7](t3) {
    WriteBack[t7](t3);
    // t7 is guaranteed to be defined when code reaches here
    WriteBack[Global](t7);
}

if IsParent[t8](t3) {
    WriteBack[t8](t3);
    // similarly, t8 is guaranteed to be defined in this block
    WriteBack[Global](t8);
}
```

## Motivation

To fix issue #299 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes

## Test Plan

A new move-prover functional test is added

Inconsistency tests manually executed on DPN code:
```bash
cd language/documentation/examples/diem-framework/move-packages/core
cargo run -p df-cli -- prove -- --check-inconsistency

cd language/documentation/examples/diem-framework/move-packages/DPN
cargo run -p df-cli -- prove -- --check-inconsistency

cd language/documentation/examples/diem-framework/move-packages/experimental
cargo run -p df-cli -- prove -- --check-inconsistency
```