### PR TITLE
[move-prover] do not remap moved nodes in borrow analysis

### DIFF
--- a/language/move-prover/bytecode/tests/borrow/basic_test.exp
+++ b/language/move-prover/bytecode/tests/borrow/basic_test.exp
@@ -277,9 +277,9 @@ fun TestBorrow::test1(): TestBorrow::R {
      # borrowed_by: LocalRoot($t0) -> {(@, Reference($t4))}, Reference($t4) -> {(.x (u64), Reference($t5))}
      # borrows_from: Reference($t4) -> {(@, LocalRoot($t0))}, Reference($t5) -> {(.x (u64), Reference($t4))}
   6: $t7 := move($t0)
-     # moved_nodes: LocalRoot($t0)
-     # borrowed_by: LocalRoot($t7) -> {(@, Reference($t4))}, Reference($t4) -> {(.x (u64), Reference($t5))}
-     # borrows_from: Reference($t4) -> {(@, LocalRoot($t7))}, Reference($t5) -> {(.x (u64), Reference($t4))}
+     # live_nodes: LocalRoot($t7)
+     # borrowed_by: LocalRoot($t0) -> {(@, Reference($t4))}, Reference($t4) -> {(.x (u64), Reference($t5))}
+     # borrows_from: Reference($t4) -> {(@, LocalRoot($t0))}, Reference($t5) -> {(.x (u64), Reference($t4))}
   7: return $t7
 }
 
@@ -338,9 +338,9 @@ fun TestBorrow::test4(): TestBorrow::R {
      # borrowed_by: LocalRoot($t0) -> {(@, Reference($t3))}
      # borrows_from: Reference($t3) -> {(@, LocalRoot($t0))}
   5: $t5 := move($t0)
-     # moved_nodes: LocalRoot($t0)
-     # borrowed_by: LocalRoot($t5) -> {(@, Reference($t3))}
-     # borrows_from: Reference($t3) -> {(@, LocalRoot($t5))}
+     # live_nodes: LocalRoot($t5)
+     # borrowed_by: LocalRoot($t0) -> {(@, Reference($t3))}
+     # borrows_from: Reference($t3) -> {(@, LocalRoot($t0))}
   6: return $t5
 }
 
@@ -379,22 +379,19 @@ fun TestBorrow::test6(): TestBorrow::R {
      # borrows_from: Reference($t4) -> {(@, LocalRoot($t0))}
   3: $t5 := TestBorrow::test5($t4)
      # live_nodes: Reference($t5)
-     # moved_nodes: Reference($t4)
      # borrowed_by: LocalRoot($t0) -> {(@, Reference($t4))}, Reference($t4) -> {(.x (u64), Reference($t5))}
      # borrows_from: Reference($t4) -> {(@, LocalRoot($t0))}, Reference($t5) -> {(.x (u64), Reference($t4))}
   4: $t6 := 0
      # live_nodes: Reference($t5)
-     # moved_nodes: Reference($t4)
      # borrowed_by: LocalRoot($t0) -> {(@, Reference($t4))}, Reference($t4) -> {(.x (u64), Reference($t5))}
      # borrows_from: Reference($t4) -> {(@, LocalRoot($t0))}, Reference($t5) -> {(.x (u64), Reference($t4))}
   5: TestBorrow::test2($t5, $t6)
-     # moved_nodes: Reference($t4)
      # borrowed_by: LocalRoot($t0) -> {(@, Reference($t4))}, Reference($t4) -> {(.x (u64), Reference($t5))}
      # borrows_from: Reference($t4) -> {(@, LocalRoot($t0))}, Reference($t5) -> {(.x (u64), Reference($t4))}
   6: $t7 := move($t0)
-     # moved_nodes: LocalRoot($t0), Reference($t4)
-     # borrowed_by: LocalRoot($t7) -> {(@, Reference($t4))}, Reference($t4) -> {(.x (u64), Reference($t5))}
-     # borrows_from: Reference($t4) -> {(@, LocalRoot($t7))}, Reference($t5) -> {(.x (u64), Reference($t4))}
+     # live_nodes: LocalRoot($t7)
+     # borrowed_by: LocalRoot($t0) -> {(@, Reference($t4))}, Reference($t4) -> {(.x (u64), Reference($t5))}
+     # borrows_from: Reference($t4) -> {(@, LocalRoot($t0))}, Reference($t5) -> {(.x (u64), Reference($t4))}
   7: return $t7
 }
 

--- a/language/move-prover/bytecode/tests/borrow/function_call.exp
+++ b/language/move-prover/bytecode/tests/borrow/function_call.exp
@@ -190,10 +190,9 @@ public fun vector::singleton<#0>($t0|e: #0): vector<#0> {
      # borrowed_by: LocalRoot($t1) -> {(@, Reference($t2))}
      # borrows_from: Reference($t2) -> {(@, LocalRoot($t1))}
   3: $t3 := move($t1)
-     # live_nodes: LocalRoot($t0)
-     # moved_nodes: LocalRoot($t1)
-     # borrowed_by: LocalRoot($t3) -> {(@, Reference($t2))}
-     # borrows_from: Reference($t2) -> {(@, LocalRoot($t3))}
+     # live_nodes: LocalRoot($t0), LocalRoot($t3)
+     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t2))}
+     # borrows_from: Reference($t2) -> {(@, LocalRoot($t1))}
   4: return $t3
 }
 
@@ -222,12 +221,10 @@ fun MultiLayerCalling::inner($t0|has_vector: &mut MultiLayerCalling::HasVector):
      # borrows_from: Reference($t1) -> {(.v (vector<MultiLayerCalling::HasAnotherVector>), Reference($t0))}
   2: $t3 := vector::borrow_mut<MultiLayerCalling::HasAnotherVector>($t1, $t2)
      # live_nodes: Reference($t0), Reference($t3)
-     # moved_nodes: Reference($t1)
      # borrowed_by: Reference($t0) -> {(.v (vector<MultiLayerCalling::HasAnotherVector>), Reference($t1))}, Reference($t1) -> {([], Reference($t3))}
      # borrows_from: Reference($t1) -> {(.v (vector<MultiLayerCalling::HasAnotherVector>), Reference($t0))}, Reference($t3) -> {([], Reference($t1))}
   3: trace_local[has_vector]($t0)
      # live_nodes: Reference($t3)
-     # moved_nodes: Reference($t1)
      # borrowed_by: Reference($t0) -> {(.v (vector<MultiLayerCalling::HasAnotherVector>), Reference($t1))}, Reference($t1) -> {([], Reference($t3))}
      # borrows_from: Reference($t1) -> {(.v (vector<MultiLayerCalling::HasAnotherVector>), Reference($t0))}, Reference($t3) -> {([], Reference($t1))}
   4: return $t3
@@ -240,12 +237,10 @@ fun MultiLayerCalling::mid($t0|has_vector: &mut MultiLayerCalling::HasVector): &
      # live_nodes: Reference($t0)
   0: $t1 := MultiLayerCalling::inner($t0)
      # live_nodes: Reference($t0), Reference($t1)
-     # moved_nodes: Reference($t0)
      # borrowed_by: Reference($t0) -> {(.v (vector<MultiLayerCalling::HasAnotherVector>)/[], Reference($t1))}
      # borrows_from: Reference($t1) -> {(.v (vector<MultiLayerCalling::HasAnotherVector>)/[], Reference($t0))}
   1: trace_local[has_vector]($t0)
      # live_nodes: Reference($t1)
-     # moved_nodes: Reference($t0)
      # borrowed_by: Reference($t0) -> {(.v (vector<MultiLayerCalling::HasAnotherVector>)/[], Reference($t1))}
      # borrows_from: Reference($t1) -> {(.v (vector<MultiLayerCalling::HasAnotherVector>)/[], Reference($t0))}
   2: return $t1
@@ -261,26 +256,21 @@ fun MultiLayerCalling::outer($t0|has_vector: &mut MultiLayerCalling::HasVector) 
      # live_nodes: Reference($t0)
   0: $t2 := MultiLayerCalling::mid($t0)
      # live_nodes: Reference($t0), Reference($t2)
-     # moved_nodes: Reference($t0)
      # borrowed_by: Reference($t0) -> {(.v (vector<MultiLayerCalling::HasAnotherVector>)/[], Reference($t2))}
      # borrows_from: Reference($t2) -> {(.v (vector<MultiLayerCalling::HasAnotherVector>)/[], Reference($t0))}
   1: $t3 := borrow_field<MultiLayerCalling::HasAnotherVector>.v($t2)
      # live_nodes: Reference($t0), Reference($t3)
-     # moved_nodes: Reference($t0)
      # borrowed_by: Reference($t0) -> {(.v (vector<MultiLayerCalling::HasAnotherVector>)/[], Reference($t2))}, Reference($t2) -> {(.v (vector<u8>), Reference($t3))}
      # borrows_from: Reference($t2) -> {(.v (vector<MultiLayerCalling::HasAnotherVector>)/[], Reference($t0))}, Reference($t3) -> {(.v (vector<u8>), Reference($t2))}
   2: $t4 := 42
      # live_nodes: Reference($t0), Reference($t3)
-     # moved_nodes: Reference($t0)
      # borrowed_by: Reference($t0) -> {(.v (vector<MultiLayerCalling::HasAnotherVector>)/[], Reference($t2))}, Reference($t2) -> {(.v (vector<u8>), Reference($t3))}
      # borrows_from: Reference($t2) -> {(.v (vector<MultiLayerCalling::HasAnotherVector>)/[], Reference($t0))}, Reference($t3) -> {(.v (vector<u8>), Reference($t2))}
   3: vector::push_back<u8>($t3, $t4)
      # live_nodes: Reference($t0)
-     # moved_nodes: Reference($t0)
      # borrowed_by: Reference($t0) -> {(.v (vector<MultiLayerCalling::HasAnotherVector>)/[], Reference($t2))}, Reference($t2) -> {(.v (vector<u8>), Reference($t3))}
      # borrows_from: Reference($t2) -> {(.v (vector<MultiLayerCalling::HasAnotherVector>)/[], Reference($t0))}, Reference($t3) -> {(.v (vector<u8>), Reference($t2))}
   4: trace_local[has_vector]($t0)
-     # moved_nodes: Reference($t0)
      # borrowed_by: Reference($t0) -> {(.v (vector<MultiLayerCalling::HasAnotherVector>)/[], Reference($t2))}, Reference($t2) -> {(.v (vector<u8>), Reference($t3))}
      # borrows_from: Reference($t2) -> {(.v (vector<MultiLayerCalling::HasAnotherVector>)/[], Reference($t0))}, Reference($t3) -> {(.v (vector<u8>), Reference($t2))}
   5: return ()

--- a/language/move-prover/bytecode/tests/borrow/hyper_edge.exp
+++ b/language/move-prover/bytecode/tests/borrow/hyper_edge.exp
@@ -198,10 +198,9 @@ public fun vector::singleton<#0>($t0|e: #0): vector<#0> {
      # borrowed_by: LocalRoot($t1) -> {(@, Reference($t2))}
      # borrows_from: Reference($t2) -> {(@, LocalRoot($t1))}
   3: $t3 := move($t1)
-     # live_nodes: LocalRoot($t0)
-     # moved_nodes: LocalRoot($t1)
-     # borrowed_by: LocalRoot($t3) -> {(@, Reference($t2))}
-     # borrows_from: Reference($t2) -> {(@, LocalRoot($t3))}
+     # live_nodes: LocalRoot($t0), LocalRoot($t3)
+     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t2))}
+     # borrows_from: Reference($t2) -> {(@, LocalRoot($t1))}
   4: return $t3
 }
 
@@ -225,12 +224,10 @@ public fun Collection::borrow_mut<#0>($t0|c: &mut Collection::Collection<#0>, $t
      # borrows_from: Reference($t2) -> {(.items (vector<#0>), Reference($t0))}
   1: $t3 := vector::borrow_mut<#0>($t2, $t1)
      # live_nodes: LocalRoot($t1), Reference($t0), Reference($t3)
-     # moved_nodes: Reference($t2)
      # borrowed_by: Reference($t0) -> {(.items (vector<#0>), Reference($t2))}, Reference($t2) -> {([], Reference($t3))}
      # borrows_from: Reference($t2) -> {(.items (vector<#0>), Reference($t0))}, Reference($t3) -> {([], Reference($t2))}
   2: trace_local[c]($t0)
      # live_nodes: LocalRoot($t1), Reference($t3)
-     # moved_nodes: Reference($t2)
      # borrowed_by: Reference($t0) -> {(.items (vector<#0>), Reference($t2))}, Reference($t2) -> {([], Reference($t3))}
      # borrows_from: Reference($t2) -> {(.items (vector<#0>), Reference($t0))}, Reference($t3) -> {([], Reference($t2))}
   3: return $t3
@@ -266,22 +263,18 @@ public fun Test::foo<#0>($t0|i: u64) {
      # borrows_from: Reference($t3) -> {(@, LocalRoot($t1))}
   2: $t4 := Collection::borrow_mut<Test::Token<#0>>($t3, $t0)
      # live_nodes: LocalRoot($t0), Reference($t4)
-     # moved_nodes: Reference($t3)
      # borrowed_by: LocalRoot($t1) -> {(@, Reference($t3))}, Reference($t3) -> {(.items (vector<Test::Token<#0>>)/[], Reference($t4))}
      # borrows_from: Reference($t3) -> {(@, LocalRoot($t1))}, Reference($t4) -> {(.items (vector<Test::Token<#0>>)/[], Reference($t3))}
   3: $t5 := 0
      # live_nodes: LocalRoot($t0), Reference($t4)
-     # moved_nodes: Reference($t3)
      # borrowed_by: LocalRoot($t1) -> {(@, Reference($t3))}, Reference($t3) -> {(.items (vector<Test::Token<#0>>)/[], Reference($t4))}
      # borrows_from: Reference($t3) -> {(@, LocalRoot($t1))}, Reference($t4) -> {(.items (vector<Test::Token<#0>>)/[], Reference($t3))}
   4: $t6 := borrow_field<Test::Token<#0>>.value($t4)
      # live_nodes: LocalRoot($t0), Reference($t6)
-     # moved_nodes: Reference($t3)
      # borrowed_by: LocalRoot($t1) -> {(@, Reference($t3))}, Reference($t3) -> {(.items (vector<Test::Token<#0>>)/[], Reference($t4))}, Reference($t4) -> {(.value (u64), Reference($t6))}
      # borrows_from: Reference($t3) -> {(@, LocalRoot($t1))}, Reference($t4) -> {(.items (vector<Test::Token<#0>>)/[], Reference($t3))}, Reference($t6) -> {(.value (u64), Reference($t4))}
   5: write_ref($t6, $t5)
      # live_nodes: LocalRoot($t0)
-     # moved_nodes: Reference($t3)
      # borrowed_by: LocalRoot($t1) -> {(@, Reference($t3))}, Reference($t3) -> {(.items (vector<Test::Token<#0>>)/[], Reference($t4))}, Reference($t4) -> {(.value (u64), Reference($t6))}
      # borrows_from: Reference($t3) -> {(@, LocalRoot($t1))}, Reference($t4) -> {(.items (vector<Test::Token<#0>>)/[], Reference($t3))}, Reference($t6) -> {(.value (u64), Reference($t4))}
   6: return ()

--- a/language/move-prover/bytecode/tests/borrow_strong/basic_test.exp
+++ b/language/move-prover/bytecode/tests/borrow_strong/basic_test.exp
@@ -383,9 +383,9 @@ fun TestBorrow::test1(): TestBorrow::R {
      # borrowed_by: LocalRoot($t0) -> {(@, Reference($t5))}, Reference($t5) -> {(.x (u64), Reference($t6))}
      # borrows_from: Reference($t5) -> {(@, LocalRoot($t0))}, Reference($t6) -> {(.x (u64), Reference($t5))}
   7: $t8 := move($t0)
-     # moved_nodes: LocalRoot($t0)
-     # borrowed_by: LocalRoot($t8) -> {(@, Reference($t5))}, Reference($t5) -> {(.x (u64), Reference($t6))}
-     # borrows_from: Reference($t5) -> {(@, LocalRoot($t8))}, Reference($t6) -> {(.x (u64), Reference($t5))}
+     # live_nodes: LocalRoot($t8)
+     # borrowed_by: LocalRoot($t0) -> {(@, Reference($t5))}, Reference($t5) -> {(.x (u64), Reference($t6))}
+     # borrows_from: Reference($t5) -> {(@, LocalRoot($t0))}, Reference($t6) -> {(.x (u64), Reference($t5))}
   8: return $t8
 }
 
@@ -434,7 +434,6 @@ fun TestBorrow::test10($t0|b: bool): TestBorrow::R {
      # borrows_from: Reference($t2) -> {(@, Reference($t7))}, Reference($t6) -> {(@, LocalRoot($t1))}, Reference($t7) -> {(.x (u64), Reference($t6))}
   9: $t2 := TestBorrow::test9($t0, $t6)
      # live_nodes: LocalRoot($t0), Reference($t2)
-     # moved_nodes: Reference($t6)
      # borrowed_by: LocalRoot($t1) -> {(@, Reference($t6))}, Reference($t6) -> {(.y (u64), Reference($t2)), (.x (u64)/@, Reference($t2)), (.x (u64), Reference($t7))}, Reference($t7) -> {(@, Reference($t2))}
      # borrows_from: Reference($t2) -> {(.y (u64), Reference($t6)), (.x (u64)/@, Reference($t6)), (@, Reference($t7))}, Reference($t6) -> {(@, LocalRoot($t1))}, Reference($t7) -> {(.x (u64), Reference($t6))}
  10: goto 13
@@ -447,29 +446,24 @@ fun TestBorrow::test10($t0|b: bool): TestBorrow::R {
      # borrows_from: Reference($t2) -> {(@, Reference($t7))}, Reference($t6) -> {(@, LocalRoot($t1))}, Reference($t7) -> {(.x (u64), Reference($t6))}
  12: destroy($t6)
      # live_nodes: LocalRoot($t0), Reference($t2)
-     # moved_nodes: Reference($t6)
      # borrowed_by: LocalRoot($t1) -> {(@, Reference($t6))}, Reference($t6) -> {(.y (u64), Reference($t2)), (.x (u64)/@, Reference($t2)), (.x (u64), Reference($t7))}, Reference($t7) -> {(@, Reference($t2))}
      # borrows_from: Reference($t2) -> {(.y (u64), Reference($t6)), (.x (u64)/@, Reference($t6)), (@, Reference($t7))}, Reference($t6) -> {(@, LocalRoot($t1))}, Reference($t7) -> {(.x (u64), Reference($t6))}
  13: label L3
      # live_nodes: LocalRoot($t0), Reference($t2)
-     # moved_nodes: Reference($t6)
      # borrowed_by: LocalRoot($t1) -> {(@, Reference($t6))}, Reference($t6) -> {(.y (u64), Reference($t2)), (.x (u64)/@, Reference($t2)), (.x (u64), Reference($t7))}, Reference($t7) -> {(@, Reference($t2))}
      # borrows_from: Reference($t2) -> {(.y (u64), Reference($t6)), (.x (u64)/@, Reference($t6)), (@, Reference($t7))}, Reference($t6) -> {(@, LocalRoot($t1))}, Reference($t7) -> {(.x (u64), Reference($t6))}
  14: $t8 := 0
      # live_nodes: LocalRoot($t0), Reference($t2)
-     # moved_nodes: Reference($t6)
      # borrowed_by: LocalRoot($t1) -> {(@, Reference($t6))}, Reference($t6) -> {(.y (u64), Reference($t2)), (.x (u64)/@, Reference($t2)), (.x (u64), Reference($t7))}, Reference($t7) -> {(@, Reference($t2))}
      # borrows_from: Reference($t2) -> {(.y (u64), Reference($t6)), (.x (u64)/@, Reference($t6)), (@, Reference($t7))}, Reference($t6) -> {(@, LocalRoot($t1))}, Reference($t7) -> {(.x (u64), Reference($t6))}
  15: write_ref($t2, $t8)
      # live_nodes: LocalRoot($t0)
-     # moved_nodes: Reference($t6)
      # borrowed_by: LocalRoot($t1) -> {(@, Reference($t6))}, Reference($t6) -> {(.y (u64), Reference($t2)), (.x (u64)/@, Reference($t2)), (.x (u64), Reference($t7))}, Reference($t7) -> {(@, Reference($t2))}
      # borrows_from: Reference($t2) -> {(.y (u64), Reference($t6)), (.x (u64)/@, Reference($t6)), (@, Reference($t7))}, Reference($t6) -> {(@, LocalRoot($t1))}, Reference($t7) -> {(.x (u64), Reference($t6))}
  16: $t9 := move($t1)
-     # live_nodes: LocalRoot($t0)
-     # moved_nodes: LocalRoot($t1), Reference($t6)
-     # borrowed_by: LocalRoot($t9) -> {(@, Reference($t6))}, Reference($t6) -> {(.y (u64), Reference($t2)), (.x (u64)/@, Reference($t2)), (.x (u64), Reference($t7))}, Reference($t7) -> {(@, Reference($t2))}
-     # borrows_from: Reference($t2) -> {(.y (u64), Reference($t6)), (.x (u64)/@, Reference($t6)), (@, Reference($t7))}, Reference($t6) -> {(@, LocalRoot($t9))}, Reference($t7) -> {(.x (u64), Reference($t6))}
+     # live_nodes: LocalRoot($t0), LocalRoot($t9)
+     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t6))}, Reference($t6) -> {(.y (u64), Reference($t2)), (.x (u64)/@, Reference($t2)), (.x (u64), Reference($t7))}, Reference($t7) -> {(@, Reference($t2))}
+     # borrows_from: Reference($t2) -> {(.y (u64), Reference($t6)), (.x (u64)/@, Reference($t6)), (@, Reference($t7))}, Reference($t6) -> {(@, LocalRoot($t1))}, Reference($t7) -> {(.x (u64), Reference($t6))}
  17: return $t9
      # live_nodes: LocalRoot($t0), Reference($t2), Reference($t6), Reference($t7)
      # borrowed_by: LocalRoot($t1) -> {(@, Reference($t6))}, Reference($t6) -> {(.x (u64), Reference($t7))}, Reference($t7) -> {(@, Reference($t2))}
@@ -554,9 +548,9 @@ fun TestBorrow::test4(): TestBorrow::R {
      # borrowed_by: LocalRoot($t0) -> {(@, Reference($t4))}
      # borrows_from: Reference($t4) -> {(@, LocalRoot($t0))}
   6: $t6 := move($t0)
-     # moved_nodes: LocalRoot($t0)
-     # borrowed_by: LocalRoot($t6) -> {(@, Reference($t4))}
-     # borrows_from: Reference($t4) -> {(@, LocalRoot($t6))}
+     # live_nodes: LocalRoot($t6)
+     # borrowed_by: LocalRoot($t0) -> {(@, Reference($t4))}
+     # borrows_from: Reference($t4) -> {(@, LocalRoot($t0))}
   7: return $t6
 }
 
@@ -597,22 +591,19 @@ fun TestBorrow::test6(): TestBorrow::R {
      # borrows_from: Reference($t5) -> {(@, LocalRoot($t0))}
   4: $t6 := TestBorrow::test5($t5)
      # live_nodes: Reference($t6)
-     # moved_nodes: Reference($t5)
      # borrowed_by: LocalRoot($t0) -> {(@, Reference($t5))}, Reference($t5) -> {(.x (u64), Reference($t6))}
      # borrows_from: Reference($t5) -> {(@, LocalRoot($t0))}, Reference($t6) -> {(.x (u64), Reference($t5))}
   5: $t7 := 0
      # live_nodes: Reference($t6)
-     # moved_nodes: Reference($t5)
      # borrowed_by: LocalRoot($t0) -> {(@, Reference($t5))}, Reference($t5) -> {(.x (u64), Reference($t6))}
      # borrows_from: Reference($t5) -> {(@, LocalRoot($t0))}, Reference($t6) -> {(.x (u64), Reference($t5))}
   6: TestBorrow::test2($t6, $t7)
-     # moved_nodes: Reference($t5)
      # borrowed_by: LocalRoot($t0) -> {(@, Reference($t5))}, Reference($t5) -> {(.x (u64), Reference($t6))}
      # borrows_from: Reference($t5) -> {(@, LocalRoot($t0))}, Reference($t6) -> {(.x (u64), Reference($t5))}
   7: $t8 := move($t0)
-     # moved_nodes: LocalRoot($t0), Reference($t5)
-     # borrowed_by: LocalRoot($t8) -> {(@, Reference($t5))}, Reference($t5) -> {(.x (u64), Reference($t6))}
-     # borrows_from: Reference($t5) -> {(@, LocalRoot($t8))}, Reference($t6) -> {(.x (u64), Reference($t5))}
+     # live_nodes: LocalRoot($t8)
+     # borrowed_by: LocalRoot($t0) -> {(@, Reference($t5))}, Reference($t5) -> {(.x (u64), Reference($t6))}
+     # borrows_from: Reference($t5) -> {(@, LocalRoot($t0))}, Reference($t6) -> {(.x (u64), Reference($t5))}
   8: return $t8
 }
 

--- a/language/move-prover/bytecode/tests/borrow_strong/mut_ref.exp
+++ b/language/move-prover/bytecode/tests/borrow_strong/mut_ref.exp
@@ -518,10 +518,9 @@ public fun vector::singleton<#0>($t0|e: #0): vector<#0> {
      # borrowed_by: LocalRoot($t1) -> {(@, Reference($t2))}
      # borrows_from: Reference($t2) -> {(@, LocalRoot($t1))}
   3: $t3 := move($t1)
-     # live_nodes: LocalRoot($t0)
-     # moved_nodes: LocalRoot($t1)
-     # borrowed_by: LocalRoot($t3) -> {(@, Reference($t2))}
-     # borrows_from: Reference($t2) -> {(@, LocalRoot($t3))}
+     # live_nodes: LocalRoot($t0), LocalRoot($t3)
+     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t2))}
+     # borrows_from: Reference($t2) -> {(@, LocalRoot($t1))}
   4: return $t3
 }
 
@@ -560,24 +559,20 @@ fun TestMutRef::call_return_ref_different_path($t0|b: bool): TestMutRef::N {
      # borrows_from: Reference($t6) -> {(@, LocalRoot($t2))}
   5: $t7 := TestMutRef::return_ref_different_path($t0, $t6)
      # live_nodes: LocalRoot($t0), Reference($t7)
-     # moved_nodes: Reference($t6)
      # borrowed_by: LocalRoot($t2) -> {(@, Reference($t6))}, Reference($t6) -> {(.value (u64), Reference($t7)), (.t (TestMutRef::T)/.value (u64), Reference($t7))}
      # borrows_from: Reference($t6) -> {(@, LocalRoot($t2))}, Reference($t7) -> {(.value (u64), Reference($t6)), (.t (TestMutRef::T)/.value (u64), Reference($t6))}
   6: $t8 := 5
      # live_nodes: LocalRoot($t0), Reference($t7)
-     # moved_nodes: Reference($t6)
      # borrowed_by: LocalRoot($t2) -> {(@, Reference($t6))}, Reference($t6) -> {(.value (u64), Reference($t7)), (.t (TestMutRef::T)/.value (u64), Reference($t7))}
      # borrows_from: Reference($t6) -> {(@, LocalRoot($t2))}, Reference($t7) -> {(.value (u64), Reference($t6)), (.t (TestMutRef::T)/.value (u64), Reference($t6))}
   7: write_ref($t7, $t8)
      # live_nodes: LocalRoot($t0)
-     # moved_nodes: Reference($t6)
      # borrowed_by: LocalRoot($t2) -> {(@, Reference($t6))}, Reference($t6) -> {(.value (u64), Reference($t7)), (.t (TestMutRef::T)/.value (u64), Reference($t7))}
      # borrows_from: Reference($t6) -> {(@, LocalRoot($t2))}, Reference($t7) -> {(.value (u64), Reference($t6)), (.t (TestMutRef::T)/.value (u64), Reference($t6))}
   8: $t9 := move($t2)
-     # live_nodes: LocalRoot($t0)
-     # moved_nodes: LocalRoot($t2), Reference($t6)
-     # borrowed_by: LocalRoot($t9) -> {(@, Reference($t6))}, Reference($t6) -> {(.value (u64), Reference($t7)), (.t (TestMutRef::T)/.value (u64), Reference($t7))}
-     # borrows_from: Reference($t6) -> {(@, LocalRoot($t9))}, Reference($t7) -> {(.value (u64), Reference($t6)), (.t (TestMutRef::T)/.value (u64), Reference($t6))}
+     # live_nodes: LocalRoot($t0), LocalRoot($t9)
+     # borrowed_by: LocalRoot($t2) -> {(@, Reference($t6))}, Reference($t6) -> {(.value (u64), Reference($t7)), (.t (TestMutRef::T)/.value (u64), Reference($t7))}
+     # borrows_from: Reference($t6) -> {(@, LocalRoot($t2))}, Reference($t7) -> {(.value (u64), Reference($t6)), (.t (TestMutRef::T)/.value (u64), Reference($t6))}
   9: return $t9
 }
 
@@ -628,40 +623,33 @@ fun TestMutRef::call_return_ref_different_path_vec($t0|b: bool): TestMutRef::V {
      # borrowed_by: LocalRoot($t1) -> {(@, Reference($t6)), (@, Reference($t8))}
      # borrows_from: Reference($t6) -> {(@, LocalRoot($t1))}, Reference($t8) -> {(@, LocalRoot($t1))}
   8: $t10 := move($t1)
-     # live_nodes: LocalRoot($t0)
-     # moved_nodes: LocalRoot($t1)
-     # borrowed_by: LocalRoot($t10) -> {(@, Reference($t6)), (@, Reference($t8))}
-     # borrows_from: Reference($t6) -> {(@, LocalRoot($t10))}, Reference($t8) -> {(@, LocalRoot($t10))}
+     # live_nodes: LocalRoot($t0), LocalRoot($t10)
+     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t6)), (@, Reference($t8))}
+     # borrows_from: Reference($t6) -> {(@, LocalRoot($t1))}, Reference($t8) -> {(@, LocalRoot($t1))}
   9: $t4 := pack TestMutRef::V($t10, $t5)
-     # live_nodes: LocalRoot($t0)
-     # moved_nodes: LocalRoot($t1)
-     # borrowed_by: LocalRoot($t10) -> {(@, Reference($t6)), (@, Reference($t8))}
-     # borrows_from: Reference($t6) -> {(@, LocalRoot($t10))}, Reference($t8) -> {(@, LocalRoot($t10))}
+     # live_nodes: LocalRoot($t0), LocalRoot($t10)
+     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t6)), (@, Reference($t8))}
+     # borrows_from: Reference($t6) -> {(@, LocalRoot($t1))}, Reference($t8) -> {(@, LocalRoot($t1))}
  10: $t11 := borrow_local($t4)
-     # live_nodes: LocalRoot($t0), Reference($t11)
-     # moved_nodes: LocalRoot($t1)
-     # borrowed_by: LocalRoot($t4) -> {(@, Reference($t11))}, LocalRoot($t10) -> {(@, Reference($t6)), (@, Reference($t8))}
-     # borrows_from: Reference($t6) -> {(@, LocalRoot($t10))}, Reference($t8) -> {(@, LocalRoot($t10))}, Reference($t11) -> {(@, LocalRoot($t4))}
+     # live_nodes: LocalRoot($t0), LocalRoot($t10), Reference($t11)
+     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t6)), (@, Reference($t8))}, LocalRoot($t4) -> {(@, Reference($t11))}
+     # borrows_from: Reference($t6) -> {(@, LocalRoot($t1))}, Reference($t8) -> {(@, LocalRoot($t1))}, Reference($t11) -> {(@, LocalRoot($t4))}
  11: $t12 := TestMutRef::return_ref_different_path_vec($t0, $t11)
-     # live_nodes: LocalRoot($t0), Reference($t12)
-     # moved_nodes: LocalRoot($t1), Reference($t11)
-     # borrowed_by: LocalRoot($t4) -> {(@, Reference($t11))}, LocalRoot($t10) -> {(@, Reference($t6)), (@, Reference($t8))}, Reference($t11) -> {(.is (vector<u64>)/[], Reference($t12))}
-     # borrows_from: Reference($t6) -> {(@, LocalRoot($t10))}, Reference($t8) -> {(@, LocalRoot($t10))}, Reference($t11) -> {(@, LocalRoot($t4))}, Reference($t12) -> {(.is (vector<u64>)/[], Reference($t11))}
+     # live_nodes: LocalRoot($t0), LocalRoot($t10), Reference($t12)
+     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t6)), (@, Reference($t8))}, LocalRoot($t4) -> {(@, Reference($t11))}, Reference($t11) -> {(.is (vector<u64>)/[], Reference($t12))}
+     # borrows_from: Reference($t6) -> {(@, LocalRoot($t1))}, Reference($t8) -> {(@, LocalRoot($t1))}, Reference($t11) -> {(@, LocalRoot($t4))}, Reference($t12) -> {(.is (vector<u64>)/[], Reference($t11))}
  12: $t13 := 5
-     # live_nodes: LocalRoot($t0), Reference($t12)
-     # moved_nodes: LocalRoot($t1), Reference($t11)
-     # borrowed_by: LocalRoot($t4) -> {(@, Reference($t11))}, LocalRoot($t10) -> {(@, Reference($t6)), (@, Reference($t8))}, Reference($t11) -> {(.is (vector<u64>)/[], Reference($t12))}
-     # borrows_from: Reference($t6) -> {(@, LocalRoot($t10))}, Reference($t8) -> {(@, LocalRoot($t10))}, Reference($t11) -> {(@, LocalRoot($t4))}, Reference($t12) -> {(.is (vector<u64>)/[], Reference($t11))}
+     # live_nodes: LocalRoot($t0), LocalRoot($t10), Reference($t12)
+     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t6)), (@, Reference($t8))}, LocalRoot($t4) -> {(@, Reference($t11))}, Reference($t11) -> {(.is (vector<u64>)/[], Reference($t12))}
+     # borrows_from: Reference($t6) -> {(@, LocalRoot($t1))}, Reference($t8) -> {(@, LocalRoot($t1))}, Reference($t11) -> {(@, LocalRoot($t4))}, Reference($t12) -> {(.is (vector<u64>)/[], Reference($t11))}
  13: write_ref($t12, $t13)
-     # live_nodes: LocalRoot($t0)
-     # moved_nodes: LocalRoot($t1), Reference($t11)
-     # borrowed_by: LocalRoot($t4) -> {(@, Reference($t11))}, LocalRoot($t10) -> {(@, Reference($t6)), (@, Reference($t8))}, Reference($t11) -> {(.is (vector<u64>)/[], Reference($t12))}
-     # borrows_from: Reference($t6) -> {(@, LocalRoot($t10))}, Reference($t8) -> {(@, LocalRoot($t10))}, Reference($t11) -> {(@, LocalRoot($t4))}, Reference($t12) -> {(.is (vector<u64>)/[], Reference($t11))}
+     # live_nodes: LocalRoot($t0), LocalRoot($t10)
+     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t6)), (@, Reference($t8))}, LocalRoot($t4) -> {(@, Reference($t11))}, Reference($t11) -> {(.is (vector<u64>)/[], Reference($t12))}
+     # borrows_from: Reference($t6) -> {(@, LocalRoot($t1))}, Reference($t8) -> {(@, LocalRoot($t1))}, Reference($t11) -> {(@, LocalRoot($t4))}, Reference($t12) -> {(.is (vector<u64>)/[], Reference($t11))}
  14: $t14 := move($t4)
-     # live_nodes: LocalRoot($t0)
-     # moved_nodes: LocalRoot($t1), LocalRoot($t4), Reference($t11)
-     # borrowed_by: LocalRoot($t10) -> {(@, Reference($t6)), (@, Reference($t8))}, LocalRoot($t14) -> {(@, Reference($t11))}, Reference($t11) -> {(.is (vector<u64>)/[], Reference($t12))}
-     # borrows_from: Reference($t6) -> {(@, LocalRoot($t10))}, Reference($t8) -> {(@, LocalRoot($t10))}, Reference($t11) -> {(@, LocalRoot($t14))}, Reference($t12) -> {(.is (vector<u64>)/[], Reference($t11))}
+     # live_nodes: LocalRoot($t0), LocalRoot($t10), LocalRoot($t14)
+     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t6)), (@, Reference($t8))}, LocalRoot($t4) -> {(@, Reference($t11))}, Reference($t11) -> {(.is (vector<u64>)/[], Reference($t12))}
+     # borrows_from: Reference($t6) -> {(@, LocalRoot($t1))}, Reference($t8) -> {(@, LocalRoot($t1))}, Reference($t11) -> {(@, LocalRoot($t4))}, Reference($t12) -> {(.is (vector<u64>)/[], Reference($t11))}
  15: return $t14
 }
 
@@ -750,45 +738,37 @@ fun TestMutRef::call_return_ref_different_path_vec2($t0|b: bool): TestMutRef::V 
      # borrowed_by: LocalRoot($t1) -> {(@, Reference($t5)), (@, Reference($t7))}, LocalRoot($t3) -> {(@, Reference($t9)), (@, Reference($t12))}
      # borrows_from: Reference($t5) -> {(@, LocalRoot($t1))}, Reference($t7) -> {(@, LocalRoot($t1))}, Reference($t9) -> {(@, LocalRoot($t3))}, Reference($t12) -> {(@, LocalRoot($t3))}
  16: $t15 := move($t1)
-     # live_nodes: LocalRoot($t0)
-     # moved_nodes: LocalRoot($t1)
-     # borrowed_by: LocalRoot($t3) -> {(@, Reference($t9)), (@, Reference($t12))}, LocalRoot($t15) -> {(@, Reference($t5)), (@, Reference($t7))}
-     # borrows_from: Reference($t5) -> {(@, LocalRoot($t15))}, Reference($t7) -> {(@, LocalRoot($t15))}, Reference($t9) -> {(@, LocalRoot($t3))}, Reference($t12) -> {(@, LocalRoot($t3))}
+     # live_nodes: LocalRoot($t0), LocalRoot($t15)
+     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t5)), (@, Reference($t7))}, LocalRoot($t3) -> {(@, Reference($t9)), (@, Reference($t12))}
+     # borrows_from: Reference($t5) -> {(@, LocalRoot($t1))}, Reference($t7) -> {(@, LocalRoot($t1))}, Reference($t9) -> {(@, LocalRoot($t3))}, Reference($t12) -> {(@, LocalRoot($t3))}
  17: $t16 := move($t3)
-     # live_nodes: LocalRoot($t0)
-     # moved_nodes: LocalRoot($t1), LocalRoot($t3)
-     # borrowed_by: LocalRoot($t15) -> {(@, Reference($t5)), (@, Reference($t7))}, LocalRoot($t16) -> {(@, Reference($t9)), (@, Reference($t12))}
-     # borrows_from: Reference($t5) -> {(@, LocalRoot($t15))}, Reference($t7) -> {(@, LocalRoot($t15))}, Reference($t9) -> {(@, LocalRoot($t16))}, Reference($t12) -> {(@, LocalRoot($t16))}
+     # live_nodes: LocalRoot($t0), LocalRoot($t15), LocalRoot($t16)
+     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t5)), (@, Reference($t7))}, LocalRoot($t3) -> {(@, Reference($t9)), (@, Reference($t12))}
+     # borrows_from: Reference($t5) -> {(@, LocalRoot($t1))}, Reference($t7) -> {(@, LocalRoot($t1))}, Reference($t9) -> {(@, LocalRoot($t3))}, Reference($t12) -> {(@, LocalRoot($t3))}
  18: $t4 := pack TestMutRef::V($t15, $t16)
-     # live_nodes: LocalRoot($t0)
-     # moved_nodes: LocalRoot($t1), LocalRoot($t3)
-     # borrowed_by: LocalRoot($t15) -> {(@, Reference($t5)), (@, Reference($t7))}, LocalRoot($t16) -> {(@, Reference($t9)), (@, Reference($t12))}
-     # borrows_from: Reference($t5) -> {(@, LocalRoot($t15))}, Reference($t7) -> {(@, LocalRoot($t15))}, Reference($t9) -> {(@, LocalRoot($t16))}, Reference($t12) -> {(@, LocalRoot($t16))}
+     # live_nodes: LocalRoot($t0), LocalRoot($t15), LocalRoot($t16)
+     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t5)), (@, Reference($t7))}, LocalRoot($t3) -> {(@, Reference($t9)), (@, Reference($t12))}
+     # borrows_from: Reference($t5) -> {(@, LocalRoot($t1))}, Reference($t7) -> {(@, LocalRoot($t1))}, Reference($t9) -> {(@, LocalRoot($t3))}, Reference($t12) -> {(@, LocalRoot($t3))}
  19: $t17 := borrow_local($t4)
-     # live_nodes: LocalRoot($t0), Reference($t17)
-     # moved_nodes: LocalRoot($t1), LocalRoot($t3)
-     # borrowed_by: LocalRoot($t4) -> {(@, Reference($t17))}, LocalRoot($t15) -> {(@, Reference($t5)), (@, Reference($t7))}, LocalRoot($t16) -> {(@, Reference($t9)), (@, Reference($t12))}
-     # borrows_from: Reference($t5) -> {(@, LocalRoot($t15))}, Reference($t7) -> {(@, LocalRoot($t15))}, Reference($t9) -> {(@, LocalRoot($t16))}, Reference($t12) -> {(@, LocalRoot($t16))}, Reference($t17) -> {(@, LocalRoot($t4))}
+     # live_nodes: LocalRoot($t0), LocalRoot($t15), LocalRoot($t16), Reference($t17)
+     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t5)), (@, Reference($t7))}, LocalRoot($t3) -> {(@, Reference($t9)), (@, Reference($t12))}, LocalRoot($t4) -> {(@, Reference($t17))}
+     # borrows_from: Reference($t5) -> {(@, LocalRoot($t1))}, Reference($t7) -> {(@, LocalRoot($t1))}, Reference($t9) -> {(@, LocalRoot($t3))}, Reference($t12) -> {(@, LocalRoot($t3))}, Reference($t17) -> {(@, LocalRoot($t4))}
  20: $t18 := TestMutRef::return_ref_different_path_vec2($t0, $t17)
-     # live_nodes: LocalRoot($t0), Reference($t18)
-     # moved_nodes: LocalRoot($t1), LocalRoot($t3), Reference($t17)
-     # borrowed_by: LocalRoot($t4) -> {(@, Reference($t17))}, LocalRoot($t15) -> {(@, Reference($t5)), (@, Reference($t7))}, LocalRoot($t16) -> {(@, Reference($t9)), (@, Reference($t12))}, Reference($t17) -> {(.is (vector<u64>)/[], Reference($t18)), (.ts (vector<TestMutRef::T>)/[]/.value (u64), Reference($t18))}
-     # borrows_from: Reference($t5) -> {(@, LocalRoot($t15))}, Reference($t7) -> {(@, LocalRoot($t15))}, Reference($t9) -> {(@, LocalRoot($t16))}, Reference($t12) -> {(@, LocalRoot($t16))}, Reference($t17) -> {(@, LocalRoot($t4))}, Reference($t18) -> {(.is (vector<u64>)/[], Reference($t17)), (.ts (vector<TestMutRef::T>)/[]/.value (u64), Reference($t17))}
+     # live_nodes: LocalRoot($t0), LocalRoot($t15), LocalRoot($t16), Reference($t18)
+     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t5)), (@, Reference($t7))}, LocalRoot($t3) -> {(@, Reference($t9)), (@, Reference($t12))}, LocalRoot($t4) -> {(@, Reference($t17))}, Reference($t17) -> {(.is (vector<u64>)/[], Reference($t18)), (.ts (vector<TestMutRef::T>)/[]/.value (u64), Reference($t18))}
+     # borrows_from: Reference($t5) -> {(@, LocalRoot($t1))}, Reference($t7) -> {(@, LocalRoot($t1))}, Reference($t9) -> {(@, LocalRoot($t3))}, Reference($t12) -> {(@, LocalRoot($t3))}, Reference($t17) -> {(@, LocalRoot($t4))}, Reference($t18) -> {(.is (vector<u64>)/[], Reference($t17)), (.ts (vector<TestMutRef::T>)/[]/.value (u64), Reference($t17))}
  21: $t19 := 5
-     # live_nodes: LocalRoot($t0), Reference($t18)
-     # moved_nodes: LocalRoot($t1), LocalRoot($t3), Reference($t17)
-     # borrowed_by: LocalRoot($t4) -> {(@, Reference($t17))}, LocalRoot($t15) -> {(@, Reference($t5)), (@, Reference($t7))}, LocalRoot($t16) -> {(@, Reference($t9)), (@, Reference($t12))}, Reference($t17) -> {(.is (vector<u64>)/[], Reference($t18)), (.ts (vector<TestMutRef::T>)/[]/.value (u64), Reference($t18))}
-     # borrows_from: Reference($t5) -> {(@, LocalRoot($t15))}, Reference($t7) -> {(@, LocalRoot($t15))}, Reference($t9) -> {(@, LocalRoot($t16))}, Reference($t12) -> {(@, LocalRoot($t16))}, Reference($t17) -> {(@, LocalRoot($t4))}, Reference($t18) -> {(.is (vector<u64>)/[], Reference($t17)), (.ts (vector<TestMutRef::T>)/[]/.value (u64), Reference($t17))}
+     # live_nodes: LocalRoot($t0), LocalRoot($t15), LocalRoot($t16), Reference($t18)
+     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t5)), (@, Reference($t7))}, LocalRoot($t3) -> {(@, Reference($t9)), (@, Reference($t12))}, LocalRoot($t4) -> {(@, Reference($t17))}, Reference($t17) -> {(.is (vector<u64>)/[], Reference($t18)), (.ts (vector<TestMutRef::T>)/[]/.value (u64), Reference($t18))}
+     # borrows_from: Reference($t5) -> {(@, LocalRoot($t1))}, Reference($t7) -> {(@, LocalRoot($t1))}, Reference($t9) -> {(@, LocalRoot($t3))}, Reference($t12) -> {(@, LocalRoot($t3))}, Reference($t17) -> {(@, LocalRoot($t4))}, Reference($t18) -> {(.is (vector<u64>)/[], Reference($t17)), (.ts (vector<TestMutRef::T>)/[]/.value (u64), Reference($t17))}
  22: write_ref($t18, $t19)
-     # live_nodes: LocalRoot($t0)
-     # moved_nodes: LocalRoot($t1), LocalRoot($t3), Reference($t17)
-     # borrowed_by: LocalRoot($t4) -> {(@, Reference($t17))}, LocalRoot($t15) -> {(@, Reference($t5)), (@, Reference($t7))}, LocalRoot($t16) -> {(@, Reference($t9)), (@, Reference($t12))}, Reference($t17) -> {(.is (vector<u64>)/[], Reference($t18)), (.ts (vector<TestMutRef::T>)/[]/.value (u64), Reference($t18))}
-     # borrows_from: Reference($t5) -> {(@, LocalRoot($t15))}, Reference($t7) -> {(@, LocalRoot($t15))}, Reference($t9) -> {(@, LocalRoot($t16))}, Reference($t12) -> {(@, LocalRoot($t16))}, Reference($t17) -> {(@, LocalRoot($t4))}, Reference($t18) -> {(.is (vector<u64>)/[], Reference($t17)), (.ts (vector<TestMutRef::T>)/[]/.value (u64), Reference($t17))}
+     # live_nodes: LocalRoot($t0), LocalRoot($t15), LocalRoot($t16)
+     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t5)), (@, Reference($t7))}, LocalRoot($t3) -> {(@, Reference($t9)), (@, Reference($t12))}, LocalRoot($t4) -> {(@, Reference($t17))}, Reference($t17) -> {(.is (vector<u64>)/[], Reference($t18)), (.ts (vector<TestMutRef::T>)/[]/.value (u64), Reference($t18))}
+     # borrows_from: Reference($t5) -> {(@, LocalRoot($t1))}, Reference($t7) -> {(@, LocalRoot($t1))}, Reference($t9) -> {(@, LocalRoot($t3))}, Reference($t12) -> {(@, LocalRoot($t3))}, Reference($t17) -> {(@, LocalRoot($t4))}, Reference($t18) -> {(.is (vector<u64>)/[], Reference($t17)), (.ts (vector<TestMutRef::T>)/[]/.value (u64), Reference($t17))}
  23: $t20 := move($t4)
-     # live_nodes: LocalRoot($t0)
-     # moved_nodes: LocalRoot($t1), LocalRoot($t3), LocalRoot($t4), Reference($t17)
-     # borrowed_by: LocalRoot($t15) -> {(@, Reference($t5)), (@, Reference($t7))}, LocalRoot($t16) -> {(@, Reference($t9)), (@, Reference($t12))}, LocalRoot($t20) -> {(@, Reference($t17))}, Reference($t17) -> {(.is (vector<u64>)/[], Reference($t18)), (.ts (vector<TestMutRef::T>)/[]/.value (u64), Reference($t18))}
-     # borrows_from: Reference($t5) -> {(@, LocalRoot($t15))}, Reference($t7) -> {(@, LocalRoot($t15))}, Reference($t9) -> {(@, LocalRoot($t16))}, Reference($t12) -> {(@, LocalRoot($t16))}, Reference($t17) -> {(@, LocalRoot($t20))}, Reference($t18) -> {(.is (vector<u64>)/[], Reference($t17)), (.ts (vector<TestMutRef::T>)/[]/.value (u64), Reference($t17))}
+     # live_nodes: LocalRoot($t0), LocalRoot($t15), LocalRoot($t16), LocalRoot($t20)
+     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t5)), (@, Reference($t7))}, LocalRoot($t3) -> {(@, Reference($t9)), (@, Reference($t12))}, LocalRoot($t4) -> {(@, Reference($t17))}, Reference($t17) -> {(.is (vector<u64>)/[], Reference($t18)), (.ts (vector<TestMutRef::T>)/[]/.value (u64), Reference($t18))}
+     # borrows_from: Reference($t5) -> {(@, LocalRoot($t1))}, Reference($t7) -> {(@, LocalRoot($t1))}, Reference($t9) -> {(@, LocalRoot($t3))}, Reference($t12) -> {(@, LocalRoot($t3))}, Reference($t17) -> {(@, LocalRoot($t4))}, Reference($t18) -> {(.is (vector<u64>)/[], Reference($t17)), (.ts (vector<TestMutRef::T>)/[]/.value (u64), Reference($t17))}
  24: return $t20
 }
 
@@ -877,45 +857,37 @@ fun TestMutRef::call_return_ref_different_path_vec2_incorrect($t0|b: bool): Test
      # borrowed_by: LocalRoot($t1) -> {(@, Reference($t5)), (@, Reference($t7))}, LocalRoot($t3) -> {(@, Reference($t9)), (@, Reference($t12))}
      # borrows_from: Reference($t5) -> {(@, LocalRoot($t1))}, Reference($t7) -> {(@, LocalRoot($t1))}, Reference($t9) -> {(@, LocalRoot($t3))}, Reference($t12) -> {(@, LocalRoot($t3))}
  16: $t15 := move($t1)
-     # live_nodes: LocalRoot($t0)
-     # moved_nodes: LocalRoot($t1)
-     # borrowed_by: LocalRoot($t3) -> {(@, Reference($t9)), (@, Reference($t12))}, LocalRoot($t15) -> {(@, Reference($t5)), (@, Reference($t7))}
-     # borrows_from: Reference($t5) -> {(@, LocalRoot($t15))}, Reference($t7) -> {(@, LocalRoot($t15))}, Reference($t9) -> {(@, LocalRoot($t3))}, Reference($t12) -> {(@, LocalRoot($t3))}
+     # live_nodes: LocalRoot($t0), LocalRoot($t15)
+     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t5)), (@, Reference($t7))}, LocalRoot($t3) -> {(@, Reference($t9)), (@, Reference($t12))}
+     # borrows_from: Reference($t5) -> {(@, LocalRoot($t1))}, Reference($t7) -> {(@, LocalRoot($t1))}, Reference($t9) -> {(@, LocalRoot($t3))}, Reference($t12) -> {(@, LocalRoot($t3))}
  17: $t16 := move($t3)
-     # live_nodes: LocalRoot($t0)
-     # moved_nodes: LocalRoot($t1), LocalRoot($t3)
-     # borrowed_by: LocalRoot($t15) -> {(@, Reference($t5)), (@, Reference($t7))}, LocalRoot($t16) -> {(@, Reference($t9)), (@, Reference($t12))}
-     # borrows_from: Reference($t5) -> {(@, LocalRoot($t15))}, Reference($t7) -> {(@, LocalRoot($t15))}, Reference($t9) -> {(@, LocalRoot($t16))}, Reference($t12) -> {(@, LocalRoot($t16))}
+     # live_nodes: LocalRoot($t0), LocalRoot($t15), LocalRoot($t16)
+     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t5)), (@, Reference($t7))}, LocalRoot($t3) -> {(@, Reference($t9)), (@, Reference($t12))}
+     # borrows_from: Reference($t5) -> {(@, LocalRoot($t1))}, Reference($t7) -> {(@, LocalRoot($t1))}, Reference($t9) -> {(@, LocalRoot($t3))}, Reference($t12) -> {(@, LocalRoot($t3))}
  18: $t4 := pack TestMutRef::V($t15, $t16)
-     # live_nodes: LocalRoot($t0)
-     # moved_nodes: LocalRoot($t1), LocalRoot($t3)
-     # borrowed_by: LocalRoot($t15) -> {(@, Reference($t5)), (@, Reference($t7))}, LocalRoot($t16) -> {(@, Reference($t9)), (@, Reference($t12))}
-     # borrows_from: Reference($t5) -> {(@, LocalRoot($t15))}, Reference($t7) -> {(@, LocalRoot($t15))}, Reference($t9) -> {(@, LocalRoot($t16))}, Reference($t12) -> {(@, LocalRoot($t16))}
+     # live_nodes: LocalRoot($t0), LocalRoot($t15), LocalRoot($t16)
+     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t5)), (@, Reference($t7))}, LocalRoot($t3) -> {(@, Reference($t9)), (@, Reference($t12))}
+     # borrows_from: Reference($t5) -> {(@, LocalRoot($t1))}, Reference($t7) -> {(@, LocalRoot($t1))}, Reference($t9) -> {(@, LocalRoot($t3))}, Reference($t12) -> {(@, LocalRoot($t3))}
  19: $t17 := borrow_local($t4)
-     # live_nodes: LocalRoot($t0), Reference($t17)
-     # moved_nodes: LocalRoot($t1), LocalRoot($t3)
-     # borrowed_by: LocalRoot($t4) -> {(@, Reference($t17))}, LocalRoot($t15) -> {(@, Reference($t5)), (@, Reference($t7))}, LocalRoot($t16) -> {(@, Reference($t9)), (@, Reference($t12))}
-     # borrows_from: Reference($t5) -> {(@, LocalRoot($t15))}, Reference($t7) -> {(@, LocalRoot($t15))}, Reference($t9) -> {(@, LocalRoot($t16))}, Reference($t12) -> {(@, LocalRoot($t16))}, Reference($t17) -> {(@, LocalRoot($t4))}
+     # live_nodes: LocalRoot($t0), LocalRoot($t15), LocalRoot($t16), Reference($t17)
+     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t5)), (@, Reference($t7))}, LocalRoot($t3) -> {(@, Reference($t9)), (@, Reference($t12))}, LocalRoot($t4) -> {(@, Reference($t17))}
+     # borrows_from: Reference($t5) -> {(@, LocalRoot($t1))}, Reference($t7) -> {(@, LocalRoot($t1))}, Reference($t9) -> {(@, LocalRoot($t3))}, Reference($t12) -> {(@, LocalRoot($t3))}, Reference($t17) -> {(@, LocalRoot($t4))}
  20: $t18 := TestMutRef::return_ref_different_path_vec2($t0, $t17)
-     # live_nodes: LocalRoot($t0), Reference($t18)
-     # moved_nodes: LocalRoot($t1), LocalRoot($t3), Reference($t17)
-     # borrowed_by: LocalRoot($t4) -> {(@, Reference($t17))}, LocalRoot($t15) -> {(@, Reference($t5)), (@, Reference($t7))}, LocalRoot($t16) -> {(@, Reference($t9)), (@, Reference($t12))}, Reference($t17) -> {(.is (vector<u64>)/[], Reference($t18)), (.ts (vector<TestMutRef::T>)/[]/.value (u64), Reference($t18))}
-     # borrows_from: Reference($t5) -> {(@, LocalRoot($t15))}, Reference($t7) -> {(@, LocalRoot($t15))}, Reference($t9) -> {(@, LocalRoot($t16))}, Reference($t12) -> {(@, LocalRoot($t16))}, Reference($t17) -> {(@, LocalRoot($t4))}, Reference($t18) -> {(.is (vector<u64>)/[], Reference($t17)), (.ts (vector<TestMutRef::T>)/[]/.value (u64), Reference($t17))}
+     # live_nodes: LocalRoot($t0), LocalRoot($t15), LocalRoot($t16), Reference($t18)
+     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t5)), (@, Reference($t7))}, LocalRoot($t3) -> {(@, Reference($t9)), (@, Reference($t12))}, LocalRoot($t4) -> {(@, Reference($t17))}, Reference($t17) -> {(.is (vector<u64>)/[], Reference($t18)), (.ts (vector<TestMutRef::T>)/[]/.value (u64), Reference($t18))}
+     # borrows_from: Reference($t5) -> {(@, LocalRoot($t1))}, Reference($t7) -> {(@, LocalRoot($t1))}, Reference($t9) -> {(@, LocalRoot($t3))}, Reference($t12) -> {(@, LocalRoot($t3))}, Reference($t17) -> {(@, LocalRoot($t4))}, Reference($t18) -> {(.is (vector<u64>)/[], Reference($t17)), (.ts (vector<TestMutRef::T>)/[]/.value (u64), Reference($t17))}
  21: $t19 := 0
-     # live_nodes: LocalRoot($t0), Reference($t18)
-     # moved_nodes: LocalRoot($t1), LocalRoot($t3), Reference($t17)
-     # borrowed_by: LocalRoot($t4) -> {(@, Reference($t17))}, LocalRoot($t15) -> {(@, Reference($t5)), (@, Reference($t7))}, LocalRoot($t16) -> {(@, Reference($t9)), (@, Reference($t12))}, Reference($t17) -> {(.is (vector<u64>)/[], Reference($t18)), (.ts (vector<TestMutRef::T>)/[]/.value (u64), Reference($t18))}
-     # borrows_from: Reference($t5) -> {(@, LocalRoot($t15))}, Reference($t7) -> {(@, LocalRoot($t15))}, Reference($t9) -> {(@, LocalRoot($t16))}, Reference($t12) -> {(@, LocalRoot($t16))}, Reference($t17) -> {(@, LocalRoot($t4))}, Reference($t18) -> {(.is (vector<u64>)/[], Reference($t17)), (.ts (vector<TestMutRef::T>)/[]/.value (u64), Reference($t17))}
+     # live_nodes: LocalRoot($t0), LocalRoot($t15), LocalRoot($t16), Reference($t18)
+     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t5)), (@, Reference($t7))}, LocalRoot($t3) -> {(@, Reference($t9)), (@, Reference($t12))}, LocalRoot($t4) -> {(@, Reference($t17))}, Reference($t17) -> {(.is (vector<u64>)/[], Reference($t18)), (.ts (vector<TestMutRef::T>)/[]/.value (u64), Reference($t18))}
+     # borrows_from: Reference($t5) -> {(@, LocalRoot($t1))}, Reference($t7) -> {(@, LocalRoot($t1))}, Reference($t9) -> {(@, LocalRoot($t3))}, Reference($t12) -> {(@, LocalRoot($t3))}, Reference($t17) -> {(@, LocalRoot($t4))}, Reference($t18) -> {(.is (vector<u64>)/[], Reference($t17)), (.ts (vector<TestMutRef::T>)/[]/.value (u64), Reference($t17))}
  22: write_ref($t18, $t19)
-     # live_nodes: LocalRoot($t0)
-     # moved_nodes: LocalRoot($t1), LocalRoot($t3), Reference($t17)
-     # borrowed_by: LocalRoot($t4) -> {(@, Reference($t17))}, LocalRoot($t15) -> {(@, Reference($t5)), (@, Reference($t7))}, LocalRoot($t16) -> {(@, Reference($t9)), (@, Reference($t12))}, Reference($t17) -> {(.is (vector<u64>)/[], Reference($t18)), (.ts (vector<TestMutRef::T>)/[]/.value (u64), Reference($t18))}
-     # borrows_from: Reference($t5) -> {(@, LocalRoot($t15))}, Reference($t7) -> {(@, LocalRoot($t15))}, Reference($t9) -> {(@, LocalRoot($t16))}, Reference($t12) -> {(@, LocalRoot($t16))}, Reference($t17) -> {(@, LocalRoot($t4))}, Reference($t18) -> {(.is (vector<u64>)/[], Reference($t17)), (.ts (vector<TestMutRef::T>)/[]/.value (u64), Reference($t17))}
+     # live_nodes: LocalRoot($t0), LocalRoot($t15), LocalRoot($t16)
+     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t5)), (@, Reference($t7))}, LocalRoot($t3) -> {(@, Reference($t9)), (@, Reference($t12))}, LocalRoot($t4) -> {(@, Reference($t17))}, Reference($t17) -> {(.is (vector<u64>)/[], Reference($t18)), (.ts (vector<TestMutRef::T>)/[]/.value (u64), Reference($t18))}
+     # borrows_from: Reference($t5) -> {(@, LocalRoot($t1))}, Reference($t7) -> {(@, LocalRoot($t1))}, Reference($t9) -> {(@, LocalRoot($t3))}, Reference($t12) -> {(@, LocalRoot($t3))}, Reference($t17) -> {(@, LocalRoot($t4))}, Reference($t18) -> {(.is (vector<u64>)/[], Reference($t17)), (.ts (vector<TestMutRef::T>)/[]/.value (u64), Reference($t17))}
  23: $t20 := move($t4)
-     # live_nodes: LocalRoot($t0)
-     # moved_nodes: LocalRoot($t1), LocalRoot($t3), LocalRoot($t4), Reference($t17)
-     # borrowed_by: LocalRoot($t15) -> {(@, Reference($t5)), (@, Reference($t7))}, LocalRoot($t16) -> {(@, Reference($t9)), (@, Reference($t12))}, LocalRoot($t20) -> {(@, Reference($t17))}, Reference($t17) -> {(.is (vector<u64>)/[], Reference($t18)), (.ts (vector<TestMutRef::T>)/[]/.value (u64), Reference($t18))}
-     # borrows_from: Reference($t5) -> {(@, LocalRoot($t15))}, Reference($t7) -> {(@, LocalRoot($t15))}, Reference($t9) -> {(@, LocalRoot($t16))}, Reference($t12) -> {(@, LocalRoot($t16))}, Reference($t17) -> {(@, LocalRoot($t20))}, Reference($t18) -> {(.is (vector<u64>)/[], Reference($t17)), (.ts (vector<TestMutRef::T>)/[]/.value (u64), Reference($t17))}
+     # live_nodes: LocalRoot($t0), LocalRoot($t15), LocalRoot($t16), LocalRoot($t20)
+     # borrowed_by: LocalRoot($t1) -> {(@, Reference($t5)), (@, Reference($t7))}, LocalRoot($t3) -> {(@, Reference($t9)), (@, Reference($t12))}, LocalRoot($t4) -> {(@, Reference($t17))}, Reference($t17) -> {(.is (vector<u64>)/[], Reference($t18)), (.ts (vector<TestMutRef::T>)/[]/.value (u64), Reference($t18))}
+     # borrows_from: Reference($t5) -> {(@, LocalRoot($t1))}, Reference($t7) -> {(@, LocalRoot($t1))}, Reference($t9) -> {(@, LocalRoot($t3))}, Reference($t12) -> {(@, LocalRoot($t3))}, Reference($t17) -> {(@, LocalRoot($t4))}, Reference($t18) -> {(.is (vector<u64>)/[], Reference($t17)), (.ts (vector<TestMutRef::T>)/[]/.value (u64), Reference($t17))}
  24: return $t20
 }
 
@@ -952,29 +924,24 @@ fun TestMutRef::call_return_ref_different_root($t0|b: bool): (TestMutRef::T, Tes
      # borrows_from: Reference($t6) -> {(@, LocalRoot($t2))}, Reference($t7) -> {(@, LocalRoot($t3))}
   6: $t8 := TestMutRef::return_ref_different_root($t0, $t6, $t7)
      # live_nodes: LocalRoot($t0), Reference($t8)
-     # moved_nodes: Reference($t6), Reference($t7)
      # borrowed_by: LocalRoot($t2) -> {(@, Reference($t6))}, LocalRoot($t3) -> {(@, Reference($t7))}, Reference($t6) -> {(.value (u64), Reference($t8))}, Reference($t7) -> {(.value (u64), Reference($t8))}
      # borrows_from: Reference($t6) -> {(@, LocalRoot($t2))}, Reference($t7) -> {(@, LocalRoot($t3))}, Reference($t8) -> {(.value (u64), Reference($t6)), (.value (u64), Reference($t7))}
   7: $t9 := 5
      # live_nodes: LocalRoot($t0), Reference($t8)
-     # moved_nodes: Reference($t6), Reference($t7)
      # borrowed_by: LocalRoot($t2) -> {(@, Reference($t6))}, LocalRoot($t3) -> {(@, Reference($t7))}, Reference($t6) -> {(.value (u64), Reference($t8))}, Reference($t7) -> {(.value (u64), Reference($t8))}
      # borrows_from: Reference($t6) -> {(@, LocalRoot($t2))}, Reference($t7) -> {(@, LocalRoot($t3))}, Reference($t8) -> {(.value (u64), Reference($t6)), (.value (u64), Reference($t7))}
   8: write_ref($t8, $t9)
      # live_nodes: LocalRoot($t0)
-     # moved_nodes: Reference($t6), Reference($t7)
      # borrowed_by: LocalRoot($t2) -> {(@, Reference($t6))}, LocalRoot($t3) -> {(@, Reference($t7))}, Reference($t6) -> {(.value (u64), Reference($t8))}, Reference($t7) -> {(.value (u64), Reference($t8))}
      # borrows_from: Reference($t6) -> {(@, LocalRoot($t2))}, Reference($t7) -> {(@, LocalRoot($t3))}, Reference($t8) -> {(.value (u64), Reference($t6)), (.value (u64), Reference($t7))}
   9: $t10 := move($t2)
-     # live_nodes: LocalRoot($t0)
-     # moved_nodes: LocalRoot($t2), Reference($t6), Reference($t7)
-     # borrowed_by: LocalRoot($t3) -> {(@, Reference($t7))}, LocalRoot($t10) -> {(@, Reference($t6))}, Reference($t6) -> {(.value (u64), Reference($t8))}, Reference($t7) -> {(.value (u64), Reference($t8))}
-     # borrows_from: Reference($t6) -> {(@, LocalRoot($t10))}, Reference($t7) -> {(@, LocalRoot($t3))}, Reference($t8) -> {(.value (u64), Reference($t6)), (.value (u64), Reference($t7))}
+     # live_nodes: LocalRoot($t0), LocalRoot($t10)
+     # borrowed_by: LocalRoot($t2) -> {(@, Reference($t6))}, LocalRoot($t3) -> {(@, Reference($t7))}, Reference($t6) -> {(.value (u64), Reference($t8))}, Reference($t7) -> {(.value (u64), Reference($t8))}
+     # borrows_from: Reference($t6) -> {(@, LocalRoot($t2))}, Reference($t7) -> {(@, LocalRoot($t3))}, Reference($t8) -> {(.value (u64), Reference($t6)), (.value (u64), Reference($t7))}
  10: $t11 := move($t3)
-     # live_nodes: LocalRoot($t0)
-     # moved_nodes: LocalRoot($t2), LocalRoot($t3), Reference($t6), Reference($t7)
-     # borrowed_by: LocalRoot($t10) -> {(@, Reference($t6))}, LocalRoot($t11) -> {(@, Reference($t7))}, Reference($t6) -> {(.value (u64), Reference($t8))}, Reference($t7) -> {(.value (u64), Reference($t8))}
-     # borrows_from: Reference($t6) -> {(@, LocalRoot($t10))}, Reference($t7) -> {(@, LocalRoot($t11))}, Reference($t8) -> {(.value (u64), Reference($t6)), (.value (u64), Reference($t7))}
+     # live_nodes: LocalRoot($t0), LocalRoot($t10), LocalRoot($t11)
+     # borrowed_by: LocalRoot($t2) -> {(@, Reference($t6))}, LocalRoot($t3) -> {(@, Reference($t7))}, Reference($t6) -> {(.value (u64), Reference($t8))}, Reference($t7) -> {(.value (u64), Reference($t8))}
+     # borrows_from: Reference($t6) -> {(@, LocalRoot($t2))}, Reference($t7) -> {(@, LocalRoot($t3))}, Reference($t8) -> {(.value (u64), Reference($t6)), (.value (u64), Reference($t7))}
  11: return ($t10, $t11)
 }
 
@@ -1038,7 +1005,6 @@ fun TestMutRef::return_ref_different_path_vec($t0|b: bool, $t1|x: &mut TestMutRe
      # borrows_from: Reference($t3) -> {(.is (vector<u64>), Reference($t1))}
   4: $t2 := vector::borrow_mut<u64>($t3, $t4)
      # live_nodes: LocalRoot($t0), Reference($t1), Reference($t2)
-     # moved_nodes: Reference($t3)
      # borrowed_by: Reference($t1) -> {(.is (vector<u64>), Reference($t3))}, Reference($t3) -> {([], Reference($t2))}
      # borrows_from: Reference($t2) -> {([], Reference($t3))}, Reference($t3) -> {(.is (vector<u64>), Reference($t1))}
   5: goto 10
@@ -1055,17 +1021,14 @@ fun TestMutRef::return_ref_different_path_vec($t0|b: bool, $t1|x: &mut TestMutRe
      # borrows_from: Reference($t5) -> {(.is (vector<u64>), Reference($t1))}
   9: $t2 := vector::borrow_mut<u64>($t5, $t6)
      # live_nodes: LocalRoot($t0), Reference($t1), Reference($t2)
-     # moved_nodes: Reference($t3), Reference($t5)
      # borrowed_by: Reference($t1) -> {(.is (vector<u64>), Reference($t3)), (.is (vector<u64>), Reference($t5))}, Reference($t3) -> {([], Reference($t2))}, Reference($t5) -> {([], Reference($t2))}
      # borrows_from: Reference($t2) -> {([], Reference($t3)), ([], Reference($t5))}, Reference($t3) -> {(.is (vector<u64>), Reference($t1))}, Reference($t5) -> {(.is (vector<u64>), Reference($t1))}
  10: label L3
      # live_nodes: LocalRoot($t0), Reference($t1), Reference($t2)
-     # moved_nodes: Reference($t3), Reference($t5)
      # borrowed_by: Reference($t1) -> {(.is (vector<u64>), Reference($t3)), (.is (vector<u64>), Reference($t5))}, Reference($t3) -> {([], Reference($t2))}, Reference($t5) -> {([], Reference($t2))}
      # borrows_from: Reference($t2) -> {([], Reference($t3)), ([], Reference($t5))}, Reference($t3) -> {(.is (vector<u64>), Reference($t1))}, Reference($t5) -> {(.is (vector<u64>), Reference($t1))}
  11: trace_local[x]($t1)
      # live_nodes: LocalRoot($t0), Reference($t2)
-     # moved_nodes: Reference($t3), Reference($t5)
      # borrowed_by: Reference($t1) -> {(.is (vector<u64>), Reference($t3)), (.is (vector<u64>), Reference($t5))}, Reference($t3) -> {([], Reference($t2))}, Reference($t5) -> {([], Reference($t2))}
      # borrows_from: Reference($t2) -> {([], Reference($t3)), ([], Reference($t5))}, Reference($t3) -> {(.is (vector<u64>), Reference($t1))}, Reference($t5) -> {(.is (vector<u64>), Reference($t1))}
  12: return $t2
@@ -1095,7 +1058,6 @@ fun TestMutRef::return_ref_different_path_vec2($t0|b: bool, $t1|x: &mut TestMutR
      # borrows_from: Reference($t3) -> {(.is (vector<u64>), Reference($t1))}
   4: $t2 := vector::borrow_mut<u64>($t3, $t4)
      # live_nodes: LocalRoot($t0), Reference($t1), Reference($t2)
-     # moved_nodes: Reference($t3)
      # borrowed_by: Reference($t1) -> {(.is (vector<u64>), Reference($t3))}, Reference($t3) -> {([], Reference($t2))}
      # borrows_from: Reference($t2) -> {([], Reference($t3))}, Reference($t3) -> {(.is (vector<u64>), Reference($t1))}
   5: goto 11
@@ -1112,22 +1074,18 @@ fun TestMutRef::return_ref_different_path_vec2($t0|b: bool, $t1|x: &mut TestMutR
      # borrows_from: Reference($t5) -> {(.ts (vector<TestMutRef::T>), Reference($t1))}
   9: $t7 := vector::borrow_mut<TestMutRef::T>($t5, $t6)
      # live_nodes: LocalRoot($t0), Reference($t1), Reference($t7)
-     # moved_nodes: Reference($t5)
      # borrowed_by: Reference($t1) -> {(.ts (vector<TestMutRef::T>), Reference($t5))}, Reference($t5) -> {([], Reference($t7))}
      # borrows_from: Reference($t5) -> {(.ts (vector<TestMutRef::T>), Reference($t1))}, Reference($t7) -> {([], Reference($t5))}
  10: $t2 := borrow_field<TestMutRef::T>.value($t7)
      # live_nodes: LocalRoot($t0), Reference($t1), Reference($t2)
-     # moved_nodes: Reference($t3), Reference($t5)
      # borrowed_by: Reference($t1) -> {(.is (vector<u64>), Reference($t3)), (.ts (vector<TestMutRef::T>), Reference($t5))}, Reference($t3) -> {([], Reference($t2))}, Reference($t5) -> {([], Reference($t7))}, Reference($t7) -> {(.value (u64), Reference($t2))}
      # borrows_from: Reference($t2) -> {([], Reference($t3)), (.value (u64), Reference($t7))}, Reference($t3) -> {(.is (vector<u64>), Reference($t1))}, Reference($t5) -> {(.ts (vector<TestMutRef::T>), Reference($t1))}, Reference($t7) -> {([], Reference($t5))}
  11: label L3
      # live_nodes: LocalRoot($t0), Reference($t1), Reference($t2)
-     # moved_nodes: Reference($t3), Reference($t5)
      # borrowed_by: Reference($t1) -> {(.is (vector<u64>), Reference($t3)), (.ts (vector<TestMutRef::T>), Reference($t5))}, Reference($t3) -> {([], Reference($t2))}, Reference($t5) -> {([], Reference($t7))}, Reference($t7) -> {(.value (u64), Reference($t2))}
      # borrows_from: Reference($t2) -> {([], Reference($t3)), (.value (u64), Reference($t7))}, Reference($t3) -> {(.is (vector<u64>), Reference($t1))}, Reference($t5) -> {(.ts (vector<TestMutRef::T>), Reference($t1))}, Reference($t7) -> {([], Reference($t5))}
  12: trace_local[x]($t1)
      # live_nodes: LocalRoot($t0), Reference($t2)
-     # moved_nodes: Reference($t3), Reference($t5)
      # borrowed_by: Reference($t1) -> {(.is (vector<u64>), Reference($t3)), (.ts (vector<TestMutRef::T>), Reference($t5))}, Reference($t3) -> {([], Reference($t2))}, Reference($t5) -> {([], Reference($t7))}, Reference($t7) -> {(.value (u64), Reference($t2))}
      # borrows_from: Reference($t2) -> {([], Reference($t3)), (.value (u64), Reference($t7))}, Reference($t3) -> {(.is (vector<u64>), Reference($t1))}, Reference($t5) -> {(.ts (vector<TestMutRef::T>), Reference($t1))}, Reference($t7) -> {([], Reference($t5))}
  13: return $t2

--- a/language/move-prover/tests/sources/regression/moved_local_with_refs.move
+++ b/language/move-prover/tests/sources/regression/moved_local_with_refs.move
@@ -1,0 +1,33 @@
+module 0x42::MovedLocalWithRefs {
+    use std::vector;
+
+    struct S has drop {
+        x: u64,
+    }
+
+    fun moved_local_in_loop(length: u64, limit: u64): vector<S> {
+        let v = vector::empty();
+        let i = 0;
+        while ({
+            spec {
+                invariant i <= length;
+                invariant len(v) == i;
+                invariant forall k in 0..i: v[k].x <= limit;
+            };
+            (i < length)
+        }) {
+            let s = S { x : 100 };
+            if (s.x >= limit) {
+                s.x = limit;
+            };
+            vector::push_back(&mut v, s);
+            i = i + 1;
+        };
+        v
+    }
+
+    spec moved_local_in_loop {
+        ensures len(result) == length;
+        ensures forall e in result: e.x <= limit;
+    }
+}


### PR DESCRIPTION
If a local is first mutably borrowed and later moved in a loop, the
reference will have two parents (and hence, write-back edges):
- one to the original local and
- the other to the LHS of the moved local.

This can be shown in the following code:

```move
loop {
  let s = S { x : 100  };
  let r = &mut s;
  if (r.x >= limit) {
    r.x = limit;
  }
  t = move(s);
}
```

The borrow analysis will conclude that the reference `r` has two
parents, `s` and `t`.

This bug can only happen in loops due to the fact that the borrow
analysis is essentially an abstract interpretation pass and the
join operator for the `BorrowInfo` is a set union. Although for any
single pass on the loop body, `r` can either point to `s` or `t`. After
the join, `r` points to both `s` and `t`, which is incorrect.

This commit fixes this issue by dropping the `remap` function on
borrowed edges for a moved node. Specifically:

```
t = move(s);
```

- Prior to this fix, all references derived from `s` will be remapped
to be deriving from `t` (which does not seem to be correct).
- After this fix, the references derived from `s` remain pointing to `s`

During the process, the `moved_nodes` in the `BorrowInfo` seems to be
obsolete as well, so it is removed, which also causes the `exp` test
cases to be updated.`

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Move Language.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Bug fix

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes

## Test Plan

- CI
- New test case added