### PR TITLE
[Move Prover] Bump up the boogie version to 2.15.7

### DIFF
--- a/language/move-prover/boogie-backend/src/boogie_wrapper.rs
+++ b/language/move-prover/boogie-backend/src/boogie_wrapper.rs
@@ -565,7 +565,12 @@ impl<'env> BoogieWrapper<'env> {
 
         if let Some(cap) = MODEL_REGION.captures(&out[*at..]) {
             *at = usize::saturating_add(*at, cap.get(0).unwrap().end());
-            match model.parse(self, cap.name("mod").unwrap().as_str()) {
+
+            // Cuts out the state info block which is not used currently.
+            let re = Regex::new(r"(?m)\*\*\* STATE(?s:.)*?\*\*\* END_STATE\n").unwrap();
+            let remnant = re.replace(cap.name("mod").unwrap().as_str(), "");
+
+            match model.parse(self, remnant.as_ref()) {
                 Ok(_) => {}
                 Err(parse_error) => {
                     let context_module = self

--- a/language/move-prover/boogie-backend/src/options.rs
+++ b/language/move-prover/boogie-backend/src/options.rs
@@ -19,7 +19,7 @@ const DEFAULT_BOOGIE_FLAGS: &[&str] = &[
     "-proverOpt:O:model_validate=true",
 ];
 
-const MIN_BOOGIE_VERSION: &str = "2.13.4";
+const MIN_BOOGIE_VERSION: &str = "2.15.7";
 const MIN_Z3_VERSION: &str = "4.10.2";
 const MIN_CVC5_VERSION: &str = "0.0.3";
 

--- a/scripts/dev_setup.sh
+++ b/scripts/dev_setup.sh
@@ -18,7 +18,7 @@ set -eo pipefail
 Z3_VERSION=4.10.2
 CVC5_VERSION=0.0.3
 DOTNET_VERSION=6.0
-BOOGIE_VERSION=2.13.4
+BOOGIE_VERSION=2.15.7
 SOLC_VERSION="v0.8.11+commit.d7f03943"
 
 SCRIPT_PATH="$(cd "$(dirname "$0")" >/dev/null 2>&1 && pwd)"


### PR DESCRIPTION
- Bumped up the boogie version to the latest one (2.15.7)
- Updated `boogie_wrapper` to ignore the state information that Boogie produces as output ("*** STATE ... *** 
-  END_STATE")
  - `boogie_wrapper` parses the model after cutting out the state info block. Otherwise, parsing would not be correctly done, and warning messages are generated.
 
## Motivation

To bump up the boogie version

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

yes

## Test Plan

cargo test