### PR TITLE
[table] use address for handle instead of two u128

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3665,7 +3665,6 @@ dependencies = [
  "move-vm-runtime",
  "move-vm-types",
  "once_cell",
- "serde 1.0.143",
  "sha3 0.9.1",
  "smallvec",
  "tempfile",

--- a/language/extensions/move-table-extension/Cargo.toml
+++ b/language/extensions/move-table-extension/Cargo.toml
@@ -28,4 +28,3 @@ tempfile = "3.2.0"
 #file_diff = "1.0.0"
 move-cli = { path = "../../tools/move-cli" }
 move-package = { path = "../../tools/move-package" }
-serde = "1.0.143"

--- a/language/extensions/move-table-extension/sources/Table.move
+++ b/language/extensions/move-table-extension/sources/Table.move
@@ -9,15 +9,9 @@ module extensions::table {
     const ENOT_FOUND: u64 = 101;
     const ENOT_EMPTY: u64 = 102;
 
-    /// Table handle, represents 32 bytes hash
-    struct TableHandle has store {
-        low: u128,
-        high: u128,
-    }
-
     /// Type of tables
     struct Table<phantom K: copy + drop, phantom V> has store {
-        handle: TableHandle,
+        handle: address,
         length: u64,
     }
 
@@ -104,7 +98,7 @@ module extensions::table {
 
     // Primitives which take as an additional type parameter `Box<V>`, so the implementation
     // can use this to determine serialization layout.
-    native fun new_table_handle<K, V>(): TableHandle;
+    native fun new_table_handle<K, V>(): address;
     native fun add_box<K: copy + drop, V, B>(table: &mut Table<K, V>, key: K, val: Box<V>);
     native fun borrow_box<K: copy + drop, V, B>(table: &Table<K, V>, key: K): &Box<V>;
     native fun borrow_box_mut<K: copy + drop, V, B>(table: &mut Table<K, V>, key: K): &mut Box<V>;

--- a/language/extensions/move-table-extension/tests/move_unit_tests.rs
+++ b/language/extensions/move-table-extension/tests/move_unit_tests.rs
@@ -6,7 +6,6 @@ use move_cli::base::test::{run_move_unit_tests, UnitTestResult};
 use move_core_types::account_address::AccountAddress;
 use move_table_extension::table_natives;
 use move_unit_test::UnitTestingConfig;
-use serde::Serialize;
 use std::path::PathBuf;
 use tempfile::tempdir;
 
@@ -49,22 +48,4 @@ where
     let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     path.push(relative.into());
     path
-}
-
-// ensure the TableHandle is compatible with [u8;32] in serde
-#[test]
-fn table_handle_serde() {
-    #[derive(Serialize)]
-    struct Handle {
-        low: u128,
-        high: u128,
-    }
-    let low = 123;
-    let high = 456;
-    let handle = Handle { low, high };
-    let bytes = bcs::to_bytes(&handle).unwrap();
-    let mut raw_bytes = u128::to_le_bytes(low).to_vec();
-    raw_bytes.append(&mut u128::to_le_bytes(high).to_vec());
-    assert_eq!(bytes, raw_bytes);
-    let _: [u8; 32] = bcs::from_bytes(&bytes).unwrap();
 }


### PR DESCRIPTION
Use u128 imposes huge usability problem for clients since the json returns back the Object {low: xxx, high: yyy} for the handle instead of 32 bytes.
Use address can mitigate the problem until we have u256 impl.
