### PR TITLE
[move-cli] add username to package lock file.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3447,6 +3447,7 @@ dependencies = [
  "termcolor",
  "toml",
  "walkdir",
+ "whoami",
 ]
 
 [[package]]
@@ -6734,6 +6735,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d743fdedc5c64377b5fc2bc036b01c7fd642205a0d96356034ae3404d49eb7fb"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "whoami"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524b58fa5a20a2fb3014dd6358b70e6579692a56ef6fce928834e488f42f65e8"
+dependencies = [
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]

--- a/language/tools/move-package/Cargo.toml
+++ b/language/tools/move-package/Cargo.toml
@@ -43,6 +43,8 @@ termcolor = { version = "1.1.2", optional = true }
 hex = { version = "0.4.3", optional = true }
 reqwest = { version = "0.10", features = ["blocking", "json"] }
 
+whoami = { version = "1.2.1" }
+
 [dev-dependencies]
 datatest-stable = "0.1.1"
 

--- a/language/tools/move-package/src/package_lock.rs
+++ b/language/tools/move-package/src/package_lock.rs
@@ -5,11 +5,14 @@
 use named_lock::{NamedLock, NamedLockGuard};
 use once_cell::sync::Lazy;
 use std::sync::{Mutex, MutexGuard};
+use whoami::username;
 
 const PACKAGE_LOCK_NAME: &str = "move_pkg_lock";
 static PACKAGE_THREAD_MUTEX: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
-static PACKAGE_PROCESS_MUTEX: Lazy<NamedLock> =
-    Lazy::new(|| NamedLock::create(PACKAGE_LOCK_NAME).unwrap());
+static PACKAGE_PROCESS_MUTEX: Lazy<NamedLock> = Lazy::new(|| {
+    let user_lock_file = format!("{}_{}", PACKAGE_LOCK_NAME, username());
+    NamedLock::create(user_lock_file.as_str()).unwrap()
+});
 
 /// The package lock is a lock held across threads and processes. This lock is held to ensure that
 /// the Move package manager has a consistent (read: serial) view of the file system. Without this


### PR DESCRIPTION
This is to address #346.

## Motivation

The same package lock file is used for different users (e.g.
`/tmp/move_package_lock.lock`), this is problematic on hosts shared by
many users. This add the username to the end of the package lock file
(e.g. `/tmp/move_package_Lock_username.lock`).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes.