### PR TITLE
[book] modify example for freeze of reference

### DIFF
--- a/language/documentation/book/src/references.md
+++ b/language/documentation/book/src/references.md
@@ -94,7 +94,7 @@ A mutable reference can be used in a context where an immutable reference is exp
 
 ```move
 let x = 7;
-let y: &mut u64 = &mut x;
+let y: &u64 = &mut x;
 ```
 
 This works because the under the hood, the compiler inserts `freeze` instructions where they are


### PR DESCRIPTION


## Motivation

In the  Move Book 
Chapter References [freeze inference](https://move-language.github.io/move/references.html#freeze-inference).
here may want to say the compile will automatic add a `freeze` action between 
`&x ` and `&mut x`
so change the former

`let y: &mut u64 = &mut x;`
to 
`let y: &u64 = &mut x;`
