### PR TITLE
[move-vm] Fix a potential deadlock bug in transitive_dep_closure

### DIFF
--- a/language/move-vm/runtime/src/loader.rs
+++ b/language/move-vm/runtime/src/loader.rs
@@ -507,14 +507,15 @@ impl Loader {
         if !visited.insert(id.clone()) {
             return;
         }
-        let entry = self.module_cache.read();
-        for dep in entry
+        let deps = self
+            .module_cache
+            .read()
             .modules
             .get(id)
             .unwrap()
             .module
-            .immediate_dependencies()
-        {
+            .immediate_dependencies();
+        for dep in deps {
             self.transitive_dep_closure(&dep, visited)
         }
     }


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Move Language.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

This PR fixes a potential deadlock bug in move-vm/runtime.
fn `transitive_dep_closure` is a recursive function, which
1. Acquires a parking_lot read-lock
2. Calls the fn itself transitively
3. The callee acquires the read-lock again!

Due to the write priority of parking_lot, when another thread tries to acquire write-lock in between step 1 and 3,
a deadlock will happen.

My fix is to limit the read-lock scope by assigning those after the read-lock to `deps`.
This way the read-lock will be dropped after the `let deps = ...` statement and will not cause deadlock.

Another possible fix involves adding `&ModuleCache` as a parameter of `transitive_dep_closure`,
and uses one read-lock before calling this fn to protect it and all the recursive callees.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes.

## Test Plan

I detected this bug via my static detector tool called lockbud.
Since the trigger of the bug usually depends on timing of scheduling, I think it is hard to detect it with a test.