### PR TITLE
[move-prover][interpreter] Add unit test for choice operator

### DIFF
--- a/language/move-prover/interpreter-testsuite/tests/concrete_check/choice.exp
+++ b/language/move-prover/interpreter-testsuite/tests/concrete_check/choice.exp
@@ -1,6 +1,8 @@
 Running Move unit tests
 [ FAIL    ] 0x2::A::simple_number_min_range_failure
 [ FAIL    ] 0x2::A::simple_number_range_failure
+[ PASS    ] 0x2::A::unroll_address_success
+[ FAIL    ] 0x2::A::unroll_address_unsatisfied_predicate
 [ FAIL    ] 0x2::A::vector_choose_min_unsatisfied_predicate
 [ PASS    ] 0x2::A::vector_choose_success
 [ FAIL    ] 0x2::A::vector_choose_unsatisfied_predicate
@@ -11,15 +13,15 @@ Failures in 0x2::A:
 
 ┌── simple_number_min_range_failure ──────
 │ error: failed to evaluate expression: enumeration of a non-address type domain is not supported
-│    ┌─ tests/concrete_check/choice.move:56:42
+│    ┌─ tests/concrete_check/choice.move:78:42
 │    │
-│ 56 │         ensures result <= (choose min x: u64 where x >= 4);
+│ 78 │         ensures result <= (choose min x: u64 where x >= 4);
 │    │                                          ^^^
 │
 │ error: failed to evaluate expression: unexpected error code
-│    ┌─ tests/concrete_check/choice.move:56:17
+│    ┌─ tests/concrete_check/choice.move:78:17
 │    │
-│ 56 │         ensures result <= (choose min x: u64 where x >= 4);
+│ 78 │         ensures result <= (choose min x: u64 where x >= 4);
 │    │                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 │
 │
@@ -28,16 +30,27 @@ Failures in 0x2::A:
 
 ┌── simple_number_range_failure ──────
 │ error: failed to evaluate expression: enumeration of a non-address type domain is not supported
-│    ┌─ tests/concrete_check/choice.move:49:38
+│    ┌─ tests/concrete_check/choice.move:71:38
 │    │
-│ 49 │         ensures result <= (choose x: u64 where x >= 4);
+│ 71 │         ensures result <= (choose x: u64 where x >= 4);
 │    │                                      ^^^
 │
 │ error: failed to evaluate expression: unexpected error code
-│    ┌─ tests/concrete_check/choice.move:49:17
+│    ┌─ tests/concrete_check/choice.move:71:17
 │    │
-│ 49 │         ensures result <= (choose x: u64 where x >= 4);
+│ 71 │         ensures result <= (choose x: u64 where x >= 4);
 │    │                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+│
+│
+└──────────────────
+
+
+┌── unroll_address_unsatisfied_predicate ──────
+│ error: failed to evaluate expression: choose fails to satisfy a predicate
+│    ┌─ tests/concrete_check/choice.move:23:51
+│    │
+│ 23 │         let post choice = choose a: address where !exists<R>(a);
+│    │                                                   ^^^^^^^^^^^^^
 │
 │
 └──────────────────
@@ -45,9 +58,9 @@ Failures in 0x2::A:
 
 ┌── vector_choose_min_unsatisfied_predicate ──────
 │ error: failed to evaluate expression: choose min fails to satisfy a predicate
-│    ┌─ tests/concrete_check/choice.move:42:68
+│    ┌─ tests/concrete_check/choice.move:64:68
 │    │
-│ 42 │         let post choice_min = choose min i in 0..len(result) where result[i] == 3;
+│ 64 │         let post choice_min = choose min i in 0..len(result) where result[i] == 3;
 │    │                                                                    ^^^^^^^^^^^^^^
 │
 │
@@ -56,12 +69,12 @@ Failures in 0x2::A:
 
 ┌── vector_choose_unsatisfied_predicate ──────
 │ error: failed to evaluate expression: choose fails to satisfy a predicate
-│    ┌─ tests/concrete_check/choice.move:29:60
+│    ┌─ tests/concrete_check/choice.move:51:60
 │    │
-│ 29 │         let post choice = choose i in 0..len(result) where result[i] == 3;
+│ 51 │         let post choice = choose i in 0..len(result) where result[i] == 3;
 │    │                                                            ^^^^^^^^^^^^^^
 │
 │
 └──────────────────
 
-Test result: FAILED. Total tests: 5; passed: 1; failed: 4
+Test result: FAILED. Total tests: 7; passed: 2; failed: 5

--- a/language/move-prover/interpreter-testsuite/tests/concrete_check/choice.move
+++ b/language/move-prover/interpreter-testsuite/tests/concrete_check/choice.move
@@ -1,6 +1,28 @@
 module 0x2::A {
     use std::vector;
 
+    struct R has key { i: u64 }
+
+    #[test(a=@0x2)]
+    public fun unroll_address_success(a: &signer) {
+        let r = R{i: 1};
+        move_to(a, r);
+    }
+
+    spec unroll_address_success {
+        let post choice = choose a: address where exists<R>(a) && global<R>(a).i == 1;
+    }
+
+    #[test(a=@0x2)]
+    public fun unroll_address_unsatisfied_predicate(a: &signer) {
+        let r = R{i: 1};
+        move_to(a, r);
+    }
+
+    spec unroll_address_unsatisfied_predicate {
+        let post choice = choose a: address where !exists<R>(a);
+    }
+
     #[test]
     public fun vector_choose_success(): vector<u64> {
         let v = vector::empty<u64>();


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Move Language.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

- Add unit test for address type domain for choice operators.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes.

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)
