### PR TITLE
Support loop unrolling in Move prover backend

### DIFF
--- a/language/move-prover/boogie-backend/src/options.rs
+++ b/language/move-prover/boogie-backend/src/options.rs
@@ -242,7 +242,6 @@ impl BoogieOptions {
             add(&[f.as_str()]);
         }
         add(&[boogie_file]);
-        println!("COMMAND: {:?}", &result);
         Ok(result)
     }
 

--- a/language/move-prover/boogie-backend/src/options.rs
+++ b/language/move-prover/boogie-backend/src/options.rs
@@ -118,6 +118,8 @@ pub struct BoogieOptions {
     pub z3_trace_file: Option<String>,
     /// Options to define user-custom native funs.
     pub custom_natives: Option<CustomNativeOptions>,
+    /// Number of iterations to unroll loops.
+    pub loop_unroll: Option<u64>,
 }
 
 impl Default for BoogieOptions {
@@ -153,6 +155,7 @@ impl Default for BoogieOptions {
             vector_theory: VectorTheory::BoogieArray,
             z3_trace_file: None,
             custom_natives: None,
+            loop_unroll: None,
         }
     }
 }
@@ -206,6 +209,9 @@ impl BoogieOptions {
                 self.lazy_threshold
             )]);
         }
+        if let Some(iters) = self.loop_unroll {
+            add(&[&format!("-loopUnroll:{}", iters)]);
+        }
         add(&[&format!(
             "-vcsCores:{}",
             if self.stable_test_output {
@@ -236,6 +242,7 @@ impl BoogieOptions {
             add(&[f.as_str()]);
         }
         add(&[boogie_file]);
+        println!("COMMAND: {:?}", &result);
         Ok(result)
     }
 

--- a/language/move-prover/bytecode/src/options.rs
+++ b/language/move-prover/bytecode/src/options.rs
@@ -82,6 +82,8 @@ pub struct ProverOptions {
     pub unconditional_abort_as_inconsistency: bool,
     /// Whether to run the transformation passes for concrete interpretation (instead of proving)
     pub for_interpretation: bool,
+    /// Whether to skip loop analysis.
+    pub skip_loop_analysis: bool,
 }
 
 // add custom struct for mutation options
@@ -113,6 +115,7 @@ impl Default for ProverOptions {
             check_inconsistency: false,
             unconditional_abort_as_inconsistency: false,
             for_interpretation: false,
+            skip_loop_analysis: false,
         }
     }
 }

--- a/language/move-prover/bytecode/src/pipeline_factory.rs
+++ b/language/move-prover/bytecode/src/pipeline_factory.rs
@@ -40,7 +40,13 @@ pub fn default_pipeline_with_options(options: &ProverOptions) -> FunctionTargetP
         CleanAndOptimizeProcessor::new(),
         UsageProcessor::new(),
         VerificationAnalysisProcessor::new(),
-        LoopAnalysisProcessor::new(),
+    ];
+
+    if !options.skip_loop_analysis {
+        processors.push(LoopAnalysisProcessor::new());
+    }
+
+    processors.append(&mut vec![
         // spec instrumentation
         SpecInstrumentationProcessor::new(),
         GlobalInvariantAnalysisProcessor::new(),
@@ -49,7 +55,7 @@ pub fn default_pipeline_with_options(options: &ProverOptions) -> FunctionTargetP
         DataInvariantInstrumentationProcessor::new(),
         // monomorphization
         MonoAnalysisProcessor::new(),
-    ];
+    ]);
 
     if options.mutation {
         // pass which may do nothing


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Move Language.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Adds two new options to the Move prover:

- `prover.skip_loop_analysis`, which skips the `LoopAnalysisProcessor` in the proving pipeline
- `backend.loop_unroll`, which is an integer that specifies the `-loopUnroll` argument to Boogie

This allows simple, low iteration count loops to be proven without requiring specifying invariants.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes

## Test Plan

Ran this on my own code

