### PR TITLE
[move-model] re-use the address map produced by move compiler

### DIFF
--- a/language/move-compiler/src/shared/mod.rs
+++ b/language/move-compiler/src/shared/mod.rs
@@ -331,7 +331,7 @@ impl Flags {
         Self {
             test: false,
             verify: true,
-            shadow: false,
+            shadow: true, // allows overlapping between sources and deps
             flavor: "".to_string(),
             bytecode_version: None,
             keep_testing_functions: false,


### PR DESCRIPTION
When constructing address aliases for the move model, use the
`NamedAddressMap` produced by the compiler instead of a handwritten one.
This allows move-model (and hence move-prover) to work even when source
and deps paths are supplied in directory format (instead of via the
package system).

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Move Language.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Code consistency and maintainance

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes

## Test Plan

CI