### PR TITLE
[vm] Add ability for adapter to observe module loader cache hits

### DIFF
--- a/language/move-vm/runtime/src/move_vm.rs
+++ b/language/move-vm/runtime/src/move_vm.rs
@@ -2,8 +2,7 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::BTreeSet;
-use std::sync::Arc;
+use std::{collections::BTreeSet, sync::Arc};
 
 use crate::{
     data_cache::TransactionDataCache, native_extensions::NativeContextExtensions,

--- a/language/move-vm/runtime/src/move_vm.rs
+++ b/language/move-vm/runtime/src/move_vm.rs
@@ -2,6 +2,7 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::BTreeSet;
 use std::sync::Arc;
 
 use crate::{
@@ -76,14 +77,24 @@ impl MoveVM {
     /// outdated. This can happen if the adapter executed a particular code publishing transaction
     /// but decided to not commit the result to the data store. Because the code cache currently
     /// does not support deletion, the cache will, incorrectly, still contain this module.
+    /// TODO: new loader architecture
     pub fn mark_loader_cache_as_invalid(&self) {
-        self.runtime.mark_loader_cache_as_invalid()
+        self.runtime.loader().mark_as_invalid()
     }
 
     /// If the loader cache has been invalidated (either by the above call or by internal logic)
     /// flush it so it is valid again. Notice that should only be called if there are no
     /// outstanding sessions created from this VM.
+    /// TODO: new loader architecture
     pub fn flush_loader_cache_if_invalidated(&self) {
-        self.runtime.flush_loader_cache_if_invalidated()
+        self.runtime.loader().flush_if_invalidated()
+    }
+
+    /// Gets and clears module cache hits. This is hack which allows the adapter to see module
+    /// reads if executing multiple transactions in a VM. Without this, the adapter only sees
+    /// the first load of a module.
+    /// TODO: new loader architecture
+    pub fn get_and_clear_module_cache_hits(&self) -> BTreeSet<ModuleId> {
+        self.runtime.loader().get_and_clear_module_cache_hits()
     }
 }

--- a/language/move-vm/runtime/src/runtime.rs
+++ b/language/move-vm/runtime/src/runtime.rs
@@ -49,14 +49,6 @@ impl VMRuntime {
         })
     }
 
-    pub(crate) fn mark_loader_cache_as_invalid(&self) {
-        self.loader.mark_as_invalid()
-    }
-
-    pub(crate) fn flush_loader_cache_if_invalidated(&self) {
-        self.loader.flush_if_invalidated()
-    }
-
     pub fn new_session<'r, S: MoveResolver>(&self, remote: &'r S) -> Session<'r, '_, S> {
         self.new_session_with_extensions(remote, NativeContextExtensions::default())
     }


### PR DESCRIPTION
If a VM is used to execute multiple sessions, the adapter is not cabable to see which modules have been loaded by a given transaction, because modules are cached internaly by the VM, and no call back to the adapters data store happens.

This PR adds a small change which allows the adapter to read out this information, roughly as follows:

```
let vm = MoveVM::new();
let session = vm.new_session();
<<work with this session>>
let cache_hits = vm.get_and_clear_module_cache_hits();
let used_modules = cache_hits + modules_read_from_storage()
// next session starts with 0 cache hits
let session = vm.new_session();
...
```
