### PR TITLE
[move-analyzer] basic function name completion

### DIFF
--- a/language/move-analyzer/editors/code/src/commands/lsp_command.ts
+++ b/language/move-analyzer/editors/code/src/commands/lsp_command.ts
@@ -1,9 +1,12 @@
 import type {
-    DocumentSymbolParams,
-    SymbolInformation,
-    DocumentSymbol,
+  DocumentSymbolParams,
+  SymbolInformation,
+  DocumentSymbol,
+  CompletionParams,
+  CompletionList,
+  CompletionItem,
 } from 'vscode-languageclient';
-import { DocumentSymbolRequest, HoverRequest } from 'vscode-languageclient';
+import { DocumentSymbolRequest, HoverRequest, CompletionRequest } from 'vscode-languageclient';
 import type { Context } from '../context';
 
 /**
@@ -19,8 +22,24 @@ export async function textDocumentDocumentSymbol(
         return Promise.reject(new Error('No language client connected.'));
     }
 
-    // Send the request to the language client.
-    return client.sendRequest(DocumentSymbolRequest.type, params);
+  // Send the request to the language client.
+  return client.sendRequest(DocumentSymbolRequest.type, params);
+}
+
+/**
+ * An LSP command textDocument/completion
+ */
+export async function textDocumentCompletion(
+  context: Readonly<Context>,
+  params: CompletionParams,
+): Promise<CompletionList | CompletionItem[] | null> {
+  const client = context.getClient();
+  if (client === undefined) {
+    return Promise.reject(new Error('No language client connected.'));
+  }
+
+  // Send the request to the language client.
+  return client.sendRequest(CompletionRequest.type, params);
 }
 
 

--- a/language/move-analyzer/editors/code/src/commands/lsp_command.ts
+++ b/language/move-analyzer/editors/code/src/commands/lsp_command.ts
@@ -1,10 +1,10 @@
 import type {
-  DocumentSymbolParams,
-  SymbolInformation,
-  DocumentSymbol,
-  CompletionParams,
-  CompletionList,
-  CompletionItem,
+    DocumentSymbolParams,
+    SymbolInformation,
+    DocumentSymbol,
+    CompletionParams,
+    CompletionList,
+    CompletionItem,
 } from 'vscode-languageclient';
 import { DocumentSymbolRequest, HoverRequest, CompletionRequest } from 'vscode-languageclient';
 import type { Context } from '../context';
@@ -15,31 +15,30 @@ import type { Context } from '../context';
 export async function textDocumentDocumentSymbol(
     context: Readonly<Context>,
     params: DocumentSymbolParams,
-)
-    : Promise<SymbolInformation[] | DocumentSymbol[] | null> {
+): Promise<SymbolInformation[] | DocumentSymbol[] | null> {
     const client = context.getClient();
     if (client === undefined) {
         return Promise.reject(new Error('No language client connected.'));
     }
 
-  // Send the request to the language client.
-  return client.sendRequest(DocumentSymbolRequest.type, params);
+    // Send the request to the language client.
+    return client.sendRequest(DocumentSymbolRequest.type, params);
 }
 
 /**
  * An LSP command textDocument/completion
  */
 export async function textDocumentCompletion(
-  context: Readonly<Context>,
-  params: CompletionParams,
+    context: Readonly<Context>,
+    params: CompletionParams,
 ): Promise<CompletionList | CompletionItem[] | null> {
-  const client = context.getClient();
-  if (client === undefined) {
-    return Promise.reject(new Error('No language client connected.'));
-  }
+    const client = context.getClient();
+    if (client === undefined) {
+        return Promise.reject(new Error('No language client connected.'));
+    }
 
-  // Send the request to the language client.
-  return client.sendRequest(CompletionRequest.type, params);
+    // Send the request to the language client.
+    return client.sendRequest(CompletionRequest.type, params);
 }
 
 

--- a/language/move-analyzer/editors/code/src/main.ts
+++ b/language/move-analyzer/editors/code/src/main.ts
@@ -75,4 +75,5 @@ export async function activate(extensionContext: Readonly<vscode.ExtensionContex
     await context.startClient();
     context.registerCommand('textDocumentDocumentSymbol', commands.textDocumentDocumentSymbol);
     context.registerCommand('textDocumentHover', commands.textDocumentHover);
+    context.registerCommand('textDocumentCompletion', commands.textDocumentCompletion);
 }

--- a/language/move-analyzer/editors/code/tests/lsp-demo/sources/Completions.move
+++ b/language/move-analyzer/editors/code/tests/lsp-demo/sources/Completions.move
@@ -1,0 +1,13 @@
+module Symbols::Completions {
+  fun add(a: u64, b: u64): u64 {
+    a + b
+  }
+
+  fun subtract(a: u64, b: u64): u64 {
+    a - b
+  }
+
+  fun divide(a: u64, b: u64): u64 {
+    a / b
+  }
+}

--- a/language/move-analyzer/editors/code/tests/lsp.test.ts
+++ b/language/move-analyzer/editors/code/tests/lsp.test.ts
@@ -207,7 +207,7 @@ Mocha.suite('LSP', () => {
         assert.ok(itemsOnColon);
 
         const keywordsOnColon = itemsOnColon.filter(i => i.kind === CompletionItemKind.Keyword);
-        // Primitive types are the only keywords returned after the inserting the colon
+        // Primitive types are the only keywords returned after inserting the colon
         assert.strictEqual(keywordsOnColon.length, PRIMITIVE_TYPES.length);
 
         // Final safety check

--- a/language/move-analyzer/src/bin/move-analyzer.rs
+++ b/language/move-analyzer/src/bin/move-analyzer.rs
@@ -223,7 +223,9 @@ fn main() {
 
 fn on_request(context: &Context, request: &Request) {
     match request.method.as_str() {
-        lsp_types::request::Completion::METHOD => on_completion_request(context, request),
+        lsp_types::request::Completion::METHOD => {
+            on_completion_request(context, request, &context.symbols.lock().unwrap())
+        }
         lsp_types::request::GotoDefinition::METHOD => {
             symbols::on_go_to_def_request(context, request, &context.symbols.lock().unwrap());
         }

--- a/language/move-analyzer/src/completion.rs
+++ b/language/move-analyzer/src/completion.rs
@@ -100,10 +100,9 @@ fn identifiers(
 
     // The completion item kind "text" indicates that the item is based on simple textual matching,
     // not any deeper semantic analysis.
-    let items = ids
-        .iter()
+    ids.iter()
         .map(|label| {
-            let item = if let Some(fun_data) = function_use_def {
+            if let Some(fun_data) = function_use_def {
                 if fun_data.clone().contains_key(&label.to_string()) {
                     completion_item(label, CompletionItemKind::Function)
                 } else {
@@ -111,13 +110,9 @@ fn identifiers(
                 }
             } else {
                 completion_item(label, CompletionItemKind::Text)
-            };
-
-            item
+            }
         })
-        .collect();
-
-    items
+        .collect()
 }
 
 /// Returns the token corresponding to the "trigger character" that precedes the user's cursor,

--- a/language/move-analyzer/src/completion.rs
+++ b/language/move-analyzer/src/completion.rs
@@ -2,7 +2,10 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{context::Context, symbols::{FunctionUseDefMap, Symbols}};
+use crate::{
+    context::Context,
+    symbols::{FunctionIdentTypeMap, Symbols},
+};
 use lsp_server::Request;
 use lsp_types::{CompletionItem, CompletionItemKind, CompletionParams, Position};
 use move_command_line_common::files::FileHash;
@@ -68,7 +71,10 @@ fn builtins() -> Vec<CompletionItem> {
 /// server did not initialize with a response indicating it's capable of providing completions. In
 /// the future, the server should be modified to return semantically valid completion items, not
 /// simple textual suggestions.
-fn identifiers(buffer: &str, function_use_def: Option<&FunctionUseDefMap>) -> Vec<CompletionItem> {
+fn identifiers(
+    buffer: &str,
+    function_use_def: Option<&FunctionIdentTypeMap>,
+) -> Vec<CompletionItem> {
     let mut lexer = Lexer::new(buffer, FileHash::new(buffer));
     if lexer.advance().is_err() {
         return vec![];
@@ -185,7 +191,7 @@ pub fn on_completion_request(context: &Context, request: &Request, symbols: &Sym
     }
 
     if let Some(buffer) = &buffer {
-        let identifiers = identifiers(buffer, symbols.file_functions.get(&path));
+        let identifiers = identifiers(buffer, symbols.get_file_functions().get(&path));
         items.extend_from_slice(&identifiers);
     }
 

--- a/language/move-analyzer/src/symbols.rs
+++ b/language/move-analyzer/src/symbols.rs
@@ -210,6 +210,10 @@ pub struct Symbolicator {
 #[derive(Debug, Clone, Eq, PartialEq)]
 struct UseDefMap(BTreeMap<u32, BTreeSet<UseDef>>);
 
+/// Maps a function name to its usage definition
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct FunctionUseDefMap(BTreeMap<String, UseDef>);
+
 /// Result of the symbolication process
 pub struct Symbols {
     /// A map from def locations to all the references (uses)
@@ -218,6 +222,8 @@ pub struct Symbols {
     file_use_defs: BTreeMap<PathBuf, UseDefMap>,
     /// A mapping from file hashes to file names
     file_name_mapping: BTreeMap<FileHash, Symbol>,
+    /// A mapping from filePath to function definitions
+    pub file_functions: BTreeMap<PathBuf, FunctionUseDefMap>,
     /// A mapping from filePath to ModuleDefs
     file_mods: BTreeMap<PathBuf, BTreeSet<ModuleDefs>>,
 }
@@ -551,6 +557,20 @@ impl UseDefMap {
     }
 }
 
+impl FunctionUseDefMap {
+    fn new() -> Self {
+        Self(BTreeMap::new())
+    }
+
+    fn insert(&mut self, key: String, val: UseDef) {
+        self.0.entry(key).or_insert_with(|| val);
+    }
+
+    pub fn contains_key(self, key: &String) -> bool {
+        self.0.contains_key(key)
+    }
+}
+
 impl Symbols {
     pub fn merge(&mut self, other: Self) {
         for (k, v) in other.references {
@@ -561,6 +581,7 @@ impl Symbols {
         }
         self.file_use_defs.extend(other.file_use_defs);
         self.file_name_mapping.extend(other.file_name_mapping);
+        self.file_functions.extend(other.file_functions);
         self.file_mods.extend(other.file_mods);
     }
 }
@@ -698,21 +719,31 @@ impl Symbolicator {
 
         let mut references = BTreeMap::new();
         let mut file_use_defs = BTreeMap::new();
+        let mut file_functions = BTreeMap::new();
+        let mut function_use_def = FunctionUseDefMap::new();
+
         for (pos, module_ident, module_def) in modules {
             let mut use_defs = mod_use_defs.remove(module_ident).unwrap();
             symbolicator.current_mod = Some(sp(pos, *module_ident));
-            symbolicator.mod_symbols(module_def, &mut references, &mut use_defs);
+            symbolicator.mod_symbols(
+                module_def,
+                &mut references,
+                &mut use_defs,
+                &mut function_use_def,
+            );
 
             let fpath = match source_files.get(&pos.file_hash()) {
                 Some((p, _)) => p,
                 None => continue,
             };
 
+            let fpath_buffer = dunce::canonicalize(fpath.as_str())
+                .unwrap_or_else(|_| PathBuf::from(fpath.as_str()));
+
+            file_functions.insert(fpath_buffer.to_owned(), function_use_def.clone());
+
             file_use_defs
-                .entry(
-                    dunce::canonicalize(fpath.as_str())
-                        .unwrap_or_else(|_| PathBuf::from(fpath.as_str())),
-                )
+                .entry(fpath_buffer)
                 .or_insert_with(UseDefMap::new)
                 .extend(use_defs.elements());
         }
@@ -722,6 +753,7 @@ impl Symbolicator {
             file_use_defs,
             file_name_mapping,
             file_mods,
+            file_functions,
         };
 
         eprintln!("get_symbols load complete");
@@ -736,6 +768,7 @@ impl Symbolicator {
             references: BTreeMap::new(),
             file_name_mapping: BTreeMap::new(),
             file_mods: BTreeMap::new(),
+            file_functions: BTreeMap::new(),
         }
     }
 
@@ -867,6 +900,7 @@ impl Symbolicator {
         mod_def: &ModuleDefinition,
         references: &mut BTreeMap<DefLoc, BTreeSet<UseLoc>>,
         use_defs: &mut UseDefMap,
+        function_use_def: &mut FunctionUseDefMap,
     ) {
         for (pos, name, fun) in &mod_def.functions {
             // enter self-definition for function name (unwrap safe - done when inserting def)
@@ -895,21 +929,21 @@ impl Symbolicator {
                     .collect(),
             );
             let ident_type_def = self.ident_type_def_loc(&use_type);
-            use_defs.insert(
-                name_start.line,
-                UseDef::new(
-                    references,
-                    pos.file_hash(),
-                    name_start,
-                    pos.file_hash(),
-                    name_start,
-                    name,
-                    use_type,
-                    ident_type_def,
-                    doc_string,
-                ),
+            let use_def = UseDef::new(
+                references,
+                pos.file_hash(),
+                name_start,
+                pos.file_hash(),
+                name_start,
+                name,
+                use_type,
+                ident_type_def,
+                doc_string,
             );
+
+            use_defs.insert(name_start.line, use_def.clone());
             self.fun_symbols(fun, references, use_defs);
+            function_use_def.insert(name.to_string(), use_def);
         }
 
         for (pos, name, c) in &mod_def.constants {

--- a/language/move-compiler/src/parser/keywords.rs
+++ b/language/move-compiler/src/parser/keywords.rs
@@ -30,7 +30,6 @@ pub const KEYWORDS: &[&str] = &[
     "true",
     "use",
     "while",
-    "signer",
 ];
 
 pub const CONTEXTUAL_KEYWORDS: &[&str] = &[

--- a/language/move-compiler/src/parser/keywords.rs
+++ b/language/move-compiler/src/parser/keywords.rs
@@ -30,6 +30,7 @@ pub const KEYWORDS: &[&str] = &[
     "true",
     "use",
     "while",
+    "signer",
 ];
 
 pub const CONTEXTUAL_KEYWORDS: &[&str] = &[
@@ -64,6 +65,8 @@ pub const CONTEXTUAL_KEYWORDS: &[&str] = &[
     "where",
     "with",
 ];
+
+pub const PRIMITIVE_TYPES: &[&str] = &["u8", "u64", "u128", "bool", "vector"];
 
 pub const BUILTINS: &[&str] = &[
     "assert",


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Move Language.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

The current move-analyzer has limited code completion support, this PR adds primitive types and function name completion.

Note: the `IdentType` in `FunctionIdentTypeMap` is not used in this PR. However, it will be used for function signature help in a future PR.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

- Open the extension in debug mode
- There should be a code completion suggestion for primitive types if you start typing a prefix of any primitive types (e.g. u64, bool etc.)
- There should be a code completion suggestion for any function name prefix inside the same file

## PRs to add after the current one

- Add more intellisense support. (e.g. show function signature help, module method completion, auto imports etc.) Each of these is likely going to be a separate PR for easier review.
