### PR TITLE
[move-compiler] Support casting without parentheses

### DIFF
--- a/language/move-compiler/src/parser/syntax.rs
+++ b/language/move-compiler/src/parser/syntax.rs
@@ -1225,7 +1225,7 @@ fn at_end_of_exp(context: &mut Context) -> bool {
         // These are the tokens that can occur after an Exp. If the grammar
         // changes, we need to make sure that these are kept up to date and that
         // none of these tokens can occur at the beginning of an Exp.
-        Tok::Else | Tok::RBrace | Tok::RParen | Tok::Comma | Tok::Colon | Tok::Semicolon | Tok::As
+        Tok::Else | Tok::RBrace | Tok::RParen | Tok::Comma | Tok::Colon | Tok::Semicolon
     )
 }
 

--- a/language/move-compiler/src/parser/syntax.rs
+++ b/language/move-compiler/src/parser/syntax.rs
@@ -881,7 +881,6 @@ fn parse_sequence(context: &mut Context) -> Result<Sequence, Diagnostic> {
 //          | <Value>
 //          | "(" Comma<Exp> ")"
 //          | "(" <Exp> ":" <Type> ")"
-//          | "(" <Exp> "as" <Type> ")"
 //          | "{" <Sequence>
 //          | "if" "(" <Exp> ")" <Exp> "else" "{" <Exp> "}"
 //          | "if" "(" <Exp> ")" "{" <Exp> "}"

--- a/language/move-compiler/tests/move_check/typing/cast.move
+++ b/language/move-compiler/tests/move_check/typing/cast.move
@@ -19,5 +19,21 @@ module 0x8675309::M {
         let _: u8 = (340282366920938463463374607431768211455u128 as u8);
         let _: u64 = (340282366920938463463374607431768211455u128 as u64);
         let _: u128 = (340282366920938463463374607431768211455u128 as u128);
+
+        let _: u8 = 123 as u8;
+        let _: u64 = 123456 as u64;
+        let _: u128 = 123456789 as u128;
+
+        let my_num: u128 = 12345;
+        let _: u64 = mul_div_u64(
+            my_num as u64,
+            my_num as u64,
+            my_num as u64,
+        );
+    }
+
+    fun mul_div_u64(a: u64, b: u64, c: u64): u64 {
+        let result = (a as u128) * (b as u128) / (c as u128);
+        result as u64
     }
 }


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Move Language.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Easier to read and type if casts do not require enclosing parentheses.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes

## Test Plan

Updated language tests, and ran:

```
cargo test --workspace --exclude move-prover --exclude move-to-yul --exclude evm-exec-utils -- --skip prove
```

