### PR TITLE
make instruction execution bound an option and increment default value

### DIFF
--- a/language/move-prover/interpreter-testsuite/tests/concrete_check_testsuite.rs
+++ b/language/move-prover/interpreter-testsuite/tests/concrete_check_testsuite.rs
@@ -14,7 +14,7 @@ fn test_runner(path: &Path) -> datatest_stable::Result<()> {
 
     let source_files = vec![path.to_str().unwrap().to_owned()];
     let config = UnitTestingConfig {
-        instruction_execution_bound: 5000,
+        instruction_execution_bound: Some(5000),
         num_threads: 1,
         source_files,
         dep_files: move_stdlib_files(),

--- a/language/tools/move-cli/src/base/test.rs
+++ b/language/tools/move-cli/src/base/test.rs
@@ -37,13 +37,8 @@ compile_error!("Unsupported OS, currently we only support windows and unix famil
 #[clap(name = "test")]
 pub struct Test {
     /// Bound the number of instructions that can be executed by any one test.
-    #[clap(
-        name = "instructions",
-        default_value = "5000",
-        short = 'i',
-        long = "instructions"
-    )]
-    pub instruction_execution_bound: u64,
+    #[clap(name = "instructions", short = 'i', long = "instructions")]
+    pub instruction_execution_bound: Option<u64>,
     /// A filter string to determine which unit tests to run. A unit test will be run only if it
     /// contains this string in its fully qualified (<addr>::<module_name>::<fn_name>) name.
     #[clap(name = "filter", short = 'f', long = "filter")]

--- a/language/tools/move-unit-test/src/lib.rs
+++ b/language/tools/move-unit-test/src/lib.rs
@@ -26,17 +26,15 @@ use std::{
     sync::Mutex,
 };
 
+/// The default value bounding the number of instructions executed in a test.
+const DEFAULT_EXECUTION_BOUND: u64 = 100_000;
+
 #[derive(Debug, Parser, Clone)]
 #[clap(author, version, about)]
 pub struct UnitTestingConfig {
     /// Bound the number of instructions that can be executed by any one test.
-    #[clap(
-        name = "instructions",
-        default_value = "5000",
-        short = 'i',
-        long = "instructions"
-    )]
-    pub instruction_execution_bound: u64,
+    #[clap(name = "instructions", short = 'i', long = "instructions")]
+    pub instruction_execution_bound: Option<u64>,
 
     /// A filter string to determine which unit tests to run
     #[clap(name = "filter", short = 'f', long = "filter")]
@@ -127,7 +125,7 @@ impl UnitTestingConfig {
     /// Create a unit testing config for use with `register_move_unit_tests`
     pub fn default_with_bound(bound: Option<u64>) -> Self {
         Self {
-            instruction_execution_bound: bound.unwrap_or(5000),
+            instruction_execution_bound: bound.or(Some(DEFAULT_EXECUTION_BOUND)),
             filter: None,
             num_threads: 8,
             report_statistics: false,
@@ -225,7 +223,8 @@ impl UnitTestingConfig {
 
         writeln!(shared_writer.lock().unwrap(), "Running Move unit tests")?;
         let mut test_runner = TestRunner::new(
-            self.instruction_execution_bound,
+            self.instruction_execution_bound
+                .unwrap_or(DEFAULT_EXECUTION_BOUND),
             self.num_threads,
             self.check_stackless_vm,
             self.verbose,

--- a/language/tools/move-unit-test/tests/move_unit_test_testsuite.rs
+++ b/language/tools/move-unit-test/tests/move_unit_test_testsuite.rs
@@ -82,7 +82,7 @@ fn run_test_impl(path: &Path) -> anyhow::Result<()> {
     let source_files = vec![path.to_str().unwrap().to_owned()];
     let unit_test_config = UnitTestingConfig {
         num_threads: 1,
-        instruction_execution_bound: 1000,
+        instruction_execution_bound: Some(1000),
         source_files,
         dep_files: move_stdlib::move_stdlib_files(),
         named_address_values: move_stdlib::move_stdlib_named_addresses()


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Move Language.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

This PR makes instruction execution bound an option in the CLI options and increments the default value since 5000 is too low.

## Test Plan

cargo test