### PR TITLE
[Build/WSL] Remove line-ending carriage returns in script files

### DIFF
--- a/docker/move-cli/Dockerfile
+++ b/docker/move-cli/Dockerfile
@@ -20,6 +20,7 @@ ENV PATH "/opt/cargo/bin:/usr/lib/golang/bin:/opt/bin:${DOTNET_ROOT}:${DOTNET_RO
 RUN mkdir -p /github/home && \
     mkdir -p /opt/cargo/ && \
     mkdir -p /opt/git/ && \
+	sed -i -e 's/\r$//' /move/scripts/*.sh && \
     /move/scripts/dev_setup.sh -t -b -p -y -d -g -n && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Adds a build step that replaces CRLF chars with LF chars in all script files, fixes a build issue I was having in WSL.

## Motivation

Build was failing in WSL. [(issue)](https://github.com/move-language/move/issues/363)

## Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes, I have.

## Test Plan

Build failed in WSL before change, succeeds after change.
