### PR TITLE
[gas] minor fixes and improvements to gas meter callbacks, views and move-stdlib

### DIFF
--- a/language/move-stdlib/src/natives/event.rs
+++ b/language/move-stdlib/src/natives/event.rs
@@ -8,6 +8,7 @@ use move_core_types::gas_algebra::InternalGasPerAbstractMemoryUnit;
 use move_vm_runtime::native_functions::{NativeContext, NativeFunction};
 use move_vm_types::{
     loaded_data::runtime_types::Type, natives::function::NativeResult, pop_arg, values::Value,
+    views::ValueView,
 };
 use smallvec::smallvec;
 use std::{collections::VecDeque, sync::Arc};
@@ -38,7 +39,7 @@ fn native_write_to_event_store(
     let seq_num = pop_arg!(arguments, u64);
     let guid = pop_arg!(arguments, Vec<u8>);
 
-    let cost = gas_params.unit_cost * std::cmp::max(msg.size(), 1.into());
+    let cost = gas_params.unit_cost * std::cmp::max(msg.legacy_abstract_memory_size(), 1.into());
 
     if !context.save_event(guid, seq_num, ty, msg)? {
         return Ok(NativeResult::err(cost, 0));

--- a/language/move-stdlib/src/natives/hash.rs
+++ b/language/move-stdlib/src/natives/hash.rs
@@ -22,8 +22,8 @@ use std::{collections::VecDeque, sync::Arc};
  **************************************************************************************************/
 #[derive(Debug, Clone)]
 pub struct Sha2_256GasParameters {
-    pub base_cost: InternalGas,
-    pub unit_cost: InternalGasPerByte,
+    pub base: InternalGas,
+    pub per_byte: InternalGasPerByte,
     pub legacy_min_input_len: NumBytes,
 }
 
@@ -39,8 +39,8 @@ fn native_sha2_256(
 
     let hash_arg = pop_arg!(arguments, Vec<u8>);
 
-    let cost = gas_params.base_cost
-        + gas_params.unit_cost
+    let cost = gas_params.base
+        + gas_params.per_byte
             * std::cmp::max(
                 NumBytes::new(hash_arg.len() as u64),
                 gas_params.legacy_min_input_len,
@@ -69,8 +69,8 @@ pub fn make_native_sha2_256(gas_params: Sha2_256GasParameters) -> NativeFunction
  **************************************************************************************************/
 #[derive(Debug, Clone)]
 pub struct Sha3_256GasParameters {
-    pub base_cost: InternalGas,
-    pub unit_cost: InternalGasPerByte,
+    pub base: InternalGas,
+    pub per_byte: InternalGasPerByte,
     pub legacy_min_input_len: NumBytes,
 }
 
@@ -86,8 +86,8 @@ fn native_sha3_256(
 
     let hash_arg = pop_arg!(arguments, Vec<u8>);
 
-    let cost = gas_params.base_cost
-        + gas_params.unit_cost
+    let cost = gas_params.base
+        + gas_params.per_byte
             * std::cmp::max(
                 NumBytes::new(hash_arg.len() as u64),
                 gas_params.legacy_min_input_len,

--- a/language/move-stdlib/src/natives/mod.rs
+++ b/language/move-stdlib/src/natives/mod.rs
@@ -36,70 +36,54 @@ impl GasParameters {
         Self {
             bcs: bcs::GasParameters {
                 to_bytes: bcs::ToBytesGasParameters {
-                    input_unit_cost: 0.into(),
-                    output_unit_cost: 0.into(),
+                    per_byte_serialized: 0.into(),
                     legacy_min_output_size: 0.into(),
-                    failure_cost: 0.into(),
+                    failure: 0.into(),
                 },
             },
 
             hash: hash::GasParameters {
                 sha2_256: hash::Sha2_256GasParameters {
-                    base_cost: 0.into(),
-                    unit_cost: 0.into(),
+                    base: 0.into(),
+                    per_byte: 0.into(),
                     legacy_min_input_len: 0.into(),
                 },
                 sha3_256: hash::Sha3_256GasParameters {
-                    base_cost: 0.into(),
-                    unit_cost: 0.into(),
+                    base: 0.into(),
+                    per_byte: 0.into(),
                     legacy_min_input_len: 0.into(),
                 },
             },
             signer: signer::GasParameters {
-                borrow_address: signer::BorrowAddressGasParameters {
-                    base_cost: 0.into(),
-                },
+                borrow_address: signer::BorrowAddressGasParameters { base: 0.into() },
             },
             string: string::GasParameters {
                 check_utf8: string::CheckUtf8GasParameters {
-                    base_cost: 0.into(),
-                    unit_cost: 0.into(),
+                    base: 0.into(),
+                    per_byte: 0.into(),
                 },
-                is_char_boundary: string::IsCharBoundaryGasParameters {
-                    base_cost: 0.into(),
-                },
+                is_char_boundary: string::IsCharBoundaryGasParameters { base: 0.into() },
                 sub_string: string::SubStringGasParameters {
-                    base_cost: 0.into(),
-                    unit_cost: 0.into(),
+                    base: 0.into(),
+                    per_byte: 0.into(),
                 },
                 index_of: string::IndexOfGasParameters {
-                    base_cost: 0.into(),
-                    unit_cost: 0.into(),
+                    base: 0.into(),
+                    per_byte_pattern: 0.into(),
+                    per_byte_searched: 0.into(),
                 },
             },
             vector: vector::GasParameters {
-                empty: vector::EmptyGasParameters {
-                    base_cost: 0.into(),
-                },
-                length: vector::LengthGasParameters {
-                    base_cost: 0.into(),
-                },
+                empty: vector::EmptyGasParameters { base: 0.into() },
+                length: vector::LengthGasParameters { base: 0.into() },
                 push_back: vector::PushBackGasParameters {
-                    base_cost: 0.into(),
-                    legacy_unit_cost: 0.into(),
+                    base: 0.into(),
+                    legacy_per_abstract_memory_unit: 0.into(),
                 },
-                borrow: vector::BorrowGasParameters {
-                    base_cost: 0.into(),
-                },
-                pop_back: vector::PopBackGasParameters {
-                    base_cost: 0.into(),
-                },
-                destroy_empty: vector::DestroyEmptyGasParameters {
-                    base_cost: 0.into(),
-                },
-                swap: vector::SwapGasParameters {
-                    base_cost: 0.into(),
-                },
+                borrow: vector::BorrowGasParameters { base: 0.into() },
+                pop_back: vector::PopBackGasParameters { base: 0.into() },
+                destroy_empty: vector::DestroyEmptyGasParameters { base: 0.into() },
+                swap: vector::SwapGasParameters { base: 0.into() },
             },
             #[cfg(feature = "testing")]
             unit_test: unit_test::GasParameters {

--- a/language/move-stdlib/src/natives/signer.rs
+++ b/language/move-stdlib/src/natives/signer.rs
@@ -23,7 +23,7 @@ use std::{collections::VecDeque, sync::Arc};
  **************************************************************************************************/
 #[derive(Debug, Clone)]
 pub struct BorrowAddressGasParameters {
-    pub base_cost: InternalGas,
+    pub base: InternalGas,
 }
 
 #[inline]
@@ -39,7 +39,7 @@ fn native_borrow_address(
     let signer_reference = pop_arg!(arguments, SignerRef);
 
     Ok(NativeResult::ok(
-        gas_params.base_cost,
+        gas_params.base,
         smallvec![signer_reference.borrow_signer()?],
     ))
 }

--- a/language/move-stdlib/src/natives/string.rs
+++ b/language/move-stdlib/src/natives/string.rs
@@ -32,8 +32,8 @@ use std::{collections::VecDeque, sync::Arc};
  **************************************************************************************************/
 #[derive(Debug, Clone)]
 pub struct CheckUtf8GasParameters {
-    pub base_cost: InternalGas,
-    pub unit_cost: InternalGasPerByte,
+    pub base: InternalGas,
+    pub per_byte: InternalGasPerByte,
 }
 
 fn native_check_utf8(
@@ -48,8 +48,7 @@ fn native_check_utf8(
     let ok = std::str::from_utf8(s_ref.as_slice()).is_ok();
     // TODO: extensible native cost tables
 
-    let cost =
-        gas_params.base_cost + gas_params.unit_cost * NumBytes::new(s_ref.as_slice().len() as u64);
+    let cost = gas_params.base + gas_params.per_byte * NumBytes::new(s_ref.as_slice().len() as u64);
 
     NativeResult::map_partial_vm_result_one(cost, Ok(Value::bool(ok)))
 }
@@ -70,7 +69,7 @@ pub fn make_native_check_utf8(gas_params: CheckUtf8GasParameters) -> NativeFunct
  **************************************************************************************************/
 #[derive(Debug, Clone)]
 pub struct IsCharBoundaryGasParameters {
-    pub base_cost: InternalGas,
+    pub base: InternalGas,
 }
 
 fn native_is_char_boundary(
@@ -87,7 +86,7 @@ fn native_is_char_boundary(
         // This is safe because we guarantee the bytes to be utf8.
         std::str::from_utf8_unchecked(s_ref.as_slice()).is_char_boundary(i as usize)
     };
-    NativeResult::map_partial_vm_result_one(gas_params.base_cost, Ok(Value::bool(ok)))
+    NativeResult::map_partial_vm_result_one(gas_params.base, Ok(Value::bool(ok)))
 }
 
 pub fn make_native_is_char_boundary(gas_params: IsCharBoundaryGasParameters) -> NativeFunction {
@@ -106,8 +105,8 @@ pub fn make_native_is_char_boundary(gas_params: IsCharBoundaryGasParameters) -> 
  **************************************************************************************************/
 #[derive(Debug, Clone)]
 pub struct SubStringGasParameters {
-    pub base_cost: InternalGas,
-    pub unit_cost: InternalGasPerByte,
+    pub base: InternalGas,
+    pub per_byte: InternalGasPerByte,
 }
 
 fn native_sub_string(
@@ -122,7 +121,7 @@ fn native_sub_string(
 
     if j < i {
         // TODO: what abort code should we use here?
-        return Ok(NativeResult::err(gas_params.base_cost, 1));
+        return Ok(NativeResult::err(gas_params.base, 1));
     }
 
     let s_arg = pop_arg!(args, VectorRef);
@@ -133,7 +132,7 @@ fn native_sub_string(
     };
     let v = Value::vector_u8((&s_str[i..j]).as_bytes().iter().cloned());
 
-    let cost = gas_params.base_cost + gas_params.unit_cost * NumBytes::new((j - i) as u64);
+    let cost = gas_params.base + gas_params.per_byte * NumBytes::new((j - i) as u64);
     NativeResult::map_partial_vm_result_one(cost, Ok(v))
 }
 
@@ -153,8 +152,9 @@ pub fn make_native_sub_string(gas_params: SubStringGasParameters) -> NativeFunct
  **************************************************************************************************/
 #[derive(Debug, Clone)]
 pub struct IndexOfGasParameters {
-    pub base_cost: InternalGas,
-    pub unit_cost: InternalGasPerByte,
+    pub base: InternalGas,
+    pub per_byte_pattern: InternalGasPerByte,
+    pub per_byte_searched: InternalGasPerByte,
 }
 
 fn native_index_of(
@@ -176,8 +176,9 @@ fn native_index_of(
     };
     // TODO(Gas): What is the algorithm used for the search?
     //            Ideally it should be something like KMP with O(n) time complexity...
-    let cost =
-        gas_params.base_cost + gas_params.unit_cost * NumBytes::new((pos + r_str.len()) as u64);
+    let cost = gas_params.base
+        + gas_params.per_byte_pattern * NumBytes::new(r_str.len() as u64)
+        + gas_params.per_byte_searched * NumBytes::new(pos as u64);
     NativeResult::map_partial_vm_result_one(cost, Ok(Value::u64(pos as u64)))
 }
 

--- a/language/move-stdlib/src/natives/vector.rs
+++ b/language/move-stdlib/src/natives/vector.rs
@@ -14,6 +14,7 @@ use move_vm_types::{
     natives::function::NativeResult,
     pop_arg,
     values::{Value, Vector, VectorRef},
+    views::ValueView,
 };
 use std::{collections::VecDeque, sync::Arc};
 
@@ -25,7 +26,7 @@ use std::{collections::VecDeque, sync::Arc};
  **************************************************************************************************/
 #[derive(Debug, Clone)]
 pub struct EmptyGasParameters {
-    pub base_cost: InternalGas,
+    pub base: InternalGas,
 }
 
 pub fn native_empty(
@@ -37,7 +38,7 @@ pub fn native_empty(
     debug_assert!(ty_args.len() == 1);
     debug_assert!(args.is_empty());
 
-    NativeResult::map_partial_vm_result_one(gas_params.base_cost, Vector::empty(&ty_args[0]))
+    NativeResult::map_partial_vm_result_one(gas_params.base, Vector::empty(&ty_args[0]))
 }
 
 pub fn make_native_empty(gas_params: EmptyGasParameters) -> NativeFunction {
@@ -56,7 +57,7 @@ pub fn make_native_empty(gas_params: EmptyGasParameters) -> NativeFunction {
  **************************************************************************************************/
 #[derive(Debug, Clone)]
 pub struct LengthGasParameters {
-    pub base_cost: InternalGas,
+    pub base: InternalGas,
 }
 
 pub fn native_length(
@@ -69,7 +70,7 @@ pub fn native_length(
     debug_assert!(args.len() == 1);
 
     let r = pop_arg!(args, VectorRef);
-    NativeResult::map_partial_vm_result_one(gas_params.base_cost, r.len(&ty_args[0]))
+    NativeResult::map_partial_vm_result_one(gas_params.base, r.len(&ty_args[0]))
 }
 
 pub fn make_native_length(gas_params: LengthGasParameters) -> NativeFunction {
@@ -88,8 +89,8 @@ pub fn make_native_length(gas_params: LengthGasParameters) -> NativeFunction {
  **************************************************************************************************/
 #[derive(Debug, Clone)]
 pub struct PushBackGasParameters {
-    pub base_cost: InternalGas,
-    pub legacy_unit_cost: InternalGasPerAbstractMemoryUnit,
+    pub base: InternalGas,
+    pub legacy_per_abstract_memory_unit: InternalGasPerAbstractMemoryUnit,
 }
 
 pub fn native_push_back(
@@ -104,9 +105,10 @@ pub fn native_push_back(
     let e = args.pop_back().unwrap();
     let r = pop_arg!(args, VectorRef);
 
-    let mut cost = gas_params.base_cost;
-    if gas_params.legacy_unit_cost != 0.into() {
-        cost += gas_params.legacy_unit_cost * std::cmp::max(e.size(), 1.into());
+    let mut cost = gas_params.base;
+    if gas_params.legacy_per_abstract_memory_unit != 0.into() {
+        cost += gas_params.legacy_per_abstract_memory_unit
+            * std::cmp::max(e.legacy_abstract_memory_size(), 1.into());
     }
 
     NativeResult::map_partial_vm_result_empty(cost, r.push_back(e, &ty_args[0]))
@@ -128,7 +130,7 @@ pub fn make_native_push_back(gas_params: PushBackGasParameters) -> NativeFunctio
  **************************************************************************************************/
 #[derive(Debug, Clone)]
 pub struct BorrowGasParameters {
-    pub base_cost: InternalGas,
+    pub base: InternalGas,
 }
 
 pub fn native_borrow(
@@ -143,7 +145,7 @@ pub fn native_borrow(
     let idx = pop_arg!(args, u64) as usize;
     let r = pop_arg!(args, VectorRef);
     NativeResult::map_partial_vm_result_one(
-        gas_params.base_cost,
+        gas_params.base,
         r.borrow_elem(idx, &ty_args[0])
             .map_err(native_error_to_abort),
     )
@@ -165,7 +167,7 @@ pub fn make_native_borrow(gas_params: BorrowGasParameters) -> NativeFunction {
  **************************************************************************************************/
 #[derive(Debug, Clone)]
 pub struct PopBackGasParameters {
-    pub base_cost: InternalGas,
+    pub base: InternalGas,
 }
 
 pub fn native_pop_back(
@@ -179,7 +181,7 @@ pub fn native_pop_back(
 
     let r = pop_arg!(args, VectorRef);
     NativeResult::map_partial_vm_result_one(
-        gas_params.base_cost,
+        gas_params.base,
         r.pop(&ty_args[0]).map_err(native_error_to_abort),
     )
 }
@@ -200,7 +202,7 @@ pub fn make_native_pop_back(gas_params: PopBackGasParameters) -> NativeFunction 
  **************************************************************************************************/
 #[derive(Debug, Clone)]
 pub struct DestroyEmptyGasParameters {
-    pub base_cost: InternalGas,
+    pub base: InternalGas,
 }
 
 pub fn native_destroy_empty(
@@ -214,7 +216,7 @@ pub fn native_destroy_empty(
 
     let v = pop_arg!(args, Vector);
     NativeResult::map_partial_vm_result_empty(
-        gas_params.base_cost,
+        gas_params.base,
         v.destroy_empty(&ty_args[0]).map_err(native_error_to_abort),
     )
 }
@@ -232,7 +234,7 @@ pub fn make_native_destroy_empty(gas_params: DestroyEmptyGasParameters) -> Nativ
  **************************************************************************************************/
 #[derive(Debug, Clone)]
 pub struct SwapGasParameters {
-    pub base_cost: InternalGas,
+    pub base: InternalGas,
 }
 
 pub fn native_swap(
@@ -248,7 +250,7 @@ pub fn native_swap(
     let idx1 = pop_arg!(args, u64) as usize;
     let r = pop_arg!(args, VectorRef);
     NativeResult::map_partial_vm_result_empty(
-        gas_params.base_cost,
+        gas_params.base,
         r.swap(idx1, idx2, &ty_args[0])
             .map_err(native_error_to_abort),
     )

--- a/language/move-vm/runtime/src/interpreter.rs
+++ b/language/move-vm/runtime/src/interpreter.rs
@@ -1027,7 +1027,7 @@ impl Frame {
                     }
                     Bytecode::ReadRef => {
                         let reference = interpreter.operand_stack.pop_as::<Reference>()?;
-                        gas_meter.charge_read_ref(&reference)?;
+                        gas_meter.charge_read_ref(reference.value_view())?;
                         let value = reference.read_ref()?;
                         interpreter.operand_stack.push(value)?;
                     }

--- a/language/move-vm/types/src/gas.rs
+++ b/language/move-vm/types/src/gas.rs
@@ -102,7 +102,7 @@ pub trait GasMeter {
         args: impl ExactSizeIterator<Item = impl ValueView>,
     ) -> PartialVMResult<()>;
 
-    fn charge_read_ref(&mut self, ref_val: impl ValueView) -> PartialVMResult<()>;
+    fn charge_read_ref(&mut self, val: impl ValueView) -> PartialVMResult<()>;
 
     fn charge_write_ref(&mut self, val: impl ValueView) -> PartialVMResult<()>;
 

--- a/language/move-vm/types/src/values/value_tests.rs
+++ b/language/move-vm/types/src/values/value_tests.rs
@@ -2,8 +2,9 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::values::*;
+use crate::{loaded_data::runtime_types::Type, values::*, views::*};
 use move_binary_format::errors::*;
+use move_core_types::account_address::AccountAddress;
 
 #[test]
 fn locals() -> PartialVMResult<()> {
@@ -118,6 +119,81 @@ fn global_value_non_struct() -> PartialVMResult<()> {
     locals.store_loc(0, Value::u8(0))?;
     let r = locals.borrow_loc(0)?;
     assert!(GlobalValue::cached(r).is_err());
+
+    Ok(())
+}
+
+#[test]
+fn leagacy_ref_abstract_memory_size_consistency() -> PartialVMResult<()> {
+    let mut locals = Locals::new(10);
+
+    locals.store_loc(0, Value::u128(0))?;
+    let r = locals.borrow_loc(0)?;
+    assert_eq!(r.legacy_abstract_memory_size(), r.legacy_size());
+
+    locals.store_loc(1, Value::vector_u8([1, 2, 3]))?;
+    let r = locals.borrow_loc(1)?;
+    assert_eq!(r.legacy_abstract_memory_size(), r.legacy_size());
+
+    let r: VectorRef = r.value_as()?;
+    let r = r.borrow_elem(0, &Type::U8)?;
+    assert_eq!(r.legacy_abstract_memory_size(), r.legacy_size());
+
+    locals.store_loc(2, Value::struct_(Struct::pack([])))?;
+    let r: Reference = locals.borrow_loc(2)?.value_as()?;
+    assert_eq!(r.legacy_abstract_memory_size(), r.legacy_size());
+
+    Ok(())
+}
+
+#[test]
+fn legacy_struct_abstract_memory_size_consistenty() -> PartialVMResult<()> {
+    let structs = [
+        Struct::pack([]),
+        Struct::pack([Value::struct_(Struct::pack([Value::u8(0), Value::u64(0)]))]),
+    ];
+
+    for s in &structs {
+        assert_eq!(s.legacy_abstract_memory_size(), s.legacy_size());
+    }
+
+    Ok(())
+}
+
+#[test]
+fn legacy_val_abstract_memory_size_consistency() -> PartialVMResult<()> {
+    let vals = [
+        Value::u8(0),
+        Value::u64(0),
+        Value::u128(0),
+        Value::bool(true),
+        Value::address(AccountAddress::ZERO),
+        Value::vector_u8([0, 1, 2]),
+        Value::vector_u64([]),
+        Value::vector_u128([1, 2, 3, 4]),
+        Value::struct_(Struct::pack([])),
+        Value::struct_(Struct::pack([Value::u8(0), Value::bool(false)])),
+        Value::vector_for_testing_only([]),
+        Value::vector_for_testing_only([Value::u8(0), Value::u8(1)]),
+    ];
+
+    let mut locals = Locals::new(vals.len());
+    for (idx, val) in vals.iter().enumerate() {
+        locals.store_loc(idx, val.copy_value()?)?;
+
+        let val_size_new = val.legacy_abstract_memory_size();
+        let val_size_old = val.legacy_size();
+
+        assert_eq!(val_size_new, val_size_old);
+
+        let val_size_through_ref = locals
+            .borrow_loc(idx)?
+            .value_as::<Reference>()?
+            .value_view()
+            .legacy_abstract_memory_size();
+
+        assert_eq!(val_size_through_ref, val_size_old)
+    }
 
     Ok(())
 }

--- a/language/move-vm/types/src/views.rs
+++ b/language/move-vm/types/src/views.rs
@@ -1,7 +1,10 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use move_core_types::{gas_algebra::AbstractMemorySize, language_storage::TypeTag};
+use move_core_types::{
+    account_address::AccountAddress, gas_algebra::AbstractMemorySize, language_storage::TypeTag,
+};
+use std::mem::size_of;
 
 /// Trait that provides an abstract view into a Move type.
 ///
@@ -17,11 +20,131 @@ pub trait TypeView {
 /// This is used to expose certain info to clients (e.g. the gas meter),
 /// usually in a lazily evaluated fashion.
 pub trait ValueView {
+    fn visit(&self, visitor: &mut impl ValueVisitor);
+
     /// Returns the abstract memory size of the value.
     ///
     /// The concept of abstract memory size is not well-defined and is only kept for backward compatibility.
     /// New applications should avoid using this.
-    fn legacy_abstract_memory_size(&self) -> AbstractMemorySize;
+    ///
+    /// TODO(Gas): Encourage clients to replicate this in their own repo and get this removed once
+    ///            they are done.
+    fn legacy_abstract_memory_size(&self) -> AbstractMemorySize {
+        use crate::values::{LEGACY_CONST_SIZE, LEGACY_REFERENCE_SIZE, LEGACY_STRUCT_SIZE};
+
+        struct Acc(AbstractMemorySize);
+
+        impl ValueVisitor for Acc {
+            fn visit_u8(&mut self, _depth: usize, _val: u8) {
+                self.0 += LEGACY_CONST_SIZE;
+            }
+
+            fn visit_u64(&mut self, _depth: usize, _val: u64) {
+                self.0 += LEGACY_CONST_SIZE;
+            }
+
+            fn visit_u128(&mut self, _depth: usize, _val: u128) {
+                self.0 += LEGACY_CONST_SIZE;
+            }
+
+            fn visit_bool(&mut self, _depth: usize, _val: bool) {
+                self.0 += LEGACY_CONST_SIZE;
+            }
+
+            fn visit_address(&mut self, _depth: usize, _val: AccountAddress) {
+                self.0 += AbstractMemorySize::new(AccountAddress::LENGTH as u64);
+            }
+
+            fn visit_struct(&mut self, _depth: usize, _len: usize) -> bool {
+                self.0 += LEGACY_STRUCT_SIZE;
+                true
+            }
+
+            fn visit_vec(&mut self, _depth: usize, _len: usize) -> bool {
+                self.0 += LEGACY_STRUCT_SIZE;
+                true
+            }
+
+            fn visit_vec_u8(&mut self, _depth: usize, vals: &[u8]) {
+                self.0 += ((size_of::<u8>() * vals.len()) as u64).into();
+            }
+
+            fn visit_vec_u64(&mut self, _depth: usize, vals: &[u64]) {
+                self.0 += ((size_of::<u64>() * vals.len()) as u64).into();
+            }
+
+            fn visit_vec_u128(&mut self, _depth: usize, vals: &[u128]) {
+                self.0 += ((size_of::<u128>() * vals.len()) as u64).into();
+            }
+
+            fn visit_vec_bool(&mut self, _depth: usize, vals: &[bool]) {
+                self.0 += ((size_of::<bool>() * vals.len()) as u64).into();
+            }
+
+            fn visit_vec_address(&mut self, _depth: usize, vals: &[AccountAddress]) {
+                self.0 += ((size_of::<AccountAddress>() * vals.len()) as u64).into();
+            }
+
+            fn visit_ref(&mut self, _depth: usize, _is_global: bool) -> bool {
+                self.0 += LEGACY_REFERENCE_SIZE;
+                false
+            }
+        }
+
+        let mut acc = Acc(0.into());
+        self.visit(&mut acc);
+
+        acc.0
+    }
+}
+
+/// Trait that defines a visitor that could be used to traverse a value recursively.
+pub trait ValueVisitor {
+    fn visit_u8(&mut self, depth: usize, val: u8);
+    fn visit_u64(&mut self, depth: usize, val: u64);
+    fn visit_u128(&mut self, depth: usize, val: u128);
+    fn visit_bool(&mut self, depth: usize, val: bool);
+    fn visit_address(&mut self, depth: usize, val: AccountAddress);
+
+    fn visit_struct(&mut self, depth: usize, len: usize) -> bool;
+    fn visit_vec(&mut self, depth: usize, len: usize) -> bool;
+
+    fn visit_ref(&mut self, depth: usize, is_global: bool) -> bool;
+
+    fn visit_vec_u8(&mut self, depth: usize, vals: &[u8]) {
+        self.visit_vec(depth, vals.len());
+        for val in vals {
+            self.visit_u8(depth + 1, *val);
+        }
+    }
+
+    fn visit_vec_u64(&mut self, depth: usize, vals: &[u64]) {
+        self.visit_vec(depth, vals.len());
+        for val in vals {
+            self.visit_u64(depth + 1, *val);
+        }
+    }
+
+    fn visit_vec_u128(&mut self, depth: usize, vals: &[u128]) {
+        self.visit_vec(depth, vals.len());
+        for val in vals {
+            self.visit_u128(depth + 1, *val);
+        }
+    }
+
+    fn visit_vec_bool(&mut self, depth: usize, vals: &[bool]) {
+        self.visit_vec(depth, vals.len());
+        for val in vals {
+            self.visit_bool(depth + 1, *val);
+        }
+    }
+
+    fn visit_vec_address(&mut self, depth: usize, vals: &[AccountAddress]) {
+        self.visit_vec(depth, vals.len());
+        for val in vals {
+            self.visit_address(depth + 1, *val);
+        }
+    }
 }
 
 impl<T> ValueView for &T
@@ -30,6 +153,10 @@ where
 {
     fn legacy_abstract_memory_size(&self) -> AbstractMemorySize {
         <T as ValueView>::legacy_abstract_memory_size(*self)
+    }
+
+    fn visit(&self, visitor: &mut impl ValueVisitor) {
+        <T as ValueView>::visit(*self, visitor)
     }
 }
 


### PR DESCRIPTION
This packs a few fixes and improves to various components:
1. `GasMeter::charge_read_ref` now correctly receives a view into the value being referenced instead of the reference value itself
2. `ValueView` now provides a `visit` function that would allow you to traverse the value recursively. 
  a. This is used to provide a new implementation of abstract memory size calculation
  b. The old `size()` functions are still kept, but they are used only in tests to check that the results produced by both implementations match.
  c. The plan is to (1) remove the `size()` functions once the new impl gets used in the wild for some time, (2) encourage clients to implement their own abstract memory size if they still need it and (3) remove the view-based abstract memory size impl
3. Some move-stdlib gas parameters now have shorter and more explicit names 