### PR TITLE
[move-prover] treat store as copy in borrow analysis

### DIFF
--- a/language/move-prover/bytecode/src/borrow_analysis.rs
+++ b/language/move-prover/bytecode/src/borrow_analysis.rs
@@ -546,11 +546,11 @@ impl<'a> TransferFunctions for BorrowAnalysis<'a> {
                 let dest_node = self.borrow_node(*dest);
                 let src_node = self.borrow_node(*src);
                 match kind {
-                    AssignKind::Move | AssignKind::Store => {
+                    AssignKind::Move => {
                         self.remap_borrow_node(state, &src_node, &dest_node);
                         state.moved_nodes.insert(src_node);
                     }
-                    AssignKind::Copy => {
+                    AssignKind::Copy | AssignKind::Store => {
                         state.add_node(dest_node.clone());
                         state.add_edge(src_node, dest_node, BorrowEdge::Direct);
                     }

--- a/language/move-prover/bytecode/tests/borrow/basic_test.exp
+++ b/language/move-prover/bytecode/tests/borrow/basic_test.exp
@@ -422,75 +422,61 @@ fun TestBorrow::test7($t0|b: bool) {
      # borrowed_by: LocalRoot($t1) -> {(@, Reference($t6))}
      # borrows_from: Reference($t6) -> {(@, LocalRoot($t1))}
   5: $t3 := $t6
-     # live_nodes: LocalRoot($t0), Reference($t3)
-     # moved_nodes: Reference($t6)
-     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t3))}
-     # borrows_from: Reference($t3) -> {(@, LocalRoot($t1))}
+     # live_nodes: LocalRoot($t0), Reference($t3), Reference($t6)
+     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t6))}, Reference($t6) -> {(@, Reference($t3))}
+     # borrows_from: Reference($t3) -> {(@, Reference($t6))}, Reference($t6) -> {(@, LocalRoot($t1))}
   6: if ($t0) goto 14 else goto 17
-     # live_nodes: LocalRoot($t0)
-     # moved_nodes: Reference($t6)
-     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t3))}
-     # borrows_from: Reference($t3) -> {(@, LocalRoot($t1))}
+     # live_nodes: LocalRoot($t0), Reference($t6)
+     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t6))}, Reference($t6) -> {(@, Reference($t3))}
+     # borrows_from: Reference($t3) -> {(@, Reference($t6))}, Reference($t6) -> {(@, LocalRoot($t1))}
   7: label L0
-     # live_nodes: LocalRoot($t0)
-     # moved_nodes: Reference($t6)
-     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t3))}
-     # borrows_from: Reference($t3) -> {(@, LocalRoot($t1))}
+     # live_nodes: LocalRoot($t0), Reference($t6)
+     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t6))}, Reference($t6) -> {(@, Reference($t3))}
+     # borrows_from: Reference($t3) -> {(@, Reference($t6))}, Reference($t6) -> {(@, LocalRoot($t1))}
   8: destroy($t6)
      # live_nodes: LocalRoot($t0)
-     # moved_nodes: Reference($t6)
-     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t3))}
-     # borrows_from: Reference($t3) -> {(@, LocalRoot($t1))}
+     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t6))}, Reference($t6) -> {(@, Reference($t3))}
+     # borrows_from: Reference($t3) -> {(@, Reference($t6))}, Reference($t6) -> {(@, LocalRoot($t1))}
   9: $t3 := borrow_local($t2)
      # live_nodes: LocalRoot($t0), Reference($t3)
-     # moved_nodes: Reference($t6)
-     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t3))}, LocalRoot($t2) -> {(@, Reference($t3))}
-     # borrows_from: Reference($t3) -> {(@, LocalRoot($t1)), (@, LocalRoot($t2))}
+     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t6))}, LocalRoot($t2) -> {(@, Reference($t3))}, Reference($t6) -> {(@, Reference($t3))}
+     # borrows_from: Reference($t3) -> {(@, LocalRoot($t2)), (@, Reference($t6))}, Reference($t6) -> {(@, LocalRoot($t1))}
  10: label L2
      # live_nodes: LocalRoot($t0), Reference($t3)
-     # moved_nodes: Reference($t6)
-     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t3))}, LocalRoot($t2) -> {(@, Reference($t3))}
-     # borrows_from: Reference($t3) -> {(@, LocalRoot($t1)), (@, LocalRoot($t2))}
+     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t6))}, LocalRoot($t2) -> {(@, Reference($t3))}, Reference($t6) -> {(@, Reference($t3))}
+     # borrows_from: Reference($t3) -> {(@, LocalRoot($t2)), (@, Reference($t6))}, Reference($t6) -> {(@, LocalRoot($t1))}
  11: $t7 := 0
      # live_nodes: LocalRoot($t0), Reference($t3)
-     # moved_nodes: Reference($t6)
-     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t3))}, LocalRoot($t2) -> {(@, Reference($t3))}
-     # borrows_from: Reference($t3) -> {(@, LocalRoot($t1)), (@, LocalRoot($t2))}
+     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t6))}, LocalRoot($t2) -> {(@, Reference($t3))}, Reference($t6) -> {(@, Reference($t3))}
+     # borrows_from: Reference($t3) -> {(@, LocalRoot($t2)), (@, Reference($t6))}, Reference($t6) -> {(@, LocalRoot($t1))}
  12: TestBorrow::test3($t3, $t7)
      # live_nodes: LocalRoot($t0)
-     # moved_nodes: Reference($t6)
-     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t3))}, LocalRoot($t2) -> {(@, Reference($t3))}
-     # borrows_from: Reference($t3) -> {(@, LocalRoot($t1)), (@, LocalRoot($t2))}
+     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t6))}, LocalRoot($t2) -> {(@, Reference($t3))}, Reference($t6) -> {(@, Reference($t3))}
+     # borrows_from: Reference($t3) -> {(@, LocalRoot($t2)), (@, Reference($t6))}, Reference($t6) -> {(@, LocalRoot($t1))}
  13: return ()
-     # live_nodes: LocalRoot($t0), Reference($t3)
-     # moved_nodes: Reference($t6)
-     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t3))}
-     # borrows_from: Reference($t3) -> {(@, LocalRoot($t1))}
+     # live_nodes: LocalRoot($t0), Reference($t3), Reference($t6)
+     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t6))}, Reference($t6) -> {(@, Reference($t3))}
+     # borrows_from: Reference($t3) -> {(@, Reference($t6))}, Reference($t6) -> {(@, LocalRoot($t1))}
  14: label L3
-     # live_nodes: LocalRoot($t0), Reference($t3)
-     # moved_nodes: Reference($t6)
-     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t3))}
-     # borrows_from: Reference($t3) -> {(@, LocalRoot($t1))}
+     # live_nodes: LocalRoot($t0), Reference($t3), Reference($t6)
+     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t6))}, Reference($t6) -> {(@, Reference($t3))}
+     # borrows_from: Reference($t3) -> {(@, Reference($t6))}, Reference($t6) -> {(@, LocalRoot($t1))}
  15: destroy($t3)
-     # live_nodes: LocalRoot($t0)
-     # moved_nodes: Reference($t6)
-     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t3))}
-     # borrows_from: Reference($t3) -> {(@, LocalRoot($t1))}
+     # live_nodes: LocalRoot($t0), Reference($t6)
+     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t6))}, Reference($t6) -> {(@, Reference($t3))}
+     # borrows_from: Reference($t3) -> {(@, Reference($t6))}, Reference($t6) -> {(@, LocalRoot($t1))}
  16: goto 7
-     # live_nodes: LocalRoot($t0), Reference($t3)
-     # moved_nodes: Reference($t6)
-     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t3))}
-     # borrows_from: Reference($t3) -> {(@, LocalRoot($t1))}
+     # live_nodes: LocalRoot($t0), Reference($t3), Reference($t6)
+     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t6))}, Reference($t6) -> {(@, Reference($t3))}
+     # borrows_from: Reference($t3) -> {(@, Reference($t6))}, Reference($t6) -> {(@, LocalRoot($t1))}
  17: label L4
-     # live_nodes: LocalRoot($t0), Reference($t3)
-     # moved_nodes: Reference($t6)
-     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t3))}
-     # borrows_from: Reference($t3) -> {(@, LocalRoot($t1))}
+     # live_nodes: LocalRoot($t0), Reference($t3), Reference($t6)
+     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t6))}, Reference($t6) -> {(@, Reference($t3))}
+     # borrows_from: Reference($t3) -> {(@, Reference($t6))}, Reference($t6) -> {(@, LocalRoot($t1))}
  18: destroy($t6)
      # live_nodes: LocalRoot($t0), Reference($t3)
-     # moved_nodes: Reference($t6)
-     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t3))}
-     # borrows_from: Reference($t3) -> {(@, LocalRoot($t1))}
+     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t6))}, Reference($t6) -> {(@, Reference($t3))}
+     # borrows_from: Reference($t3) -> {(@, Reference($t6))}, Reference($t6) -> {(@, LocalRoot($t1))}
  19: goto 10
 }
 

--- a/language/move-prover/bytecode/tests/borrow_strong/basic_test.exp
+++ b/language/move-prover/bytecode/tests/borrow_strong/basic_test.exp
@@ -417,95 +417,83 @@ fun TestBorrow::test10($t0|b: bool): TestBorrow::R {
      # borrowed_by: LocalRoot($t1) -> {(@, Reference($t6))}, Reference($t6) -> {(.x (u64), Reference($t7))}
      # borrows_from: Reference($t6) -> {(@, LocalRoot($t1))}, Reference($t7) -> {(.x (u64), Reference($t6))}
   5: $t2 := $t7
-     # live_nodes: LocalRoot($t0), Reference($t2), Reference($t6)
-     # moved_nodes: Reference($t7)
-     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t6))}, Reference($t6) -> {(.x (u64), Reference($t2))}
-     # borrows_from: Reference($t2) -> {(.x (u64), Reference($t6))}, Reference($t6) -> {(@, LocalRoot($t1))}
+     # live_nodes: LocalRoot($t0), Reference($t2), Reference($t6), Reference($t7)
+     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t6))}, Reference($t6) -> {(.x (u64), Reference($t7))}, Reference($t7) -> {(@, Reference($t2))}
+     # borrows_from: Reference($t2) -> {(@, Reference($t7))}, Reference($t6) -> {(@, LocalRoot($t1))}, Reference($t7) -> {(.x (u64), Reference($t6))}
   6: if ($t0) goto 18 else goto 21
-     # live_nodes: LocalRoot($t0), Reference($t6)
-     # moved_nodes: Reference($t7)
-     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t6))}, Reference($t6) -> {(.x (u64), Reference($t2))}
-     # borrows_from: Reference($t2) -> {(.x (u64), Reference($t6))}, Reference($t6) -> {(@, LocalRoot($t1))}
+     # live_nodes: LocalRoot($t0), Reference($t6), Reference($t7)
+     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t6))}, Reference($t6) -> {(.x (u64), Reference($t7))}, Reference($t7) -> {(@, Reference($t2))}
+     # borrows_from: Reference($t2) -> {(@, Reference($t7))}, Reference($t6) -> {(@, LocalRoot($t1))}, Reference($t7) -> {(.x (u64), Reference($t6))}
   7: label L0
-     # live_nodes: LocalRoot($t0), Reference($t6)
-     # moved_nodes: Reference($t7)
-     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t6))}, Reference($t6) -> {(.x (u64), Reference($t2))}
-     # borrows_from: Reference($t2) -> {(.x (u64), Reference($t6))}, Reference($t6) -> {(@, LocalRoot($t1))}
+     # live_nodes: LocalRoot($t0), Reference($t6), Reference($t7)
+     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t6))}, Reference($t6) -> {(.x (u64), Reference($t7))}, Reference($t7) -> {(@, Reference($t2))}
+     # borrows_from: Reference($t2) -> {(@, Reference($t7))}, Reference($t6) -> {(@, LocalRoot($t1))}, Reference($t7) -> {(.x (u64), Reference($t6))}
   8: destroy($t7)
      # live_nodes: LocalRoot($t0), Reference($t6)
-     # moved_nodes: Reference($t7)
-     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t6))}, Reference($t6) -> {(.x (u64), Reference($t2))}
-     # borrows_from: Reference($t2) -> {(.x (u64), Reference($t6))}, Reference($t6) -> {(@, LocalRoot($t1))}
+     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t6))}, Reference($t6) -> {(.x (u64), Reference($t7))}, Reference($t7) -> {(@, Reference($t2))}
+     # borrows_from: Reference($t2) -> {(@, Reference($t7))}, Reference($t6) -> {(@, LocalRoot($t1))}, Reference($t7) -> {(.x (u64), Reference($t6))}
   9: $t2 := TestBorrow::test9($t0, $t6)
      # live_nodes: LocalRoot($t0), Reference($t2)
-     # moved_nodes: Reference($t6), Reference($t7)
-     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t6))}, Reference($t6) -> {(.x (u64), Reference($t2)), (.y (u64), Reference($t2))}
-     # borrows_from: Reference($t2) -> {(.x (u64), Reference($t6)), (.y (u64), Reference($t6))}, Reference($t6) -> {(@, LocalRoot($t1))}
+     # moved_nodes: Reference($t6)
+     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t6))}, Reference($t6) -> {(.y (u64), Reference($t2)), (.x (u64)/@, Reference($t2)), (.x (u64), Reference($t7))}, Reference($t7) -> {(@, Reference($t2))}
+     # borrows_from: Reference($t2) -> {(.y (u64), Reference($t6)), (.x (u64)/@, Reference($t6)), (@, Reference($t7))}, Reference($t6) -> {(@, LocalRoot($t1))}, Reference($t7) -> {(.x (u64), Reference($t6))}
  10: goto 13
      # live_nodes: LocalRoot($t0), Reference($t2), Reference($t6)
-     # moved_nodes: Reference($t7)
-     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t6))}, Reference($t6) -> {(.x (u64), Reference($t2))}
-     # borrows_from: Reference($t2) -> {(.x (u64), Reference($t6))}, Reference($t6) -> {(@, LocalRoot($t1))}
+     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t6))}, Reference($t6) -> {(.x (u64), Reference($t7))}, Reference($t7) -> {(@, Reference($t2))}
+     # borrows_from: Reference($t2) -> {(@, Reference($t7))}, Reference($t6) -> {(@, LocalRoot($t1))}, Reference($t7) -> {(.x (u64), Reference($t6))}
  11: label L2
      # live_nodes: LocalRoot($t0), Reference($t2), Reference($t6)
-     # moved_nodes: Reference($t7)
-     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t6))}, Reference($t6) -> {(.x (u64), Reference($t2))}
-     # borrows_from: Reference($t2) -> {(.x (u64), Reference($t6))}, Reference($t6) -> {(@, LocalRoot($t1))}
+     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t6))}, Reference($t6) -> {(.x (u64), Reference($t7))}, Reference($t7) -> {(@, Reference($t2))}
+     # borrows_from: Reference($t2) -> {(@, Reference($t7))}, Reference($t6) -> {(@, LocalRoot($t1))}, Reference($t7) -> {(.x (u64), Reference($t6))}
  12: destroy($t6)
      # live_nodes: LocalRoot($t0), Reference($t2)
-     # moved_nodes: Reference($t6), Reference($t7)
-     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t6))}, Reference($t6) -> {(.x (u64), Reference($t2)), (.y (u64), Reference($t2))}
-     # borrows_from: Reference($t2) -> {(.x (u64), Reference($t6)), (.y (u64), Reference($t6))}, Reference($t6) -> {(@, LocalRoot($t1))}
+     # moved_nodes: Reference($t6)
+     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t6))}, Reference($t6) -> {(.y (u64), Reference($t2)), (.x (u64)/@, Reference($t2)), (.x (u64), Reference($t7))}, Reference($t7) -> {(@, Reference($t2))}
+     # borrows_from: Reference($t2) -> {(.y (u64), Reference($t6)), (.x (u64)/@, Reference($t6)), (@, Reference($t7))}, Reference($t6) -> {(@, LocalRoot($t1))}, Reference($t7) -> {(.x (u64), Reference($t6))}
  13: label L3
      # live_nodes: LocalRoot($t0), Reference($t2)
-     # moved_nodes: Reference($t6), Reference($t7)
-     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t6))}, Reference($t6) -> {(.x (u64), Reference($t2)), (.y (u64), Reference($t2))}
-     # borrows_from: Reference($t2) -> {(.x (u64), Reference($t6)), (.y (u64), Reference($t6))}, Reference($t6) -> {(@, LocalRoot($t1))}
+     # moved_nodes: Reference($t6)
+     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t6))}, Reference($t6) -> {(.y (u64), Reference($t2)), (.x (u64)/@, Reference($t2)), (.x (u64), Reference($t7))}, Reference($t7) -> {(@, Reference($t2))}
+     # borrows_from: Reference($t2) -> {(.y (u64), Reference($t6)), (.x (u64)/@, Reference($t6)), (@, Reference($t7))}, Reference($t6) -> {(@, LocalRoot($t1))}, Reference($t7) -> {(.x (u64), Reference($t6))}
  14: $t8 := 0
      # live_nodes: LocalRoot($t0), Reference($t2)
-     # moved_nodes: Reference($t6), Reference($t7)
-     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t6))}, Reference($t6) -> {(.x (u64), Reference($t2)), (.y (u64), Reference($t2))}
-     # borrows_from: Reference($t2) -> {(.x (u64), Reference($t6)), (.y (u64), Reference($t6))}, Reference($t6) -> {(@, LocalRoot($t1))}
+     # moved_nodes: Reference($t6)
+     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t6))}, Reference($t6) -> {(.y (u64), Reference($t2)), (.x (u64)/@, Reference($t2)), (.x (u64), Reference($t7))}, Reference($t7) -> {(@, Reference($t2))}
+     # borrows_from: Reference($t2) -> {(.y (u64), Reference($t6)), (.x (u64)/@, Reference($t6)), (@, Reference($t7))}, Reference($t6) -> {(@, LocalRoot($t1))}, Reference($t7) -> {(.x (u64), Reference($t6))}
  15: write_ref($t2, $t8)
      # live_nodes: LocalRoot($t0)
-     # moved_nodes: Reference($t6), Reference($t7)
-     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t6))}, Reference($t6) -> {(.x (u64), Reference($t2)), (.y (u64), Reference($t2))}
-     # borrows_from: Reference($t2) -> {(.x (u64), Reference($t6)), (.y (u64), Reference($t6))}, Reference($t6) -> {(@, LocalRoot($t1))}
+     # moved_nodes: Reference($t6)
+     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t6))}, Reference($t6) -> {(.y (u64), Reference($t2)), (.x (u64)/@, Reference($t2)), (.x (u64), Reference($t7))}, Reference($t7) -> {(@, Reference($t2))}
+     # borrows_from: Reference($t2) -> {(.y (u64), Reference($t6)), (.x (u64)/@, Reference($t6)), (@, Reference($t7))}, Reference($t6) -> {(@, LocalRoot($t1))}, Reference($t7) -> {(.x (u64), Reference($t6))}
  16: $t9 := move($t1)
      # live_nodes: LocalRoot($t0)
-     # moved_nodes: LocalRoot($t1), Reference($t6), Reference($t7)
-     # borrowed_by: LocalRoot($t9) -> {(@, Reference($t6))}, Reference($t6) -> {(.x (u64), Reference($t2)), (.y (u64), Reference($t2))}
-     # borrows_from: Reference($t2) -> {(.x (u64), Reference($t6)), (.y (u64), Reference($t6))}, Reference($t6) -> {(@, LocalRoot($t9))}
+     # moved_nodes: LocalRoot($t1), Reference($t6)
+     # borrowed_by: LocalRoot($t9) -> {(@, Reference($t6))}, Reference($t6) -> {(.y (u64), Reference($t2)), (.x (u64)/@, Reference($t2)), (.x (u64), Reference($t7))}, Reference($t7) -> {(@, Reference($t2))}
+     # borrows_from: Reference($t2) -> {(.y (u64), Reference($t6)), (.x (u64)/@, Reference($t6)), (@, Reference($t7))}, Reference($t6) -> {(@, LocalRoot($t9))}, Reference($t7) -> {(.x (u64), Reference($t6))}
  17: return $t9
-     # live_nodes: LocalRoot($t0), Reference($t2), Reference($t6)
-     # moved_nodes: Reference($t7)
-     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t6))}, Reference($t6) -> {(.x (u64), Reference($t2))}
-     # borrows_from: Reference($t2) -> {(.x (u64), Reference($t6))}, Reference($t6) -> {(@, LocalRoot($t1))}
+     # live_nodes: LocalRoot($t0), Reference($t2), Reference($t6), Reference($t7)
+     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t6))}, Reference($t6) -> {(.x (u64), Reference($t7))}, Reference($t7) -> {(@, Reference($t2))}
+     # borrows_from: Reference($t2) -> {(@, Reference($t7))}, Reference($t6) -> {(@, LocalRoot($t1))}, Reference($t7) -> {(.x (u64), Reference($t6))}
  18: label L4
-     # live_nodes: LocalRoot($t0), Reference($t2), Reference($t6)
-     # moved_nodes: Reference($t7)
-     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t6))}, Reference($t6) -> {(.x (u64), Reference($t2))}
-     # borrows_from: Reference($t2) -> {(.x (u64), Reference($t6))}, Reference($t6) -> {(@, LocalRoot($t1))}
+     # live_nodes: LocalRoot($t0), Reference($t2), Reference($t6), Reference($t7)
+     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t6))}, Reference($t6) -> {(.x (u64), Reference($t7))}, Reference($t7) -> {(@, Reference($t2))}
+     # borrows_from: Reference($t2) -> {(@, Reference($t7))}, Reference($t6) -> {(@, LocalRoot($t1))}, Reference($t7) -> {(.x (u64), Reference($t6))}
  19: destroy($t2)
-     # live_nodes: LocalRoot($t0), Reference($t6)
-     # moved_nodes: Reference($t7)
-     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t6))}, Reference($t6) -> {(.x (u64), Reference($t2))}
-     # borrows_from: Reference($t2) -> {(.x (u64), Reference($t6))}, Reference($t6) -> {(@, LocalRoot($t1))}
+     # live_nodes: LocalRoot($t0), Reference($t6), Reference($t7)
+     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t6))}, Reference($t6) -> {(.x (u64), Reference($t7))}, Reference($t7) -> {(@, Reference($t2))}
+     # borrows_from: Reference($t2) -> {(@, Reference($t7))}, Reference($t6) -> {(@, LocalRoot($t1))}, Reference($t7) -> {(.x (u64), Reference($t6))}
  20: goto 7
-     # live_nodes: LocalRoot($t0), Reference($t2), Reference($t6)
-     # moved_nodes: Reference($t7)
-     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t6))}, Reference($t6) -> {(.x (u64), Reference($t2))}
-     # borrows_from: Reference($t2) -> {(.x (u64), Reference($t6))}, Reference($t6) -> {(@, LocalRoot($t1))}
+     # live_nodes: LocalRoot($t0), Reference($t2), Reference($t6), Reference($t7)
+     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t6))}, Reference($t6) -> {(.x (u64), Reference($t7))}, Reference($t7) -> {(@, Reference($t2))}
+     # borrows_from: Reference($t2) -> {(@, Reference($t7))}, Reference($t6) -> {(@, LocalRoot($t1))}, Reference($t7) -> {(.x (u64), Reference($t6))}
  21: label L5
-     # live_nodes: LocalRoot($t0), Reference($t2), Reference($t6)
-     # moved_nodes: Reference($t7)
-     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t6))}, Reference($t6) -> {(.x (u64), Reference($t2))}
-     # borrows_from: Reference($t2) -> {(.x (u64), Reference($t6))}, Reference($t6) -> {(@, LocalRoot($t1))}
+     # live_nodes: LocalRoot($t0), Reference($t2), Reference($t6), Reference($t7)
+     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t6))}, Reference($t6) -> {(.x (u64), Reference($t7))}, Reference($t7) -> {(@, Reference($t2))}
+     # borrows_from: Reference($t2) -> {(@, Reference($t7))}, Reference($t6) -> {(@, LocalRoot($t1))}, Reference($t7) -> {(.x (u64), Reference($t6))}
  22: destroy($t7)
      # live_nodes: LocalRoot($t0), Reference($t2), Reference($t6)
-     # moved_nodes: Reference($t7)
-     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t6))}, Reference($t6) -> {(.x (u64), Reference($t2))}
-     # borrows_from: Reference($t2) -> {(.x (u64), Reference($t6))}, Reference($t6) -> {(@, LocalRoot($t1))}
+     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t6))}, Reference($t6) -> {(.x (u64), Reference($t7))}, Reference($t7) -> {(@, Reference($t2))}
+     # borrows_from: Reference($t2) -> {(@, Reference($t7))}, Reference($t6) -> {(@, LocalRoot($t1))}, Reference($t7) -> {(.x (u64), Reference($t6))}
  23: goto 11
 }
 
@@ -658,75 +646,61 @@ fun TestBorrow::test7($t0|b: bool) {
      # borrowed_by: LocalRoot($t1) -> {(@, Reference($t8))}
      # borrows_from: Reference($t8) -> {(@, LocalRoot($t1))}
   7: $t3 := $t8
-     # live_nodes: LocalRoot($t0), Reference($t3)
-     # moved_nodes: Reference($t8)
-     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t3))}
-     # borrows_from: Reference($t3) -> {(@, LocalRoot($t1))}
+     # live_nodes: LocalRoot($t0), Reference($t3), Reference($t8)
+     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t8))}, Reference($t8) -> {(@, Reference($t3))}
+     # borrows_from: Reference($t3) -> {(@, Reference($t8))}, Reference($t8) -> {(@, LocalRoot($t1))}
   8: if ($t0) goto 16 else goto 19
-     # live_nodes: LocalRoot($t0)
-     # moved_nodes: Reference($t8)
-     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t3))}
-     # borrows_from: Reference($t3) -> {(@, LocalRoot($t1))}
+     # live_nodes: LocalRoot($t0), Reference($t8)
+     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t8))}, Reference($t8) -> {(@, Reference($t3))}
+     # borrows_from: Reference($t3) -> {(@, Reference($t8))}, Reference($t8) -> {(@, LocalRoot($t1))}
   9: label L0
-     # live_nodes: LocalRoot($t0)
-     # moved_nodes: Reference($t8)
-     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t3))}
-     # borrows_from: Reference($t3) -> {(@, LocalRoot($t1))}
+     # live_nodes: LocalRoot($t0), Reference($t8)
+     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t8))}, Reference($t8) -> {(@, Reference($t3))}
+     # borrows_from: Reference($t3) -> {(@, Reference($t8))}, Reference($t8) -> {(@, LocalRoot($t1))}
  10: destroy($t8)
      # live_nodes: LocalRoot($t0)
-     # moved_nodes: Reference($t8)
-     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t3))}
-     # borrows_from: Reference($t3) -> {(@, LocalRoot($t1))}
+     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t8))}, Reference($t8) -> {(@, Reference($t3))}
+     # borrows_from: Reference($t3) -> {(@, Reference($t8))}, Reference($t8) -> {(@, LocalRoot($t1))}
  11: $t3 := borrow_local($t2)
      # live_nodes: LocalRoot($t0), Reference($t3)
-     # moved_nodes: Reference($t8)
-     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t3))}, LocalRoot($t2) -> {(@, Reference($t3))}
-     # borrows_from: Reference($t3) -> {(@, LocalRoot($t1)), (@, LocalRoot($t2))}
+     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t8))}, LocalRoot($t2) -> {(@, Reference($t3))}, Reference($t8) -> {(@, Reference($t3))}
+     # borrows_from: Reference($t3) -> {(@, LocalRoot($t2)), (@, Reference($t8))}, Reference($t8) -> {(@, LocalRoot($t1))}
  12: label L2
      # live_nodes: LocalRoot($t0), Reference($t3)
-     # moved_nodes: Reference($t8)
-     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t3))}, LocalRoot($t2) -> {(@, Reference($t3))}
-     # borrows_from: Reference($t3) -> {(@, LocalRoot($t1)), (@, LocalRoot($t2))}
+     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t8))}, LocalRoot($t2) -> {(@, Reference($t3))}, Reference($t8) -> {(@, Reference($t3))}
+     # borrows_from: Reference($t3) -> {(@, LocalRoot($t2)), (@, Reference($t8))}, Reference($t8) -> {(@, LocalRoot($t1))}
  13: $t9 := 0
      # live_nodes: LocalRoot($t0), Reference($t3)
-     # moved_nodes: Reference($t8)
-     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t3))}, LocalRoot($t2) -> {(@, Reference($t3))}
-     # borrows_from: Reference($t3) -> {(@, LocalRoot($t1)), (@, LocalRoot($t2))}
+     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t8))}, LocalRoot($t2) -> {(@, Reference($t3))}, Reference($t8) -> {(@, Reference($t3))}
+     # borrows_from: Reference($t3) -> {(@, LocalRoot($t2)), (@, Reference($t8))}, Reference($t8) -> {(@, LocalRoot($t1))}
  14: TestBorrow::test3($t3, $t9)
      # live_nodes: LocalRoot($t0)
-     # moved_nodes: Reference($t8)
-     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t3))}, LocalRoot($t2) -> {(@, Reference($t3))}
-     # borrows_from: Reference($t3) -> {(@, LocalRoot($t1)), (@, LocalRoot($t2))}
+     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t8))}, LocalRoot($t2) -> {(@, Reference($t3))}, Reference($t8) -> {(@, Reference($t3))}
+     # borrows_from: Reference($t3) -> {(@, LocalRoot($t2)), (@, Reference($t8))}, Reference($t8) -> {(@, LocalRoot($t1))}
  15: return ()
-     # live_nodes: LocalRoot($t0), Reference($t3)
-     # moved_nodes: Reference($t8)
-     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t3))}
-     # borrows_from: Reference($t3) -> {(@, LocalRoot($t1))}
+     # live_nodes: LocalRoot($t0), Reference($t3), Reference($t8)
+     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t8))}, Reference($t8) -> {(@, Reference($t3))}
+     # borrows_from: Reference($t3) -> {(@, Reference($t8))}, Reference($t8) -> {(@, LocalRoot($t1))}
  16: label L3
-     # live_nodes: LocalRoot($t0), Reference($t3)
-     # moved_nodes: Reference($t8)
-     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t3))}
-     # borrows_from: Reference($t3) -> {(@, LocalRoot($t1))}
+     # live_nodes: LocalRoot($t0), Reference($t3), Reference($t8)
+     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t8))}, Reference($t8) -> {(@, Reference($t3))}
+     # borrows_from: Reference($t3) -> {(@, Reference($t8))}, Reference($t8) -> {(@, LocalRoot($t1))}
  17: destroy($t3)
-     # live_nodes: LocalRoot($t0)
-     # moved_nodes: Reference($t8)
-     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t3))}
-     # borrows_from: Reference($t3) -> {(@, LocalRoot($t1))}
+     # live_nodes: LocalRoot($t0), Reference($t8)
+     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t8))}, Reference($t8) -> {(@, Reference($t3))}
+     # borrows_from: Reference($t3) -> {(@, Reference($t8))}, Reference($t8) -> {(@, LocalRoot($t1))}
  18: goto 9
-     # live_nodes: LocalRoot($t0), Reference($t3)
-     # moved_nodes: Reference($t8)
-     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t3))}
-     # borrows_from: Reference($t3) -> {(@, LocalRoot($t1))}
+     # live_nodes: LocalRoot($t0), Reference($t3), Reference($t8)
+     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t8))}, Reference($t8) -> {(@, Reference($t3))}
+     # borrows_from: Reference($t3) -> {(@, Reference($t8))}, Reference($t8) -> {(@, LocalRoot($t1))}
  19: label L4
-     # live_nodes: LocalRoot($t0), Reference($t3)
-     # moved_nodes: Reference($t8)
-     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t3))}
-     # borrows_from: Reference($t3) -> {(@, LocalRoot($t1))}
+     # live_nodes: LocalRoot($t0), Reference($t3), Reference($t8)
+     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t8))}, Reference($t8) -> {(@, Reference($t3))}
+     # borrows_from: Reference($t3) -> {(@, Reference($t8))}, Reference($t8) -> {(@, LocalRoot($t1))}
  20: destroy($t8)
      # live_nodes: LocalRoot($t0), Reference($t3)
-     # moved_nodes: Reference($t8)
-     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t3))}
-     # borrows_from: Reference($t3) -> {(@, LocalRoot($t1))}
+     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t8))}, Reference($t8) -> {(@, Reference($t3))}
+     # borrows_from: Reference($t3) -> {(@, Reference($t8))}, Reference($t8) -> {(@, LocalRoot($t1))}
  21: goto 12
 }
 
@@ -913,95 +887,77 @@ fun TestBorrow::test9($t0|b: bool, $t1|r_ref: &mut TestBorrow::R): &mut u64 {
      # borrowed_by: Reference($t1) -> {(.x (u64), Reference($t3))}
      # borrows_from: Reference($t3) -> {(.x (u64), Reference($t1))}
   1: $t2 := $t3
-     # live_nodes: LocalRoot($t0), Reference($t1), Reference($t2)
-     # moved_nodes: Reference($t3)
-     # borrowed_by: Reference($t1) -> {(.x (u64), Reference($t2))}
-     # borrows_from: Reference($t2) -> {(.x (u64), Reference($t1))}
+     # live_nodes: LocalRoot($t0), Reference($t1), Reference($t2), Reference($t3)
+     # borrowed_by: Reference($t1) -> {(.x (u64), Reference($t3))}, Reference($t3) -> {(@, Reference($t2))}
+     # borrows_from: Reference($t2) -> {(@, Reference($t3))}, Reference($t3) -> {(.x (u64), Reference($t1))}
   2: if ($t0) goto 14 else goto 17
-     # live_nodes: LocalRoot($t0), Reference($t1)
-     # moved_nodes: Reference($t3)
-     # borrowed_by: Reference($t1) -> {(.x (u64), Reference($t2))}
-     # borrows_from: Reference($t2) -> {(.x (u64), Reference($t1))}
+     # live_nodes: LocalRoot($t0), Reference($t1), Reference($t3)
+     # borrowed_by: Reference($t1) -> {(.x (u64), Reference($t3))}, Reference($t3) -> {(@, Reference($t2))}
+     # borrows_from: Reference($t2) -> {(@, Reference($t3))}, Reference($t3) -> {(.x (u64), Reference($t1))}
   3: label L0
-     # live_nodes: LocalRoot($t0), Reference($t1)
-     # moved_nodes: Reference($t3)
-     # borrowed_by: Reference($t1) -> {(.x (u64), Reference($t2))}
-     # borrows_from: Reference($t2) -> {(.x (u64), Reference($t1))}
+     # live_nodes: LocalRoot($t0), Reference($t1), Reference($t3)
+     # borrowed_by: Reference($t1) -> {(.x (u64), Reference($t3))}, Reference($t3) -> {(@, Reference($t2))}
+     # borrows_from: Reference($t2) -> {(@, Reference($t3))}, Reference($t3) -> {(.x (u64), Reference($t1))}
   4: destroy($t3)
      # live_nodes: LocalRoot($t0), Reference($t1)
-     # moved_nodes: Reference($t3)
-     # borrowed_by: Reference($t1) -> {(.x (u64), Reference($t2))}
-     # borrows_from: Reference($t2) -> {(.x (u64), Reference($t1))}
+     # borrowed_by: Reference($t1) -> {(.x (u64), Reference($t3))}, Reference($t3) -> {(@, Reference($t2))}
+     # borrows_from: Reference($t2) -> {(@, Reference($t3))}, Reference($t3) -> {(.x (u64), Reference($t1))}
   5: $t2 := borrow_field<TestBorrow::R>.y($t1)
      # live_nodes: LocalRoot($t0), Reference($t1), Reference($t2)
-     # moved_nodes: Reference($t3)
-     # borrowed_by: Reference($t1) -> {(.x (u64), Reference($t2)), (.y (u64), Reference($t2))}
-     # borrows_from: Reference($t2) -> {(.x (u64), Reference($t1)), (.y (u64), Reference($t1))}
+     # borrowed_by: Reference($t1) -> {(.y (u64), Reference($t2)), (.x (u64), Reference($t3))}, Reference($t3) -> {(@, Reference($t2))}
+     # borrows_from: Reference($t2) -> {(.y (u64), Reference($t1)), (@, Reference($t3))}, Reference($t3) -> {(.x (u64), Reference($t1))}
   6: goto 9
      # live_nodes: LocalRoot($t0), Reference($t1), Reference($t2)
-     # moved_nodes: Reference($t3)
-     # borrowed_by: Reference($t1) -> {(.x (u64), Reference($t2))}
-     # borrows_from: Reference($t2) -> {(.x (u64), Reference($t1))}
+     # borrowed_by: Reference($t1) -> {(.x (u64), Reference($t3))}, Reference($t3) -> {(@, Reference($t2))}
+     # borrows_from: Reference($t2) -> {(@, Reference($t3))}, Reference($t3) -> {(.x (u64), Reference($t1))}
   7: label L2
      # live_nodes: LocalRoot($t0), Reference($t1), Reference($t2)
-     # moved_nodes: Reference($t3)
-     # borrowed_by: Reference($t1) -> {(.x (u64), Reference($t2))}
-     # borrows_from: Reference($t2) -> {(.x (u64), Reference($t1))}
+     # borrowed_by: Reference($t1) -> {(.x (u64), Reference($t3))}, Reference($t3) -> {(@, Reference($t2))}
+     # borrows_from: Reference($t2) -> {(@, Reference($t3))}, Reference($t3) -> {(.x (u64), Reference($t1))}
   8: destroy($t1)
      # live_nodes: LocalRoot($t0), Reference($t1), Reference($t2)
-     # moved_nodes: Reference($t3)
-     # borrowed_by: Reference($t1) -> {(.x (u64), Reference($t2)), (.y (u64), Reference($t2))}
-     # borrows_from: Reference($t2) -> {(.x (u64), Reference($t1)), (.y (u64), Reference($t1))}
+     # borrowed_by: Reference($t1) -> {(.y (u64), Reference($t2)), (.x (u64), Reference($t3))}, Reference($t3) -> {(@, Reference($t2))}
+     # borrows_from: Reference($t2) -> {(.y (u64), Reference($t1)), (@, Reference($t3))}, Reference($t3) -> {(.x (u64), Reference($t1))}
   9: label L3
      # live_nodes: LocalRoot($t0), Reference($t1), Reference($t2)
-     # moved_nodes: Reference($t3)
-     # borrowed_by: Reference($t1) -> {(.x (u64), Reference($t2)), (.y (u64), Reference($t2))}
-     # borrows_from: Reference($t2) -> {(.x (u64), Reference($t1)), (.y (u64), Reference($t1))}
+     # borrowed_by: Reference($t1) -> {(.y (u64), Reference($t2)), (.x (u64), Reference($t3))}, Reference($t3) -> {(@, Reference($t2))}
+     # borrows_from: Reference($t2) -> {(.y (u64), Reference($t1)), (@, Reference($t3))}, Reference($t3) -> {(.x (u64), Reference($t1))}
  10: $t4 := 0
      # live_nodes: LocalRoot($t0), Reference($t1), Reference($t2)
-     # moved_nodes: Reference($t3)
-     # borrowed_by: Reference($t1) -> {(.x (u64), Reference($t2)), (.y (u64), Reference($t2))}
-     # borrows_from: Reference($t2) -> {(.x (u64), Reference($t1)), (.y (u64), Reference($t1))}
+     # borrowed_by: Reference($t1) -> {(.y (u64), Reference($t2)), (.x (u64), Reference($t3))}, Reference($t3) -> {(@, Reference($t2))}
+     # borrows_from: Reference($t2) -> {(.y (u64), Reference($t1)), (@, Reference($t3))}, Reference($t3) -> {(.x (u64), Reference($t1))}
  11: write_ref($t2, $t4)
      # live_nodes: LocalRoot($t0), Reference($t1), Reference($t2)
-     # moved_nodes: Reference($t3)
-     # borrowed_by: Reference($t1) -> {(.x (u64), Reference($t2)), (.y (u64), Reference($t2))}
-     # borrows_from: Reference($t2) -> {(.x (u64), Reference($t1)), (.y (u64), Reference($t1))}
+     # borrowed_by: Reference($t1) -> {(.y (u64), Reference($t2)), (.x (u64), Reference($t3))}, Reference($t3) -> {(@, Reference($t2))}
+     # borrows_from: Reference($t2) -> {(.y (u64), Reference($t1)), (@, Reference($t3))}, Reference($t3) -> {(.x (u64), Reference($t1))}
  12: trace_local[r_ref]($t1)
      # live_nodes: LocalRoot($t0), Reference($t2)
-     # moved_nodes: Reference($t3)
-     # borrowed_by: Reference($t1) -> {(.x (u64), Reference($t2)), (.y (u64), Reference($t2))}
-     # borrows_from: Reference($t2) -> {(.x (u64), Reference($t1)), (.y (u64), Reference($t1))}
+     # borrowed_by: Reference($t1) -> {(.y (u64), Reference($t2)), (.x (u64), Reference($t3))}, Reference($t3) -> {(@, Reference($t2))}
+     # borrows_from: Reference($t2) -> {(.y (u64), Reference($t1)), (@, Reference($t3))}, Reference($t3) -> {(.x (u64), Reference($t1))}
  13: return $t2
-     # live_nodes: LocalRoot($t0), Reference($t1), Reference($t2)
-     # moved_nodes: Reference($t3)
-     # borrowed_by: Reference($t1) -> {(.x (u64), Reference($t2))}
-     # borrows_from: Reference($t2) -> {(.x (u64), Reference($t1))}
+     # live_nodes: LocalRoot($t0), Reference($t1), Reference($t2), Reference($t3)
+     # borrowed_by: Reference($t1) -> {(.x (u64), Reference($t3))}, Reference($t3) -> {(@, Reference($t2))}
+     # borrows_from: Reference($t2) -> {(@, Reference($t3))}, Reference($t3) -> {(.x (u64), Reference($t1))}
  14: label L4
-     # live_nodes: LocalRoot($t0), Reference($t1), Reference($t2)
-     # moved_nodes: Reference($t3)
-     # borrowed_by: Reference($t1) -> {(.x (u64), Reference($t2))}
-     # borrows_from: Reference($t2) -> {(.x (u64), Reference($t1))}
+     # live_nodes: LocalRoot($t0), Reference($t1), Reference($t2), Reference($t3)
+     # borrowed_by: Reference($t1) -> {(.x (u64), Reference($t3))}, Reference($t3) -> {(@, Reference($t2))}
+     # borrows_from: Reference($t2) -> {(@, Reference($t3))}, Reference($t3) -> {(.x (u64), Reference($t1))}
  15: destroy($t2)
-     # live_nodes: LocalRoot($t0), Reference($t1)
-     # moved_nodes: Reference($t3)
-     # borrowed_by: Reference($t1) -> {(.x (u64), Reference($t2))}
-     # borrows_from: Reference($t2) -> {(.x (u64), Reference($t1))}
+     # live_nodes: LocalRoot($t0), Reference($t1), Reference($t3)
+     # borrowed_by: Reference($t1) -> {(.x (u64), Reference($t3))}, Reference($t3) -> {(@, Reference($t2))}
+     # borrows_from: Reference($t2) -> {(@, Reference($t3))}, Reference($t3) -> {(.x (u64), Reference($t1))}
  16: goto 3
-     # live_nodes: LocalRoot($t0), Reference($t1), Reference($t2)
-     # moved_nodes: Reference($t3)
-     # borrowed_by: Reference($t1) -> {(.x (u64), Reference($t2))}
-     # borrows_from: Reference($t2) -> {(.x (u64), Reference($t1))}
+     # live_nodes: LocalRoot($t0), Reference($t1), Reference($t2), Reference($t3)
+     # borrowed_by: Reference($t1) -> {(.x (u64), Reference($t3))}, Reference($t3) -> {(@, Reference($t2))}
+     # borrows_from: Reference($t2) -> {(@, Reference($t3))}, Reference($t3) -> {(.x (u64), Reference($t1))}
  17: label L5
-     # live_nodes: LocalRoot($t0), Reference($t1), Reference($t2)
-     # moved_nodes: Reference($t3)
-     # borrowed_by: Reference($t1) -> {(.x (u64), Reference($t2))}
-     # borrows_from: Reference($t2) -> {(.x (u64), Reference($t1))}
+     # live_nodes: LocalRoot($t0), Reference($t1), Reference($t2), Reference($t3)
+     # borrowed_by: Reference($t1) -> {(.x (u64), Reference($t3))}, Reference($t3) -> {(@, Reference($t2))}
+     # borrows_from: Reference($t2) -> {(@, Reference($t3))}, Reference($t3) -> {(.x (u64), Reference($t1))}
  18: destroy($t3)
      # live_nodes: LocalRoot($t0), Reference($t1), Reference($t2)
-     # moved_nodes: Reference($t3)
-     # borrowed_by: Reference($t1) -> {(.x (u64), Reference($t2))}
-     # borrows_from: Reference($t2) -> {(.x (u64), Reference($t1))}
+     # borrowed_by: Reference($t1) -> {(.x (u64), Reference($t3))}, Reference($t3) -> {(@, Reference($t2))}
+     # borrows_from: Reference($t2) -> {(@, Reference($t3))}, Reference($t3) -> {(.x (u64), Reference($t1))}
  19: goto 7
 }
 
@@ -1014,5 +970,5 @@ borrowed_by: Reference($t0) -> {(.x (u64), Return(0))}
 borrows_from: Return(0) -> {(.x (u64), Reference($t0))}
 
 fun TestBorrow::test9[baseline]
-borrowed_by: Reference($t1) -> {(.x (u64), Return(0)), (.y (u64), Return(0))}
-borrows_from: Return(0) -> {(.x (u64), Reference($t1)), (.y (u64), Reference($t1))}
+borrowed_by: Reference($t1) -> {(.y (u64), Return(0)), (.x (u64)/@, Return(0))}
+borrows_from: Return(0) -> {(.y (u64), Reference($t1)), (.x (u64)/@, Reference($t1))}

--- a/language/move-prover/bytecode/tests/memory_instr/basic_test.exp
+++ b/language/move-prover/bytecode/tests/memory_instr/basic_test.exp
@@ -358,34 +358,39 @@ fun TestPackref::test7($t0|b: bool) {
      var $t5: u64
      var $t6: &mut TestPackref::R
      var $t7: u64
+     var $t8: bool
   0: $t4 := 3
   1: $t1 := pack TestPackref::R($t4)
   2: $t5 := 4
   3: $t2 := pack TestPackref::R($t5)
   4: $t6 := borrow_local($t1)
   5: $t3 := $t6
-  6: write_back[LocalRoot($t1)@]($t6)
-  7: trace_local[r1]($t1)
-  8: if ($t0) goto 20 else goto 25
-  9: label L0
+  6: if ($t0) goto 25 else goto 29
+  7: label L0
+  8: write_back[LocalRoot($t1)@]($t6)
+  9: trace_local[r1]($t1)
  10: destroy($t6)
  11: $t3 := borrow_local($t2)
  12: label L2
  13: $t7 := 0
  14: TestPackref::test3($t3, $t7)
- 15: write_back[LocalRoot($t1)@]($t3)
- 16: trace_local[r1]($t1)
- 17: write_back[LocalRoot($t2)@]($t3)
- 18: trace_local[r2]($t2)
- 19: return ()
- 20: label L3
- 21: write_back[LocalRoot($t1)@]($t3)
+ 15: write_back[LocalRoot($t2)@]($t3)
+ 16: trace_local[r2]($t2)
+ 17: $t8 := is_parent[Reference($t6)@]($t3)
+ 18: if ($t8) goto 19 else goto 23
+ 19: label L5
+ 20: write_back[Reference($t6)@]($t3)
+ 21: write_back[LocalRoot($t1)@]($t6)
  22: trace_local[r1]($t1)
- 23: destroy($t3)
- 24: goto 9
- 25: label L4
- 26: destroy($t6)
- 27: goto 12
+ 23: label L6
+ 24: return ()
+ 25: label L3
+ 26: write_back[Reference($t6)@]($t3)
+ 27: destroy($t3)
+ 28: goto 7
+ 29: label L4
+ 30: destroy($t6)
+ 31: goto 12
 }
 
 

--- a/language/move-prover/tests/sources/functional/loops_with_memory_ops.cvc5_exp
+++ b/language/move-prover/tests/sources/functional/loops_with_memory_ops.cvc5_exp
@@ -43,13 +43,10 @@ error: unknown assertion failed
    =         y = <redacted>
    =     at tests/sources/functional/loops_with_memory_ops.move:80: nested_loop2
    =     at tests/sources/functional/loops_with_memory_ops.move:81: nested_loop2
-   =     at <internal>:1
-   =     at tests/sources/functional/loops_with_memory_ops.move:81: nested_loop2
    =         b = <redacted>
-   =     at <internal>:1
-   =     at tests/sources/functional/loops_with_memory_ops.move:81: nested_loop2
-   =     at <internal>:1
-   =     at tests/sources/functional/loops_with_memory_ops.move:81: nested_loop2
+   =         b = <redacted>
+   =         a = <redacted>
+   =         a = <redacted>
    =     at tests/sources/functional/loops_with_memory_ops.move:85: nested_loop2
    =         i = <redacted>
    =     at tests/sources/functional/loops_with_memory_ops.move:86: nested_loop2
@@ -99,14 +96,10 @@ error: induction case of the loop invariant does not hold
    =         y = <redacted>
    =     at tests/sources/functional/loops_with_memory_ops.move:80: nested_loop2
    =     at tests/sources/functional/loops_with_memory_ops.move:81: nested_loop2
-   =     at <internal>:1
-   =     at tests/sources/functional/loops_with_memory_ops.move:81: nested_loop2
-   =     at <internal>:1
-   =     at tests/sources/functional/loops_with_memory_ops.move:81: nested_loop2
-   =     at <internal>:1
-   =     at tests/sources/functional/loops_with_memory_ops.move:81: nested_loop2
-   =     at <internal>:1
-   =     at tests/sources/functional/loops_with_memory_ops.move:81: nested_loop2
+   =         b = <redacted>
+   =         b = <redacted>
+   =         a = <redacted>
+   =         a = <redacted>
    =     at tests/sources/functional/loops_with_memory_ops.move:85: nested_loop2
    =         i = <redacted>
    =     at tests/sources/functional/loops_with_memory_ops.move:86: nested_loop2

--- a/language/move-prover/tests/sources/functional/loops_with_memory_ops.move
+++ b/language/move-prover/tests/sources/functional/loops_with_memory_ops.move
@@ -1,5 +1,5 @@
+// separate_baseline: cvc5
 module 0x42::VerifyLoopsWithMemoryOps {
-
     use std::vector;
     spec module {
         pragma verify=true;

--- a/language/move-prover/tests/sources/functional/mut_ref_arg_return.move
+++ b/language/move-prover/tests/sources/functional/mut_ref_arg_return.move
@@ -1,0 +1,36 @@
+module 0x42::Test {
+    // test case 1
+    fun one_of_two(cond: bool, r1: &mut u64, r2: &mut u64): &mut u64 {
+        if (cond) {r1} else {r2}
+    }
+
+    fun test1(cond: bool, v1: u64, v2: u64) {
+        let r = one_of_two(cond, &mut v1, &mut v2);
+        *r = 0;
+
+        spec {
+            assert cond ==> v1 == 0;
+            assert !cond ==> v2 == 0;
+        }
+    }
+
+    // test case 2
+    fun max_mut(ma: &mut u64, mb: &mut u64): &mut u64 {
+        if (*ma >= *mb) {
+            ma
+        } else {
+            mb
+        }
+    }
+
+    fun test2(a: u64, b: u64) {
+        let mc = max_mut(&mut a, &mut b);
+        *mc = *mc + 7;
+
+        spec {
+            assert a != b;
+            assert (a > b) ==> (a - b >= 7);
+            assert (a < b) ==> (b - a >= 7);
+        }
+    }
+}


### PR DESCRIPTION
Prover panic-ed when trying to verify this simple program:

```move
    fun one_of_two(cond: bool, r1: &mut u64, r2: &mut u64): &mut u64 {
        if (cond) {r1} else {r2}
    }

    fun test1(cond: bool, v1: u64, v2: u64) {
        let r = one_of_two(cond, &mut v1, &mut v2);
        *r = 0;

        spec {
            assert cond ==> v1 == 0;
            assert !cond ==> v2 == 0;
        }
    }
```

A further analysis found that the borrow summary for function `one_of_two` is not
properly constructed, with the return result not borrowing from neither `r1` or `r2`
(which it should be a direct borrow of `r1` or `r2`).

After some digging in the bytecode, it seems that we are using `r := r1` and `r = r2` 
for the assignment, which is considered as a `Store` assignment and is treated
the same way as a `Move` assignment. This seems correct in terms borrow semantics
but there is no way of summarizing that `r` can be borrowed from either `r1` or `r2`
which is needed in the verification of `test1`.

A quick solution to this is to model `Store` as a `Copy` assignment, which adds
the `BorrowEdge::Direct` in the borrow graph. The downside, however, is that the
RHS of the assignment now lives longer until it is `destroy()`-ed, as can be seen in
the changes of the baseline file.

## Motivation

To verify the above simple program.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes

## Test Plan

- CI
- A new unit test is added
- Manually run the prover inconsistency tests against DPN