### PR TITLE
[move-cli] A proper "docgen" implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2424,6 +2424,7 @@ dependencies = [
  "move-core-types",
  "move-coverage",
  "move-disassembler",
+ "move-docgen",
  "move-errmapgen",
  "move-ir-types",
  "move-package",

--- a/language/tools/move-cli/Cargo.toml
+++ b/language/tools/move-cli/Cargo.toml
@@ -24,6 +24,7 @@ itertools = "0.10.0"
 bcs = "0.1.2"
 move-bytecode-verifier = { path = "../../move-bytecode-verifier" }
 move-disassembler = { path = "../move-disassembler" }
+move-docgen = { path = "../../move-prover/move-docgen" }
 move-command-line-common = { path = "../../move-command-line-common" }
 move-bytecode-utils = { path = "../move-bytecode-utils" }
 move-coverage = { path = "../move-coverage" }

--- a/language/tools/move-cli/src/base/docgen.rs
+++ b/language/tools/move-cli/src/base/docgen.rs
@@ -1,48 +1,125 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::base::prove::{Prove, ProverOptions};
+use super::reroot_path;
 use clap::*;
-use move_package::BuildConfig;
-use std::path::PathBuf;
+use move_docgen::DocgenOptions;
+use move_package::{BuildConfig, ModelConfig};
+use std::{fs, path::PathBuf};
 
-/// Generating javadoc style documentation for packages using the Move Prover
+/// Generate javadoc style documentation for Move packages
 #[derive(Parser)]
 #[clap(name = "docgen")]
 pub struct Docgen {
-    /// Do not print out other than errors
-    #[clap(long = "quiet", short = 'q')]
-    pub quiet: bool,
-    /// A template for documentation generation.
+    /// The level where we start sectioning. Often markdown sections are rendered with
+    /// unnecessary large section fonts, setting this value high reduces the size
+    #[clap(long = "section-level-start", value_name = "HEADER_LEVEL")]
+    pub section_level_start: Option<usize>,
+    /// Whether to exclude private functions in the generated docs
+    #[clap(long = "exclude-private-fun")]
+    pub exclude_private_fun: bool,
+    /// Whether to exclude specifications in the generated docs
+    #[clap(long = "exclude-specs")]
+    pub exclude_specs: bool,
+    /// Whether to put specifications in the same section as a declaration or put them all
+    /// into an independent section
+    #[clap(long = "independent-specs")]
+    pub independent_specs: bool,
+    /// Whether to exclude Move implementations
+    #[clap(long = "exclude-impl")]
+    pub exclude_impl: bool,
+    /// Max depth to which sections are displayed in table-of-contents
+    #[clap(long = "toc-depth", value_name = "DEPTH")]
+    pub toc_depth: Option<usize>,
+    /// Do not use collapsed sections (<details>) for impl and specs
+    #[clap(long = "no-collapsed-sections")]
+    pub no_collapsed_sections: bool,
+    /// In which directory to store output
+    #[clap(long = "output-directory", value_name = "PATH")]
+    pub output_directory: Option<String>,
+    /// A template for documentation generation. Can be multiple
     #[clap(long = "template", short = 't', value_name = "FILE")]
-    pub template: Option<String>,
+    pub template: Vec<String>,
+    /// An optional file containing reference definitions. The content of this file will
+    /// be added to each generated markdown doc
+    #[clap(long = "references-file", value_name = "FILE")]
+    pub references_file: Option<String>,
+    /// Whether to include dependency diagrams in the generated docs
+    #[clap(long = "include-dep-diagrams")]
+    pub include_dep_diagrams: bool,
+    /// Whether to include call diagrams in the generated docs
+    #[clap(long = "include-call-diagrams")]
+    pub include_call_diagrams: bool,
+    /// If this is being compiled relative to a different place where it will be stored (output directory)
+    #[clap(long = "compile-relative-to-output-dir")]
+    pub compile_relative_to_output_dir: bool,
 }
 
 impl Docgen {
-    /// Simply calling the Move Prover with "--docgen"
-    /// Forwarding `--docgen-template` and setting `--verbose` to `error` if applicable
+    /// Calling the Docgen
     pub fn execute(self, path: Option<PathBuf>, config: BuildConfig) -> anyhow::Result<()> {
-        let mut options_list = vec!["--docgen".to_string()];
-
-        if self.quiet {
-            options_list.push("--verbose".to_string());
-            options_list.push("error".to_string());
-        }
-        if self.template.is_some() {
-            options_list.push("--docgen-template".to_string());
-            options_list.push(self.template.unwrap());
-        }
-
-        let options = Some(ProverOptions::Options(options_list));
-
-        Prove::execute(
-            Prove {
+        let model = config.move_model_for_package(
+            &reroot_path(path).unwrap(),
+            ModelConfig {
+                all_files_as_targets: false,
                 target_filter: None,
-                for_test: false,
-                options,
             },
-            path,
-            config,
-        )
+        )?;
+
+        let mut options = DocgenOptions::default();
+
+        if !self.template.is_empty() {
+            options.root_doc_templates = self.template;
+        }
+        if self.section_level_start.is_some() {
+            options.section_level_start = self.section_level_start.unwrap();
+        }
+        if self.exclude_private_fun {
+            options.include_private_fun = false;
+        }
+        if self.exclude_specs {
+            options.include_specs = false;
+        }
+        if self.independent_specs {
+            options.specs_inlined = false;
+        }
+        if self.exclude_impl {
+            options.include_impl = false;
+        }
+        if self.toc_depth.is_some() {
+            options.toc_depth = self.toc_depth.unwrap();
+        }
+        if self.no_collapsed_sections {
+            options.collapsed_sections = false;
+        }
+        if self.output_directory.is_some() {
+            options.output_directory = self.output_directory.unwrap();
+        }
+        if self.references_file.is_some() {
+            options.references_file = self.references_file;
+        }
+        if self.compile_relative_to_output_dir {
+            options.compile_relative_to_output_dir = true;
+        }
+
+        // We are using the full namespace, since we already use `Docgen` here.
+        // Docgen is the most suitable name for both: this Docgen subcommand,
+        // and the actual move_docgen::Docgen.
+        let generator = move_docgen::Docgen::new(&model, &options);
+
+        for (file, content) in generator.gen() {
+            let path = PathBuf::from(&file);
+            fs::create_dir_all(path.parent().unwrap())?;
+            fs::write(path.as_path(), content)?;
+            println!("Generated {:?}", path);
+        }
+
+        anyhow::ensure!(
+            !model.has_errors(),
+            "Errors encountered while generating documentation!"
+        );
+
+        println!("\nDocumentation generation successful!");
+        Ok(())
     }
 }

--- a/language/tools/move-cli/tests/build_tests/simple_build_with_docs/args.exp
+++ b/language/tools/move-cli/tests/build_tests/simple_build_with_docs/args.exp
@@ -2,8 +2,15 @@ Command `new --path . Foo`:
 Command `build`:
 INCLUDING DEPENDENCY MoveStdlib
 BUILDING Foo
-Command `docgen --quiet --template template.md`:
+Command `docgen --template template.md --exclude-impl --exclude-private-fun --exclude-specs --include-call-diagrams --include-dep-diagrams --independent-specs --no-collapsed-sections --output-directory doc --references-file template.md --section-level-start 3 --toc-depth 3`:
+Generated "doc/template.md"
+Generated "doc/Foo.md"
+
+Documentation generation successful!
 External Command `grep documentation doc/Foo.md`:
 Test documentation comment
 External Command `cat doc/template.md`:
+This is a test template
+
+
 This is a test template

--- a/language/tools/move-cli/tests/build_tests/simple_build_with_docs/args.txt
+++ b/language/tools/move-cli/tests/build_tests/simple_build_with_docs/args.txt
@@ -1,5 +1,5 @@
 new --path . Foo
 build
-docgen --quiet --template template.md
+docgen --template template.md --exclude-impl --exclude-private-fun --exclude-specs --include-call-diagrams --include-dep-diagrams --independent-specs --no-collapsed-sections --output-directory doc --references-file template.md --section-level-start 3 --toc-depth 3
 > grep documentation doc/Foo.md
 > cat doc/template.md


### PR DESCRIPTION
A rudimentary version of the "docgen" command was implemented in 55a40d583 ("[move-cli] Added "docgen" command (#291)", 2022-07-28). However, the implementation was relying on the Move Prover, only exposing one Docgen switch to the user.

This implementation is using the actual Dogen, giving us a possibility to expose all the Docgen switches to the user. The enable/disable logic is modeled against current default settings for Docgen. This is also an indirect way to communicate the default settings to the user.

Addressing the actual Docgen as move_docgen::Docgen, because both, this subcommand and the Move Docgen are entitled to that name: this subcommand because of the Move CLI coding convention, and the actual Move prover because it's the most descriptive short name.

Removed --quiet, since output on successful execution is now deterministic.

The test is currently testing all the switches, creating (almost) totally opposite settings from the default settings.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Move Language.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

The first implementation of "docgen" used Move Prover. Now using the actual Docgen instead to access all the functionality.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes.

## Test Plan

In addition to the unit test (`cargo test -p move-cli`) you can test the actual documentation generation by running:

```
cargo build -p move-cli
./target/debug/move --path ./language/documentation/tutorial/step_8/BasicCoin docgen
```

You should get something like:

```
Generated "doc/BasicCoin.md"

Documentation generation successful!
```

And then you should have the final generated markdown documentation at `./language/documentation/tutorial/step_8/BasicCoin/doc/BasicCoin.md`.
