### PR TITLE
[move-analyzer] Added support for displaying paramter names on hover

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1238,6 +1238,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "223089cd5a4e4491f0a0dddd9933f9575123160cf96ca2bb56a690046ecf1745"
 
 [[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2 1.0.28",
+ "quote 1.0.9",
+ "syn 1.0.74",
+]
+
+[[package]]
 name = "derive_more"
 version = "0.99.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2989,6 +3000,7 @@ dependencies = [
  "clap 3.1.8",
  "codespan-reporting",
  "crossbeam",
+ "derivative",
  "dunce",
  "im",
  "lsp-server",

--- a/language/move-analyzer/Cargo.toml
+++ b/language/move-analyzer/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0.52"
 codespan-reporting = "0.11.1"
+derivative = "2.2.0"
 dunce = "1.0.2"
 im = "15.1.0"
 lsp-server = "0.5.1"


### PR DESCRIPTION
## Motivation

Recently added support for displaying function documentation in the on-hover text box exposed a mild problem - function documentation often refers to parameter names which were previously not displayed as part of the function's signature (only the types were). This PR fixes this problem:

![image](https://user-images.githubusercontent.com/1724397/185482622-481c809a-e165-4d53-8fbb-3f61e8502178.png)


This PR also includes a refactoring/fix where one of the maps used to obtain symbols information was removed in favor of the information being encoded elsewhere. An additional reason for this change was that the map was not quite implemented correctly (particularly considering upcoming changes using it: #381) as we can have multiple functions with the same name in the same (multi-module) file.

The function type used to be computed based on the signature (for definitions) or based on the call site info (for calls), and now it's computed once for definitions and referred to (by module/name combo) when needed for call.


### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes
