### PR TITLE
[move-prover] Add evaluation logic for choice operators

### DIFF
--- a/language/move-prover/interpreter-testsuite/tests/concrete_check/choice.exp
+++ b/language/move-prover/interpreter-testsuite/tests/concrete_check/choice.exp
@@ -1,0 +1,67 @@
+Running Move unit tests
+[ FAIL    ] 0x2::A::simple_number_min_range_failure
+[ FAIL    ] 0x2::A::simple_number_range_failure
+[ FAIL    ] 0x2::A::vector_choose_min_unsatisfied_predicate
+[ PASS    ] 0x2::A::vector_choose_success
+[ FAIL    ] 0x2::A::vector_choose_unsatisfied_predicate
+
+Test failures:
+
+Failures in 0x2::A:
+
+┌── simple_number_min_range_failure ──────
+│ error: failed to evaluate expression: enumeration of a non-address type domain is not supported
+│    ┌─ tests/concrete_check/choice.move:56:42
+│    │
+│ 56 │         ensures result <= (choose min x: u64 where x >= 4);
+│    │                                          ^^^
+│
+│ error: failed to evaluate expression: unexpected error code
+│    ┌─ tests/concrete_check/choice.move:56:17
+│    │
+│ 56 │         ensures result <= (choose min x: u64 where x >= 4);
+│    │                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+│
+│
+└──────────────────
+
+
+┌── simple_number_range_failure ──────
+│ error: failed to evaluate expression: enumeration of a non-address type domain is not supported
+│    ┌─ tests/concrete_check/choice.move:49:38
+│    │
+│ 49 │         ensures result <= (choose x: u64 where x >= 4);
+│    │                                      ^^^
+│
+│ error: failed to evaluate expression: unexpected error code
+│    ┌─ tests/concrete_check/choice.move:49:17
+│    │
+│ 49 │         ensures result <= (choose x: u64 where x >= 4);
+│    │                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+│
+│
+└──────────────────
+
+
+┌── vector_choose_min_unsatisfied_predicate ──────
+│ error: failed to evaluate expression: choose min fails to satisfy a predicate
+│    ┌─ tests/concrete_check/choice.move:42:68
+│    │
+│ 42 │         let post choice_min = choose min i in 0..len(result) where result[i] == 3;
+│    │                                                                    ^^^^^^^^^^^^^^
+│
+│
+└──────────────────
+
+
+┌── vector_choose_unsatisfied_predicate ──────
+│ error: failed to evaluate expression: choose fails to satisfy a predicate
+│    ┌─ tests/concrete_check/choice.move:29:60
+│    │
+│ 29 │         let post choice = choose i in 0..len(result) where result[i] == 3;
+│    │                                                            ^^^^^^^^^^^^^^
+│
+│
+└──────────────────
+
+Test result: FAILED. Total tests: 5; passed: 1; failed: 4

--- a/language/move-prover/interpreter-testsuite/tests/concrete_check/choice.move
+++ b/language/move-prover/interpreter-testsuite/tests/concrete_check/choice.move
@@ -1,0 +1,64 @@
+module 0x2::A {
+    // use std::signer;
+    use std::vector;
+
+    struct R has key { i: u64 }
+
+    struct S has key { i: u64 }
+
+
+    #[test]
+    public fun vector_choose_success(): vector<u64> {
+        let v = vector::empty<u64>();
+        vector::push_back(&mut v, 1);
+        vector::push_back(&mut v, 2);
+        vector::push_back(&mut v, 1);
+        v
+    }
+
+    spec vector_choose_success {
+        let post choice = choose i in 0..len(result) where result[i] == 1;
+        ensures choice == 0 || choice == 2;
+        ensures (choose min i in 0..len(result) where result[i] == 1) == 0;
+    }
+
+    #[test, expected_failure]
+    public fun vector_choose_unsatisfied_predicate(): vector<u64> {
+        let v = vector::empty<u64>();
+        vector::push_back(&mut v, 1);
+        vector::push_back(&mut v, 2);
+        vector::push_back(&mut v, 1);
+        v
+    }
+
+    spec vector_choose_unsatisfied_predicate {
+        let post choice = choose i in 0..len(result) where result[i] == 3;
+    }
+
+    #[test, expected_failure]
+    public fun vector_choose_min_unsatisfied_predicate(): vector<u64> {
+        let v = vector::empty<u64>();
+        vector::push_back(&mut v, 1);
+        vector::push_back(&mut v, 2);
+        vector::push_back(&mut v, 1);
+        v
+    }
+
+    spec vector_choose_min_unsatisfied_predicate {
+        let post choice_min = choose min i in 0..len(result) where result[i] == 3;
+    }
+
+    #[test, expected_failure]
+    public fun simple_number_range_failure(): u64 { 1 }
+
+    spec simple_number_range_failure {
+        ensures result <= (choose x: u64 where x >= 4);
+    }
+
+    #[test, expected_failure]
+    public fun simple_number_min_range_failure(): u64 { 1 }
+
+    spec simple_number_min_range_failure {
+        ensures result <= (choose min x: u64 where x >= 4);
+    }
+}

--- a/language/move-prover/interpreter-testsuite/tests/concrete_check/choice.move
+++ b/language/move-prover/interpreter-testsuite/tests/concrete_check/choice.move
@@ -1,11 +1,5 @@
 module 0x2::A {
-    // use std::signer;
     use std::vector;
-
-    struct R has key { i: u64 }
-
-    struct S has key { i: u64 }
-
 
     #[test]
     public fun vector_choose_success(): vector<u64> {
@@ -22,7 +16,7 @@ module 0x2::A {
         ensures (choose min i in 0..len(result) where result[i] == 1) == 0;
     }
 
-    #[test, expected_failure]
+    #[test]
     public fun vector_choose_unsatisfied_predicate(): vector<u64> {
         let v = vector::empty<u64>();
         vector::push_back(&mut v, 1);
@@ -35,7 +29,7 @@ module 0x2::A {
         let post choice = choose i in 0..len(result) where result[i] == 3;
     }
 
-    #[test, expected_failure]
+    #[test]
     public fun vector_choose_min_unsatisfied_predicate(): vector<u64> {
         let v = vector::empty<u64>();
         vector::push_back(&mut v, 1);
@@ -48,14 +42,14 @@ module 0x2::A {
         let post choice_min = choose min i in 0..len(result) where result[i] == 3;
     }
 
-    #[test, expected_failure]
+    #[test]
     public fun simple_number_range_failure(): u64 { 1 }
 
     spec simple_number_range_failure {
         ensures result <= (choose x: u64 where x >= 4);
     }
 
-    #[test, expected_failure]
+    #[test]
     public fun simple_number_min_range_failure(): u64 { 1 }
 
     spec simple_number_min_range_failure {

--- a/language/move-prover/interpreter-testsuite/tests/concrete_check/quantifier.move
+++ b/language/move-prover/interpreter-testsuite/tests/concrete_check/quantifier.move
@@ -31,7 +31,7 @@ module 0x2::A {
         ensures exists i in 0..len(result): result[i] == 1;
     }
 
-    #[test, expected_failure]
+    #[test]
     public fun init_vector_failure(): vector<u64> {
         let v = vector::empty<u64>();
         vector::push_back(&mut v, 1);

--- a/language/move-prover/interpreter/src/concrete/local_state.rs
+++ b/language/move-prover/interpreter/src/concrete/local_state.rs
@@ -69,16 +69,19 @@ pub struct LocalState {
     termination: TerminationStatus,
     /// mutable parameters that gets destroyed during the execution
     destroyed_args: BTreeMap<TempIndex, TypedValue>,
+    /// whether specification checking needs to be skipped
+    skip_specs: bool,
 }
 
 impl LocalState {
-    pub fn new(slots: Vec<LocalSlot>) -> Self {
+    pub fn new(slots: Vec<LocalSlot>, skip_specs: bool) -> Self {
         Self {
             slots,
             pc: 0,
             pc_branch: false,
             termination: TerminationStatus::None,
             destroyed_args: BTreeMap::new(),
+            skip_specs,
         }
     }
 
@@ -207,5 +210,15 @@ impl LocalState {
     /// Consume and reduce the state into termination status
     pub fn into_termination_status(self) -> TerminationStatus {
         self.termination
+    }
+
+    /// Mark the spec checking disabled for the rest of the function
+    pub fn skip_specs(&mut self) {
+        self.skip_specs = true;
+    }
+
+    /// Check whether we are skipping the specs
+    pub fn is_spec_skipped(&self) -> bool {
+        self.skip_specs
     }
 }


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Move Language.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

- Complete the evaluator for the `choose` and `choose min` operators. All the values in the range that satisfy the predicate are extracted and the value in the last position of the vector is returned deterministically for the `choose` operator.
- Update the evaluator for assume expression to return `EvalResult` to distinguish `None` results from choice operators and other assertions. Move `skip_specs` from the function context to the local state to enable the `let` binding. If the choice operators return `None`, skip the following specs to log the error message.
- When no value satisfies the predicate for the choice operators, log the error message and abort the execution.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes.

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)
