### PR TITLE
[move-core] better ChangeSet impl

### DIFF
--- a/language/extensions/async/move-async-vm/tests/sources/AccountStateMachine.exp
+++ b/language/extensions/async/move-async-vm/tests/sources/AccountStateMachine.exp
@@ -5,10 +5,10 @@ publishing vector
 publishing AccountStateMachine
 actor 0x4 created from 0x3::AccountStateMachine
   SUCCESS
-  commit 0x3::AccountStateMachine::AccountStateMachine[0x4] := [00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00]
+  commit 0x3::AccountStateMachine::AccountStateMachine[0x4] := New("[00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00]")
 actor 0x5 created from 0x3::AccountStateMachine
   SUCCESS
-  commit 0x3::AccountStateMachine::AccountStateMachine[0x5] := [00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00]
+  commit 0x3::AccountStateMachine::AccountStateMachine[0x5] := New("[00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00]")
 actor 0x4 handling 0x3::AccountStateMachine::start (hash=0x5438F379BC9E3BCB)
   SUCCESS
   sent 0x4 <- 0x4C40DD3C3521A146 argc=1
@@ -20,28 +20,28 @@ actor 0x5 handling 0x3::AccountStateMachine::start (hash=0x5438F379BC9E3BCB)
   SUCCESS
 actor 0x4 handling 0x3::AccountStateMachine::deposit (hash=0x4C40DD3C3521A146)
   SUCCESS
-  commit 0x3::AccountStateMachine::AccountStateMachine[0x4] := [64, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00]
+  commit 0x3::AccountStateMachine::AccountStateMachine[0x4] := Modify("[64, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00]")
 actor 0x5 handling 0x3::AccountStateMachine::deposit (hash=0x4C40DD3C3521A146)
   SUCCESS
-  commit 0x3::AccountStateMachine::AccountStateMachine[0x5] := [64, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00]
+  commit 0x3::AccountStateMachine::AccountStateMachine[0x5] := Modify("[64, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00]")
 actor 0x4 handling 0x3::AccountStateMachine::xfer (hash=0xF8ECAD16D8E182BB)
   SUCCESS
   sent 0x5 <- 0xB32E0FAF108F638 argc=3
-  commit 0x3::AccountStateMachine::AccountStateMachine[0x4] := [64, 00, 00, 00, 00, 00, 00, 00, 01, 00, 00, 00, 00, 00, 00, 00, 01, 00, 00, 00, 00, 00, 00, 00, 00, 14, 00, 00, 00, 00, 00, 00, 00, A0, 69, 62, 02, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00]
+  commit 0x3::AccountStateMachine::AccountStateMachine[0x4] := Modify("[64, 00, 00, 00, 00, 00, 00, 00, 01, 00, 00, 00, 00, 00, 00, 00, 01, 00, 00, 00, 00, 00, 00, 00, 00, 14, 00, 00, 00, 00, 00, 00, 00, A0, 69, 62, 02, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00]")
 actor 0x4 handling 0x3::AccountStateMachine::cleanup (hash=0xDD840198DA7DE13E)
   SUCCESS
-  commit 0x3::AccountStateMachine::AccountStateMachine[0x4] := [64, 00, 00, 00, 00, 00, 00, 00, 01, 00, 00, 00, 00, 00, 00, 00, 01, 00, 00, 00, 00, 00, 00, 00, 00, 14, 00, 00, 00, 00, 00, 00, 00, A0, 69, 62, 02, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00]
+  commit 0x3::AccountStateMachine::AccountStateMachine[0x4] := Modify("[64, 00, 00, 00, 00, 00, 00, 00, 01, 00, 00, 00, 00, 00, 00, 00, 01, 00, 00, 00, 00, 00, 00, 00, 00, 14, 00, 00, 00, 00, 00, 00, 00, A0, 69, 62, 02, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00]")
 actor 0x5 handling 0x3::AccountStateMachine::cleanup (hash=0xDD840198DA7DE13E)
   SUCCESS
-  commit 0x3::AccountStateMachine::AccountStateMachine[0x5] := [64, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00]
+  commit 0x3::AccountStateMachine::AccountStateMachine[0x5] := Modify("[64, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00]")
 actor 0x5 handling 0x3::AccountStateMachine::xfer_deposit (hash=0xB32E0FAF108F638)
   SUCCESS
   sent 0x4 <- 0xB8229D65C5B58BBA argc=1
-  commit 0x3::AccountStateMachine::AccountStateMachine[0x5] := [78, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00]
+  commit 0x3::AccountStateMachine::AccountStateMachine[0x5] := Modify("[78, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00]")
 actor 0x4 handling 0x3::AccountStateMachine::xfer_finish (hash=0xB8229D65C5B58BBA)
   SUCCESS
   sent 0x4 <- 0x22801C54EE790BE3 argc=0
-  commit 0x3::AccountStateMachine::AccountStateMachine[0x4] := [50, 00, 00, 00, 00, 00, 00, 00, 01, 00, 00, 00, 00, 00, 00, 00, 00]
+  commit 0x3::AccountStateMachine::AccountStateMachine[0x4] := Modify("[50, 00, 00, 00, 00, 00, 00, 00, 01, 00, 00, 00, 00, 00, 00, 00, 00]")
 actor 0x4 handling 0x3::AccountStateMachine::end (hash=0x22801C54EE790BE3)
   SUCCESS
   sent 0x4 <- 0x3450A8717C6383FF argc=1

--- a/language/extensions/async/move-async-vm/tests/sources/Basic.exp
+++ b/language/extensions/async/move-async-vm/tests/sources/Basic.exp
@@ -3,30 +3,30 @@ publishing bcs
 publishing Basic
 actor 0x4 created from 0x3::Basic
   SUCCESS
-  commit 0x3::Basic::Basic[0x4] := [00, 00, 00, 00, 00, 00, 00, 00]
+  commit 0x3::Basic::Basic[0x4] := New("[00, 00, 00, 00, 00, 00, 00, 00]")
 actor 0x4 handling 0x3::Basic::start (hash=0xA9C2CD33311F2015)
   SUCCESS
   sent 0x4 <- 0x45F84510862E6905 argc=1
 actor 0x4 handling 0x3::Basic::count_down (hash=0x45F84510862E6905)
   SUCCESS
   sent 0x4 <- 0x45F84510862E6905 argc=1
-  commit 0x3::Basic::Basic[0x4] := [01, 00, 00, 00, 00, 00, 00, 00]
+  commit 0x3::Basic::Basic[0x4] := Modify("[01, 00, 00, 00, 00, 00, 00, 00]")
 actor 0x4 handling 0x3::Basic::count_down (hash=0x45F84510862E6905)
   SUCCESS
   sent 0x4 <- 0x45F84510862E6905 argc=1
-  commit 0x3::Basic::Basic[0x4] := [02, 00, 00, 00, 00, 00, 00, 00]
+  commit 0x3::Basic::Basic[0x4] := Modify("[02, 00, 00, 00, 00, 00, 00, 00]")
 actor 0x4 handling 0x3::Basic::count_down (hash=0x45F84510862E6905)
   SUCCESS
   sent 0x4 <- 0x45F84510862E6905 argc=1
-  commit 0x3::Basic::Basic[0x4] := [03, 00, 00, 00, 00, 00, 00, 00]
+  commit 0x3::Basic::Basic[0x4] := Modify("[03, 00, 00, 00, 00, 00, 00, 00]")
 actor 0x4 handling 0x3::Basic::count_down (hash=0x45F84510862E6905)
   SUCCESS
   sent 0x4 <- 0x45F84510862E6905 argc=1
-  commit 0x3::Basic::Basic[0x4] := [04, 00, 00, 00, 00, 00, 00, 00]
+  commit 0x3::Basic::Basic[0x4] := Modify("[04, 00, 00, 00, 00, 00, 00, 00]")
 actor 0x4 handling 0x3::Basic::count_down (hash=0x45F84510862E6905)
   SUCCESS
   sent 0x4 <- 0x45F84510862E6905 argc=1
-  commit 0x3::Basic::Basic[0x4] := [05, 00, 00, 00, 00, 00, 00, 00]
+  commit 0x3::Basic::Basic[0x4] := Modify("[05, 00, 00, 00, 00, 00, 00, 00]")
 actor 0x4 handling 0x3::Basic::count_down (hash=0x45F84510862E6905)
   SUCCESS
-  commit 0x3::Basic::Basic[0x4] := [05, 00, 00, 00, 00, 00, 00, 00]
+  commit 0x3::Basic::Basic[0x4] := Modify("[05, 00, 00, 00, 00, 00, 00, 00]")

--- a/language/move-vm/integration-tests/src/tests/bad_storage_tests.rs
+++ b/language/move-vm/integration-tests/src/tests/bad_storage_tests.rs
@@ -6,7 +6,7 @@ use crate::compiler::{as_module, as_script, compile_units};
 use move_binary_format::errors::{Location, PartialVMError, VMError};
 use move_core_types::{
     account_address::AccountAddress,
-    effects::ChangeSet,
+    effects::{ChangeSet, Op},
     identifier::Identifier,
     language_storage::{ModuleId, StructTag},
     resolver::{ModuleResolver, ResourceResolver},
@@ -598,8 +598,8 @@ fn test_storage_returns_bogus_error_when_loading_resource() {
     m.serialize(&mut m_blob).unwrap();
     s.serialize(&mut s_blob).unwrap();
     let mut delta = ChangeSet::new();
-    delta.publish_module(m.self_id(), m_blob).unwrap();
-    delta.publish_module(s.self_id(), s_blob).unwrap();
+    delta.add_module_op(m.self_id(), Op::New(m_blob)).unwrap();
+    delta.add_module_op(s.self_id(), Op::New(s_blob)).unwrap();
 
     let m_id = m.self_id();
     let foo_name = Identifier::new("foo").unwrap();

--- a/language/move-vm/runtime/src/data_cache.rs
+++ b/language/move-vm/runtime/src/data_cache.rs
@@ -7,7 +7,7 @@ use crate::loader::Loader;
 use move_binary_format::errors::*;
 use move_core_types::{
     account_address::AccountAddress,
-    effects::{AccountChangeSet, ChangeSet, Event},
+    effects::{AccountChangeSet, ChangeSet, Event, Op},
     identifier::Identifier,
     language_storage::{ModuleId, TypeTag},
     resolver::MoveResolver,
@@ -17,13 +17,13 @@ use move_core_types::{
 use move_vm_types::{
     data_store::DataStore,
     loaded_data::runtime_types::Type,
-    values::{GlobalValue, GlobalValueEffect, Value},
+    values::{GlobalValue, Value},
 };
 use std::collections::btree_map::BTreeMap;
 
 pub struct AccountDataCache {
     data_map: BTreeMap<Type, (MoveTypeLayout, GlobalValue)>,
-    module_map: BTreeMap<Identifier, Vec<u8>>,
+    module_map: BTreeMap<Identifier, (Vec<u8>, bool)>,
 }
 
 impl AccountDataCache {
@@ -36,7 +36,7 @@ impl AccountDataCache {
 }
 
 /// Transaction data cache. Keep updates within a transaction so they can all be published at
-/// once when the transaction succeeeds.
+/// once when the transaction succeeds.
 ///
 /// It also provides an implementation for the opcodes that refer to storage and gives the
 /// proper guarantees of reference lifetime.
@@ -75,37 +75,53 @@ impl<'r, 'l, S: MoveResolver> TransactionDataCache<'r, 'l, S> {
         let mut change_set = ChangeSet::new();
         for (addr, account_data_cache) in self.account_map.into_iter() {
             let mut modules = BTreeMap::new();
-            for (module_name, module_blob) in account_data_cache.module_map {
-                modules.insert(module_name, Some(module_blob));
+            for (module_name, (module_blob, is_republishing)) in account_data_cache.module_map {
+                let op = if is_republishing {
+                    Op::Modify(module_blob)
+                } else {
+                    Op::New(module_blob)
+                };
+                modules.insert(module_name, op);
             }
 
             let mut resources = BTreeMap::new();
             for (ty, (layout, gv)) in account_data_cache.data_map {
-                match gv.into_effect()? {
-                    GlobalValueEffect::None => (),
-                    GlobalValueEffect::Deleted => {
-                        let struct_tag = match self.loader.type_to_type_tag(&ty)? {
-                            TypeTag::Struct(struct_tag) => struct_tag,
-                            _ => return Err(PartialVMError::new(StatusCode::INTERNAL_TYPE_ERROR)),
-                        };
-                        resources.insert(struct_tag, None);
-                    }
-                    GlobalValueEffect::Changed(val) => {
-                        let struct_tag = match self.loader.type_to_type_tag(&ty)? {
-                            TypeTag::Struct(struct_tag) => struct_tag,
-                            _ => return Err(PartialVMError::new(StatusCode::INTERNAL_TYPE_ERROR)),
-                        };
+                let op = match gv.into_effect() {
+                    Some(op) => op,
+                    None => continue,
+                };
+
+                let struct_tag = match self.loader.type_to_type_tag(&ty)? {
+                    TypeTag::Struct(struct_tag) => struct_tag,
+                    _ => return Err(PartialVMError::new(StatusCode::INTERNAL_TYPE_ERROR)),
+                };
+
+                match op {
+                    Op::New(val) => {
                         let resource_blob = val
                             .simple_serialize(&layout)
                             .ok_or_else(|| PartialVMError::new(StatusCode::INTERNAL_TYPE_ERROR))?;
-                        resources.insert(struct_tag, Some(resource_blob));
+                        resources.insert(struct_tag, Op::New(resource_blob));
+                    }
+                    Op::Modify(val) => {
+                        let resource_blob = val
+                            .simple_serialize(&layout)
+                            .ok_or_else(|| PartialVMError::new(StatusCode::INTERNAL_TYPE_ERROR))?;
+                        resources.insert(struct_tag, Op::Modify(resource_blob));
+                    }
+                    Op::Delete => {
+                        resources.insert(struct_tag, Op::Delete);
                     }
                 }
             }
-            change_set.publish_or_overwrite_account_change_set(
-                addr,
-                AccountChangeSet::from_modules_resources(modules, resources),
-            );
+            if !modules.is_empty() || !resources.is_empty() {
+                change_set
+                    .add_account_changeset(
+                        addr,
+                        AccountChangeSet::from_modules_resources(modules, resources),
+                    )
+                    .expect("accounts should be unique");
+            }
         }
 
         let mut events = vec![];
@@ -207,7 +223,7 @@ impl<'r, 'l, S: MoveResolver> DataStore for TransactionDataCache<'r, 'l, S> {
 
     fn load_module(&self, module_id: &ModuleId) -> VMResult<Vec<u8>> {
         if let Some(account_cache) = self.account_map.get(module_id.address()) {
-            if let Some(blob) = account_cache.module_map.get(module_id.name()) {
+            if let Some((blob, _is_republishing)) = account_cache.module_map.get(module_id.name()) {
                 return Ok(blob.clone());
             }
         }
@@ -227,7 +243,12 @@ impl<'r, 'l, S: MoveResolver> DataStore for TransactionDataCache<'r, 'l, S> {
         }
     }
 
-    fn publish_module(&mut self, module_id: &ModuleId, blob: Vec<u8>) -> VMResult<()> {
+    fn publish_module(
+        &mut self,
+        module_id: &ModuleId,
+        blob: Vec<u8>,
+        is_republishing: bool,
+    ) -> VMResult<()> {
         let account_cache =
             Self::get_mut_or_insert_with(&mut self.account_map, module_id.address(), || {
                 (*module_id.address(), AccountDataCache::new())
@@ -235,7 +256,7 @@ impl<'r, 'l, S: MoveResolver> DataStore for TransactionDataCache<'r, 'l, S> {
 
         account_cache
             .module_map
-            .insert(module_id.name().to_owned(), blob);
+            .insert(module_id.name().to_owned(), (blob, is_republishing));
 
         Ok(())
     }

--- a/language/move-vm/runtime/src/runtime.rs
+++ b/language/move-vm/runtime/src/runtime.rs
@@ -189,12 +189,13 @@ impl VMRuntime {
 
         // All modules verified, publish them to data cache
         for (module, blob) in compiled_modules.into_iter().zip(modules.into_iter()) {
-            if data_store.exists_module(&module.self_id())? {
+            let is_republishing = data_store.exists_module(&module.self_id())?;
+            if is_republishing {
                 // This is an upgrade, so invalidate the loader cache, which still contains the
                 // old module.
                 self.loader.mark_as_invalid();
             }
-            data_store.publish_module(&module.self_id(), blob)?;
+            data_store.publish_module(&module.self_id(), blob, is_republishing)?;
         }
         Ok(())
     }

--- a/language/move-vm/types/src/data_store.rs
+++ b/language/move-vm/types/src/data_store.rs
@@ -34,7 +34,12 @@ pub trait DataStore {
     fn load_module(&self, module_id: &ModuleId) -> VMResult<Vec<u8>>;
 
     /// Publish a module.
-    fn publish_module(&mut self, module_id: &ModuleId, blob: Vec<u8>) -> VMResult<()>;
+    fn publish_module(
+        &mut self,
+        module_id: &ModuleId,
+        blob: Vec<u8>,
+        is_republishing: bool,
+    ) -> VMResult<()>;
 
     /// Check if this module exists.
     fn exists_module(&self, module_id: &ModuleId) -> VMResult<bool>;

--- a/language/testing-infra/test-generation/src/lib.rs
+++ b/language/testing-infra/test-generation/src/lib.rs
@@ -28,7 +28,7 @@ use move_bytecode_verifier::verify_module;
 use move_compiler::{compiled_unit::AnnotatedCompiledUnit, Compiler};
 use move_core_types::{
     account_address::AccountAddress,
-    effects::ChangeSet,
+    effects::{ChangeSet, Op},
     language_storage::TypeTag,
     resolver::MoveResolver,
     value::MoveValue,
@@ -133,7 +133,9 @@ fn execute_function_in_module(
         let mut changeset = ChangeSet::new();
         let mut blob = vec![];
         module.serialize(&mut blob).unwrap();
-        changeset.publish_or_overwrite_module(module_id.clone(), blob);
+        changeset
+            .add_module_op(module_id.clone(), Op::New(blob))
+            .unwrap();
         let delta_storage = DeltaStorage::new(storage, &changeset);
         let mut sess = vm.new_session(&delta_storage);
 

--- a/language/tools/move-cli/src/sandbox/commands/publish.rs
+++ b/language/tools/move-cli/src/sandbox/commands/publish.rs
@@ -141,11 +141,13 @@ pub fn publish(
             let (changeset, events) = session.finish().map_err(|e| e.into_vm_status())?;
             assert!(events.is_empty());
             if verbose {
-                explain_publish_changeset(&changeset, state);
+                explain_publish_changeset(&changeset);
             }
             let modules: Vec<_> = changeset
                 .into_modules()
-                .map(|(module_id, blob_opt)| (module_id, blob_opt.expect("must be non-deletion")))
+                .map(|(module_id, blob_opt)| {
+                    (module_id, blob_opt.ok().expect("must be non-deletion"))
+                })
                 .collect();
             state.save_modules(&modules)?;
         }

--- a/language/tools/move-unit-test/src/test_runner.rs
+++ b/language/tools/move-unit-test/src/test_runner.rs
@@ -17,7 +17,7 @@ use move_compiler::{
 };
 use move_core_types::{
     account_address::AccountAddress,
-    effects::ChangeSet,
+    effects::{ChangeSet, Op},
     gas_schedule::{GasAlgebra, GasUnits},
     identifier::IdentStr,
     value::serialize_values,
@@ -117,8 +117,8 @@ fn print_resources_and_extensions(
     for (account_addr, account_state) in cs.accounts() {
         writeln!(&mut buf, "0x{}:", account_addr.short_str_lossless())?;
 
-        for (tag, resource_opt) in account_state.resources() {
-            if let Some(resource) = resource_opt {
+        for (tag, resource_op) in account_state.resources() {
+            if let Op::New(resource) | Op::Modify(resource) = resource_op {
                 writeln!(
                     &mut buf,
                     "\t{}",


### PR DESCRIPTION
This makes a few improvements to the `ChangeSet`:
1. `Option<Vec<u8>>` gets replaced by `enum Op { New(..), Modify(..), Delete }`. This means the `ChangeSet` now differentiates writing a new entry from modifying an existing one.
2. Some old APIs with ambiguous semantics (e.g. publish_xxx) gets replaced by new ones (add_xxx). The `ChangeSet` now functions more like a delta rather than some sort of ad-hoc storage.

This change benefits tools like move-cli by providing the information they need (new vs modify). It also makes it possible to charge gas based on the number of new entries created. 