### PR TITLE
[vm] Allow to access module metadata

### DIFF
--- a/language/move-vm/runtime/src/loader.rs
+++ b/language/move-vm/runtime/src/loader.rs
@@ -24,6 +24,7 @@ use move_bytecode_verifier::{self, cyclic_dependencies, dependencies, VerifierCo
 use move_core_types::{
     identifier::{IdentStr, Identifier},
     language_storage::{ModuleId, StructTag, TypeTag},
+    metadata::Metadata,
     value::{MoveStructLayout, MoveTypeLayout},
     vm_status::StatusCode,
 };
@@ -532,6 +533,16 @@ impl Loader {
     /// Mark this cache as invalidated.
     pub(crate) fn mark_as_invalid(&self) {
         *self.invalidated.write() = true;
+    }
+
+    /// Copies metadata out of a modules bytecode if available.
+    pub(crate) fn get_metadata(&self, module: ModuleId, key: &[u8]) -> Option<Metadata> {
+        let cache = self.module_cache.read();
+        cache
+            .modules
+            .get(&module)
+            .and_then(|module| module.module.metadata.iter().find(|md| md.key == key))
+            .cloned()
     }
 
     //

--- a/language/move-vm/runtime/src/move_vm.rs
+++ b/language/move-vm/runtime/src/move_vm.rs
@@ -15,7 +15,7 @@ use move_binary_format::{
 use move_bytecode_verifier::VerifierConfig;
 use move_core_types::{
     account_address::AccountAddress, identifier::Identifier, language_storage::ModuleId,
-    resolver::MoveResolver,
+    metadata::Metadata, resolver::MoveResolver,
 };
 
 pub struct MoveVM {
@@ -104,5 +104,22 @@ impl MoveVM {
     /// TODO: new loader architecture
     pub fn get_and_clear_module_cache_hits(&self) -> BTreeSet<ModuleId> {
         self.runtime.loader().get_and_clear_module_cache_hits()
+    }
+
+    /// Attempts to discover metadata in a given module with given key. Availability
+    /// of this data may depend on multiple aspects. In general, no hard assumptions of
+    /// availability should be made, but typically, one can expect that
+    /// the modules which have been involved in the execution of the last session are available.
+    ///
+    /// This is called by an adapter to extract, for example, debug information out of
+    /// the metadata section of the code for post mortem analysis. Notice that because
+    /// of ownership of the underlying binary representation of modules hidden behind an rwlock,
+    /// this actually has to hand back a copy of the associated metadata, so metadata should
+    /// be organized keeping this in mind.
+    ///
+    /// TODO: in the new loader architecture, as the loader is visible to the adapter, one would
+    ///   call this directly via the loader instead of the VM.
+    pub fn get_module_metadata(&self, module: ModuleId, key: &[u8]) -> Option<Metadata> {
+        self.runtime.loader().get_metadata(module, key)
     }
 }


### PR DESCRIPTION
This adds an API to allow the adapter to access module metadata. Metadata can be accessed depending on whether the code is in the cache or not. No guarantees for the availability of metadata are to be expected. Once we have the code loader owned by the adapter, we can remove this API from the VM and let the adapter directly call into the loader.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Move Language.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Better debugging support

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes

## Test Plan

NA