### PR TITLE
[verifier] add option to limit nested loop depth

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3084,6 +3084,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "move-binary-format",
+ "move-bytecode-verifier",
  "move-compiler",
  "move-core-types",
  "move-stdlib",

--- a/language/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/code_unit_tests.rs
+++ b/language/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/code_unit_tests.rs
@@ -10,7 +10,7 @@ use move_core_types::vm_status::StatusCode;
 #[test]
 fn invalid_fallthrough_br_true() {
     let module = dummy_procedure_module(vec![Bytecode::LdFalse, Bytecode::BrTrue(1)]);
-    let result = CodeUnitVerifier::verify_module(&module);
+    let result = CodeUnitVerifier::verify_module(&Default::default(), &module);
     assert_eq!(
         result.unwrap_err().major_status(),
         StatusCode::INVALID_FALL_THROUGH
@@ -20,7 +20,7 @@ fn invalid_fallthrough_br_true() {
 #[test]
 fn invalid_fallthrough_br_false() {
     let module = dummy_procedure_module(vec![Bytecode::LdTrue, Bytecode::BrFalse(1)]);
-    let result = CodeUnitVerifier::verify_module(&module);
+    let result = CodeUnitVerifier::verify_module(&Default::default(), &module);
     assert_eq!(
         result.unwrap_err().major_status(),
         StatusCode::INVALID_FALL_THROUGH
@@ -31,7 +31,7 @@ fn invalid_fallthrough_br_false() {
 #[test]
 fn invalid_fallthrough_non_branch() {
     let module = dummy_procedure_module(vec![Bytecode::LdTrue, Bytecode::Pop]);
-    let result = CodeUnitVerifier::verify_module(&module);
+    let result = CodeUnitVerifier::verify_module(&Default::default(), &module);
     assert_eq!(
         result.unwrap_err().major_status(),
         StatusCode::INVALID_FALL_THROUGH
@@ -41,20 +41,20 @@ fn invalid_fallthrough_non_branch() {
 #[test]
 fn valid_fallthrough_branch() {
     let module = dummy_procedure_module(vec![Bytecode::Branch(0)]);
-    let result = CodeUnitVerifier::verify_module(&module);
+    let result = CodeUnitVerifier::verify_module(&Default::default(), &module);
     assert!(result.is_ok());
 }
 
 #[test]
 fn valid_fallthrough_ret() {
     let module = dummy_procedure_module(vec![Bytecode::Ret]);
-    let result = CodeUnitVerifier::verify_module(&module);
+    let result = CodeUnitVerifier::verify_module(&Default::default(), &module);
     assert!(result.is_ok());
 }
 
 #[test]
 fn valid_fallthrough_abort() {
     let module = dummy_procedure_module(vec![Bytecode::LdU64(7), Bytecode::Abort]);
-    let result = CodeUnitVerifier::verify_module(&module);
+    let result = CodeUnitVerifier::verify_module(&Default::default(), &module);
     assert!(result.is_ok());
 }

--- a/language/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/control_flow_tests.rs
+++ b/language/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/control_flow_tests.rs
@@ -8,10 +8,10 @@ use move_binary_format::{
     errors::PartialVMResult,
     file_format::{Bytecode, CompiledModule, FunctionDefinitionIndex, TableIndex},
 };
-use move_bytecode_verifier::control_flow;
+use move_bytecode_verifier::{control_flow, VerifierConfig};
 use move_core_types::vm_status::StatusCode;
 
-fn verify_module(module: &CompiledModule) -> PartialVMResult<()> {
+fn verify_module(verifier_config: &VerifierConfig, module: &CompiledModule) -> PartialVMResult<()> {
     for (idx, function_definition) in module
         .function_defs()
         .iter()
@@ -19,6 +19,7 @@ fn verify_module(module: &CompiledModule) -> PartialVMResult<()> {
         .filter(|(_, def)| !def.is_native())
     {
         control_flow::verify(
+            verifier_config,
             Some(FunctionDefinitionIndex(idx as TableIndex)),
             function_definition
                 .code
@@ -36,7 +37,7 @@ fn verify_module(module: &CompiledModule) -> PartialVMResult<()> {
 #[test]
 fn invalid_fallthrough_br_true() {
     let module = dummy_procedure_module(vec![Bytecode::LdFalse, Bytecode::BrTrue(1)]);
-    let result = verify_module(&module);
+    let result = verify_module(&Default::default(), &module);
     assert_eq!(
         result.unwrap_err().major_status(),
         StatusCode::INVALID_FALL_THROUGH
@@ -46,7 +47,7 @@ fn invalid_fallthrough_br_true() {
 #[test]
 fn invalid_fallthrough_br_false() {
     let module = dummy_procedure_module(vec![Bytecode::LdTrue, Bytecode::BrFalse(1)]);
-    let result = verify_module(&module);
+    let result = verify_module(&Default::default(), &module);
     assert_eq!(
         result.unwrap_err().major_status(),
         StatusCode::INVALID_FALL_THROUGH
@@ -57,7 +58,7 @@ fn invalid_fallthrough_br_false() {
 #[test]
 fn invalid_fallthrough_non_branch() {
     let module = dummy_procedure_module(vec![Bytecode::LdTrue, Bytecode::Pop]);
-    let result = verify_module(&module);
+    let result = verify_module(&Default::default(), &module);
     assert_eq!(
         result.unwrap_err().major_status(),
         StatusCode::INVALID_FALL_THROUGH
@@ -67,20 +68,61 @@ fn invalid_fallthrough_non_branch() {
 #[test]
 fn valid_fallthrough_branch() {
     let module = dummy_procedure_module(vec![Bytecode::Branch(0)]);
-    let result = verify_module(&module);
+    let result = verify_module(&Default::default(), &module);
     assert!(result.is_ok());
 }
 
 #[test]
 fn valid_fallthrough_ret() {
     let module = dummy_procedure_module(vec![Bytecode::Ret]);
-    let result = verify_module(&module);
+    let result = verify_module(&Default::default(), &module);
     assert!(result.is_ok());
 }
 
 #[test]
 fn valid_fallthrough_abort() {
     let module = dummy_procedure_module(vec![Bytecode::LdU64(7), Bytecode::Abort]);
-    let result = verify_module(&module);
+    let result = verify_module(&Default::default(), &module);
     assert!(result.is_ok());
+}
+
+#[test]
+fn nested_loops_max_depth() {
+    let module = dummy_procedure_module(vec![
+        Bytecode::LdFalse,
+        Bytecode::LdFalse,
+        Bytecode::BrFalse(1),
+        Bytecode::BrFalse(0),
+        Bytecode::Ret,
+    ]);
+    let result = verify_module(
+        &VerifierConfig {
+            max_loop_depth: Some(2),
+        },
+        &module,
+    );
+    assert!(result.is_ok());
+}
+
+#[test]
+fn nested_loops_exceed_max_depth() {
+    let module = dummy_procedure_module(vec![
+        Bytecode::LdFalse,
+        Bytecode::LdFalse,
+        Bytecode::LdFalse,
+        Bytecode::BrFalse(2),
+        Bytecode::BrFalse(1),
+        Bytecode::BrFalse(0),
+        Bytecode::Ret,
+    ]);
+    let result = verify_module(
+        &VerifierConfig {
+            max_loop_depth: Some(2),
+        },
+        &module,
+    );
+    assert_eq!(
+        result.unwrap_err().major_status(),
+        StatusCode::LOOP_MAX_DEPTH_REACHED
+    );
 }

--- a/language/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/negative_stack_size_tests.rs
+++ b/language/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/negative_stack_size_tests.rs
@@ -10,7 +10,7 @@ use move_core_types::vm_status::StatusCode;
 #[test]
 fn one_pop_no_push() {
     let module = dummy_procedure_module(vec![Bytecode::Pop, Bytecode::Ret]);
-    let result = CodeUnitVerifier::verify_module(&module);
+    let result = CodeUnitVerifier::verify_module(&Default::default(), &module);
     assert_eq!(
         result.unwrap_err().major_status(),
         StatusCode::NEGATIVE_STACK_SIZE_WITHIN_BLOCK
@@ -21,7 +21,7 @@ fn one_pop_no_push() {
 fn one_pop_one_push() {
     // Height: 0 + (-1 + 1) = 0 would have passed original usage verifier
     let module = dummy_procedure_module(vec![Bytecode::ReadRef, Bytecode::Ret]);
-    let result = CodeUnitVerifier::verify_module(&module);
+    let result = CodeUnitVerifier::verify_module(&Default::default(), &module);
     assert_eq!(
         result.unwrap_err().major_status(),
         StatusCode::NEGATIVE_STACK_SIZE_WITHIN_BLOCK
@@ -32,7 +32,7 @@ fn one_pop_one_push() {
 fn two_pop_one_push() {
     // Height: 0 + 1 + (-2 + 1) = 0 would have passed original usage verifier
     let module = dummy_procedure_module(vec![Bytecode::LdU64(0), Bytecode::Add, Bytecode::Ret]);
-    let result = CodeUnitVerifier::verify_module(&module);
+    let result = CodeUnitVerifier::verify_module(&Default::default(), &module);
     assert_eq!(
         result.unwrap_err().major_status(),
         StatusCode::NEGATIVE_STACK_SIZE_WITHIN_BLOCK
@@ -42,7 +42,7 @@ fn two_pop_one_push() {
 #[test]
 fn two_pop_no_push() {
     let module = dummy_procedure_module(vec![Bytecode::WriteRef, Bytecode::Ret]);
-    let result = CodeUnitVerifier::verify_module(&module);
+    let result = CodeUnitVerifier::verify_module(&Default::default(), &module);
     assert_eq!(
         result.unwrap_err().major_status(),
         StatusCode::NEGATIVE_STACK_SIZE_WITHIN_BLOCK

--- a/language/move-bytecode-verifier/src/lib.rs
+++ b/language/move-bytecode-verifier/src/lib.rs
@@ -31,7 +31,10 @@ pub use script_signature::{
 };
 pub use signature::SignatureChecker;
 pub use struct_defs::RecursiveStructDefChecker;
-pub use verifier::{verify_module, verify_script};
+pub use verifier::{
+    verify_module, verify_module_with_config, verify_script, verify_script_with_config,
+    VerifierConfig,
+};
 
 mod acquires_list_verifier;
 mod locals_safety;

--- a/language/move-core/types/src/vm_status.rs
+++ b/language/move-core/types/src/vm_status.rs
@@ -599,6 +599,8 @@ pub enum StatusCode {
     INVALID_PHANTOM_TYPE_PARAM_POSITION = 1108,
     VEC_UPDATE_EXISTS_MUTABLE_BORROW_ERROR = 1109,
     VEC_BORROW_ELEMENT_EXISTS_MUTABLE_BORROW_ERROR = 1110,
+    // Loops are too deeply nested.
+    LOOP_MAX_DEPTH_REACHED = 1111,
 
     // These are errors that the VM might raise if a violation of internal
     // invariants takes place.

--- a/language/move-vm/integration-tests/Cargo.toml
+++ b/language/move-vm/integration-tests/Cargo.toml
@@ -17,6 +17,7 @@ tempfile = "3.2.0"
 
 move-core-types = {path = "../../move-core/types" }
 move-binary-format = { path = "../../move-binary-format" }
+move-bytecode-verifier = { path = "../../move-bytecode-verifier" }
 move-compiler = { path = "../../move-compiler" }
 move-vm-runtime = { path = "../runtime" }
 move-vm-types = { path = "../types" }

--- a/language/move-vm/integration-tests/src/tests/mod.rs
+++ b/language/move-vm/integration-tests/src/tests/mod.rs
@@ -8,4 +8,5 @@ mod exec_func_effects_tests;
 mod function_arg_tests;
 mod loader_tests;
 mod mutated_accounts_tests;
+mod nested_loop_tests;
 mod return_value_tests;

--- a/language/move-vm/integration-tests/src/tests/nested_loop_tests.rs
+++ b/language/move-vm/integration-tests/src/tests/nested_loop_tests.rs
@@ -1,0 +1,141 @@
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::compiler::{as_module, as_script, compile_units};
+use move_bytecode_verifier::VerifierConfig;
+use move_core_types::account_address::AccountAddress;
+use move_vm_runtime::move_vm::MoveVM;
+use move_vm_test_utils::InMemoryStorage;
+use move_vm_types::gas::UnmeteredGasMeter;
+
+const TEST_ADDR: AccountAddress = AccountAddress::new([42; AccountAddress::LENGTH]);
+
+#[test]
+fn test_publish_module_with_nested_loops() {
+    // Compile the modules and scripts.
+    // TODO: find a better way to include the Signer module.
+    let code = r#"
+        module {{ADDR}}::M {
+            fun foo() {
+                let i = 0;
+                while (i < 10) {
+                    let j = 0;
+                    while (j < 10) {
+                        j = j + 1;
+                    };
+                    i = i + 1;
+                };
+            }
+        }
+    "#;
+    let code = code.replace("{{ADDR}}", &format!("0x{}", TEST_ADDR));
+    let mut units = compile_units(&code).unwrap();
+
+    let m = as_module(units.pop().unwrap());
+    let mut m_blob = vec![];
+    m.serialize(&mut m_blob).unwrap();
+
+    // Should succeed with max_loop_depth = 2
+    {
+        let storage = InMemoryStorage::new();
+        let vm = MoveVM::new_with_verifier_config(
+            move_stdlib::natives::all_natives(
+                AccountAddress::from_hex_literal("0x1").unwrap(),
+                move_stdlib::natives::GasParameters::zeros(),
+            ),
+            VerifierConfig {
+                max_loop_depth: Some(2),
+            },
+        )
+        .unwrap();
+
+        let mut sess = vm.new_session(&storage);
+        sess.publish_module(m_blob.clone(), TEST_ADDR, &mut UnmeteredGasMeter)
+            .unwrap();
+    }
+
+    // Should fail with max_loop_depth = 1
+    {
+        let storage = InMemoryStorage::new();
+        let vm = MoveVM::new_with_verifier_config(
+            move_stdlib::natives::all_natives(
+                AccountAddress::from_hex_literal("0x1").unwrap(),
+                move_stdlib::natives::GasParameters::zeros(),
+            ),
+            VerifierConfig {
+                max_loop_depth: Some(1),
+            },
+        )
+        .unwrap();
+
+        let mut sess = vm.new_session(&storage);
+        sess.publish_module(m_blob, TEST_ADDR, &mut UnmeteredGasMeter)
+            .unwrap_err();
+    }
+}
+
+#[test]
+fn test_run_script_with_nested_loops() {
+    // Compile the modules and scripts.
+    // TODO: find a better way to include the Signer module.
+    let code = r#"
+        script {
+            fun main() {
+                let i = 0;
+                while (i < 10) {
+                    let j = 0;
+                    while (j < 10) {
+                        j = j + 1;
+                    };
+                    i = i + 1;
+                };
+            }
+        }
+    "#;
+    let code = code.replace("{{ADDR}}", &format!("0x{}", TEST_ADDR));
+    let mut units = compile_units(&code).unwrap();
+
+    let s = as_script(units.pop().unwrap());
+    let mut s_blob: Vec<u8> = vec![];
+    s.serialize(&mut s_blob).unwrap();
+
+    // Should succeed with max_loop_depth = 2
+    {
+        let storage = InMemoryStorage::new();
+        let vm = MoveVM::new_with_verifier_config(
+            move_stdlib::natives::all_natives(
+                AccountAddress::from_hex_literal("0x1").unwrap(),
+                move_stdlib::natives::GasParameters::zeros(),
+            ),
+            VerifierConfig {
+                max_loop_depth: Some(2),
+            },
+        )
+        .unwrap();
+
+        let mut sess = vm.new_session(&storage);
+        let args: Vec<Vec<u8>> = vec![];
+        sess.execute_script(s_blob.clone(), vec![], args, &mut UnmeteredGasMeter)
+            .unwrap();
+    }
+
+    // Should fail with max_loop_depth = 1
+    {
+        let storage = InMemoryStorage::new();
+        let vm = MoveVM::new_with_verifier_config(
+            move_stdlib::natives::all_natives(
+                AccountAddress::from_hex_literal("0x1").unwrap(),
+                move_stdlib::natives::GasParameters::zeros(),
+            ),
+            VerifierConfig {
+                max_loop_depth: Some(1),
+            },
+        )
+        .unwrap();
+
+        let mut sess = vm.new_session(&storage);
+        let args: Vec<Vec<u8>> = vec![];
+        sess.execute_script(s_blob, vec![], args, &mut UnmeteredGasMeter)
+            .unwrap_err();
+    }
+}

--- a/language/move-vm/runtime/src/move_vm.rs
+++ b/language/move-vm/runtime/src/move_vm.rs
@@ -12,6 +12,7 @@ use move_binary_format::{
     errors::{Location, VMResult},
     CompiledModule,
 };
+use move_bytecode_verifier::VerifierConfig;
 use move_core_types::{
     account_address::AccountAddress, identifier::Identifier, language_storage::ModuleId,
     resolver::MoveResolver,
@@ -25,8 +26,16 @@ impl MoveVM {
     pub fn new(
         natives: impl IntoIterator<Item = (AccountAddress, Identifier, Identifier, NativeFunction)>,
     ) -> VMResult<Self> {
+        Self::new_with_verifier_config(natives, VerifierConfig::default())
+    }
+
+    pub fn new_with_verifier_config(
+        natives: impl IntoIterator<Item = (AccountAddress, Identifier, Identifier, NativeFunction)>,
+        verifier_config: VerifierConfig,
+    ) -> VMResult<Self> {
         Ok(Self {
-            runtime: VMRuntime::new(natives).map_err(|err| err.finish(Location::Undefined))?,
+            runtime: VMRuntime::new(natives, verifier_config)
+                .map_err(|err| err.finish(Location::Undefined))?,
         })
     }
 

--- a/language/move-vm/runtime/src/runtime.rs
+++ b/language/move-vm/runtime/src/runtime.rs
@@ -17,7 +17,7 @@ use move_binary_format::{
     file_format::LocalIndex,
     normalized, CompiledModule, IndexKind,
 };
-use move_bytecode_verifier::script_signature;
+use move_bytecode_verifier::{script_signature, VerifierConfig};
 use move_core_types::{
     account_address::AccountAddress,
     identifier::{IdentStr, Identifier},
@@ -43,9 +43,10 @@ pub(crate) struct VMRuntime {
 impl VMRuntime {
     pub(crate) fn new(
         natives: impl IntoIterator<Item = (AccountAddress, Identifier, Identifier, NativeFunction)>,
+        verifier_config: VerifierConfig,
     ) -> PartialVMResult<Self> {
         Ok(VMRuntime {
-            loader: Loader::new(NativeFunctions::new(natives)?),
+            loader: Loader::new(NativeFunctions::new(natives)?, verifier_config),
         })
     }
 


### PR DESCRIPTION
## Summary
This allows the bytecode verifier to limit the depth of nested loops. To enable this check, you'll need to pass in a `VerifierConfig` via the new entry points (`xxx_with_config`). The old entry points are kept to maintain backward compatibility, but they delegate to the new entry points under the hood.

## Test Plan
New verifier unit tests & move vm integration tests have been added to ensure this check can be activated properly