### PR TITLE
[move-prover] Bump up the version number of the Prover dependencies

### DIFF
--- a/language/move-prover/boogie-backend/src/boogie_wrapper.rs
+++ b/language/move-prover/boogie-backend/src/boogie_wrapper.rs
@@ -1682,7 +1682,7 @@ impl<'s> ModelParser<'s> {
 
     fn parse_key(&mut self) -> Result<ModelValue, ModelParseError> {
         let mut comps = vec![];
-        while !self.looking_at("->") {
+        while !self.looking_at("->") && self.at < self.input.len() {
             let value = self.parse_value()?;
             comps.push(value);
         }

--- a/language/move-prover/boogie-backend/src/options.rs
+++ b/language/move-prover/boogie-backend/src/options.rs
@@ -19,8 +19,8 @@ const DEFAULT_BOOGIE_FLAGS: &[&str] = &[
     "-proverOpt:O:model_validate=true",
 ];
 
-const MIN_BOOGIE_VERSION: &str = "2.9.0";
-const MIN_Z3_VERSION: &str = "4.8.9";
+const MIN_BOOGIE_VERSION: &str = "2.13.4";
+const MIN_Z3_VERSION: &str = "4.10.2";
 const MIN_CVC5_VERSION: &str = "0.0.3";
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
@@ -319,6 +319,9 @@ impl BoogieOptions {
                     given,
                     tool
                 ));
+            }
+            if gn > en {
+                break;
             }
         }
         Ok(())

--- a/language/move-prover/tests/sources/functional/loops_with_memory_ops.exp
+++ b/language/move-prover/tests/sources/functional/loops_with_memory_ops.exp
@@ -45,9 +45,11 @@ error: unknown assertion failed
    =         y = <redacted>
    =     at tests/sources/functional/loops_with_memory_ops.move:80: nested_loop2
    =     at tests/sources/functional/loops_with_memory_ops.move:81: nested_loop2
+   =     at <internal>:1
+   =     at tests/sources/functional/loops_with_memory_ops.move:81: nested_loop2
    =         b = <redacted>
-   =         b = <redacted>
-   =         a = <redacted>
+   =     at <internal>:1
+   =     at tests/sources/functional/loops_with_memory_ops.move:81: nested_loop2
    =         a = <redacted>
    =     at tests/sources/functional/loops_with_memory_ops.move:85: nested_loop2
    =         i = <redacted>
@@ -100,13 +102,10 @@ error: induction case of the loop invariant does not hold
    =         y = <redacted>
    =     at tests/sources/functional/loops_with_memory_ops.move:80: nested_loop2
    =     at tests/sources/functional/loops_with_memory_ops.move:81: nested_loop2
-   =     at <internal>:1
-   =     at tests/sources/functional/loops_with_memory_ops.move:81: nested_loop2
-   =     at <internal>:1
-   =     at tests/sources/functional/loops_with_memory_ops.move:81: nested_loop2
+   =         b = <redacted>
+   =         b = <redacted>
    =         a = <redacted>
-   =     at <internal>:1
-   =     at tests/sources/functional/loops_with_memory_ops.move:81: nested_loop2
+   =         a = <redacted>
    =     at tests/sources/functional/loops_with_memory_ops.move:85: nested_loop2
    =         i = <redacted>
    =     at tests/sources/functional/loops_with_memory_ops.move:86: nested_loop2

--- a/scripts/dev_setup.sh
+++ b/scripts/dev_setup.sh
@@ -15,10 +15,10 @@
 # fast fail.
 set -eo pipefail
 
-Z3_VERSION=4.8.13
+Z3_VERSION=4.10.2
 CVC5_VERSION=0.0.3
-DOTNET_VERSION=5.0
-BOOGIE_VERSION=2.9.6
+DOTNET_VERSION=6.0
+BOOGIE_VERSION=2.13.4
 SOLC_VERSION="v0.8.11+commit.d7f03943"
 
 SCRIPT_PATH="$(cd "$(dirname "$0")" >/dev/null 2>&1 && pwd)"
@@ -294,7 +294,7 @@ function install_z3 {
     return
   fi
   if [[ "$(uname)" == "Linux" ]]; then
-    Z3_PKG="z3-$Z3_VERSION-x64-glibc-2.28"
+    Z3_PKG="z3-$Z3_VERSION-x64-glibc-2.31"
   elif [[ "$(uname)" == "Darwin" ]]; then
     Z3_PKG="z3-$Z3_VERSION-x64-osx-10.16"
   else
@@ -306,7 +306,7 @@ function install_z3 {
   mkdir -p "$TMPFILE"/
   (
     cd "$TMPFILE" || exit
-    curl -LOs "https://github.com/junkil-park/z3/releases/download/z3-$Z3_VERSION/$Z3_PKG.zip"
+    curl -LOs "https://github.com/Z3Prover/z3/releases/download/z3-$Z3_VERSION/$Z3_PKG.zip"
     unzip -q "$Z3_PKG.zip"
     cp "$Z3_PKG/bin/z3" "${INSTALL_DIR}"
     chmod +x "${INSTALL_DIR}z3"


### PR DESCRIPTION
- Updated the Z3 version to the latest one.
- Updated the Boogie version to latest one that is compatible with Prover.
  - Incompatibility issue filed in the Boogie repo: https://github.com/boogie-org/boogie/issues/609
- Fixed a few bugs in `boogie_wrapper`.

## Motivation

To bump up the version number of Prover's deps.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

yes

## Test Plan
cargo test -p move-prover
