### PR TITLE
[move-stdlib] Add keccak 256 native function

### DIFF
--- a/language/move-prover/bytecode/src/read_write_set_analysis.rs
+++ b/language/move-prover/bytecode/src/read_write_set_analysis.rs
@@ -689,7 +689,7 @@ fn call_native_function(
         | ("string", "internal_sub_string")
         | ("string", "internal_index_of") => (),
         ("event", "write_to_event_store") => (),
-        ("hash", "sha3_256") | ("hash", "sha2_256") | ("hash", "keccak_256")=> (),
+        ("hash", "sha3_256") | ("hash", "sha2_256") | ("hash", "keccak_256") => (),
         ("Signature", "ed25519_validate_pubkey") | ("Signature", "ed25519_verify") => (),
         (m, f) => {
             panic!("Unsupported native function {:?}::{:?}", m, f)

--- a/language/move-prover/bytecode/src/read_write_set_analysis.rs
+++ b/language/move-prover/bytecode/src/read_write_set_analysis.rs
@@ -689,7 +689,7 @@ fn call_native_function(
         | ("string", "internal_sub_string")
         | ("string", "internal_index_of") => (),
         ("event", "write_to_event_store") => (),
-        ("hash", "sha3_256") | ("hash", "sha2_256") => (),
+        ("hash", "sha3_256") | ("hash", "sha2_256") | ("hash", "keccak_256")=> (),
         ("Signature", "ed25519_validate_pubkey") | ("Signature", "ed25519_verify") => (),
         (m, f) => {
             panic!("Unsupported native function {:?}::{:?}", m, f)

--- a/language/move-prover/interpreter/crypto/src/lib.rs
+++ b/language/move-prover/interpreter/crypto/src/lib.rs
@@ -18,7 +18,7 @@ use ed25519_dalek::{
     PUBLIC_KEY_LENGTH as ED25519_PUBLIC_KEY_LENGTH, SIGNATURE_LENGTH as ED25519_SIGNATURE_LENGTH,
 };
 use sha2::{Digest, Sha256};
-use sha3::{Sha3_256, Keccak256};
+use sha3::{Keccak256, Sha3_256};
 use std::cmp::Ordering;
 
 /// The order of ed25519 as defined in [RFC8032](https://tools.ietf.org/html/rfc8032).

--- a/language/move-prover/interpreter/crypto/src/lib.rs
+++ b/language/move-prover/interpreter/crypto/src/lib.rs
@@ -18,7 +18,7 @@ use ed25519_dalek::{
     PUBLIC_KEY_LENGTH as ED25519_PUBLIC_KEY_LENGTH, SIGNATURE_LENGTH as ED25519_SIGNATURE_LENGTH,
 };
 use sha2::{Digest, Sha256};
-use sha3::Sha3_256;
+use sha3::{Sha3_256, Keccak256};
 use std::cmp::Ordering;
 
 /// The order of ed25519 as defined in [RFC8032](https://tools.ietf.org/html/rfc8032).
@@ -34,6 +34,10 @@ pub fn sha2_256_of(bytes: &[u8]) -> Vec<u8> {
 
 pub fn sha3_256_of(bytes: &[u8]) -> Vec<u8> {
     Sha3_256::digest(bytes).to_vec()
+}
+
+pub fn keccak_256_of(bytes: &[u8]) -> Vec<u8> {
+    Keccak256::digest(bytes).to_vec()
 }
 
 // Ed25519

--- a/language/move-prover/interpreter/src/concrete/player.rs
+++ b/language/move-prover/interpreter/src/concrete/player.rs
@@ -9,7 +9,7 @@ use std::{collections::BTreeMap, rc::Rc};
 
 use bytecode_interpreter_crypto::{
     ed25519_deserialize_public_key, ed25519_deserialize_signature, ed25519_verify_signature,
-    sha2_256_of, sha3_256_of, keccak_256_of
+    keccak_256_of, sha2_256_of, sha3_256_of,
 };
 use move_binary_format::errors::Location;
 use move_core_types::{

--- a/language/move-stdlib/docs/hash.md
+++ b/language/move-stdlib/docs/hash.md
@@ -11,6 +11,7 @@ as in the Move prover's prelude.
 
 -  [Function `sha2_256`](#0x1_hash_sha2_256)
 -  [Function `sha3_256`](#0x1_hash_sha3_256)
+-  [Function `keccak_256`](#0x1_hash_keccak_256)
 
 
 <pre><code></code></pre>
@@ -55,6 +56,28 @@ as in the Move prover's prelude.
 
 
 <pre><code><b>native</b> <b>public</b> <b>fun</b> <a href="hash.md#0x1_hash_sha3_256">sha3_256</a>(data: <a href="vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="vector.md#0x1_vector">vector</a>&lt;u8&gt;;
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_hash_keccak_256"></a>
+
+## Function `keccak_256`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="hash.md#0x1_hash_keccak_256">keccak_256</a>(data: <a href="vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="vector.md#0x1_vector">vector</a>&lt;u8&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>native</b> <b>public</b> <b>fun</b> <a href="hash.md#0x1_hash_keccak_256">keccak_256</a>(data: <a href="vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="vector.md#0x1_vector">vector</a>&lt;u8&gt;;
 </code></pre>
 
 

--- a/language/move-stdlib/sources/hash.move
+++ b/language/move-stdlib/sources/hash.move
@@ -5,4 +5,5 @@
 module std::hash {
     native public fun sha2_256(data: vector<u8>): vector<u8>;
     native public fun sha3_256(data: vector<u8>): vector<u8>;
+    native public fun keccak_256(data: vector<u8>): vector<u8>;
 }

--- a/language/move-stdlib/src/natives/hash.rs
+++ b/language/move-stdlib/src/natives/hash.rs
@@ -9,7 +9,7 @@ use move_vm_types::{
     loaded_data::runtime_types::Type, natives::function::NativeResult, pop_arg, values::Value,
 };
 use sha2::{Digest, Sha256};
-use sha3::{Sha3_256, Keccak256};
+use sha3::{Keccak256, Sha3_256};
 use smallvec::smallvec;
 use std::{collections::VecDeque, sync::Arc};
 
@@ -105,42 +105,42 @@ pub fn make_native_sha3_256(gas_params: Sha3_256GasParameters) -> NativeFunction
  *   gas cost: base_cost + unit_cost * max(input_length_in_bytes, legacy_min_input_len)
  *
  **************************************************************************************************/
- #[derive(Debug, Clone)]
- pub struct Keccak256gasParameters {
-     pub base_cost: u64,
-     pub unit_cost: u64,
-     pub legacy_min_input_len: usize,
- }
- 
- #[inline]
- fn native_keccak_256(
-     gas_params: &Keccak256gasParameters,
-     _context: &mut NativeContext,
-     _ty_args: Vec<Type>,
-     mut arguments: VecDeque<Value>,
- ) -> PartialVMResult<NativeResult> {
-     debug_assert!(_ty_args.is_empty());
-     debug_assert!(arguments.len() == 1);
- 
-     let hash_arg = pop_arg!(arguments, Vec<u8>);
- 
-     let cost = gas_params.base_cost
-         + gas_params.unit_cost * usize::max(hash_arg.len(), gas_params.legacy_min_input_len) as u64;
- 
-     let hash_vec = Keccak256::digest(hash_arg.as_slice()).to_vec();
-     Ok(NativeResult::ok(
-         cost,
-         smallvec![Value::vector_u8(hash_vec)],
-     ))
- }
- 
- pub fn make_native_keccak_256(gas_params: Keccak256gasParameters) -> NativeFunction {
-     Arc::new(
-         move |context, ty_args, args| -> PartialVMResult<NativeResult> {
+#[derive(Debug, Clone)]
+pub struct Keccak256gasParameters {
+    pub base_cost: u64,
+    pub unit_cost: u64,
+    pub legacy_min_input_len: usize,
+}
+
+#[inline]
+fn native_keccak_256(
+    gas_params: &Keccak256gasParameters,
+    _context: &mut NativeContext,
+    _ty_args: Vec<Type>,
+    mut arguments: VecDeque<Value>,
+) -> PartialVMResult<NativeResult> {
+    debug_assert!(_ty_args.is_empty());
+    debug_assert!(arguments.len() == 1);
+
+    let hash_arg = pop_arg!(arguments, Vec<u8>);
+
+    let cost = gas_params.base_cost
+        + gas_params.unit_cost * usize::max(hash_arg.len(), gas_params.legacy_min_input_len) as u64;
+
+    let hash_vec = Keccak256::digest(hash_arg.as_slice()).to_vec();
+    Ok(NativeResult::ok(
+        cost,
+        smallvec![Value::vector_u8(hash_vec)],
+    ))
+}
+
+pub fn make_native_keccak_256(gas_params: Keccak256gasParameters) -> NativeFunction {
+    Arc::new(
+        move |context, ty_args, args| -> PartialVMResult<NativeResult> {
             native_keccak_256(&gas_params, context, ty_args, args)
-         },
-     )
- }
+        },
+    )
+}
 
 /***************************************************************************************************
  * module

--- a/language/move-stdlib/src/natives/hash.rs
+++ b/language/move-stdlib/src/natives/hash.rs
@@ -9,7 +9,7 @@ use move_vm_types::{
     loaded_data::runtime_types::Type, natives::function::NativeResult, pop_arg, values::Value,
 };
 use sha2::{Digest, Sha256};
-use sha3::Sha3_256;
+use sha3::{Sha3_256, Keccak256};
 use smallvec::smallvec;
 use std::{collections::VecDeque, sync::Arc};
 
@@ -100,18 +100,63 @@ pub fn make_native_sha3_256(gas_params: Sha3_256GasParameters) -> NativeFunction
 }
 
 /***************************************************************************************************
+ * native fun keccak_256
+ *
+ *   gas cost: base_cost + unit_cost * max(input_length_in_bytes, legacy_min_input_len)
+ *
+ **************************************************************************************************/
+ #[derive(Debug, Clone)]
+ pub struct Keccak256gasParameters {
+     pub base_cost: u64,
+     pub unit_cost: u64,
+     pub legacy_min_input_len: usize,
+ }
+ 
+ #[inline]
+ fn native_keccak_256(
+     gas_params: &Keccak256gasParameters,
+     _context: &mut NativeContext,
+     _ty_args: Vec<Type>,
+     mut arguments: VecDeque<Value>,
+ ) -> PartialVMResult<NativeResult> {
+     debug_assert!(_ty_args.is_empty());
+     debug_assert!(arguments.len() == 1);
+ 
+     let hash_arg = pop_arg!(arguments, Vec<u8>);
+ 
+     let cost = gas_params.base_cost
+         + gas_params.unit_cost * usize::max(hash_arg.len(), gas_params.legacy_min_input_len) as u64;
+ 
+     let hash_vec = Keccak256::digest(hash_arg.as_slice()).to_vec();
+     Ok(NativeResult::ok(
+         cost,
+         smallvec![Value::vector_u8(hash_vec)],
+     ))
+ }
+ 
+ pub fn make_native_keccak_256(gas_params: Keccak256gasParameters) -> NativeFunction {
+     Arc::new(
+         move |context, ty_args, args| -> PartialVMResult<NativeResult> {
+            native_keccak_256(&gas_params, context, ty_args, args)
+         },
+     )
+ }
+
+/***************************************************************************************************
  * module
  **************************************************************************************************/
 #[derive(Debug, Clone)]
 pub struct GasParameters {
     pub sha2_256: Sha2_256GasParameters,
     pub sha3_256: Sha3_256GasParameters,
+    pub keccak_256: Keccak256gasParameters,
 }
 
 pub fn make_all(gas_params: GasParameters) -> impl Iterator<Item = (String, NativeFunction)> {
     let natives = [
         ("sha2_256", make_native_sha2_256(gas_params.sha2_256)),
         ("sha3_256", make_native_sha3_256(gas_params.sha3_256)),
+        ("keccak_256", make_native_keccak_256(gas_params.keccak_256)),
     ];
 
     make_module_natives(natives)

--- a/language/move-stdlib/src/natives/mod.rs
+++ b/language/move-stdlib/src/natives/mod.rs
@@ -54,6 +54,11 @@ impl GasParameters {
                     unit_cost: 0,
                     legacy_min_input_len: 0,
                 },
+                keccak_256: hash::Keccak256gasParameters {
+                    base_cost: 0,
+                    unit_cost: 0,
+                    legacy_min_input_len: 0,
+                },
             },
             signer: signer::GasParameters {
                 borrow_address: signer::BorrowAddressGasParameters { base_cost: 0 },


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Move Language.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->
keccak256 function support may be required in move development
But the method is not provided in stdlib, so I added this native function
## Motivation

I hope move stdlib can provide a keccak256 native function

## Test Plan
- hash.move
```
native public fun keccak_256(data: vector<u8>): vector<u8>; 
```
- hash.rs
```
 fn native_keccak_256(
     gas_params: &Keccak256gasParameters,
     _context: &mut NativeContext,
     _ty_args: Vec<Type>,
     mut arguments: VecDeque<Value>,
 ) -> PartialVMResult<NativeResult> {
     debug_assert!(_ty_args.is_empty());
     debug_assert!(arguments.len() == 1);
 
     let hash_arg = pop_arg!(arguments, Vec<u8>);
 
     let cost = gas_params.base_cost
         + gas_params.unit_cost * usize::max(hash_arg.len(), gas_params.legacy_min_input_len) as u64;
 
     let hash_vec = Keccak256::digest(hash_arg.as_slice()).to_vec();
     Ok(NativeResult::ok(
         cost,
         smallvec![Value::vector_u8(hash_vec)],
     ))
 }
```
