### PR TITLE
[move-prover] remove the destroy instruction for imm borrow removal

### DIFF
--- a/language/move-prover/bytecode/src/eliminate_imm_refs.rs
+++ b/language/move-prover/bytecode/src/eliminate_imm_refs.rs
@@ -105,6 +105,9 @@ impl<'a> EliminateImmRefs<'a> {
                         aa,
                     ));
                 }
+                Destroy if self.is_imm_ref(srcs[0]) => {
+                    // skip the destroy on an immutable ref
+                }
                 _ => self.builder.emit(Call(attr_id, dests, op, srcs, aa)),
             },
             _ => self.builder.emit(bytecode),

--- a/language/move-prover/bytecode/tests/eliminate_imm_refs/basic_test.exp
+++ b/language/move-prover/bytecode/tests/eliminate_imm_refs/basic_test.exp
@@ -90,6 +90,27 @@ fun TestEliminateImmRefs::test4(): u64 {
   7: return $t6
 }
 
+
+[variant baseline]
+fun TestEliminateImmRefs::test5(): TestEliminateImmRefs::R {
+     var $t0|p: &TestEliminateImmRefs::R
+     var $t1|r: TestEliminateImmRefs::R
+     var $t2: u64
+     var $t3: TestEliminateImmRefs::R
+     var $t4: &TestEliminateImmRefs::R
+     var $t5: &TestEliminateImmRefs::R
+     var $t6: TestEliminateImmRefs::R
+  0: $t2 := 3
+  1: $t3 := pack TestEliminateImmRefs::R($t2)
+  2: $t1 := $t3
+  3: $t4 := borrow_local($t1)
+  4: $t0 := $t4
+  5: $t5 := move($t0)
+  6: destroy($t5)
+  7: $t6 := move($t1)
+  8: return $t6
+}
+
 ============ after pipeline `eliminate_imm_refs` ================
 
 [variant baseline]
@@ -179,5 +200,25 @@ fun TestEliminateImmRefs::test4(): u64 {
   4: $t1 := $t4
   5: $t5 := move($t1)
   6: $t6 := TestEliminateImmRefs::test3($t5)
+  7: return $t6
+}
+
+
+[variant baseline]
+fun TestEliminateImmRefs::test5(): TestEliminateImmRefs::R {
+     var $t0|p: TestEliminateImmRefs::R
+     var $t1|r: TestEliminateImmRefs::R
+     var $t2: u64
+     var $t3: TestEliminateImmRefs::R
+     var $t4: TestEliminateImmRefs::R
+     var $t5: TestEliminateImmRefs::R
+     var $t6: TestEliminateImmRefs::R
+  0: $t2 := 3
+  1: $t3 := pack TestEliminateImmRefs::R($t2)
+  2: $t1 := $t3
+  3: $t4 := copy($t1)
+  4: $t0 := $t4
+  5: $t5 := move($t0)
+  6: $t6 := move($t1)
   7: return $t6
 }

--- a/language/move-prover/bytecode/tests/eliminate_imm_refs/basic_test.move
+++ b/language/move-prover/bytecode/tests/eliminate_imm_refs/basic_test.move
@@ -29,4 +29,11 @@ module 0x42::TestEliminateImmRefs {
         let r_ref = & r;
         test3(r_ref)
     }
+
+    fun test5() : R {
+        let r = R {x: 3};
+        let p = &r;
+        let _ = p;
+        r
+    }
 }

--- a/language/move-prover/bytecode/tests/livevar/basic_test.exp
+++ b/language/move-prover/bytecode/tests/livevar/basic_test.exp
@@ -152,20 +152,18 @@ fun TestLiveVars::test2($t0|b: bool): u64 {
   3: $t7 := pack TestLiveVars::R($t6)
      # live vars: b, $t5, $t7
   4: $t3 := $t5
-     # live vars: b, r_ref, $t5, $t7
-  5: if ($t0) goto 6 else goto 9
-     # live vars: $t5, $t7
-  6: label L0
-     # live vars: $t5, $t7
-  7: destroy($t5)
+     # live vars: b, r_ref, $t7
+  5: if ($t0) goto 6 else goto 8
      # live vars: $t7
-  8: $t3 := $t7
+  6: label L0
+     # live vars: $t7
+  7: $t3 := $t7
      # live vars: r_ref
-  9: label L2
+  8: label L2
      # live vars: r_ref
- 10: $t8 := TestLiveVars::test1($t3)
+  9: $t8 := TestLiveVars::test1($t3)
      # live vars: $t8
- 11: return $t8
+ 10: return $t8
 }
 
 
@@ -200,43 +198,41 @@ fun TestLiveVars::test3($t0|n: u64, $t1|r_ref: TestLiveVars::R): u64 {
      # live vars: n, r_ref, $t5, $t7, $t8
   6: $t9 := <($t8, $t0)
      # live vars: n, r_ref, $t5, $t7, $t9
-  7: if ($t9) goto 8 else goto 24
-     # live vars: n, r_ref, $t5, $t7
+  7: if ($t9) goto 8 else goto 23
+     # live vars: n, $t5, $t7
   8: label L0
-     # live vars: n, r_ref, $t5, $t7
-  9: destroy($t1)
      # live vars: n, $t5, $t7
- 10: $t10 := 2
+  9: $t10 := 2
      # live vars: n, $t5, $t7, $t10
- 11: $t11 := /($t0, $t10)
+ 10: $t11 := /($t0, $t10)
      # live vars: n, $t5, $t7, $t11
- 12: $t12 := 0
+ 11: $t12 := 0
      # live vars: n, $t5, $t7, $t11, $t12
- 13: $t13 := ==($t11, $t12)
+ 12: $t13 := ==($t11, $t12)
      # live vars: n, $t5, $t7, $t13
- 14: if ($t13) goto 15 else goto 18
+ 13: if ($t13) goto 14 else goto 17
      # live vars: n, $t5, $t7
- 15: label L3
+ 14: label L3
      # live vars: n, $t5, $t7
- 16: $t1 := $t5
+ 15: $t1 := $t5
      # live vars: n, r_ref, $t5, $t7
- 17: goto 20
+ 16: goto 19
      # live vars: n, $t5, $t7
- 18: label L5
+ 17: label L5
      # live vars: n, $t5, $t7
- 19: $t1 := $t7
+ 18: $t1 := $t7
      # live vars: n, r_ref, $t5, $t7
- 20: label L6
+ 19: label L6
      # live vars: n, r_ref, $t5, $t7
- 21: $t14 := 1
+ 20: $t14 := 1
      # live vars: n, r_ref, $t5, $t7, $t14
- 22: $t0 := -($t0, $t14)
+ 21: $t0 := -($t0, $t14)
      # live vars: n, r_ref, $t5, $t7
- 23: goto 4
+ 22: goto 4
      # live vars: r_ref
- 24: label L2
+ 23: label L2
      # live vars: r_ref
- 25: $t15 := TestLiveVars::test1($t1)
+ 24: $t15 := TestLiveVars::test1($t1)
      # live vars: $t15
- 26: return $t15
+ 25: return $t15
 }

--- a/language/move-prover/interpreter-testsuite/tests/concrete_check/destroy.exp
+++ b/language/move-prover/interpreter-testsuite/tests/concrete_check/destroy.exp
@@ -1,2 +1,3 @@
 Running Move unit tests
-Test result: OK. Total tests: 0; passed: 0; failed: 0
+[ PASS    ] 0x2::A::destroy
+Test result: OK. Total tests: 1; passed: 1; failed: 0

--- a/language/move-prover/interpreter-testsuite/tests/concrete_check/destroy.move
+++ b/language/move-prover/interpreter-testsuite/tests/concrete_check/destroy.move
@@ -8,8 +8,7 @@ module 0x2::A {
         s.f2
     }
 
-    // TODO (mengxu) there is a bug that tries to destroy a value instead of reference
-    // #[test]
+    #[test]
     public fun destroy(): S {
         let s = S { f1: true, f2: 42 };
         let p = &s;


### PR DESCRIPTION
The `destroy($t1)` bytecode is not removed in the immutable borrow
pass, which it should be, otherwise we will observe an `destroy($t1)`
where `$t1` is not a reference type.

This does not cause any issue with the symbolic reasoning as `destroy`
is essentially translated into a no-op. Instead, it is caught by the
concrete executor.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Move Language.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Improve the stackless bytecode

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes

## Test Plan

CI, with new test cases
