### PR TITLE
[move-prover][interpreter] two bug fixes to re-enable disabled tests

### DIFF
--- a/language/move-prover/interpreter-testsuite/tests/concrete_check/property/mono.exp
+++ b/language/move-prover/interpreter-testsuite/tests/concrete_check/property/mono.exp
@@ -1,2 +1,19 @@
 Running Move unit tests
-Test result: OK. Total tests: 0; passed: 0; failed: 0
+[ FAIL    ] 0x2::Test::check_0x1_fail
+[ PASS    ] 0x2::Test::check_0x2_pass
+
+Test failures:
+
+Failures in 0x2::Test:
+
+┌── check_0x1_fail ──────
+│ error: property does not hold
+│    ┌─ tests/concrete_check/property/mono.move:50:13
+│    │
+│ 50 │             (Base::has_b() && has_r<T>()) ==> old(has_r<T>());
+│    │             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+│
+│
+└──────────────────
+
+Test result: FAILED. Total tests: 2; passed: 1; failed: 1

--- a/language/move-prover/interpreter-testsuite/tests/concrete_check/property/mono.move
+++ b/language/move-prover/interpreter-testsuite/tests/concrete_check/property/mono.move
@@ -29,14 +29,12 @@ module Test {
         move_to(s, R { f: v });
     }
 
-    // TODO (mengxu), after mono, the global invariant is changed to Base::has_b() ==> true...
-    // #[test(s=@0x2)]
+    #[test(s=@0x2)]
     public fun check_0x2_pass(s: &signer) {
         put_r(s, true);
     }
 
-    // TODO (mengxu), after mono, the global invariant is changed to Base::has_b() ==> true...
-    // #[test(s=@0x1)]
+    #[test(s=@0x1)]
     public fun check_0x1_fail(s: &signer) {
         put_r(s, true);
     }
@@ -48,9 +46,8 @@ module Test {
     }
 
     spec module {
-        invariant update
-            Base::has_b() ==>
-                (forall t: type where has_r<t>(): old(has_r<t>()));
+        invariant<T> update
+            (Base::has_b() && has_r<T>()) ==> old(has_r<T>());
     }
 }
 }

--- a/language/move-prover/interpreter-testsuite/tests/concrete_check/return_mut_ref.exp
+++ b/language/move-prover/interpreter-testsuite/tests/concrete_check/return_mut_ref.exp
@@ -1,4 +1,5 @@
 Running Move unit tests
 [ PASS    ] 0x2::A::return_ref_path
+[ PASS    ] 0x2::A::return_ref_path_vec_1
 [ PASS    ] 0x2::A::return_ref_root
-Test result: OK. Total tests: 2; passed: 2; failed: 0
+Test result: OK. Total tests: 3; passed: 3; failed: 0

--- a/language/move-prover/interpreter-testsuite/tests/concrete_check/return_mut_ref.move
+++ b/language/move-prover/interpreter-testsuite/tests/concrete_check/return_mut_ref.move
@@ -47,8 +47,7 @@ module 0x2::A {
         }
     }
 
-    // TODO there is a bug in spec_instrumenter that produces wrong goto labels:
-    // #[test]
+    #[test]
     public fun return_ref_path_vec_1(): V {
         let is = vector::empty();
         let ts = vector::empty();

--- a/language/move-prover/interpreter/src/concrete/local_state.rs
+++ b/language/move-prover/interpreter/src/concrete/local_state.rs
@@ -170,6 +170,11 @@ impl LocalState {
             .iter()
             .enumerate()
             .filter_map(|(idx, slot)| slot.get_content().map(|(_, ptr)| (idx, ptr)))
+            .chain(
+                self.destroyed_args
+                    .iter()
+                    .map(|(idx, val)| (*idx, val.get_ptr())),
+            )
             .collect()
     }
 

--- a/language/move-prover/interpreter/src/concrete/player.rs
+++ b/language/move-prover/interpreter/src/concrete/player.rs
@@ -1448,7 +1448,7 @@ impl<'env> FunctionContext<'env> {
                 // TODO (mengxu): refactor the code to remove this clone
                 let mut cur = op_val.clone();
                 for (i, (val, edge)) in path.into_iter().zip(edges.iter()).rev().enumerate() {
-                    let ptr = trace.get(steps - 1 - i).unwrap();
+                    let ptr = trace.get(i).unwrap();
                     let sub = match edge {
                         BorrowEdge::Field(_, field_num) => {
                             val.update_ref_struct_field(*field_num, cur)

--- a/language/move-prover/interpreter/src/shared/variant.rs
+++ b/language/move-prover/interpreter/src/shared/variant.rs
@@ -23,7 +23,10 @@ pub fn choose_variant<'env>(
                 }
             }
             FunctionVariant::Verification(VerificationFlavor::Regular) => {
-                target_variant = Some(target);
+                // TODO (mengxu): think about a way to handle ghost type parameters
+                if target.data.ghost_type_param_count == 0 {
+                    target_variant = Some(target);
+                }
             }
             _ => (),
         }


### PR DESCRIPTION
The first commit fixes two bugs to re-enable the failing test:

- collect pointers for write-backs even when the local slot is destroyed
- fix the indexing of the borrow edge in the write-back process.

The second commit picks the `baseline` version for callee with ghost type params

- This is a temporary solution until we have a better way to multiplex the
spec evaluation against multiple universially quantified types.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Move Language.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

As title

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes

## Test Plan

CI, with the re-enabled test.