### PR TITLE
[gas] add gas meter callbacks

### DIFF
--- a/language/extensions/async/move-async-vm/src/async_vm.rs
+++ b/language/extensions/async/move-async-vm/src/async_vm.rs
@@ -190,6 +190,7 @@ impl<'r, 'l, S: MoveResolver> AsyncSession<'r, 'l, S> {
             .vm_session
             .get_data_store()
             .load_resource(actor_addr, &state_type)
+            .map(|(gv, _)| gv)
             .map_err(partial_vm_error_to_async)?;
         if state.exists().map_err(partial_vm_error_to_async)? {
             return Err(async_extension_error(format!(
@@ -284,6 +285,7 @@ impl<'r, 'l, S: MoveResolver> AsyncSession<'r, 'l, S> {
             .vm_session
             .get_data_store()
             .load_resource(actor_addr, &state_type)
+            .map(|(gv, _)| gv)
             .map_err(partial_vm_error_to_async)?;
         let actor_state = actor_state_global
             .borrow_global()

--- a/language/extensions/move-table-extension/src/lib.rs
+++ b/language/extensions/move-table-extension/src/lib.rs
@@ -256,7 +256,8 @@ impl Table {
         self.content
             .entry(key_bytes)
             .or_insert_with(GlobalValue::none)
-            .move_to(val)?;
+            .move_to(val)
+            .map_err(|(err, _val)| err)?;
         Ok((key_size, val_size))
     }
 

--- a/language/move-vm/runtime/src/loader.rs
+++ b/language/move-vm/runtime/src/loader.rs
@@ -1344,6 +1344,7 @@ impl<'a> Resolver<'a> {
         Ok(instantiation)
     }
 
+    #[allow(unused)]
     pub(crate) fn type_params_count(&self, idx: FunctionInstantiationIndex) -> usize {
         let func_inst = match &self.binary {
             BinaryType::Module(module) => module.function_instantiation_at(idx.0),

--- a/language/move-vm/test-utils/src/storage.rs
+++ b/language/move-vm/test-utils/src/storage.rs
@@ -2,11 +2,10 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::{bail, Error, Result};
+use anyhow::{bail, Result};
 use move_core_types::{
     account_address::AccountAddress,
     effects::{AccountChangeSet, ChangeSet, Op},
-    gas_algebra::InternalGas,
     identifier::Identifier,
     language_storage::{ModuleId, StructTag},
     resolver::{ModuleResolver, MoveResolver, ResourceResolver},
@@ -17,7 +16,11 @@ use std::{
 };
 
 #[cfg(feature = "table-extension")]
-use move_table_extension::{TableChangeSet, TableHandle, TableOperation, TableResolver};
+use {
+    anyhow::Error,
+    move_core_types::gas_algebra::InternalGas,
+    move_table_extension::{TableChangeSet, TableHandle, TableOperation, TableResolver},
+};
 
 /// A dummy storage containing no modules or resources.
 #[derive(Debug, Clone)]

--- a/language/move-vm/types/src/data_store.rs
+++ b/language/move-vm/types/src/data_store.rs
@@ -8,7 +8,8 @@ use crate::{
 };
 use move_binary_format::errors::{PartialVMResult, VMResult};
 use move_core_types::{
-    account_address::AccountAddress, language_storage::ModuleId, value::MoveTypeLayout,
+    account_address::AccountAddress, gas_algebra::NumBytes, language_storage::ModuleId,
+    value::MoveTypeLayout,
 };
 
 /// Provide an implementation for bytecodes related to data with a given data store.
@@ -28,7 +29,7 @@ pub trait DataStore {
         &mut self,
         addr: AccountAddress,
         ty: &Type,
-    ) -> PartialVMResult<&mut GlobalValue>;
+    ) -> PartialVMResult<(&mut GlobalValue, Option<Option<NumBytes>>)>;
 
     /// Get the serialized format of a `CompiledModule` given a `ModuleId`.
     fn load_module(&self, module_id: &ModuleId) -> VMResult<Vec<u8>>;

--- a/language/move-vm/types/src/gas.rs
+++ b/language/move-vm/types/src/gas.rs
@@ -1,27 +1,199 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use move_binary_format::{errors::PartialVMResult, file_format_common::Opcodes};
-use move_core_types::gas_algebra::{AbstractMemorySize, InternalGas};
+use crate::views::{TypeView, ValueView};
+use move_binary_format::errors::PartialVMResult;
+use move_core_types::{
+    gas_algebra::{InternalGas, NumArgs, NumBytes},
+    language_storage::ModuleId,
+};
 
+/// Enum of instructions that do not need extra information for gas metering.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SimpleInstruction {
+    Nop,
+    Ret,
+
+    BrTrue,
+    BrFalse,
+    Branch,
+
+    Pop,
+    LdU8,
+    LdU64,
+    LdU128,
+    LdTrue,
+    LdFalse,
+
+    FreezeRef,
+    MutBorrowLoc,
+    ImmBorrowLoc,
+    ImmBorrowField,
+    MutBorrowField,
+    ImmBorrowFieldGeneric,
+    MutBorrowFieldGeneric,
+
+    CastU8,
+    CastU64,
+    CastU128,
+
+    Add,
+    Sub,
+    Mul,
+    Mod,
+    Div,
+
+    BitOr,
+    BitAnd,
+    Xor,
+    Shl,
+    Shr,
+
+    Or,
+    And,
+    Not,
+
+    Lt,
+    Gt,
+    Le,
+    Ge,
+
+    Abort,
+}
+
+/// Trait that defines a generic gas meter interface, allowing clients of the Move VM to implement
+/// their own metering scheme.
 pub trait GasMeter {
     /// Charge an instruction and fail if not enough gas units are left.
-    fn charge_instr(&mut self, opcode: Opcodes) -> PartialVMResult<()>;
+    fn charge_simple_instr(&mut self, instr: SimpleInstruction) -> PartialVMResult<()>;
 
-    /// Charge an instruction over data with a given size and fail if not enough gas units are left.
-    fn charge_instr_with_size(
+    fn charge_call(
         &mut self,
-        opcode: Opcodes,
-        size: AbstractMemorySize,
+        module_id: &ModuleId,
+        func_name: &str,
+        args: impl ExactSizeIterator<Item = impl ValueView>,
     ) -> PartialVMResult<()>;
 
-    /// Charge a given amount in the unit of measurement native to the GasMeter implementation.
+    fn charge_call_generic(
+        &mut self,
+        module_id: &ModuleId,
+        func_name: &str,
+        ty_args: impl ExactSizeIterator<Item = impl TypeView>,
+        args: impl ExactSizeIterator<Item = impl ValueView>,
+    ) -> PartialVMResult<()>;
+
+    fn charge_ld_const(&mut self, size: NumBytes) -> PartialVMResult<()>;
+
+    fn charge_copy_loc(&mut self, val: impl ValueView) -> PartialVMResult<()>;
+
+    fn charge_move_loc(&mut self, val: impl ValueView) -> PartialVMResult<()>;
+
+    fn charge_store_loc(&mut self, val: impl ValueView) -> PartialVMResult<()>;
+
+    fn charge_pack(
+        &mut self,
+        is_generic: bool,
+        args: impl ExactSizeIterator<Item = impl ValueView>,
+    ) -> PartialVMResult<()>;
+
+    fn charge_unpack(
+        &mut self,
+        is_generic: bool,
+        args: impl ExactSizeIterator<Item = impl ValueView>,
+    ) -> PartialVMResult<()>;
+
+    fn charge_read_ref(&mut self, ref_val: impl ValueView) -> PartialVMResult<()>;
+
+    fn charge_write_ref(&mut self, val: impl ValueView) -> PartialVMResult<()>;
+
+    fn charge_eq(&mut self, lhs: impl ValueView, rhs: impl ValueView) -> PartialVMResult<()>;
+
+    fn charge_neq(&mut self, lhs: impl ValueView, rhs: impl ValueView) -> PartialVMResult<()>;
+
+    fn charge_borrow_global(
+        &mut self,
+        is_mut: bool,
+        is_generic: bool,
+        ty: impl TypeView,
+        is_success: bool,
+    ) -> PartialVMResult<()>;
+
+    fn charge_exists(
+        &mut self,
+        is_generic: bool,
+        ty: impl TypeView,
+        // TODO(Gas): see if we can get rid of this param
+        exists: bool,
+    ) -> PartialVMResult<()>;
+
+    fn charge_move_from(
+        &mut self,
+        is_generic: bool,
+        ty: impl TypeView,
+        val: Option<impl ValueView>,
+    ) -> PartialVMResult<()>;
+
+    fn charge_move_to(
+        &mut self,
+        is_generic: bool,
+        ty: impl TypeView,
+        val: impl ValueView,
+        is_success: bool,
+    ) -> PartialVMResult<()>;
+
+    fn charge_vec_pack<'a>(
+        &mut self,
+        ty: impl TypeView + 'a,
+        args: impl ExactSizeIterator<Item = impl ValueView>,
+    ) -> PartialVMResult<()>;
+
+    fn charge_vec_len(&mut self, ty: impl TypeView) -> PartialVMResult<()>;
+
+    fn charge_vec_borrow(
+        &mut self,
+        is_mut: bool,
+        ty: impl TypeView,
+        is_success: bool,
+    ) -> PartialVMResult<()>;
+
+    fn charge_vec_push_back(
+        &mut self,
+        ty: impl TypeView,
+        val: impl ValueView,
+    ) -> PartialVMResult<()>;
+
+    fn charge_vec_pop_back(
+        &mut self,
+        ty: impl TypeView,
+        val: Option<impl ValueView>,
+    ) -> PartialVMResult<()>;
+
+    // TODO(Gas): Expose the elements
+    fn charge_vec_unpack(
+        &mut self,
+        ty: impl TypeView,
+        expect_num_elements: NumArgs,
+    ) -> PartialVMResult<()>;
+
+    // TODO(Gas): Expose the two elements
+    fn charge_vec_swap(&mut self, ty: impl TypeView) -> PartialVMResult<()>;
+
+    /// Charges for loading a resource from storage. This is only called when the resource is not
+    /// cached.
+    /// - `Some(n)` means `n` bytes are loaded.
+    /// - `None` means a load operation is performed but the resource does not exist.
+    ///
+    /// WARNING: This can be dangerous if you execute multiple user transactions in the same
+    /// session -- identical transactions can have different gas costs. Use at your own risk.
+    fn charge_load_resource(&mut self, loaded: Option<NumBytes>) -> PartialVMResult<()>;
+
+    /// Charge for executing a native function.
+    /// The cost is calculated returned by the native function implementation.
     /// Should fail if not enough gas units are left.
     ///
-    /// This is used for metering native functions currently.
-    /// However, in the future, we may want to remove this and directly pass a reference to the GasMeter
+    /// In the future, we may want to remove this and directly pass a reference to the GasMeter
     /// instance to the native functions to allow gas to be deducted during computation.
-    fn charge_in_native_unit(&mut self, amount: InternalGas) -> PartialVMResult<()>;
+    fn charge_native_function(&mut self, amount: InternalGas) -> PartialVMResult<()>;
 }
 
 /// A dummy gas meter that does not meter anything.
@@ -29,19 +201,169 @@ pub trait GasMeter {
 pub struct UnmeteredGasMeter;
 
 impl GasMeter for UnmeteredGasMeter {
-    fn charge_instr(&mut self, _opcode: Opcodes) -> PartialVMResult<()> {
+    fn charge_simple_instr(&mut self, _instr: SimpleInstruction) -> PartialVMResult<()> {
         Ok(())
     }
 
-    fn charge_instr_with_size(
+    fn charge_call(
         &mut self,
-        _opcode: Opcodes,
-        _size: AbstractMemorySize,
+        _module_id: &ModuleId,
+        _func_name: &str,
+        _args: impl IntoIterator<Item = impl ValueView>,
     ) -> PartialVMResult<()> {
         Ok(())
     }
 
-    fn charge_in_native_unit(&mut self, _amount: InternalGas) -> PartialVMResult<()> {
+    fn charge_call_generic(
+        &mut self,
+        _module_id: &ModuleId,
+        _func_name: &str,
+        _ty_args: impl ExactSizeIterator<Item = impl TypeView>,
+        _args: impl ExactSizeIterator<Item = impl ValueView>,
+    ) -> PartialVMResult<()> {
+        Ok(())
+    }
+
+    fn charge_ld_const(&mut self, _size: NumBytes) -> PartialVMResult<()> {
+        Ok(())
+    }
+
+    fn charge_copy_loc(&mut self, _val: impl ValueView) -> PartialVMResult<()> {
+        Ok(())
+    }
+
+    fn charge_move_loc(&mut self, _val: impl ValueView) -> PartialVMResult<()> {
+        Ok(())
+    }
+
+    fn charge_store_loc(&mut self, _val: impl ValueView) -> PartialVMResult<()> {
+        Ok(())
+    }
+
+    fn charge_pack(
+        &mut self,
+        _is_generic: bool,
+        _args: impl ExactSizeIterator<Item = impl ValueView>,
+    ) -> PartialVMResult<()> {
+        Ok(())
+    }
+
+    fn charge_unpack(
+        &mut self,
+        _is_generic: bool,
+        _args: impl ExactSizeIterator<Item = impl ValueView>,
+    ) -> PartialVMResult<()> {
+        Ok(())
+    }
+
+    fn charge_read_ref(&mut self, _val: impl ValueView) -> PartialVMResult<()> {
+        Ok(())
+    }
+
+    fn charge_write_ref(&mut self, _val: impl ValueView) -> PartialVMResult<()> {
+        Ok(())
+    }
+
+    fn charge_eq(&mut self, _lhs: impl ValueView, _rhs: impl ValueView) -> PartialVMResult<()> {
+        Ok(())
+    }
+
+    fn charge_neq(&mut self, _lhs: impl ValueView, _rhs: impl ValueView) -> PartialVMResult<()> {
+        Ok(())
+    }
+
+    fn charge_borrow_global(
+        &mut self,
+        _is_mut: bool,
+        _is_generic: bool,
+        _ty: impl TypeView,
+        _is_success: bool,
+    ) -> PartialVMResult<()> {
+        Ok(())
+    }
+
+    fn charge_exists(
+        &mut self,
+        _is_generic: bool,
+        _ty: impl TypeView,
+        _exists: bool,
+    ) -> PartialVMResult<()> {
+        Ok(())
+    }
+
+    fn charge_move_from(
+        &mut self,
+        _is_generic: bool,
+        _ty: impl TypeView,
+        _val: Option<impl ValueView>,
+    ) -> PartialVMResult<()> {
+        Ok(())
+    }
+
+    fn charge_move_to(
+        &mut self,
+        _is_generic: bool,
+        _ty: impl TypeView,
+        _val: impl ValueView,
+        _is_success: bool,
+    ) -> PartialVMResult<()> {
+        Ok(())
+    }
+
+    fn charge_vec_pack<'a>(
+        &mut self,
+        _ty: impl TypeView + 'a,
+        _args: impl ExactSizeIterator<Item = impl ValueView>,
+    ) -> PartialVMResult<()> {
+        Ok(())
+    }
+
+    fn charge_vec_len(&mut self, _ty: impl TypeView) -> PartialVMResult<()> {
+        Ok(())
+    }
+
+    fn charge_vec_borrow(
+        &mut self,
+        _is_mut: bool,
+        _ty: impl TypeView,
+        _is_success: bool,
+    ) -> PartialVMResult<()> {
+        Ok(())
+    }
+
+    fn charge_vec_push_back(
+        &mut self,
+        _ty: impl TypeView,
+        _val: impl ValueView,
+    ) -> PartialVMResult<()> {
+        Ok(())
+    }
+
+    fn charge_vec_pop_back(
+        &mut self,
+        _ty: impl TypeView,
+        _val: Option<impl ValueView>,
+    ) -> PartialVMResult<()> {
+        Ok(())
+    }
+
+    fn charge_vec_unpack(
+        &mut self,
+        _ty: impl TypeView,
+        _expect_num_elements: NumArgs,
+    ) -> PartialVMResult<()> {
+        Ok(())
+    }
+
+    fn charge_vec_swap(&mut self, _ty: impl TypeView) -> PartialVMResult<()> {
+        Ok(())
+    }
+
+    fn charge_load_resource(&mut self, _loaded: Option<NumBytes>) -> PartialVMResult<()> {
+        Ok(())
+    }
+
+    fn charge_native_function(&mut self, _amount: InternalGas) -> PartialVMResult<()> {
         Ok(())
     }
 }

--- a/language/move-vm/types/src/lib.rs
+++ b/language/move-vm/types/src/lib.rs
@@ -27,6 +27,7 @@ pub mod gas;
 pub mod loaded_data;
 pub mod natives;
 pub mod values;
+pub mod views;
 
 #[cfg(test)]
 mod unit_tests;

--- a/language/move-vm/types/src/views.rs
+++ b/language/move-vm/types/src/views.rs
@@ -1,0 +1,43 @@
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use move_core_types::{gas_algebra::AbstractMemorySize, language_storage::TypeTag};
+
+/// Trait that provides an abstract view into a Move type.
+///
+/// This is used to expose certain info to clients (e.g. the gas meter),
+/// usually in a lazily evaluated fashion.
+pub trait TypeView {
+    /// Returns the `TypeTag` (fully qualified name) of the type.
+    fn to_type_tag(&self) -> TypeTag;
+}
+
+/// Trait that provides an abstract view into a Move Value.
+///
+/// This is used to expose certain info to clients (e.g. the gas meter),
+/// usually in a lazily evaluated fashion.
+pub trait ValueView {
+    /// Returns the abstract memory size of the value.
+    ///
+    /// The concept of abstract memory size is not well-defined and is only kept for backward compatibility.
+    /// New applications should avoid using this.
+    fn legacy_abstract_memory_size(&self) -> AbstractMemorySize;
+}
+
+impl<T> ValueView for &T
+where
+    T: ValueView,
+{
+    fn legacy_abstract_memory_size(&self) -> AbstractMemorySize {
+        <T as ValueView>::legacy_abstract_memory_size(*self)
+    }
+}
+
+impl<T> TypeView for &T
+where
+    T: TypeView,
+{
+    fn to_type_tag(&self) -> TypeTag {
+        <T as TypeView>::to_type_tag(*self)
+    }
+}


### PR DESCRIPTION
This extends the `GasMeter` trait with callbacks for various operations, allowing precise control. As a byproduct, this also adds two traits `TypeView` and `ValueView` which are used to expose certain info to the gas meter in a lazy fashion.

The changes are (hopefully) implemented in a backward-compatible manner, meaning that one should be able to maintain the old gas semantics if implementing the callbacks in a certain way. (See the current `GasStatus` impl for an example.)

**Note: this depends on https://github.com/move-language/move/pull/383, and please be aware that the first commit belongs to that PR.**