### PR TITLE
[vm] Invalidate and flush code loader cache

### DIFF
--- a/language/move-vm/runtime/src/loader.rs
+++ b/language/move-vm/runtime/src/loader.rs
@@ -442,7 +442,7 @@ pub(crate) struct Loader {
     type_cache: RwLock<TypeCache>,
     natives: NativeFunctions,
 
-    // A boolean indicating that this cache has become invalid and needs to be flushed
+    // A boolean indicating that this cache has become outdated and needs to be flushed
     // for the next session. This is to work around multiple bugs in the loader architecture:
     //
     // - After module upgrade, the new module version isn't yet in the cache, which causes
@@ -477,7 +477,7 @@ impl Loader {
     }
 
     /// Mark this cache as invalidated.
-    pub(crate) fn invalidate(&self) {
+    pub(crate) fn mark_as_invalid(&self) {
         *self.invalidated.write() = true;
     }
 

--- a/language/move-vm/runtime/src/loader.rs
+++ b/language/move-vm/runtime/src/loader.rs
@@ -442,15 +442,31 @@ pub(crate) struct Loader {
     type_cache: RwLock<TypeCache>,
     natives: NativeFunctions,
 
-    // A boolean indicating that this cache has become outdated and needs to be flushed
-    // for the next session. This is to work around multiple bugs in the loader architecture:
+    // The below field supports a hack to workaround well-known issues with the
+    // loader cache. This cache is not designed to support module upgrade or deletion.
+    // This leads to situations where the cache does not reflect the state of storage:
     //
-    // - After module upgrade, the new module version isn't yet in the cache, which causes
-    //   inconsistencies if this module is accessed subsequently. The logic for upgrading
-    //   inside of this module will set this flag.
-    // - An external call on the VM may set this flag as well. For example, if module
-    //   publishing succeeds but the transaction is not committed to global storage, the
-    ///  module is still in the cache if it shouldn't.
+    // 1. On module upgrade, the upgraded module is in storage, but the old one still in the cache.
+    // 2. On an abandoned code publishing transaction, the cache may contain a module which was
+    //    never committed to storage by the adapter.
+    //
+    // The solution is to add a flag to Loader marking it as 'invalidated'. For scenario (1),
+    // the VM sets the flag itself. For scenario (2), a public API allows the adapter to set
+    // the flag.
+    //
+    // If the cache is invalidated, it can (and must) still be used until there are no more
+    // sessions alive which are derived from a VM with this loader. This is because there are
+    // internal data structures derived from the loader which can become inconsistent. Therefore
+    // the adapter must explicitly call a function to flush the invalidated loader.
+    //
+    // This code (the loader) needs a complete refactoring. The new loader should
+    //
+    // - support upgrade and deletion of modules, while still preserving max cache lookup
+    //   performance. This is essential for a cache like this in a multi-tenant execution
+    //   environment.
+    // - should delegate lifetime ownership to the adapter. Code loading (including verification)
+    //   is a major execution bottleneck. We should be able to reuse a cache for the lifetime of
+    //   the adapter/node, not just a VM or even session (as effectively today).
     invalidated: RwLock<bool>,
 }
 

--- a/language/move-vm/runtime/src/move_vm.rs
+++ b/language/move-vm/runtime/src/move_vm.rs
@@ -76,7 +76,7 @@ impl MoveVM {
     /// outdated. This can happen if the adapter executed a particular code publishing transaction
     /// but decided to not commit the result to the data store. Because the code cache currently
     /// does not support deletion, the cache will, incorrectly, still contain this module.
-    pub fn invalidate_loader_cache(&self) {
-        self.runtime.invalidate_loader_cache()
+    pub fn mark_loader_cache_as_invalid(&self) {
+        self.runtime.mark_loader_cache_as_invalid()
     }
 }

--- a/language/move-vm/runtime/src/move_vm.rs
+++ b/language/move-vm/runtime/src/move_vm.rs
@@ -71,4 +71,12 @@ impl MoveVM {
             )
             .map(|arc_module| arc_module.arc_module())
     }
+
+    /// Allows the adapter to announce to the VM that the code loading cache should be considered
+    /// outdated. This can happen if the adapter executed a particular code publishing transaction
+    /// but decided to not commit the result to the data store. Because the code cache currently
+    /// does not support deletion, the cache will, incorrectly, still contain this module.
+    pub fn invalidate_loader_cache(&self) {
+        self.runtime.invalidate_loader_cache()
+    }
 }

--- a/language/move-vm/runtime/src/move_vm.rs
+++ b/language/move-vm/runtime/src/move_vm.rs
@@ -79,4 +79,11 @@ impl MoveVM {
     pub fn mark_loader_cache_as_invalid(&self) {
         self.runtime.mark_loader_cache_as_invalid()
     }
+
+    /// If the loader cache has been invalidated (either by the above call or by internal logic)
+    /// flush it so it is valid again. Notice that should only be called if there are no
+    /// outstanding sessions created from this VM.
+    pub fn flush_loader_cache_if_invalidated(&self) {
+        self.runtime.flush_loader_cache_if_invalidated()
+    }
 }

--- a/language/move-vm/runtime/src/runtime.rs
+++ b/language/move-vm/runtime/src/runtime.rs
@@ -53,6 +53,10 @@ impl VMRuntime {
         self.loader.mark_as_invalid()
     }
 
+    pub(crate) fn flush_loader_cache_if_invalidated(&self) {
+        self.loader.flush_if_invalidated()
+    }
+
     pub fn new_session<'r, S: MoveResolver>(&self, remote: &'r S) -> Session<'r, '_, S> {
         self.new_session_with_extensions(remote, NativeContextExtensions::default())
     }
@@ -62,8 +66,6 @@ impl VMRuntime {
         remote: &'r S,
         native_extensions: NativeContextExtensions<'r>,
     ) -> Session<'r, '_, S> {
-        // If the loader cache is invalidated, flush it for the new session
-        self.loader.flush_if_invalidated();
         Session {
             runtime: self,
             data_cache: TransactionDataCache::new(remote, &self.loader),


### PR DESCRIPTION
This is a hack to workaround well-known issues with the VMs code loader cache. This cache is not designed to support module upgrade or deletion. This leads to situations where the cache does not reflect the state of storage:

1. On module upgrade, the upgraded module is in storage, but the old one still in the cache.
2. On an abandoned code publishing transaction, the cache may contain a module which was never committed to storage by the adapter.

The solution is to add a flag to `Loader` marking it as 'invalidated'. For scenario (1), the VM sets the flag itself. For scenario (2), a public API allows the adapter to set the flag.

If the cache invalidated, it can (and must) still be used until the end of the session. This is because during session execution, data might have been extracted which indirectly refers to the current cache (e.g. `CachedStructIndex`). The adapter is responsible to flush an invalidated cache.


