### PR TITLE
[Move analyzer] Increased stack size of initial symbolication run

### DIFF
--- a/language/move-analyzer/src/symbols.rs
+++ b/language/move-analyzer/src/symbols.rs
@@ -90,6 +90,9 @@ use move_symbol_pool::Symbol;
 /// Enabling/disabling the language server reporting readiness to support go-to-def and
 /// go-to-references to the IDE.
 pub const DEFS_AND_REFS_SUPPORT: bool = true;
+// Building Move code requires a larger stack size on Windows (16M has been chosen somewhat
+// arbitrarily)
+pub const STACK_SIZE_BYTES: usize = 16 * 1024 * 1024;
 
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Copy)]
 /// Location of a definition's identifier
@@ -334,7 +337,7 @@ impl SymbolicatorRunner {
         let runner = SymbolicatorRunner { mtx_cvar };
 
         thread::Builder::new()
-            .stack_size(16 * 1024 * 1024) // building Move code requires a larger stack size on Windows
+            .stack_size(STACK_SIZE_BYTES)
             .spawn(move || {
                 let (mtx, cvar) = &*thread_mtx_cvar;
                 // Locations opened in the IDE (files or directories) for which manifest file is missing


### PR DESCRIPTION
## Motivation

This is a follow-up to https://github.com/move-language/move/pull/292 - this PR moves initial symbolication run to be executed by a thread with increased stack size to have all symbolicator runs (both the initial one and the following ones) work correctly on Windows.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes

