### PR TITLE
[Move Prover] Support constant vector of addresses

### DIFF
--- a/language/evm/move-to-yul/src/functions.rs
+++ b/language/evm/move-to-yul/src/functions.rs
@@ -614,6 +614,7 @@ impl<'a> FunctionGenerator<'a> {
                 format!("0x{}", a.to_str_radix(16))
             }
             Constant::ByteArray(_) => "".to_string(),
+            Constant::AddressArray(_) => "".to_string(),
         };
         if !val_str.is_empty() {
             emitln!(ctx.writer, "{} := {}", dest, val_str);

--- a/language/move-model/src/ast.rs
+++ b/language/move-model/src/ast.rs
@@ -957,6 +957,7 @@ pub enum Value {
     Number(BigInt),
     Bool(bool),
     ByteArray(Vec<u8>),
+    AddressArray(Vec<BigUint>),
 }
 
 impl fmt::Display for Value {
@@ -967,6 +968,7 @@ impl fmt::Display for Value {
             Value::Bool(b) => write!(f, "{}", b),
             // TODO(tzakian): Figure out a better story for byte array displays
             Value::ByteArray(bytes) => write!(f, "{:?}", bytes),
+            Value::AddressArray(array) => write!(f, "{:?}", array),
         }
     }
 }

--- a/language/move-model/src/builder/module_builder.rs
+++ b/language/move-model/src/builder/module_builder.rs
@@ -358,8 +358,8 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
                 .unwrap();
         let mut et = ExpTranslator::new(self);
         let loc = et.to_loc(&def.loc);
-        let value = et.translate_from_move_value(&loc, &move_value);
         let ty = et.translate_type(&def.signature);
+        let value = et.translate_from_move_value(&loc, &ty, &move_value);
         et.parent
             .parent
             .define_const(qsym, ConstEntry { loc, ty, value });

--- a/language/move-prover/boogie-backend/src/boogie_helpers.rs
+++ b/language/move-prover/boogie-backend/src/boogie_helpers.rs
@@ -17,6 +17,7 @@ use move_model::{
     well_known::TABLE_TABLE,
 };
 use move_stackless_bytecode::function_target::FunctionTarget;
+use num::BigUint;
 
 pub const MAX_MAKE_VEC_ARGS: usize = 4;
 
@@ -304,6 +305,15 @@ pub fn boogie_byte_blob(_options: &BoogieOptions, val: &[u8]) -> String {
     let args = val.iter().map(|v| format!("{}", *v)).collect_vec();
     if args.is_empty() {
         "$EmptyVec'u8'()".to_string()
+    } else {
+        boogie_make_vec_from_strings(&args)
+    }
+}
+
+pub fn boogie_address_blob(_options: &BoogieOptions, val: &[BigUint]) -> String {
+    let args = val.iter().map(|v| format!("{}", *v)).collect_vec();
+    if args.is_empty() {
+        "$EmptyVec'address'()".to_string()
     } else {
         boogie_make_vec_from_strings(&args)
     }

--- a/language/move-prover/boogie-backend/src/bytecode_translator.rs
+++ b/language/move-prover/boogie-backend/src/bytecode_translator.rs
@@ -26,7 +26,7 @@ use move_stackless_bytecode::{
 
 use crate::{
     boogie_helpers::{
-        boogie_byte_blob, boogie_debug_track_abort, boogie_debug_track_local,
+        boogie_address_blob, boogie_byte_blob, boogie_debug_track_abort, boogie_debug_track_local,
         boogie_debug_track_return, boogie_equality_for_type, boogie_field_sel, boogie_field_update,
         boogie_function_name, boogie_make_vec_from_strings, boogie_modifies_memory_name,
         boogie_resource_memory_name, boogie_struct_name, boogie_temp, boogie_type,
@@ -849,6 +849,7 @@ impl<'env> FunctionTranslator<'env> {
                     Constant::U256(num) => num.to_string(),
                     Constant::Address(val) => val.to_string(),
                     Constant::ByteArray(val) => boogie_byte_blob(options, val),
+                    Constant::AddressArray(val) => boogie_address_blob(options, val),
                 };
                 let dest_str = str_local(*dest);
                 emitln!(writer, "{} := {};", dest_str, value);

--- a/language/move-prover/boogie-backend/src/spec_translator.rs
+++ b/language/move-prover/boogie-backend/src/spec_translator.rs
@@ -24,10 +24,10 @@ use move_model::{
 
 use crate::{
     boogie_helpers::{
-        boogie_byte_blob, boogie_choice_fun_name, boogie_declare_global, boogie_field_sel,
-        boogie_inst_suffix, boogie_modifies_memory_name, boogie_resource_memory_name,
-        boogie_spec_fun_name, boogie_spec_var_name, boogie_struct_name, boogie_type,
-        boogie_type_suffix, boogie_well_formed_expr,
+        boogie_address_blob, boogie_byte_blob, boogie_choice_fun_name, boogie_declare_global,
+        boogie_field_sel, boogie_inst_suffix, boogie_modifies_memory_name,
+        boogie_resource_memory_name, boogie_spec_fun_name, boogie_spec_var_name,
+        boogie_struct_name, boogie_type, boogie_type_suffix, boogie_well_formed_expr,
     },
     options::BoogieOptions,
 };
@@ -637,6 +637,7 @@ impl<'env> SpecTranslator<'env> {
             Value::Number(val) => emit!(self.writer, "{}", val),
             Value::Bool(val) => emit!(self.writer, "{}", val),
             Value::ByteArray(val) => emit!(self.writer, &boogie_byte_blob(self.options, val)),
+            Value::AddressArray(val) => emit!(self.writer, &boogie_address_blob(self.options, val)),
         }
     }
 

--- a/language/move-prover/bytecode/src/stackless_bytecode.rs
+++ b/language/move-prover/bytecode/src/stackless_bytecode.rs
@@ -93,6 +93,7 @@ pub enum Constant {
     U256(U256),
     Address(BigUint),
     ByteArray(Vec<u8>),
+    AddressArray(Vec<BigUint>),
 }
 
 /// An operation -- target of a call. This contains user functions, builtin functions, and
@@ -1122,6 +1123,13 @@ impl fmt::Display for Constant {
             U256(x) => write!(f, "{}", x)?,
             Address(x) => write!(f, "0x{}", x.to_str_radix(16))?,
             ByteArray(x) => write!(f, "{:?}", x)?,
+            AddressArray(x) => write!(
+                f,
+                "{:?}",
+                x.iter()
+                    .map(|v| format!("0x{}", v.to_str_radix(16)))
+                    .collect_vec()
+            )?,
         }
         Ok(())
     }

--- a/language/move-prover/interpreter/src/concrete/evaluator.rs
+++ b/language/move-prover/interpreter/src/concrete/evaluator.rs
@@ -246,6 +246,15 @@ impl<'env> Evaluator<'env> {
             Value::ByteArray(v) => {
                 BaseValue::mk_vector(v.iter().map(|e| BaseValue::mk_u8(*e)).collect())
             }
+            Value::AddressArray(v) => BaseValue::mk_vector(
+                v.iter()
+                    .map(|e| {
+                        BaseValue::mk_address(
+                            AccountAddress::from_hex_literal(&format!("{:#x}", e)).unwrap(),
+                        )
+                    })
+                    .collect(),
+            ),
         }
     }
 

--- a/language/move-prover/interpreter/src/concrete/player.rs
+++ b/language/move-prover/interpreter/src/concrete/player.rs
@@ -446,6 +446,17 @@ impl<'env> FunctionContext<'env> {
                 let elems = v.iter().map(|e| TypedValue::mk_u8(*e)).collect();
                 TypedValue::mk_vector(BaseType::mk_u8(), elems)
             }
+            Constant::AddressArray(v) => {
+                let elems = v
+                    .iter()
+                    .map(|e| {
+                        TypedValue::mk_address(
+                            AccountAddress::from_hex_literal(&format!("{:#x}", *e)).unwrap(),
+                        )
+                    })
+                    .collect();
+                TypedValue::mk_vector(BaseType::mk_address(), elems)
+            }
         };
         local_state.put_value_override(dst, val);
     }

--- a/language/move-prover/tests/sources/functional/consts.exp
+++ b/language/move-prover/tests/sources/functional/consts.exp
@@ -1,12 +1,38 @@
 Move prover returns: exiting with verification errors
-error: post-condition does not hold
-   ┌─ tests/sources/functional/consts.move:29:9
+error: unknown assertion failed
+   ┌─ tests/sources/functional/consts.move:43:13
    │
-29 │         ensures !result.b;
+43 │             assert BYTE_ARRAY[0] == 22;
+   │             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   =     at tests/sources/functional/consts.move:43: array_1_incorrect
+
+error: unknown assertion failed
+   ┌─ tests/sources/functional/consts.move:49:13
+   │
+49 │             assert ADDRESS_ARRAY[0] == @0x222;
+   │             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   =     at tests/sources/functional/consts.move:49: array_2_incorrect
+
+error: unknown assertion failed
+   ┌─ tests/sources/functional/consts.move:63:13
+   │
+63 │             assert v1[0] == @0x111 && v1[1] == @0x222 && v1[2] == @0x333;
+   │             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   =     at tests/sources/functional/consts.move:61: array_in_fun_incorrect
+   =         v1 = <redacted>
+   =     at tests/sources/functional/consts.move:63: array_in_fun_incorrect
+
+error: post-condition does not hold
+   ┌─ tests/sources/functional/consts.move:31:9
+   │
+31 │         ensures !result.b;
    │         ^^^^^^^^^^^^^^^^^^
    │
-   =     at tests/sources/functional/consts.move:24: init_incorrect
+   =     at tests/sources/functional/consts.move:26: init_incorrect
    =         result = <redacted>
-   =     at tests/sources/functional/consts.move:25: init_incorrect
-   =     at tests/sources/functional/consts.move:28: init_incorrect (spec)
-   =     at tests/sources/functional/consts.move:29: init_incorrect (spec)
+   =     at tests/sources/functional/consts.move:27: init_incorrect
+   =     at tests/sources/functional/consts.move:30: init_incorrect (spec)
+   =     at tests/sources/functional/consts.move:31: init_incorrect (spec)

--- a/language/move-prover/tests/sources/functional/consts.move
+++ b/language/move-prover/tests/sources/functional/consts.move
@@ -10,6 +10,8 @@ module 0x42::TestConst {
     const INIT_VAL_BOOL: bool = true;
     const ONE: u64 = 1;
     const ADDR: address = @0x2;
+    const BYTE_ARRAY: vector<u8> = vector<u8>[11, 22, 33];
+    const ADDRESS_ARRAY: vector<address> = vector<address>[@0x111, @0x222, @0x333];
 
     public fun init(): T {
         T { x: 43, b: !INIT_VAL_BOOL, a: ADDR }
@@ -29,4 +31,36 @@ module 0x42::TestConst {
         ensures !result.b;
     }
 
+    public fun array_correct() {
+        spec {
+            assert BYTE_ARRAY[0] == 11 && BYTE_ARRAY[1] == 22 && BYTE_ARRAY[2] == 33;
+            assert ADDRESS_ARRAY[0] == @0x111 && ADDRESS_ARRAY[1] == @0x222 && ADDRESS_ARRAY[2] == @0x333;
+        };
+    }
+
+    public fun array_1_incorrect() {
+        spec {
+            assert BYTE_ARRAY[0] == 22;
+        };
+    }
+
+    public fun array_2_incorrect() {
+        spec {
+            assert ADDRESS_ARRAY[0] == @0x222;
+        };
+    }
+
+    public fun array_in_fun() {
+        let v1 = vector<address> [@0x1, @0x2, @0x3];
+        spec {
+            assert v1[0] == @0x1 && v1[1] == @0x2 && v1[2] == @0x3;
+        };
+    }
+
+    public fun array_in_fun_incorrect() {
+        let v1 = vector<address> [@0x1, @0x2, @0x3];
+        spec {
+            assert v1[0] == @0x111 && v1[1] == @0x222 && v1[2] == @0x333;
+        };
+    }
 }

--- a/language/move-prover/tools/spec-flatten/src/ast_print.rs
+++ b/language/move-prover/tools/spec-flatten/src/ast_print.rs
@@ -49,6 +49,10 @@ impl SpecPrinter<'_> {
                     v.iter().map(|e| format!("{:02x}", e)).join(""),
                 )),
             },
+            Value::AddressArray(v) => Self::doc(format!(
+                "x\"{}\"",
+                v.iter().map(|e| format!("@{:#x}", e)).join(""),
+            )),
         }
     }
 


### PR DESCRIPTION
- Extended the move-model with `AddressArray` to support constant vectors of addresses
- They can be defined in `const A:vector<address> = [...]` at the module level and in `let A = vector<address>[...]` in a function body. This commit supports both cases.
- Added some test cases

## Motivation

To support constant vector of address

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes

## Test Plan

cargo test
