### PR TITLE
[move-core-types] Update ModuleId Display impl to use short_str_lossless

### DIFF
--- a/language/move-bytecode-verifier/transactional-tests/tests/ability_field_requirements/unrestricted_has_resource_field.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/ability_field_requirements/unrestricted_has_resource_field.exp
@@ -1,7 +1,7 @@
 processed 1 task
 
 task 0 'publish'. lines 1-10:
-Error: Unable to publish module '00000000000000000000000000000042::Test'. Got VMError: {
+Error: Unable to publish module '0x42::Test'. Got VMError: {
     major_status: FIELD_MISSING_TYPE_ABILITY,
     sub_status: None,
     location: 0x42::Test,

--- a/language/move-bytecode-verifier/transactional-tests/tests/check_bounds/too_few_type_actuals.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/check_bounds/too_few_type_actuals.exp
@@ -1,7 +1,7 @@
 processed 1 task
 
 task 0 'publish'. lines 1-11:
-Error: Unable to publish module '00000000000000000000000000000001::M'. Got VMError: {
+Error: Unable to publish module '0x1::M'. Got VMError: {
     major_status: NUMBER_OF_TYPE_ARGUMENTS_MISMATCH,
     sub_status: None,
     location: undefined,

--- a/language/move-bytecode-verifier/transactional-tests/tests/check_bounds/too_many_type_actuals.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/check_bounds/too_many_type_actuals.exp
@@ -1,7 +1,7 @@
 processed 1 task
 
 task 0 'publish'. lines 1-11:
-Error: Unable to publish module '00000000000000000000000000000001::M'. Got VMError: {
+Error: Unable to publish module '0x1::M'. Got VMError: {
     major_status: NUMBER_OF_TYPE_ARGUMENTS_MISMATCH,
     sub_status: None,
     location: undefined,

--- a/language/move-bytecode-verifier/transactional-tests/tests/check_duplication/duplicate_field_name.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/check_duplication/duplicate_field_name.exp
@@ -1,7 +1,7 @@
 processed 1 task
 
 task 0 'publish'. lines 1-7:
-Error: Unable to publish module '00000000000000000000000000000001::M'. Got VMError: {
+Error: Unable to publish module '0x1::M'. Got VMError: {
     major_status: DUPLICATE_ELEMENT,
     sub_status: None,
     location: 0x1::M,

--- a/language/move-bytecode-verifier/transactional-tests/tests/check_duplication/duplicate_function_name.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/check_duplication/duplicate_function_name.exp
@@ -1,7 +1,7 @@
 processed 1 task
 
 task 0 'publish'. lines 1-6:
-Error: Unable to publish module '00000000000000000000000000000042::M'. Got VMError: {
+Error: Unable to publish module '0x42::M'. Got VMError: {
     major_status: DUPLICATE_ELEMENT,
     sub_status: None,
     location: 0x42::M,

--- a/language/move-bytecode-verifier/transactional-tests/tests/check_duplication/duplicate_struct_name.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/check_duplication/duplicate_struct_name.exp
@@ -1,7 +1,7 @@
 processed 1 task
 
 task 0 'publish'. lines 1-6:
-Error: Unable to publish module '00000000000000000000000000000042::M'. Got VMError: {
+Error: Unable to publish module '0x42::M'. Got VMError: {
     major_status: DUPLICATE_ELEMENT,
     sub_status: None,
     location: 0x42::M,

--- a/language/move-bytecode-verifier/transactional-tests/tests/check_duplication/empty_structs.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/check_duplication/empty_structs.exp
@@ -1,7 +1,7 @@
 processed 1 task
 
 task 0 'publish'. lines 1-6:
-Error: Unable to publish module '00000000000000000000000000000001::EmptyStruct'. Got VMError: {
+Error: Unable to publish module '0x1::EmptyStruct'. Got VMError: {
     major_status: ZERO_SIZED_STRUCT,
     sub_status: None,
     location: 0x1::EmptyStruct,

--- a/language/move-bytecode-verifier/transactional-tests/tests/check_duplication/friend_decl_duplicated.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/check_duplication/friend_decl_duplicated.exp
@@ -1,7 +1,7 @@
 processed 2 tasks
 
 task 1 'publish'. lines 5-10:
-Error: Unable to publish module '00000000000000000000000000000042::B'. Got VMError: {
+Error: Unable to publish module '0x42::B'. Got VMError: {
     major_status: DUPLICATE_ELEMENT,
     sub_status: None,
     location: 0x42::B,

--- a/language/move-bytecode-verifier/transactional-tests/tests/dependencies/access_friend_function_invalid.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/dependencies/access_friend_function_invalid.exp
@@ -1,7 +1,7 @@
 processed 2 tasks
 
 task 1 'publish'. lines 9-18:
-Error: Unable to publish module '00000000000000000000000000000042::N'. Got VMError: {
+Error: Unable to publish module '0x42::N'. Got VMError: {
     major_status: LOOKUP_FAILED,
     sub_status: None,
     location: 0x42::N,

--- a/language/move-bytecode-verifier/transactional-tests/tests/friends/friend_decl_cyclic.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/friends/friend_decl_cyclic.exp
@@ -1,7 +1,7 @@
 processed 3 tasks
 
 task 2 'publish'. lines 10-14:
-Error: Unable to publish module '00000000000000000000000000000042::A'. Got VMError: {
+Error: Unable to publish module '0x42::A'. Got VMError: {
     major_status: CYCLIC_MODULE_FRIENDSHIP,
     sub_status: None,
     location: 0x42::A,

--- a/language/move-bytecode-verifier/transactional-tests/tests/friends/friend_decl_cyclic_transitive.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/friends/friend_decl_cyclic_transitive.exp
@@ -1,7 +1,7 @@
 processed 4 tasks
 
 task 3 'publish'. lines 15-19:
-Error: Unable to publish module '00000000000000000000000000000042::A'. Got VMError: {
+Error: Unable to publish module '0x42::A'. Got VMError: {
     major_status: CYCLIC_MODULE_FRIENDSHIP,
     sub_status: None,
     location: 0x42::A,

--- a/language/move-bytecode-verifier/transactional-tests/tests/friends/friend_decl_deps.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/friends/friend_decl_deps.exp
@@ -1,7 +1,7 @@
 processed 2 tasks
 
 task 1 'publish'. lines 9-19:
-Error: Unable to publish module '00000000000000000000000000000042::M'. Got VMError: {
+Error: Unable to publish module '0x42::M'. Got VMError: {
     major_status: INVALID_FRIEND_DECL_WITH_MODULES_IN_DEPENDENCIES,
     sub_status: None,
     location: 0x42::M,

--- a/language/move-bytecode-verifier/transactional-tests/tests/friends/friend_decl_deps_transitive.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/friends/friend_decl_deps_transitive.exp
@@ -1,7 +1,7 @@
 processed 3 tasks
 
 task 2 'publish'. lines 19-29:
-Error: Unable to publish module '00000000000000000000000000000042::C'. Got VMError: {
+Error: Unable to publish module '0x42::C'. Got VMError: {
     major_status: INVALID_FRIEND_DECL_WITH_MODULES_IN_DEPENDENCIES,
     sub_status: None,
     location: 0x42::C,

--- a/language/move-bytecode-verifier/transactional-tests/tests/friends/friend_decl_different_address.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/friends/friend_decl_different_address.exp
@@ -1,7 +1,7 @@
 processed 2 tasks
 
 task 1 'publish'. lines 5-9:
-Error: Unable to publish module '00000000000000000000000000000044::N'. Got VMError: {
+Error: Unable to publish module '0x44::N'. Got VMError: {
     major_status: INVALID_FRIEND_DECL_WITH_MODULES_OUTSIDE_ACCOUNT_ADDRESS,
     sub_status: None,
     location: 0x44::N,

--- a/language/move-bytecode-verifier/transactional-tests/tests/friends/friend_decl_non_existing.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/friends/friend_decl_non_existing.exp
@@ -1,7 +1,7 @@
 processed 1 task
 
 task 0 'publish'. lines 1-5:
-Error: Unable to publish module '00000000000000000000000000000042::M'. Got VMError: {
+Error: Unable to publish module '0x42::M'. Got VMError: {
     major_status: LINKER_ERROR,
     sub_status: None,
     location: undefined,

--- a/language/move-bytecode-verifier/transactional-tests/tests/friends/friend_decl_self.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/friends/friend_decl_self.exp
@@ -1,7 +1,7 @@
 processed 1 task
 
 task 0 'publish'. lines 1-5:
-Error: Unable to publish module '00000000000000000000000000000042::M'. Got VMError: {
+Error: Unable to publish module '0x42::M'. Got VMError: {
     major_status: INVALID_FRIEND_DECL_WITH_SELF,
     sub_status: None,
     location: 0x42::M,

--- a/language/move-bytecode-verifier/transactional-tests/tests/instantiation_loops/complex_1.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/instantiation_loops/complex_1.exp
@@ -1,7 +1,7 @@
 processed 3 tasks
 
 task 0 'publish'. lines 1-51:
-Error: Unable to publish module '00000000000000000000000000000001::M'. Got VMError: {
+Error: Unable to publish module '0x1::M'. Got VMError: {
     major_status: LOOP_IN_INSTANTIATION_GRAPH,
     sub_status: None,
     location: 0x1::M,
@@ -10,7 +10,7 @@ Error: Unable to publish module '00000000000000000000000000000001::M'. Got VMErr
 }
 
 task 1 'publish'. lines 53-70:
-Error: Unable to publish module '00000000000000000000000000000001::M2'. Got VMError: {
+Error: Unable to publish module '0x1::M2'. Got VMError: {
     major_status: LOOP_IN_INSTANTIATION_GRAPH,
     sub_status: None,
     location: 0x1::M2,
@@ -19,7 +19,7 @@ Error: Unable to publish module '00000000000000000000000000000001::M2'. Got VMEr
 }
 
 task 2 'publish'. lines 72-122:
-Error: Unable to publish module '00000000000000000000000000000001::M3'. Got VMError: {
+Error: Unable to publish module '0x1::M3'. Got VMError: {
     major_status: LOOP_IN_INSTANTIATION_GRAPH,
     sub_status: None,
     location: 0x1::M3,

--- a/language/move-bytecode-verifier/transactional-tests/tests/instantiation_loops/mutually_recursive_three_args_type_con_shifting.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/instantiation_loops/mutually_recursive_three_args_type_con_shifting.exp
@@ -1,7 +1,7 @@
 processed 1 task
 
 task 0 'publish'. lines 1-23:
-Error: Unable to publish module '00000000000000000000000000000001::M'. Got VMError: {
+Error: Unable to publish module '0x1::M'. Got VMError: {
     major_status: LOOP_IN_INSTANTIATION_GRAPH,
     sub_status: None,
     location: 0x1::M,

--- a/language/move-bytecode-verifier/transactional-tests/tests/instantiation_loops/mutually_recursive_two_args_swapping_type_con.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/instantiation_loops/mutually_recursive_two_args_swapping_type_con.exp
@@ -1,7 +1,7 @@
 processed 1 task
 
 task 0 'publish'. lines 1-17:
-Error: Unable to publish module '00000000000000000000000000000001::M'. Got VMError: {
+Error: Unable to publish module '0x1::M'. Got VMError: {
     major_status: LOOP_IN_INSTANTIATION_GRAPH,
     sub_status: None,
     location: 0x1::M,

--- a/language/move-bytecode-verifier/transactional-tests/tests/instantiation_loops/mutually_recursive_type_con.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/instantiation_loops/mutually_recursive_type_con.exp
@@ -1,7 +1,7 @@
 processed 1 task
 
 task 0 'publish'. lines 1-20:
-Error: Unable to publish module '00000000000000000000000000000001::M'. Got VMError: {
+Error: Unable to publish module '0x1::M'. Got VMError: {
     major_status: LOOP_IN_INSTANTIATION_GRAPH,
     sub_status: None,
     location: 0x1::M,

--- a/language/move-bytecode-verifier/transactional-tests/tests/instantiation_loops/nested_types_1.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/instantiation_loops/nested_types_1.exp
@@ -1,7 +1,7 @@
 processed 1 task
 
 task 0 'publish'. lines 1-11:
-Error: Unable to publish module '00000000000000000000000000000001::M'. Got VMError: {
+Error: Unable to publish module '0x1::M'. Got VMError: {
     major_status: LOOP_IN_INSTANTIATION_GRAPH,
     sub_status: None,
     location: 0x1::M,

--- a/language/move-bytecode-verifier/transactional-tests/tests/instantiation_loops/nested_types_2.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/instantiation_loops/nested_types_2.exp
@@ -1,7 +1,7 @@
 processed 1 task
 
 task 0 'publish'. lines 1-13:
-Error: Unable to publish module '00000000000000000000000000000001::M'. Got VMError: {
+Error: Unable to publish module '0x1::M'. Got VMError: {
     major_status: LOOP_IN_INSTANTIATION_GRAPH,
     sub_status: None,
     location: 0x1::M,

--- a/language/move-bytecode-verifier/transactional-tests/tests/instantiation_loops/recursive_infinite_type_terminates.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/instantiation_loops/recursive_infinite_type_terminates.exp
@@ -1,7 +1,7 @@
 processed 1 task
 
 task 0 'publish'. lines 1-45:
-Error: Unable to publish module '00000000000000000000000000000001::M'. Got VMError: {
+Error: Unable to publish module '0x1::M'. Got VMError: {
     major_status: LOOP_IN_INSTANTIATION_GRAPH,
     sub_status: None,
     location: 0x1::M,

--- a/language/move-bytecode-verifier/transactional-tests/tests/instantiation_loops/recursive_one_arg_type_con.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/instantiation_loops/recursive_one_arg_type_con.exp
@@ -1,7 +1,7 @@
 processed 1 task
 
 task 0 'publish'. lines 1-13:
-Error: Unable to publish module '00000000000000000000000000000001::M'. Got VMError: {
+Error: Unable to publish module '0x1::M'. Got VMError: {
     major_status: LOOP_IN_INSTANTIATION_GRAPH,
     sub_status: None,
     location: 0x1::M,

--- a/language/move-bytecode-verifier/transactional-tests/tests/instantiation_loops/recursive_two_args_swapping_type_con.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/instantiation_loops/recursive_two_args_swapping_type_con.exp
@@ -1,7 +1,7 @@
 processed 1 task
 
 task 0 'publish'. lines 1-14:
-Error: Unable to publish module '00000000000000000000000000000001::M'. Got VMError: {
+Error: Unable to publish module '0x1::M'. Got VMError: {
     major_status: LOOP_IN_INSTANTIATION_GRAPH,
     sub_status: None,
     location: 0x1::M,

--- a/language/move-bytecode-verifier/transactional-tests/tests/instantiation_loops/two_loops.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/instantiation_loops/two_loops.exp
@@ -1,7 +1,7 @@
 processed 1 task
 
 task 0 'publish'. lines 1-20:
-Error: Unable to publish module '00000000000000000000000000000001::M'. Got VMError: {
+Error: Unable to publish module '0x1::M'. Got VMError: {
     major_status: LOOP_IN_INSTANTIATION_GRAPH,
     sub_status: None,
     location: 0x1::M,

--- a/language/move-bytecode-verifier/transactional-tests/tests/locals_safety/join_failure.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/locals_safety/join_failure.exp
@@ -1,7 +1,7 @@
 processed 5 tasks
 
 task 0 'publish'. lines 1-20:
-Error: Unable to publish module '00000000000000000000000000000001::M'. Got VMError: {
+Error: Unable to publish module '0x1::M'. Got VMError: {
     major_status: MOVELOC_UNAVAILABLE_ERROR,
     sub_status: None,
     location: 0x1::M,
@@ -10,7 +10,7 @@ Error: Unable to publish module '00000000000000000000000000000001::M'. Got VMErr
 }
 
 task 1 'publish'. lines 22-40:
-Error: Unable to publish module '00000000000000000000000000000001::M'. Got VMError: {
+Error: Unable to publish module '0x1::M'. Got VMError: {
     major_status: UNSAFE_RET_UNUSED_VALUES_WITHOUT_DROP,
     sub_status: None,
     location: 0x1::M,
@@ -19,7 +19,7 @@ Error: Unable to publish module '00000000000000000000000000000001::M'. Got VMErr
 }
 
 task 2 'publish'. lines 42-61:
-Error: Unable to publish module '00000000000000000000000000000001::M'. Got VMError: {
+Error: Unable to publish module '0x1::M'. Got VMError: {
     major_status: STLOC_UNSAFE_TO_DESTROY_ERROR,
     sub_status: None,
     location: 0x1::M,
@@ -28,7 +28,7 @@ Error: Unable to publish module '00000000000000000000000000000001::M'. Got VMErr
 }
 
 task 3 'publish'. lines 63-82:
-Error: Unable to publish module '00000000000000000000000000000001::M'. Got VMError: {
+Error: Unable to publish module '0x1::M'. Got VMError: {
     major_status: COPYLOC_UNAVAILABLE_ERROR,
     sub_status: None,
     location: 0x1::M,
@@ -37,7 +37,7 @@ Error: Unable to publish module '00000000000000000000000000000001::M'. Got VMErr
 }
 
 task 4 'publish'. lines 84-104:
-Error: Unable to publish module '00000000000000000000000000000001::M'. Got VMError: {
+Error: Unable to publish module '0x1::M'. Got VMError: {
     major_status: BORROWLOC_UNAVAILABLE_ERROR,
     sub_status: None,
     location: 0x1::M,

--- a/language/move-bytecode-verifier/transactional-tests/tests/locals_safety/vector_ops_non_droppable_resource_not_destroyed.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/locals_safety/vector_ops_non_droppable_resource_not_destroyed.exp
@@ -1,7 +1,7 @@
 processed 1 task
 
 task 0 'publish'. lines 1-10:
-Error: Unable to publish module '00000000000000000000000000000001::M'. Got VMError: {
+Error: Unable to publish module '0x1::M'. Got VMError: {
     major_status: UNSAFE_RET_UNUSED_VALUES_WITHOUT_DROP,
     sub_status: None,
     location: 0x1::M,

--- a/language/move-bytecode-verifier/transactional-tests/tests/reference_safety/assign_field_after_local.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/reference_safety/assign_field_after_local.exp
@@ -1,7 +1,7 @@
 processed 1 task
 
 task 0 'publish'. lines 1-22:
-Error: Unable to publish module '00000000000000000000000000000042::Tester'. Got VMError: {
+Error: Unable to publish module '0x42::Tester'. Got VMError: {
     major_status: WRITEREF_EXISTS_BORROW_ERROR,
     sub_status: None,
     location: 0x42::Tester,

--- a/language/move-bytecode-verifier/transactional-tests/tests/reference_safety/borrow_global_acquires_duplicate_annotation.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/reference_safety/borrow_global_acquires_duplicate_annotation.exp
@@ -1,7 +1,7 @@
 processed 1 task
 
 task 0 'publish'. lines 1-13:
-Error: Unable to publish module '00000000000000000000000000000001::A'. Got VMError: {
+Error: Unable to publish module '0x1::A'. Got VMError: {
     major_status: DUPLICATE_ACQUIRES_ANNOTATION,
     sub_status: None,
     location: 0x1::A,

--- a/language/move-bytecode-verifier/transactional-tests/tests/reference_safety/borrow_global_acquires_extraneous_annotation.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/reference_safety/borrow_global_acquires_extraneous_annotation.exp
@@ -1,7 +1,7 @@
 processed 1 task
 
 task 0 'publish'. lines 1-11:
-Error: Unable to publish module '00000000000000000000000000000001::A'. Got VMError: {
+Error: Unable to publish module '0x1::A'. Got VMError: {
     major_status: EXTRANEOUS_ACQUIRES_ANNOTATION,
     sub_status: None,
     location: 0x1::A,

--- a/language/move-bytecode-verifier/transactional-tests/tests/reference_safety/borrow_global_acquires_invalid_1.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/reference_safety/borrow_global_acquires_invalid_1.exp
@@ -1,7 +1,7 @@
 processed 1 task
 
 task 0 'publish'. lines 1-23:
-Error: Unable to publish module '00000000000000000000000000000001::A'. Got VMError: {
+Error: Unable to publish module '0x1::A'. Got VMError: {
     major_status: GLOBAL_REFERENCE_ERROR,
     sub_status: None,
     location: 0x1::A,

--- a/language/move-bytecode-verifier/transactional-tests/tests/reference_safety/borrow_global_acquires_invalid_2.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/reference_safety/borrow_global_acquires_invalid_2.exp
@@ -1,7 +1,7 @@
 processed 3 tasks
 
 task 0 'publish'. lines 1-29:
-Error: Unable to publish module '00000000000000000000000000000001::A'. Got VMError: {
+Error: Unable to publish module '0x1::A'. Got VMError: {
     major_status: GLOBAL_REFERENCE_ERROR,
     sub_status: None,
     location: 0x1::A,
@@ -10,7 +10,7 @@ Error: Unable to publish module '00000000000000000000000000000001::A'. Got VMErr
 }
 
 task 1 'publish'. lines 31-59:
-Error: Unable to publish module '00000000000000000000000000000001::A2'. Got VMError: {
+Error: Unable to publish module '0x1::A2'. Got VMError: {
     major_status: GLOBAL_REFERENCE_ERROR,
     sub_status: None,
     location: 0x1::A2,
@@ -19,7 +19,7 @@ Error: Unable to publish module '00000000000000000000000000000001::A2'. Got VMEr
 }
 
 task 2 'publish'. lines 61-89:
-Error: Unable to publish module '00000000000000000000000000000001::A2'. Got VMError: {
+Error: Unable to publish module '0x1::A2'. Got VMError: {
     major_status: GLOBAL_REFERENCE_ERROR,
     sub_status: None,
     location: 0x1::A2,

--- a/language/move-bytecode-verifier/transactional-tests/tests/reference_safety/borrow_global_acquires_invalid_3.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/reference_safety/borrow_global_acquires_invalid_3.exp
@@ -1,7 +1,7 @@
 processed 3 tasks
 
 task 0 'publish'. lines 1-33:
-Error: Unable to publish module '00000000000000000000000000000001::A'. Got VMError: {
+Error: Unable to publish module '0x1::A'. Got VMError: {
     major_status: GLOBAL_REFERENCE_ERROR,
     sub_status: None,
     location: 0x1::A,
@@ -10,7 +10,7 @@ Error: Unable to publish module '00000000000000000000000000000001::A'. Got VMErr
 }
 
 task 1 'publish'. lines 35-68:
-Error: Unable to publish module '00000000000000000000000000000001::A2'. Got VMError: {
+Error: Unable to publish module '0x1::A2'. Got VMError: {
     major_status: GLOBAL_REFERENCE_ERROR,
     sub_status: None,
     location: 0x1::A2,
@@ -19,7 +19,7 @@ Error: Unable to publish module '00000000000000000000000000000001::A2'. Got VMEr
 }
 
 task 2 'publish'. lines 70-102:
-Error: Unable to publish module '00000000000000000000000000000001::A3'. Got VMError: {
+Error: Unable to publish module '0x1::A3'. Got VMError: {
     major_status: GLOBAL_REFERENCE_ERROR,
     sub_status: None,
     location: 0x1::A3,

--- a/language/move-bytecode-verifier/transactional-tests/tests/reference_safety/borrow_global_acquires_invalid_annotation.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/reference_safety/borrow_global_acquires_invalid_annotation.exp
@@ -1,7 +1,7 @@
 processed 1 task
 
 task 0 'publish'. lines 1-12:
-Error: Unable to publish module '00000000000000000000000000000001::A'. Got VMError: {
+Error: Unable to publish module '0x1::A'. Got VMError: {
     major_status: INVALID_ACQUIRES_ANNOTATION,
     sub_status: None,
     location: 0x1::A,

--- a/language/move-bytecode-verifier/transactional-tests/tests/reference_safety/borrow_global_acquires_missing_annotation.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/reference_safety/borrow_global_acquires_missing_annotation.exp
@@ -1,7 +1,7 @@
 processed 1 task
 
 task 0 'publish'. lines 1-13:
-Error: Unable to publish module '00000000000000000000000000000001::A'. Got VMError: {
+Error: Unable to publish module '0x1::A'. Got VMError: {
     major_status: MISSING_ACQUIRES_ANNOTATION,
     sub_status: None,
     location: 0x1::A,

--- a/language/move-bytecode-verifier/transactional-tests/tests/reference_safety/borrow_global_acquires_return_reference_invalid_1.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/reference_safety/borrow_global_acquires_return_reference_invalid_1.exp
@@ -1,7 +1,7 @@
 processed 1 task
 
 task 0 'publish'. lines 1-17:
-Error: Unable to publish module '00000000000000000000000000000001::A'. Got VMError: {
+Error: Unable to publish module '0x1::A'. Got VMError: {
     major_status: UNSAFE_RET_LOCAL_OR_RESOURCE_STILL_BORROWED,
     sub_status: None,
     location: 0x1::A,

--- a/language/move-bytecode-verifier/transactional-tests/tests/reference_safety/borrow_global_bad0.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/reference_safety/borrow_global_bad0.exp
@@ -1,7 +1,7 @@
 processed 1 task
 
 task 0 'publish'. lines 1-17:
-Error: Unable to publish module '00000000000000000000000000000001::A'. Got VMError: {
+Error: Unable to publish module '0x1::A'. Got VMError: {
     major_status: GLOBAL_REFERENCE_ERROR,
     sub_status: None,
     location: 0x1::A,

--- a/language/move-bytecode-verifier/transactional-tests/tests/reference_safety/borrow_global_bad1.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/reference_safety/borrow_global_bad1.exp
@@ -1,7 +1,7 @@
 processed 1 task
 
 task 0 'publish'. lines 1-18:
-Error: Unable to publish module '00000000000000000000000000000001::A'. Got VMError: {
+Error: Unable to publish module '0x1::A'. Got VMError: {
     major_status: GLOBAL_REFERENCE_ERROR,
     sub_status: None,
     location: 0x1::A,

--- a/language/move-bytecode-verifier/transactional-tests/tests/reference_safety/borrow_global_bad2.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/reference_safety/borrow_global_bad2.exp
@@ -1,7 +1,7 @@
 processed 1 task
 
 task 0 'publish'. lines 1-19:
-Error: Unable to publish module '00000000000000000000000000000001::A'. Got VMError: {
+Error: Unable to publish module '0x1::A'. Got VMError: {
     major_status: GLOBAL_REFERENCE_ERROR,
     sub_status: None,
     location: 0x1::A,

--- a/language/move-bytecode-verifier/transactional-tests/tests/reference_safety/borrow_global_bad5.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/reference_safety/borrow_global_bad5.exp
@@ -1,7 +1,7 @@
 processed 1 task
 
 task 0 'publish'. lines 1-28:
-Error: Unable to publish module '00000000000000000000000000000001::A'. Got VMError: {
+Error: Unable to publish module '0x1::A'. Got VMError: {
     major_status: GLOBAL_REFERENCE_ERROR,
     sub_status: None,
     location: 0x1::A,

--- a/language/move-bytecode-verifier/transactional-tests/tests/reference_safety/borrow_return_mutable_borrow_bad.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/reference_safety/borrow_return_mutable_borrow_bad.exp
@@ -1,7 +1,7 @@
 processed 1 task
 
 task 0 'publish'. lines 1-16:
-Error: Unable to publish module '00000000000000000000000000000001::M'. Got VMError: {
+Error: Unable to publish module '0x1::M'. Got VMError: {
     major_status: RET_BORROWED_MUTABLE_REFERENCE_ERROR,
     sub_status: None,
     location: 0x1::M,

--- a/language/move-bytecode-verifier/transactional-tests/tests/reference_safety/copy_loc_borrowed_field_invalid.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/reference_safety/copy_loc_borrowed_field_invalid.exp
@@ -1,7 +1,7 @@
 processed 1 task
 
 task 0 'publish'. lines 1-17:
-Error: Unable to publish module '00000000000000000000000000000001::Tester'. Got VMError: {
+Error: Unable to publish module '0x1::Tester'. Got VMError: {
     major_status: COPYLOC_EXISTS_BORROW_ERROR,
     sub_status: None,
     location: 0x1::Tester,

--- a/language/move-bytecode-verifier/transactional-tests/tests/reference_safety/copy_loc_borrowed_indirect_invalid.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/reference_safety/copy_loc_borrowed_indirect_invalid.exp
@@ -1,7 +1,7 @@
 processed 1 task
 
 task 0 'publish'. lines 1-20:
-Error: Unable to publish module '00000000000000000000000000000001::Tester'. Got VMError: {
+Error: Unable to publish module '0x1::Tester'. Got VMError: {
     major_status: COPYLOC_EXISTS_BORROW_ERROR,
     sub_status: None,
     location: 0x1::Tester,

--- a/language/move-bytecode-verifier/transactional-tests/tests/reference_safety/copy_loc_borrowed_invalid.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/reference_safety/copy_loc_borrowed_invalid.exp
@@ -1,7 +1,7 @@
 processed 1 task
 
 task 0 'publish'. lines 1-13:
-Error: Unable to publish module '00000000000000000000000000000001::Tester'. Got VMError: {
+Error: Unable to publish module '0x1::Tester'. Got VMError: {
     major_status: COPYLOC_EXISTS_BORROW_ERROR,
     sub_status: None,
     location: 0x1::Tester,

--- a/language/move-bytecode-verifier/transactional-tests/tests/reference_safety/deref_eq_bad.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/reference_safety/deref_eq_bad.exp
@@ -1,7 +1,7 @@
 processed 1 task
 
 task 0 'publish'. lines 1-18:
-Error: Unable to publish module '00000000000000000000000000000001::M'. Got VMError: {
+Error: Unable to publish module '0x1::M'. Got VMError: {
     major_status: READREF_EXISTS_MUTABLE_BORROW_ERROR,
     sub_status: None,
     location: 0x1::M,

--- a/language/move-bytecode-verifier/transactional-tests/tests/reference_safety/eq_bad.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/reference_safety/eq_bad.exp
@@ -1,7 +1,7 @@
 processed 4 tasks
 
 task 0 'publish'. lines 1-13:
-Error: Unable to publish module '00000000000000000000000000000001::Tester'. Got VMError: {
+Error: Unable to publish module '0x1::Tester'. Got VMError: {
     major_status: READREF_EXISTS_MUTABLE_BORROW_ERROR,
     sub_status: None,
     location: 0x1::Tester,
@@ -10,7 +10,7 @@ Error: Unable to publish module '00000000000000000000000000000001::Tester'. Got 
 }
 
 task 1 'publish'. lines 15-27:
-Error: Unable to publish module '00000000000000000000000000000001::Tester2'. Got VMError: {
+Error: Unable to publish module '0x1::Tester2'. Got VMError: {
     major_status: READREF_EXISTS_MUTABLE_BORROW_ERROR,
     sub_status: None,
     location: 0x1::Tester2,
@@ -19,7 +19,7 @@ Error: Unable to publish module '00000000000000000000000000000001::Tester2'. Got
 }
 
 task 2 'publish'. lines 29-41:
-Error: Unable to publish module '00000000000000000000000000000001::Tester3'. Got VMError: {
+Error: Unable to publish module '0x1::Tester3'. Got VMError: {
     major_status: READREF_EXISTS_MUTABLE_BORROW_ERROR,
     sub_status: None,
     location: 0x1::Tester3,
@@ -28,7 +28,7 @@ Error: Unable to publish module '00000000000000000000000000000001::Tester3'. Got
 }
 
 task 3 'publish'. lines 43-55:
-Error: Unable to publish module '00000000000000000000000000000001::Tester4'. Got VMError: {
+Error: Unable to publish module '0x1::Tester4'. Got VMError: {
     major_status: READREF_EXISTS_MUTABLE_BORROW_ERROR,
     sub_status: None,
     location: 0x1::Tester4,

--- a/language/move-bytecode-verifier/transactional-tests/tests/reference_safety/factor_invalid_1.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/reference_safety/factor_invalid_1.exp
@@ -1,7 +1,7 @@
 processed 2 tasks
 
 task 0 'publish'. lines 1-28:
-Error: Unable to publish module '00000000000000000000000000000001::M'. Got VMError: {
+Error: Unable to publish module '0x1::M'. Got VMError: {
     major_status: CALL_BORROWED_MUTABLE_REFERENCE_ERROR,
     sub_status: None,
     location: 0x1::M,
@@ -10,7 +10,7 @@ Error: Unable to publish module '00000000000000000000000000000001::M'. Got VMErr
 }
 
 task 1 'publish'. lines 30-57:
-Error: Unable to publish module '00000000000000000000000000000001::M2'. Got VMError: {
+Error: Unable to publish module '0x1::M2'. Got VMError: {
     major_status: CALL_BORROWED_MUTABLE_REFERENCE_ERROR,
     sub_status: None,
     location: 0x1::M2,

--- a/language/move-bytecode-verifier/transactional-tests/tests/reference_safety/factor_invalid_2.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/reference_safety/factor_invalid_2.exp
@@ -1,7 +1,7 @@
 processed 1 task
 
 task 0 'publish'. lines 1-31:
-Error: Unable to publish module '00000000000000000000000000000001::M'. Got VMError: {
+Error: Unable to publish module '0x1::M'. Got VMError: {
     major_status: BORROWFIELD_EXISTS_MUTABLE_BORROW_ERROR,
     sub_status: None,
     location: 0x1::M,

--- a/language/move-bytecode-verifier/transactional-tests/tests/reference_safety/imm_borrow_global_invalid.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/reference_safety/imm_borrow_global_invalid.exp
@@ -1,7 +1,7 @@
 processed 4 tasks
 
 task 1 'publish'. lines 31-46:
-Error: Unable to publish module '00000000000000000000000000000001::Tester'. Got VMError: {
+Error: Unable to publish module '0x1::Tester'. Got VMError: {
     major_status: GLOBAL_REFERENCE_ERROR,
     sub_status: None,
     location: 0x1::Tester,
@@ -10,7 +10,7 @@ Error: Unable to publish module '00000000000000000000000000000001::Tester'. Got 
 }
 
 task 2 'publish'. lines 48-62:
-Error: Unable to publish module '00000000000000000000000000000001::Tester'. Got VMError: {
+Error: Unable to publish module '0x1::Tester'. Got VMError: {
     major_status: GLOBAL_REFERENCE_ERROR,
     sub_status: None,
     location: 0x1::Tester,
@@ -19,7 +19,7 @@ Error: Unable to publish module '00000000000000000000000000000001::Tester'. Got 
 }
 
 task 3 'publish'. lines 64-82:
-Error: Unable to publish module '00000000000000000000000000000001::Tester'. Got VMError: {
+Error: Unable to publish module '0x1::Tester'. Got VMError: {
     major_status: GLOBAL_REFERENCE_ERROR,
     sub_status: None,
     location: 0x1::Tester,

--- a/language/move-bytecode-verifier/transactional-tests/tests/reference_safety/imm_borrow_global_lossy_acquire_invalid.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/reference_safety/imm_borrow_global_lossy_acquire_invalid.exp
@@ -1,7 +1,7 @@
 processed 2 tasks
 
 task 1 'publish'. lines 32-58:
-Error: Unable to publish module '00000000000000000000000000000001::Tester'. Got VMError: {
+Error: Unable to publish module '0x1::Tester'. Got VMError: {
     major_status: GLOBAL_REFERENCE_ERROR,
     sub_status: None,
     location: 0x1::Tester,

--- a/language/move-bytecode-verifier/transactional-tests/tests/reference_safety/imm_borrow_global_requires_acquire.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/reference_safety/imm_borrow_global_requires_acquire.exp
@@ -1,7 +1,7 @@
 processed 1 task
 
 task 0 'publish'. lines 1-12:
-Error: Unable to publish module '00000000000000000000000000000001::A'. Got VMError: {
+Error: Unable to publish module '0x1::A'. Got VMError: {
     major_status: MISSING_ACQUIRES_ANNOTATION,
     sub_status: None,
     location: 0x1::A,

--- a/language/move-bytecode-verifier/transactional-tests/tests/reference_safety/imm_borrow_on_mut_invalid.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/reference_safety/imm_borrow_on_mut_invalid.exp
@@ -1,7 +1,7 @@
 processed 2 tasks
 
 task 0 'publish'. lines 1-51:
-Error: Unable to publish module '00000000000000000000000000000001::Tester'. Got VMError: {
+Error: Unable to publish module '0x1::Tester'. Got VMError: {
     major_status: BORROWFIELD_EXISTS_MUTABLE_BORROW_ERROR,
     sub_status: None,
     location: 0x1::Tester,
@@ -10,7 +10,7 @@ Error: Unable to publish module '00000000000000000000000000000001::Tester'. Got 
 }
 
 task 1 'publish'. lines 53-103:
-Error: Unable to publish module '00000000000000000000000000000001::Tester2'. Got VMError: {
+Error: Unable to publish module '0x1::Tester2'. Got VMError: {
     major_status: FREEZEREF_EXISTS_MUTABLE_BORROW_ERROR,
     sub_status: None,
     location: 0x1::Tester2,

--- a/language/move-bytecode-verifier/transactional-tests/tests/reference_safety/imm_borrow_on_mut_trivial_invalid.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/reference_safety/imm_borrow_on_mut_trivial_invalid.exp
@@ -1,7 +1,7 @@
 processed 1 task
 
 task 0 'publish'. lines 1-29:
-Error: Unable to publish module '00000000000000000000000000000001::Tester'. Got VMError: {
+Error: Unable to publish module '0x1::Tester'. Got VMError: {
     major_status: BORROWFIELD_EXISTS_MUTABLE_BORROW_ERROR,
     sub_status: None,
     location: 0x1::Tester,

--- a/language/move-bytecode-verifier/transactional-tests/tests/reference_safety/mutable_borrow_invalid.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/reference_safety/mutable_borrow_invalid.exp
@@ -1,7 +1,7 @@
 processed 2 tasks
 
 task 0 'publish'. lines 1-19:
-Error: Unable to publish module '00000000000000000000000000000001::M'. Got VMError: {
+Error: Unable to publish module '0x1::M'. Got VMError: {
     major_status: WRITEREF_EXISTS_BORROW_ERROR,
     sub_status: None,
     location: 0x1::M,
@@ -10,7 +10,7 @@ Error: Unable to publish module '00000000000000000000000000000001::M'. Got VMErr
 }
 
 task 1 'publish'. lines 21-44:
-Error: Unable to publish module '00000000000000000000000000000001::M2'. Got VMError: {
+Error: Unable to publish module '0x1::M2'. Got VMError: {
     major_status: CALL_BORROWED_MUTABLE_REFERENCE_ERROR,
     sub_status: None,
     location: 0x1::M2,

--- a/language/move-bytecode-verifier/transactional-tests/tests/reference_safety/mutable_borrow_local_twice_invalid.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/reference_safety/mutable_borrow_local_twice_invalid.exp
@@ -1,7 +1,7 @@
 processed 1 task
 
 task 0 'publish'. lines 1-17:
-Error: Unable to publish module '00000000000000000000000000000001::M'. Got VMError: {
+Error: Unable to publish module '0x1::M'. Got VMError: {
     major_status: WRITEREF_EXISTS_BORROW_ERROR,
     sub_status: None,
     location: 0x1::M,

--- a/language/move-bytecode-verifier/transactional-tests/tests/reference_safety/mutate_resource_holder.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/reference_safety/mutate_resource_holder.exp
@@ -1,7 +1,7 @@
 processed 1 task
 
 task 0 'publish'. lines 1-11:
-Error: Unable to publish module '00000000000000000000000000000042::A'. Got VMError: {
+Error: Unable to publish module '0x42::A'. Got VMError: {
     major_status: WRITEREF_WITHOUT_DROP_ABILITY,
     sub_status: None,
     location: 0x42::A,

--- a/language/move-bytecode-verifier/transactional-tests/tests/reference_safety/mutate_with_borrowed_loc_invalid.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/reference_safety/mutate_with_borrowed_loc_invalid.exp
@@ -1,7 +1,7 @@
 processed 1 task
 
 task 0 'publish'. lines 1-13:
-Error: Unable to publish module '00000000000000000000000000000001::M'. Got VMError: {
+Error: Unable to publish module '0x1::M'. Got VMError: {
     major_status: STLOC_UNSAFE_TO_DESTROY_ERROR,
     sub_status: None,
     location: 0x1::M,

--- a/language/move-bytecode-verifier/transactional-tests/tests/reference_safety/mutate_with_borrowed_loc_struct_invalid.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/reference_safety/mutate_with_borrowed_loc_struct_invalid.exp
@@ -1,7 +1,7 @@
 processed 2 tasks
 
 task 0 'publish'. lines 1-17:
-Error: Unable to publish module '00000000000000000000000000000001::M'. Got VMError: {
+Error: Unable to publish module '0x1::M'. Got VMError: {
     major_status: STLOC_UNSAFE_TO_DESTROY_ERROR,
     sub_status: None,
     location: 0x1::M,
@@ -10,7 +10,7 @@ Error: Unable to publish module '00000000000000000000000000000001::M'. Got VMErr
 }
 
 task 1 'publish'. lines 19-35:
-Error: Unable to publish module '00000000000000000000000000000001::N'. Got VMError: {
+Error: Unable to publish module '0x1::N'. Got VMError: {
     major_status: STLOC_UNSAFE_TO_DESTROY_ERROR,
     sub_status: None,
     location: 0x1::N,

--- a/language/move-bytecode-verifier/transactional-tests/tests/reference_safety/read_field_after_assign_local.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/reference_safety/read_field_after_assign_local.exp
@@ -1,7 +1,7 @@
 processed 1 task
 
 task 0 'publish'. lines 1-21:
-Error: Unable to publish module '00000000000000000000000000000042::Tester'. Got VMError: {
+Error: Unable to publish module '0x42::Tester'. Got VMError: {
     major_status: WRITEREF_EXISTS_BORROW_ERROR,
     sub_status: None,
     location: 0x42::Tester,

--- a/language/move-bytecode-verifier/transactional-tests/tests/reference_safety/return_local_ref.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/reference_safety/return_local_ref.exp
@@ -1,7 +1,7 @@
 processed 1 task
 
 task 0 'publish'. lines 1-12:
-Error: Unable to publish module '00000000000000000000000000000042::Tester'. Got VMError: {
+Error: Unable to publish module '0x42::Tester'. Got VMError: {
     major_status: UNSAFE_RET_LOCAL_OR_RESOURCE_STILL_BORROWED,
     sub_status: None,
     location: 0x42::Tester,

--- a/language/move-bytecode-verifier/transactional-tests/tests/reference_safety/return_with_borrowed_loc_invalid.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/reference_safety/return_with_borrowed_loc_invalid.exp
@@ -1,7 +1,7 @@
 processed 4 tasks
 
 task 0 'publish'. lines 1-15:
-Error: Unable to publish module '00000000000000000000000000000001::M'. Got VMError: {
+Error: Unable to publish module '0x1::M'. Got VMError: {
     major_status: UNSAFE_RET_LOCAL_OR_RESOURCE_STILL_BORROWED,
     sub_status: None,
     location: 0x1::M,
@@ -10,7 +10,7 @@ Error: Unable to publish module '00000000000000000000000000000001::M'. Got VMErr
 }
 
 task 1 'publish'. lines 17-30:
-Error: Unable to publish module '00000000000000000000000000000001::M2'. Got VMError: {
+Error: Unable to publish module '0x1::M2'. Got VMError: {
     major_status: UNSAFE_RET_LOCAL_OR_RESOURCE_STILL_BORROWED,
     sub_status: None,
     location: 0x1::M2,
@@ -19,7 +19,7 @@ Error: Unable to publish module '00000000000000000000000000000001::M2'. Got VMEr
 }
 
 task 2 'publish'. lines 32-49:
-Error: Unable to publish module '00000000000000000000000000000001::M3'. Got VMError: {
+Error: Unable to publish module '0x1::M3'. Got VMError: {
     major_status: UNSAFE_RET_LOCAL_OR_RESOURCE_STILL_BORROWED,
     sub_status: None,
     location: 0x1::M3,
@@ -28,7 +28,7 @@ Error: Unable to publish module '00000000000000000000000000000001::M3'. Got VMEr
 }
 
 task 3 'publish'. lines 51-68:
-Error: Unable to publish module '00000000000000000000000000000001::M4'. Got VMError: {
+Error: Unable to publish module '0x1::M4'. Got VMError: {
     major_status: UNSAFE_RET_LOCAL_OR_RESOURCE_STILL_BORROWED,
     sub_status: None,
     location: 0x1::M4,

--- a/language/move-bytecode-verifier/transactional-tests/tests/reference_safety/return_with_borrowed_loc_resource_invalid.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/reference_safety/return_with_borrowed_loc_resource_invalid.exp
@@ -1,7 +1,7 @@
 processed 1 task
 
 task 0 'publish'. lines 1-13:
-Error: Unable to publish module '00000000000000000000000000000001::M'. Got VMError: {
+Error: Unable to publish module '0x1::M'. Got VMError: {
     major_status: UNSAFE_RET_UNUSED_VALUES_WITHOUT_DROP,
     sub_status: None,
     location: 0x1::M,

--- a/language/move-bytecode-verifier/transactional-tests/tests/reference_safety/use_after_move.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/reference_safety/use_after_move.exp
@@ -1,7 +1,7 @@
 processed 2 tasks
 
 task 1 'publish'. lines 12-37:
-Error: Unable to publish module '00000000000000000000000000000042::A'. Got VMError: {
+Error: Unable to publish module '0x42::A'. Got VMError: {
     major_status: WRITEREF_EXISTS_BORROW_ERROR,
     sub_status: None,
     location: 0x42::A,

--- a/language/move-bytecode-verifier/transactional-tests/tests/reference_safety/use_suffix_after_move.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/reference_safety/use_suffix_after_move.exp
@@ -1,7 +1,7 @@
 processed 2 tasks
 
 task 1 'publish'. lines 19-41:
-Error: Unable to publish module '00000000000000000000000000000042::A'. Got VMError: {
+Error: Unable to publish module '0x42::A'. Got VMError: {
     major_status: WRITEREF_EXISTS_BORROW_ERROR,
     sub_status: None,
     location: 0x42::A,

--- a/language/move-bytecode-verifier/transactional-tests/tests/reference_safety/writeref_borrow_invalid.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/reference_safety/writeref_borrow_invalid.exp
@@ -1,7 +1,7 @@
 processed 1 task
 
 task 0 'publish'. lines 1-17:
-Error: Unable to publish module '00000000000000000000000000000001::M'. Got VMError: {
+Error: Unable to publish module '0x1::M'. Got VMError: {
     major_status: WRITEREF_EXISTS_BORROW_ERROR,
     sub_status: None,
     location: 0x1::M,

--- a/language/move-bytecode-verifier/transactional-tests/tests/signature/all_as_resource.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/signature/all_as_resource.exp
@@ -1,7 +1,7 @@
 processed 1 task
 
 task 0 'publish'. lines 1-11:
-Error: Unable to publish module '00000000000000000000000000000001::M'. Got VMError: {
+Error: Unable to publish module '0x1::M'. Got VMError: {
     major_status: CONSTRAINT_NOT_SATISFIED,
     sub_status: None,
     location: 0x1::M,

--- a/language/move-bytecode-verifier/transactional-tests/tests/signature/all_as_unrestricted.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/signature/all_as_unrestricted.exp
@@ -1,7 +1,7 @@
 processed 1 task
 
 task 0 'publish'. lines 1-11:
-Error: Unable to publish module '00000000000000000000000000000001::M'. Got VMError: {
+Error: Unable to publish module '0x1::M'. Got VMError: {
     major_status: CONSTRAINT_NOT_SATISFIED,
     sub_status: None,
     location: 0x1::M,

--- a/language/move-bytecode-verifier/transactional-tests/tests/signature/reference_as_type_actual_for_bytecode_instruction.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/signature/reference_as_type_actual_for_bytecode_instruction.exp
@@ -1,7 +1,7 @@
 processed 1 task
 
 task 0 'publish'. lines 1-14:
-Error: Unable to publish module '00000000000000000000000000000001::M'. Got VMError: {
+Error: Unable to publish module '0x1::M'. Got VMError: {
     major_status: INVALID_SIGNATURE_TOKEN,
     sub_status: None,
     location: 0x1::M,

--- a/language/move-bytecode-verifier/transactional-tests/tests/signature/reference_as_type_actual_for_struct.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/signature/reference_as_type_actual_for_struct.exp
@@ -1,7 +1,7 @@
 processed 1 task
 
 task 0 'publish'. lines 1-11:
-Error: Unable to publish module '00000000000000000000000000000001::M'. Got VMError: {
+Error: Unable to publish module '0x1::M'. Got VMError: {
     major_status: INVALID_SIGNATURE_TOKEN,
     sub_status: None,
     location: 0x1::M,

--- a/language/move-bytecode-verifier/transactional-tests/tests/signature/reference_as_type_actual_in_struct_inst_for_bytecode_instruction.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/signature/reference_as_type_actual_in_struct_inst_for_bytecode_instruction.exp
@@ -1,7 +1,7 @@
 processed 9 tasks
 
 task 0 'publish'. lines 1-13:
-Error: Unable to publish module '00000000000000000000000000000001::M'. Got VMError: {
+Error: Unable to publish module '0x1::M'. Got VMError: {
     major_status: INVALID_SIGNATURE_TOKEN,
     sub_status: None,
     location: 0x1::M,
@@ -10,7 +10,7 @@ Error: Unable to publish module '00000000000000000000000000000001::M'. Got VMErr
 }
 
 task 1 'publish'. lines 15-28:
-Error: Unable to publish module '00000000000000000000000000000001::M'. Got VMError: {
+Error: Unable to publish module '0x1::M'. Got VMError: {
     major_status: INVALID_SIGNATURE_TOKEN,
     sub_status: None,
     location: 0x1::M,
@@ -19,7 +19,7 @@ Error: Unable to publish module '00000000000000000000000000000001::M'. Got VMErr
 }
 
 task 2 'publish'. lines 30-42:
-Error: Unable to publish module '00000000000000000000000000000001::M'. Got VMError: {
+Error: Unable to publish module '0x1::M'. Got VMError: {
     major_status: INVALID_SIGNATURE_TOKEN,
     sub_status: None,
     location: 0x1::M,
@@ -28,7 +28,7 @@ Error: Unable to publish module '00000000000000000000000000000001::M'. Got VMErr
 }
 
 task 3 'publish'. lines 44-57:
-Error: Unable to publish module '00000000000000000000000000000001::M'. Got VMError: {
+Error: Unable to publish module '0x1::M'. Got VMError: {
     major_status: INVALID_SIGNATURE_TOKEN,
     sub_status: None,
     location: 0x1::M,
@@ -37,7 +37,7 @@ Error: Unable to publish module '00000000000000000000000000000001::M'. Got VMErr
 }
 
 task 4 'publish'. lines 59-70:
-Error: Unable to publish module '00000000000000000000000000000001::M'. Got VMError: {
+Error: Unable to publish module '0x1::M'. Got VMError: {
     major_status: INVALID_SIGNATURE_TOKEN,
     sub_status: None,
     location: 0x1::M,
@@ -46,7 +46,7 @@ Error: Unable to publish module '00000000000000000000000000000001::M'. Got VMErr
 }
 
 task 5 'publish'. lines 72-86:
-Error: Unable to publish module '00000000000000000000000000000001::M'. Got VMError: {
+Error: Unable to publish module '0x1::M'. Got VMError: {
     major_status: INVALID_SIGNATURE_TOKEN,
     sub_status: None,
     location: 0x1::M,
@@ -55,7 +55,7 @@ Error: Unable to publish module '00000000000000000000000000000001::M'. Got VMErr
 }
 
 task 6 'publish'. lines 88-100:
-Error: Unable to publish module '00000000000000000000000000000001::M'. Got VMError: {
+Error: Unable to publish module '0x1::M'. Got VMError: {
     major_status: INVALID_SIGNATURE_TOKEN,
     sub_status: None,
     location: 0x1::M,
@@ -64,7 +64,7 @@ Error: Unable to publish module '00000000000000000000000000000001::M'. Got VMErr
 }
 
 task 7 'publish'. lines 102-111:
-Error: Unable to publish module '00000000000000000000000000000001::M'. Got VMError: {
+Error: Unable to publish module '0x1::M'. Got VMError: {
     major_status: INVALID_SIGNATURE_TOKEN,
     sub_status: None,
     location: 0x1::M,
@@ -73,7 +73,7 @@ Error: Unable to publish module '00000000000000000000000000000001::M'. Got VMErr
 }
 
 task 8 'publish'. lines 113-122:
-Error: Unable to publish module '00000000000000000000000000000001::M'. Got VMError: {
+Error: Unable to publish module '0x1::M'. Got VMError: {
     major_status: INVALID_SIGNATURE_TOKEN,
     sub_status: None,
     location: 0x1::M,

--- a/language/move-bytecode-verifier/transactional-tests/tests/signature/reference_in_fields.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/signature/reference_in_fields.exp
@@ -1,7 +1,7 @@
 processed 1 task
 
 task 0 'publish'. lines 1-5:
-Error: Unable to publish module '00000000000000000000000000000042::M'. Got VMError: {
+Error: Unable to publish module '0x42::M'. Got VMError: {
     major_status: INVALID_SIGNATURE_TOKEN,
     sub_status: None,
     location: 0x42::M,

--- a/language/move-bytecode-verifier/transactional-tests/tests/signature/resource_as_unrestricted.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/signature/resource_as_unrestricted.exp
@@ -1,7 +1,7 @@
 processed 1 task
 
 task 0 'publish'. lines 1-12:
-Error: Unable to publish module '00000000000000000000000000000001::M'. Got VMError: {
+Error: Unable to publish module '0x1::M'. Got VMError: {
     major_status: CONSTRAINT_NOT_SATISFIED,
     sub_status: None,
     location: 0x1::M,

--- a/language/move-bytecode-verifier/transactional-tests/tests/signature/two_type_actuals_reverse_order.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/signature/two_type_actuals_reverse_order.exp
@@ -1,7 +1,7 @@
 processed 2 tasks
 
 task 0 'publish'. lines 1-11:
-Error: Unable to publish module '00000000000000000000000000000001::M'. Got VMError: {
+Error: Unable to publish module '0x1::M'. Got VMError: {
     major_status: CONSTRAINT_NOT_SATISFIED,
     sub_status: None,
     location: 0x1::M,
@@ -10,7 +10,7 @@ Error: Unable to publish module '00000000000000000000000000000001::M'. Got VMErr
 }
 
 task 1 'publish'. lines 13-24:
-Error: Unable to publish module '00000000000000000000000000000001::M2'. Got VMError: {
+Error: Unable to publish module '0x1::M2'. Got VMError: {
     major_status: CONSTRAINT_NOT_SATISFIED,
     sub_status: None,
     location: 0x1::M2,

--- a/language/move-bytecode-verifier/transactional-tests/tests/signature/unrestricted_as_resource.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/signature/unrestricted_as_resource.exp
@@ -1,7 +1,7 @@
 processed 1 task
 
 task 0 'publish'. lines 1-11:
-Error: Unable to publish module '00000000000000000000000000000001::M'. Got VMError: {
+Error: Unable to publish module '0x1::M'. Got VMError: {
     major_status: CONSTRAINT_NOT_SATISFIED,
     sub_status: None,
     location: 0x1::M,

--- a/language/move-bytecode-verifier/transactional-tests/tests/stack_usage_verifier/multiple_return_values_extra_value.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/stack_usage_verifier/multiple_return_values_extra_value.exp
@@ -1,7 +1,7 @@
 processed 1 task
 
 task 0 'publish'. lines 1-22:
-Error: Unable to publish module '00000000000000000000000000000001::Test'. Got VMError: {
+Error: Unable to publish module '0x1::Test'. Got VMError: {
     major_status: POSITIVE_STACK_SIZE_AT_BLOCK_END,
     sub_status: None,
     location: 0x1::Test,

--- a/language/move-bytecode-verifier/transactional-tests/tests/stack_usage_verifier/multiple_return_values_missing_value.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/stack_usage_verifier/multiple_return_values_missing_value.exp
@@ -1,7 +1,7 @@
 processed 1 task
 
 task 0 'publish'. lines 1-22:
-Error: Unable to publish module '00000000000000000000000000000001::Test'. Got VMError: {
+Error: Unable to publish module '0x1::Test'. Got VMError: {
     major_status: NEGATIVE_STACK_SIZE_WITHIN_BLOCK,
     sub_status: None,
     location: 0x1::Test,

--- a/language/move-bytecode-verifier/transactional-tests/tests/stack_usage_verifier/pop_negative.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/stack_usage_verifier/pop_negative.exp
@@ -1,7 +1,7 @@
 processed 1 task
 
 task 0 'publish'. lines 1-14:
-Error: Unable to publish module '00000000000000000000000000000001::A'. Got VMError: {
+Error: Unable to publish module '0x1::A'. Got VMError: {
     major_status: NEGATIVE_STACK_SIZE_WITHIN_BLOCK,
     sub_status: None,
     location: 0x1::A,

--- a/language/move-bytecode-verifier/transactional-tests/tests/stack_usage_verifier/pop_positive.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/stack_usage_verifier/pop_positive.exp
@@ -1,7 +1,7 @@
 processed 1 task
 
 task 0 'publish'. lines 1-14:
-Error: Unable to publish module '00000000000000000000000000000001::A'. Got VMError: {
+Error: Unable to publish module '0x1::A'. Got VMError: {
     major_status: POSITIVE_STACK_SIZE_AT_BLOCK_END,
     sub_status: None,
     location: 0x1::A,

--- a/language/move-bytecode-verifier/transactional-tests/tests/stack_usage_verifier/signer_move_to_extra_arg.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/stack_usage_verifier/signer_move_to_extra_arg.exp
@@ -1,7 +1,7 @@
 processed 2 tasks
 
 task 0 'publish'. lines 1-13:
-Error: Unable to publish module '00000000000000000000000000000042::M'. Got VMError: {
+Error: Unable to publish module '0x42::M'. Got VMError: {
     major_status: POSITIVE_STACK_SIZE_AT_BLOCK_END,
     sub_status: None,
     location: 0x42::M,
@@ -10,7 +10,7 @@ Error: Unable to publish module '00000000000000000000000000000042::M'. Got VMErr
 }
 
 task 1 'publish'. lines 15-24:
-Error: Unable to publish module '00000000000000000000000000000042::N'. Got VMError: {
+Error: Unable to publish module '0x42::N'. Got VMError: {
     major_status: POSITIVE_STACK_SIZE_AT_BLOCK_END,
     sub_status: None,
     location: 0x42::N,

--- a/language/move-bytecode-verifier/transactional-tests/tests/stack_usage_verifier/signer_move_to_missing_resource.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/stack_usage_verifier/signer_move_to_missing_resource.exp
@@ -1,7 +1,7 @@
 processed 2 tasks
 
 task 0 'publish'. lines 1-11:
-Error: Unable to publish module '00000000000000000000000000000042::M'. Got VMError: {
+Error: Unable to publish module '0x42::M'. Got VMError: {
     major_status: NEGATIVE_STACK_SIZE_WITHIN_BLOCK,
     sub_status: None,
     location: 0x42::M,
@@ -10,7 +10,7 @@ Error: Unable to publish module '00000000000000000000000000000042::M'. Got VMErr
 }
 
 task 1 'publish'. lines 13-22:
-Error: Unable to publish module '00000000000000000000000000000042::N'. Got VMError: {
+Error: Unable to publish module '0x42::N'. Got VMError: {
     major_status: NEGATIVE_STACK_SIZE_WITHIN_BLOCK,
     sub_status: None,
     location: 0x42::N,

--- a/language/move-bytecode-verifier/transactional-tests/tests/stack_usage_verifier/signer_move_to_missing_signer.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/stack_usage_verifier/signer_move_to_missing_signer.exp
@@ -1,7 +1,7 @@
 processed 2 tasks
 
 task 0 'publish'. lines 1-11:
-Error: Unable to publish module '00000000000000000000000000000042::M'. Got VMError: {
+Error: Unable to publish module '0x42::M'. Got VMError: {
     major_status: NEGATIVE_STACK_SIZE_WITHIN_BLOCK,
     sub_status: None,
     location: 0x42::M,
@@ -10,7 +10,7 @@ Error: Unable to publish module '00000000000000000000000000000042::M'. Got VMErr
 }
 
 task 1 'publish'. lines 13-22:
-Error: Unable to publish module '00000000000000000000000000000042::N'. Got VMError: {
+Error: Unable to publish module '0x42::N'. Got VMError: {
     major_status: NEGATIVE_STACK_SIZE_WITHIN_BLOCK,
     sub_status: None,
     location: 0x42::N,

--- a/language/move-bytecode-verifier/transactional-tests/tests/stack_usage_verifier/signer_move_to_no_args.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/stack_usage_verifier/signer_move_to_no_args.exp
@@ -1,7 +1,7 @@
 processed 2 tasks
 
 task 0 'publish'. lines 1-10:
-Error: Unable to publish module '00000000000000000000000000000042::M'. Got VMError: {
+Error: Unable to publish module '0x42::M'. Got VMError: {
     major_status: NEGATIVE_STACK_SIZE_WITHIN_BLOCK,
     sub_status: None,
     location: 0x42::M,
@@ -10,7 +10,7 @@ Error: Unable to publish module '00000000000000000000000000000042::M'. Got VMErr
 }
 
 task 1 'publish'. lines 12-21:
-Error: Unable to publish module '00000000000000000000000000000042::N'. Got VMError: {
+Error: Unable to publish module '0x42::N'. Got VMError: {
     major_status: NEGATIVE_STACK_SIZE_WITHIN_BLOCK,
     sub_status: None,
     location: 0x42::N,

--- a/language/move-bytecode-verifier/transactional-tests/tests/stack_usage_verifier/unpack_extra_binding.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/stack_usage_verifier/unpack_extra_binding.exp
@@ -1,7 +1,7 @@
 processed 1 task
 
 task 0 'publish'. lines 1-23:
-Error: Unable to publish module '00000000000000000000000000000001::Test'. Got VMError: {
+Error: Unable to publish module '0x1::Test'. Got VMError: {
     major_status: NEGATIVE_STACK_SIZE_WITHIN_BLOCK,
     sub_status: None,
     location: 0x1::Test,

--- a/language/move-bytecode-verifier/transactional-tests/tests/stack_usage_verifier/unpack_missing_binding.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/stack_usage_verifier/unpack_missing_binding.exp
@@ -1,7 +1,7 @@
 processed 1 task
 
 task 0 'publish'. lines 1-23:
-Error: Unable to publish module '00000000000000000000000000000001::Test'. Got VMError: {
+Error: Unable to publish module '0x1::Test'. Got VMError: {
     major_status: POSITIVE_STACK_SIZE_AT_BLOCK_END,
     sub_status: None,
     location: 0x1::Test,

--- a/language/move-bytecode-verifier/transactional-tests/tests/struct_defs/mutual_recursive_struct.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/struct_defs/mutual_recursive_struct.exp
@@ -1,7 +1,7 @@
 processed 1 task
 
 task 0 'publish'. lines 1-6:
-Error: Unable to publish module '00000000000000000000000000000042::M'. Got VMError: {
+Error: Unable to publish module '0x42::M'. Got VMError: {
     major_status: RECURSIVE_STRUCT_DEFINITION,
     sub_status: None,
     location: 0x42::M,

--- a/language/move-bytecode-verifier/transactional-tests/tests/struct_defs/recursive_struct.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/struct_defs/recursive_struct.exp
@@ -1,7 +1,7 @@
 processed 6 tasks
 
 task 1 'publish'. lines 10-14:
-Error: Unable to publish module '00000000000000000000000000000001::M0'. Got VMError: {
+Error: Unable to publish module '0x1::M0'. Got VMError: {
     major_status: RECURSIVE_STRUCT_DEFINITION,
     sub_status: None,
     location: 0x1::M0,
@@ -10,7 +10,7 @@ Error: Unable to publish module '00000000000000000000000000000001::M0'. Got VMEr
 }
 
 task 2 'publish'. lines 16-28:
-Error: Unable to publish module '00000000000000000000000000000001::M1'. Got VMError: {
+Error: Unable to publish module '0x1::M1'. Got VMError: {
     major_status: RECURSIVE_STRUCT_DEFINITION,
     sub_status: None,
     location: 0x1::M1,
@@ -19,7 +19,7 @@ Error: Unable to publish module '00000000000000000000000000000001::M1'. Got VMEr
 }
 
 task 3 'publish'. lines 30-49:
-Error: Unable to publish module '00000000000000000000000000000001::M2'. Got VMError: {
+Error: Unable to publish module '0x1::M2'. Got VMError: {
     major_status: RECURSIVE_STRUCT_DEFINITION,
     sub_status: None,
     location: 0x1::M2,
@@ -28,7 +28,7 @@ Error: Unable to publish module '00000000000000000000000000000001::M2'. Got VMEr
 }
 
 task 4 'publish'. lines 51-58:
-Error: Unable to publish module '00000000000000000000000000000001::M3'. Got VMError: {
+Error: Unable to publish module '0x1::M3'. Got VMError: {
     major_status: RECURSIVE_STRUCT_DEFINITION,
     sub_status: None,
     location: 0x1::M3,
@@ -37,7 +37,7 @@ Error: Unable to publish module '00000000000000000000000000000001::M3'. Got VMEr
 }
 
 task 5 'publish'. lines 60-70:
-Error: Unable to publish module '00000000000000000000000000000001::M3'. Got VMError: {
+Error: Unable to publish module '0x1::M3'. Got VMError: {
     major_status: RECURSIVE_STRUCT_DEFINITION,
     sub_status: None,
     location: 0x1::M3,

--- a/language/move-bytecode-verifier/transactional-tests/tests/type_safety/assign_local_resource.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/type_safety/assign_local_resource.exp
@@ -1,7 +1,7 @@
 processed 1 task
 
 task 0 'publish'. lines 1-11:
-Error: Unable to publish module '00000000000000000000000000000042::A'. Got VMError: {
+Error: Unable to publish module '0x42::A'. Got VMError: {
     major_status: WRITEREF_WITHOUT_DROP_ABILITY,
     sub_status: None,
     location: 0x42::A,

--- a/language/move-bytecode-verifier/transactional-tests/tests/type_safety/assign_local_resource_twice.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/type_safety/assign_local_resource_twice.exp
@@ -1,7 +1,7 @@
 processed 1 task
 
 task 0 'publish'. lines 1-13:
-Error: Unable to publish module '00000000000000000000000000000042::A'. Got VMError: {
+Error: Unable to publish module '0x42::A'. Got VMError: {
     major_status: WRITEREF_WITHOUT_DROP_ABILITY,
     sub_status: None,
     location: 0x42::A,

--- a/language/move-bytecode-verifier/transactional-tests/tests/type_safety/assign_resource_type.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/type_safety/assign_resource_type.exp
@@ -1,7 +1,7 @@
 processed 1 task
 
 task 0 'publish'. lines 1-14:
-Error: Unable to publish module '00000000000000000000000000000042::A'. Got VMError: {
+Error: Unable to publish module '0x42::A'. Got VMError: {
     major_status: WRITEREF_WITHOUT_DROP_ABILITY,
     sub_status: None,
     location: 0x42::A,

--- a/language/move-bytecode-verifier/transactional-tests/tests/type_safety/cant_deref_resource.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/type_safety/cant_deref_resource.exp
@@ -1,7 +1,7 @@
 processed 1 task
 
 task 0 'publish'. lines 1-48:
-Error: Unable to publish module '00000000000000000000000000000001::Token'. Got VMError: {
+Error: Unable to publish module '0x1::Token'. Got VMError: {
     major_status: READREF_WITHOUT_COPY_ABILITY,
     sub_status: None,
     location: 0x1::Token,

--- a/language/move-bytecode-verifier/transactional-tests/tests/type_safety/casting_operators_types_mismatch.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/type_safety/casting_operators_types_mismatch.exp
@@ -55,7 +55,7 @@ Error: Script execution failed with VMError: {
 }
 
 task 6 'publish'. lines 48-56:
-Error: Unable to publish module '00000000000000000000000000000042::M'. Got VMError: {
+Error: Unable to publish module '0x42::M'. Got VMError: {
     major_status: INTEGER_OP_TYPE_MISMATCH_ERROR,
     sub_status: None,
     location: 0x42::M,
@@ -64,7 +64,7 @@ Error: Unable to publish module '00000000000000000000000000000042::M'. Got VMErr
 }
 
 task 7 'publish'. lines 58-66:
-Error: Unable to publish module '00000000000000000000000000000042::M'. Got VMError: {
+Error: Unable to publish module '0x42::M'. Got VMError: {
     major_status: INTEGER_OP_TYPE_MISMATCH_ERROR,
     sub_status: None,
     location: 0x42::M,
@@ -73,7 +73,7 @@ Error: Unable to publish module '00000000000000000000000000000042::M'. Got VMErr
 }
 
 task 8 'publish'. lines 68-76:
-Error: Unable to publish module '00000000000000000000000000000042::M'. Got VMError: {
+Error: Unable to publish module '0x42::M'. Got VMError: {
     major_status: INTEGER_OP_TYPE_MISMATCH_ERROR,
     sub_status: None,
     location: 0x42::M,

--- a/language/move-bytecode-verifier/transactional-tests/tests/type_safety/equality_resource_values.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/type_safety/equality_resource_values.exp
@@ -1,7 +1,7 @@
 processed 1 task
 
 task 0 'publish'. lines 1-11:
-Error: Unable to publish module '00000000000000000000000000000001::Token'. Got VMError: {
+Error: Unable to publish module '0x1::Token'. Got VMError: {
     major_status: EQUALITY_OP_TYPE_MISMATCH_ERROR,
     sub_status: None,
     location: 0x1::Token,

--- a/language/move-bytecode-verifier/transactional-tests/tests/type_safety/generic_abilities_borrow_global.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/type_safety/generic_abilities_borrow_global.exp
@@ -1,7 +1,7 @@
 processed 1 task
 
 task 0 'publish'. lines 1-12:
-Error: Unable to publish module '00000000000000000000000000000001::M'. Got VMError: {
+Error: Unable to publish module '0x1::M'. Got VMError: {
     major_status: BORROWGLOBAL_WITHOUT_KEY_ABILITY,
     sub_status: None,
     location: 0x1::M,

--- a/language/move-bytecode-verifier/transactional-tests/tests/type_safety/generic_abilities_borrow_global_mut.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/type_safety/generic_abilities_borrow_global_mut.exp
@@ -1,7 +1,7 @@
 processed 1 task
 
 task 0 'publish'. lines 1-11:
-Error: Unable to publish module '00000000000000000000000000000001::M'. Got VMError: {
+Error: Unable to publish module '0x1::M'. Got VMError: {
     major_status: BORROWGLOBAL_WITHOUT_KEY_ABILITY,
     sub_status: None,
     location: 0x1::M,

--- a/language/move-bytecode-verifier/transactional-tests/tests/type_safety/generic_abilities_call.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/type_safety/generic_abilities_call.exp
@@ -1,7 +1,7 @@
 processed 1 task
 
 task 0 'publish'. lines 1-15:
-Error: Unable to publish module '00000000000000000000000000000001::M'. Got VMError: {
+Error: Unable to publish module '0x1::M'. Got VMError: {
     major_status: COPYLOC_WITHOUT_COPY_ABILITY,
     sub_status: None,
     location: 0x1::M,

--- a/language/move-bytecode-verifier/transactional-tests/tests/type_safety/generic_abilities_exists.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/type_safety/generic_abilities_exists.exp
@@ -1,7 +1,7 @@
 processed 1 task
 
 task 0 'publish'. lines 1-9:
-Error: Unable to publish module '00000000000000000000000000000001::M'. Got VMError: {
+Error: Unable to publish module '0x1::M'. Got VMError: {
     major_status: EXISTS_WITHOUT_KEY_ABILITY_OR_BAD_ARGUMENT,
     sub_status: None,
     location: 0x1::M,

--- a/language/move-bytecode-verifier/transactional-tests/tests/type_safety/generic_abilities_struct_non_nominal_resource.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/type_safety/generic_abilities_struct_non_nominal_resource.exp
@@ -1,7 +1,7 @@
 processed 1 task
 
 task 0 'publish'. lines 1-12:
-Error: Unable to publish module '00000000000000000000000000000001::M'. Got VMError: {
+Error: Unable to publish module '0x1::M'. Got VMError: {
     major_status: COPYLOC_WITHOUT_COPY_ABILITY,
     sub_status: None,
     location: 0x1::M,

--- a/language/move-bytecode-verifier/transactional-tests/tests/type_safety/generic_abilities_type_param_all.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/type_safety/generic_abilities_type_param_all.exp
@@ -1,7 +1,7 @@
 processed 1 task
 
 task 0 'publish'. lines 1-9:
-Error: Unable to publish module '00000000000000000000000000000001::M'. Got VMError: {
+Error: Unable to publish module '0x1::M'. Got VMError: {
     major_status: COPYLOC_WITHOUT_COPY_ABILITY,
     sub_status: None,
     location: 0x1::M,

--- a/language/move-bytecode-verifier/transactional-tests/tests/type_safety/generic_abilities_type_param_resource.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/type_safety/generic_abilities_type_param_resource.exp
@@ -1,7 +1,7 @@
 processed 1 task
 
 task 0 'publish'. lines 1-9:
-Error: Unable to publish module '00000000000000000000000000000001::M'. Got VMError: {
+Error: Unable to publish module '0x1::M'. Got VMError: {
     major_status: COPYLOC_WITHOUT_COPY_ABILITY,
     sub_status: None,
     location: 0x1::M,

--- a/language/move-bytecode-verifier/transactional-tests/tests/type_safety/generic_abilities_unpack.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/type_safety/generic_abilities_unpack.exp
@@ -1,7 +1,7 @@
 processed 1 task
 
 task 0 'publish'. lines 1-11:
-Error: Unable to publish module '00000000000000000000000000000001::M'. Got VMError: {
+Error: Unable to publish module '0x1::M'. Got VMError: {
     major_status: UNSAFE_RET_UNUSED_VALUES_WITHOUT_DROP,
     sub_status: None,
     location: 0x1::M,

--- a/language/move-bytecode-verifier/transactional-tests/tests/type_safety/integer_binary_operators_types_mismatch.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/type_safety/integer_binary_operators_types_mismatch.exp
@@ -109,7 +109,7 @@ Error: Script execution failed with VMError: {
 }
 
 task 12 'publish'. lines 102-110:
-Error: Unable to publish module '00000000000000000000000000000042::M'. Got VMError: {
+Error: Unable to publish module '0x42::M'. Got VMError: {
     major_status: INTEGER_OP_TYPE_MISMATCH_ERROR,
     sub_status: None,
     location: 0x42::M,
@@ -118,7 +118,7 @@ Error: Unable to publish module '00000000000000000000000000000042::M'. Got VMErr
 }
 
 task 13 'publish'. lines 112-120:
-Error: Unable to publish module '00000000000000000000000000000042::M'. Got VMError: {
+Error: Unable to publish module '0x42::M'. Got VMError: {
     major_status: INTEGER_OP_TYPE_MISMATCH_ERROR,
     sub_status: None,
     location: 0x42::M,
@@ -127,7 +127,7 @@ Error: Unable to publish module '00000000000000000000000000000042::M'. Got VMErr
 }
 
 task 14 'publish'. lines 122-134:
-Error: Unable to publish module '00000000000000000000000000000042::M'. Got VMError: {
+Error: Unable to publish module '0x42::M'. Got VMError: {
     major_status: INTEGER_OP_TYPE_MISMATCH_ERROR,
     sub_status: None,
     location: 0x42::M,
@@ -244,7 +244,7 @@ Error: Script execution failed with VMError: {
 }
 
 task 27 'publish'. lines 231-239:
-Error: Unable to publish module '00000000000000000000000000000042::M'. Got VMError: {
+Error: Unable to publish module '0x42::M'. Got VMError: {
     major_status: INTEGER_OP_TYPE_MISMATCH_ERROR,
     sub_status: None,
     location: 0x42::M,
@@ -253,7 +253,7 @@ Error: Unable to publish module '00000000000000000000000000000042::M'. Got VMErr
 }
 
 task 28 'publish'. lines 241-249:
-Error: Unable to publish module '00000000000000000000000000000042::M'. Got VMError: {
+Error: Unable to publish module '0x42::M'. Got VMError: {
     major_status: INTEGER_OP_TYPE_MISMATCH_ERROR,
     sub_status: None,
     location: 0x42::M,
@@ -262,7 +262,7 @@ Error: Unable to publish module '00000000000000000000000000000042::M'. Got VMErr
 }
 
 task 29 'publish'. lines 251-263:
-Error: Unable to publish module '00000000000000000000000000000042::M'. Got VMError: {
+Error: Unable to publish module '0x42::M'. Got VMError: {
     major_status: INTEGER_OP_TYPE_MISMATCH_ERROR,
     sub_status: None,
     location: 0x42::M,
@@ -379,7 +379,7 @@ Error: Script execution failed with VMError: {
 }
 
 task 42 'publish'. lines 360-368:
-Error: Unable to publish module '00000000000000000000000000000042::M'. Got VMError: {
+Error: Unable to publish module '0x42::M'. Got VMError: {
     major_status: INTEGER_OP_TYPE_MISMATCH_ERROR,
     sub_status: None,
     location: 0x42::M,
@@ -388,7 +388,7 @@ Error: Unable to publish module '00000000000000000000000000000042::M'. Got VMErr
 }
 
 task 43 'publish'. lines 370-378:
-Error: Unable to publish module '00000000000000000000000000000042::M'. Got VMError: {
+Error: Unable to publish module '0x42::M'. Got VMError: {
     major_status: INTEGER_OP_TYPE_MISMATCH_ERROR,
     sub_status: None,
     location: 0x42::M,
@@ -397,7 +397,7 @@ Error: Unable to publish module '00000000000000000000000000000042::M'. Got VMErr
 }
 
 task 44 'publish'. lines 380-392:
-Error: Unable to publish module '00000000000000000000000000000042::M'. Got VMError: {
+Error: Unable to publish module '0x42::M'. Got VMError: {
     major_status: INTEGER_OP_TYPE_MISMATCH_ERROR,
     sub_status: None,
     location: 0x42::M,
@@ -514,7 +514,7 @@ Error: Script execution failed with VMError: {
 }
 
 task 57 'publish'. lines 489-497:
-Error: Unable to publish module '00000000000000000000000000000042::M'. Got VMError: {
+Error: Unable to publish module '0x42::M'. Got VMError: {
     major_status: INTEGER_OP_TYPE_MISMATCH_ERROR,
     sub_status: None,
     location: 0x42::M,
@@ -523,7 +523,7 @@ Error: Unable to publish module '00000000000000000000000000000042::M'. Got VMErr
 }
 
 task 58 'publish'. lines 499-507:
-Error: Unable to publish module '00000000000000000000000000000042::M'. Got VMError: {
+Error: Unable to publish module '0x42::M'. Got VMError: {
     major_status: INTEGER_OP_TYPE_MISMATCH_ERROR,
     sub_status: None,
     location: 0x42::M,
@@ -532,7 +532,7 @@ Error: Unable to publish module '00000000000000000000000000000042::M'. Got VMErr
 }
 
 task 59 'publish'. lines 509-521:
-Error: Unable to publish module '00000000000000000000000000000042::M'. Got VMError: {
+Error: Unable to publish module '0x42::M'. Got VMError: {
     major_status: INTEGER_OP_TYPE_MISMATCH_ERROR,
     sub_status: None,
     location: 0x42::M,
@@ -649,7 +649,7 @@ Error: Script execution failed with VMError: {
 }
 
 task 72 'publish'. lines 618-626:
-Error: Unable to publish module '00000000000000000000000000000042::M'. Got VMError: {
+Error: Unable to publish module '0x42::M'. Got VMError: {
     major_status: INTEGER_OP_TYPE_MISMATCH_ERROR,
     sub_status: None,
     location: 0x42::M,
@@ -658,7 +658,7 @@ Error: Unable to publish module '00000000000000000000000000000042::M'. Got VMErr
 }
 
 task 73 'publish'. lines 628-636:
-Error: Unable to publish module '00000000000000000000000000000042::M'. Got VMError: {
+Error: Unable to publish module '0x42::M'. Got VMError: {
     major_status: INTEGER_OP_TYPE_MISMATCH_ERROR,
     sub_status: None,
     location: 0x42::M,
@@ -667,7 +667,7 @@ Error: Unable to publish module '00000000000000000000000000000042::M'. Got VMErr
 }
 
 task 74 'publish'. lines 638-650:
-Error: Unable to publish module '00000000000000000000000000000042::M'. Got VMError: {
+Error: Unable to publish module '0x42::M'. Got VMError: {
     major_status: INTEGER_OP_TYPE_MISMATCH_ERROR,
     sub_status: None,
     location: 0x42::M,
@@ -784,7 +784,7 @@ Error: Script execution failed with VMError: {
 }
 
 task 87 'publish'. lines 747-755:
-Error: Unable to publish module '00000000000000000000000000000042::M'. Got VMError: {
+Error: Unable to publish module '0x42::M'. Got VMError: {
     major_status: INTEGER_OP_TYPE_MISMATCH_ERROR,
     sub_status: None,
     location: 0x42::M,
@@ -793,7 +793,7 @@ Error: Unable to publish module '00000000000000000000000000000042::M'. Got VMErr
 }
 
 task 88 'publish'. lines 757-765:
-Error: Unable to publish module '00000000000000000000000000000042::M'. Got VMError: {
+Error: Unable to publish module '0x42::M'. Got VMError: {
     major_status: INTEGER_OP_TYPE_MISMATCH_ERROR,
     sub_status: None,
     location: 0x42::M,
@@ -802,7 +802,7 @@ Error: Unable to publish module '00000000000000000000000000000042::M'. Got VMErr
 }
 
 task 89 'publish'. lines 767-779:
-Error: Unable to publish module '00000000000000000000000000000042::M'. Got VMError: {
+Error: Unable to publish module '0x42::M'. Got VMError: {
     major_status: INTEGER_OP_TYPE_MISMATCH_ERROR,
     sub_status: None,
     location: 0x42::M,
@@ -919,7 +919,7 @@ Error: Script execution failed with VMError: {
 }
 
 task 102 'publish'. lines 876-884:
-Error: Unable to publish module '00000000000000000000000000000042::M'. Got VMError: {
+Error: Unable to publish module '0x42::M'. Got VMError: {
     major_status: INTEGER_OP_TYPE_MISMATCH_ERROR,
     sub_status: None,
     location: 0x42::M,
@@ -928,7 +928,7 @@ Error: Unable to publish module '00000000000000000000000000000042::M'. Got VMErr
 }
 
 task 103 'publish'. lines 886-894:
-Error: Unable to publish module '00000000000000000000000000000042::M'. Got VMError: {
+Error: Unable to publish module '0x42::M'. Got VMError: {
     major_status: INTEGER_OP_TYPE_MISMATCH_ERROR,
     sub_status: None,
     location: 0x42::M,
@@ -937,7 +937,7 @@ Error: Unable to publish module '00000000000000000000000000000042::M'. Got VMErr
 }
 
 task 104 'publish'. lines 896-908:
-Error: Unable to publish module '00000000000000000000000000000042::M'. Got VMError: {
+Error: Unable to publish module '0x42::M'. Got VMError: {
     major_status: INTEGER_OP_TYPE_MISMATCH_ERROR,
     sub_status: None,
     location: 0x42::M,
@@ -1036,7 +1036,7 @@ Error: Script execution failed with VMError: {
 }
 
 task 115 'publish'. lines 989-997:
-Error: Unable to publish module '00000000000000000000000000000042::M'. Got VMError: {
+Error: Unable to publish module '0x42::M'. Got VMError: {
     major_status: EQUALITY_OP_TYPE_MISMATCH_ERROR,
     sub_status: None,
     location: 0x42::M,
@@ -1045,7 +1045,7 @@ Error: Unable to publish module '00000000000000000000000000000042::M'. Got VMErr
 }
 
 task 116 'publish'. lines 999-1010:
-Error: Unable to publish module '00000000000000000000000000000042::M'. Got VMError: {
+Error: Unable to publish module '0x42::M'. Got VMError: {
     major_status: EQUALITY_OP_TYPE_MISMATCH_ERROR,
     sub_status: None,
     location: 0x42::M,
@@ -1144,7 +1144,7 @@ Error: Script execution failed with VMError: {
 }
 
 task 127 'publish'. lines 1091-1099:
-Error: Unable to publish module '00000000000000000000000000000042::M'. Got VMError: {
+Error: Unable to publish module '0x42::M'. Got VMError: {
     major_status: EQUALITY_OP_TYPE_MISMATCH_ERROR,
     sub_status: None,
     location: 0x42::M,
@@ -1153,7 +1153,7 @@ Error: Unable to publish module '00000000000000000000000000000042::M'. Got VMErr
 }
 
 task 128 'publish'. lines 1101-1113:
-Error: Unable to publish module '00000000000000000000000000000042::M'. Got VMError: {
+Error: Unable to publish module '0x42::M'. Got VMError: {
     major_status: EQUALITY_OP_TYPE_MISMATCH_ERROR,
     sub_status: None,
     location: 0x42::M,
@@ -1594,7 +1594,7 @@ Error: Script execution failed with VMError: {
 }
 
 task 177 'publish'. lines 1502-1510:
-Error: Unable to publish module '00000000000000000000000000000042::M'. Got VMError: {
+Error: Unable to publish module '0x42::M'. Got VMError: {
     major_status: INTEGER_OP_TYPE_MISMATCH_ERROR,
     sub_status: None,
     location: 0x42::M,
@@ -1603,7 +1603,7 @@ Error: Unable to publish module '00000000000000000000000000000042::M'. Got VMErr
 }
 
 task 178 'publish'. lines 1512-1520:
-Error: Unable to publish module '00000000000000000000000000000042::M'. Got VMError: {
+Error: Unable to publish module '0x42::M'. Got VMError: {
     major_status: INTEGER_OP_TYPE_MISMATCH_ERROR,
     sub_status: None,
     location: 0x42::M,
@@ -1612,7 +1612,7 @@ Error: Unable to publish module '00000000000000000000000000000042::M'. Got VMErr
 }
 
 task 179 'publish'. lines 1522-1534:
-Error: Unable to publish module '00000000000000000000000000000042::M'. Got VMError: {
+Error: Unable to publish module '0x42::M'. Got VMError: {
     major_status: INTEGER_OP_TYPE_MISMATCH_ERROR,
     sub_status: None,
     location: 0x42::M,
@@ -1693,7 +1693,7 @@ Error: Script execution failed with VMError: {
 }
 
 task 188 'publish'. lines 1599-1607:
-Error: Unable to publish module '00000000000000000000000000000042::M'. Got VMError: {
+Error: Unable to publish module '0x42::M'. Got VMError: {
     major_status: INTEGER_OP_TYPE_MISMATCH_ERROR,
     sub_status: None,
     location: 0x42::M,
@@ -1702,7 +1702,7 @@ Error: Unable to publish module '00000000000000000000000000000042::M'. Got VMErr
 }
 
 task 189 'publish'. lines 1609-1617:
-Error: Unable to publish module '00000000000000000000000000000042::M'. Got VMError: {
+Error: Unable to publish module '0x42::M'. Got VMError: {
     major_status: INTEGER_OP_TYPE_MISMATCH_ERROR,
     sub_status: None,
     location: 0x42::M,
@@ -1711,7 +1711,7 @@ Error: Unable to publish module '00000000000000000000000000000042::M'. Got VMErr
 }
 
 task 190 'publish'. lines 1619-1627:
-Error: Unable to publish module '00000000000000000000000000000042::M'. Got VMError: {
+Error: Unable to publish module '0x42::M'. Got VMError: {
     major_status: INTEGER_OP_TYPE_MISMATCH_ERROR,
     sub_status: None,
     location: 0x42::M,

--- a/language/move-bytecode-verifier/transactional-tests/tests/type_safety/invalid_field_write.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/type_safety/invalid_field_write.exp
@@ -1,7 +1,7 @@
 processed 1 task
 
 task 0 'publish'. lines 1-18:
-Error: Unable to publish module '00000000000000000000000000000042::Test'. Got VMError: {
+Error: Unable to publish module '0x42::Test'. Got VMError: {
     major_status: WRITEREF_TYPE_MISMATCH_ERROR,
     sub_status: None,
     location: 0x42::Test,

--- a/language/move-bytecode-verifier/transactional-tests/tests/type_safety/invalid_resource_write.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/type_safety/invalid_resource_write.exp
@@ -1,7 +1,7 @@
 processed 1 task
 
 task 0 'publish'. lines 1-14:
-Error: Unable to publish module '00000000000000000000000000000042::RTest'. Got VMError: {
+Error: Unable to publish module '0x42::RTest'. Got VMError: {
     major_status: WRITEREF_WITHOUT_DROP_ABILITY,
     sub_status: None,
     location: 0x42::RTest,

--- a/language/move-bytecode-verifier/transactional-tests/tests/type_safety/mut_borrow_from_imm_ref.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/type_safety/mut_borrow_from_imm_ref.exp
@@ -1,7 +1,7 @@
 processed 1 task
 
 task 0 'publish'. lines 1-25:
-Error: Unable to publish module '00000000000000000000000000000042::Token'. Got VMError: {
+Error: Unable to publish module '0x42::Token'. Got VMError: {
     major_status: BORROWFIELD_TYPE_MISMATCH_ERROR,
     sub_status: None,
     location: 0x42::Token,

--- a/language/move-bytecode-verifier/transactional-tests/tests/type_safety/mut_call_with_imm_ref.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/type_safety/mut_call_with_imm_ref.exp
@@ -1,7 +1,7 @@
 processed 1 task
 
 task 0 'publish'. lines 1-33:
-Error: Unable to publish module '00000000000000000000000000000042::Token'. Got VMError: {
+Error: Unable to publish module '0x42::Token'. Got VMError: {
     major_status: CALL_TYPE_MISMATCH_ERROR,
     sub_status: None,
     location: 0x42::Token,

--- a/language/move-bytecode-verifier/transactional-tests/tests/type_safety/phantom_params/bytecode_ops_abilities_bad.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/type_safety/phantom_params/bytecode_ops_abilities_bad.exp
@@ -1,7 +1,7 @@
 processed 9 tasks
 
 task 1 'publish'. lines 10-22:
-Error: Unable to publish module '00000000000000000000000000000001::M2'. Got VMError: {
+Error: Unable to publish module '0x1::M2'. Got VMError: {
     major_status: WRITEREF_WITHOUT_DROP_ABILITY,
     sub_status: None,
     location: 0x1::M2,
@@ -10,7 +10,7 @@ Error: Unable to publish module '00000000000000000000000000000001::M2'. Got VMEr
 }
 
 task 2 'publish'. lines 24-36:
-Error: Unable to publish module '00000000000000000000000000000001::M3'. Got VMError: {
+Error: Unable to publish module '0x1::M3'. Got VMError: {
     major_status: POP_WITHOUT_DROP_ABILITY,
     sub_status: None,
     location: 0x1::M3,
@@ -19,7 +19,7 @@ Error: Unable to publish module '00000000000000000000000000000001::M3'. Got VMEr
 }
 
 task 3 'publish'. lines 38-49:
-Error: Unable to publish module '00000000000000000000000000000001::M4'. Got VMError: {
+Error: Unable to publish module '0x1::M4'. Got VMError: {
     major_status: UNSAFE_RET_UNUSED_VALUES_WITHOUT_DROP,
     sub_status: None,
     location: 0x1::M4,
@@ -28,7 +28,7 @@ Error: Unable to publish module '00000000000000000000000000000001::M4'. Got VMEr
 }
 
 task 4 'publish'. lines 51-61:
-Error: Unable to publish module '00000000000000000000000000000001::M5'. Got VMError: {
+Error: Unable to publish module '0x1::M5'. Got VMError: {
     major_status: COPYLOC_WITHOUT_COPY_ABILITY,
     sub_status: None,
     location: 0x1::M5,
@@ -37,7 +37,7 @@ Error: Unable to publish module '00000000000000000000000000000001::M5'. Got VMEr
 }
 
 task 5 'publish'. lines 63-76:
-Error: Unable to publish module '00000000000000000000000000000001::M6'. Got VMError: {
+Error: Unable to publish module '0x1::M6'. Got VMError: {
     major_status: MOVETO_WITHOUT_KEY_ABILITY,
     sub_status: None,
     location: 0x1::M6,
@@ -46,7 +46,7 @@ Error: Unable to publish module '00000000000000000000000000000001::M6'. Got VMEr
 }
 
 task 6 'publish'. lines 78-89:
-Error: Unable to publish module '00000000000000000000000000000001::M7'. Got VMError: {
+Error: Unable to publish module '0x1::M7'. Got VMError: {
     major_status: MOVEFROM_WITHOUT_KEY_ABILITY,
     sub_status: None,
     location: 0x1::M7,
@@ -55,7 +55,7 @@ Error: Unable to publish module '00000000000000000000000000000001::M7'. Got VMEr
 }
 
 task 7 'publish'. lines 91-102:
-Error: Unable to publish module '00000000000000000000000000000001::M8'. Got VMError: {
+Error: Unable to publish module '0x1::M8'. Got VMError: {
     major_status: EXISTS_WITHOUT_KEY_ABILITY_OR_BAD_ARGUMENT,
     sub_status: None,
     location: 0x1::M8,
@@ -64,7 +64,7 @@ Error: Unable to publish module '00000000000000000000000000000001::M8'. Got VMEr
 }
 
 task 8 'publish'. lines 104-115:
-Error: Unable to publish module '00000000000000000000000000000001::M9'. Got VMError: {
+Error: Unable to publish module '0x1::M9'. Got VMError: {
     major_status: CONSTRAINT_NOT_SATISFIED,
     sub_status: None,
     location: 0x1::M9,

--- a/language/move-bytecode-verifier/transactional-tests/tests/type_safety/phantom_params/constraints_abilities_bad.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/type_safety/phantom_params/constraints_abilities_bad.exp
@@ -1,7 +1,7 @@
 processed 6 tasks
 
 task 1 'publish'. lines 7-15:
-Error: Unable to publish module '00000000000000000000000000000001::M2'. Got VMError: {
+Error: Unable to publish module '0x1::M2'. Got VMError: {
     major_status: CONSTRAINT_NOT_SATISFIED,
     sub_status: None,
     location: 0x1::M2,
@@ -10,7 +10,7 @@ Error: Unable to publish module '00000000000000000000000000000001::M2'. Got VMEr
 }
 
 task 2 'publish'. lines 17-34:
-Error: Unable to publish module '00000000000000000000000000000001::M3'. Got VMError: {
+Error: Unable to publish module '0x1::M3'. Got VMError: {
     major_status: CONSTRAINT_NOT_SATISFIED,
     sub_status: None,
     location: 0x1::M3,
@@ -19,7 +19,7 @@ Error: Unable to publish module '00000000000000000000000000000001::M3'. Got VMEr
 }
 
 task 3 'publish'. lines 36-46:
-Error: Unable to publish module '00000000000000000000000000000001::M4'. Got VMError: {
+Error: Unable to publish module '0x1::M4'. Got VMError: {
     major_status: CONSTRAINT_NOT_SATISFIED,
     sub_status: None,
     location: 0x1::M4,
@@ -28,7 +28,7 @@ Error: Unable to publish module '00000000000000000000000000000001::M4'. Got VMEr
 }
 
 task 5 'publish'. lines 60-75:
-Error: Unable to publish module '00000000000000000000000000000001::M5'. Got VMError: {
+Error: Unable to publish module '0x1::M5'. Got VMError: {
     major_status: CONSTRAINT_NOT_SATISFIED,
     sub_status: None,
     location: 0x1::M5,

--- a/language/move-bytecode-verifier/transactional-tests/tests/type_safety/phantom_params/fields_abilities_bad.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/type_safety/phantom_params/fields_abilities_bad.exp
@@ -1,7 +1,7 @@
 processed 5 tasks
 
 task 1 'publish'. lines 16-21:
-Error: Unable to publish module '00000000000000000000000000000001::M2'. Got VMError: {
+Error: Unable to publish module '0x1::M2'. Got VMError: {
     major_status: FIELD_MISSING_TYPE_ABILITY,
     sub_status: None,
     location: 0x1::M2,
@@ -10,7 +10,7 @@ Error: Unable to publish module '00000000000000000000000000000001::M2'. Got VMEr
 }
 
 task 2 'publish'. lines 23-28:
-Error: Unable to publish module '00000000000000000000000000000001::M3'. Got VMError: {
+Error: Unable to publish module '0x1::M3'. Got VMError: {
     major_status: FIELD_MISSING_TYPE_ABILITY,
     sub_status: None,
     location: 0x1::M3,
@@ -19,7 +19,7 @@ Error: Unable to publish module '00000000000000000000000000000001::M3'. Got VMEr
 }
 
 task 3 'publish'. lines 30-35:
-Error: Unable to publish module '00000000000000000000000000000001::M4'. Got VMError: {
+Error: Unable to publish module '0x1::M4'. Got VMError: {
     major_status: FIELD_MISSING_TYPE_ABILITY,
     sub_status: None,
     location: 0x1::M4,
@@ -28,7 +28,7 @@ Error: Unable to publish module '00000000000000000000000000000001::M4'. Got VMEr
 }
 
 task 4 'publish'. lines 37-42:
-Error: Unable to publish module '00000000000000000000000000000001::M5'. Got VMError: {
+Error: Unable to publish module '0x1::M5'. Got VMError: {
     major_status: FIELD_MISSING_TYPE_ABILITY,
     sub_status: None,
     location: 0x1::M5,

--- a/language/move-bytecode-verifier/transactional-tests/tests/type_safety/phantom_params/struct_definition_bad.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/type_safety/phantom_params/struct_definition_bad.exp
@@ -1,7 +1,7 @@
 processed 6 tasks
 
 task 0 'publish'. lines 1-11:
-Error: Unable to publish module '00000000000000000000000000000001::M1'. Got VMError: {
+Error: Unable to publish module '0x1::M1'. Got VMError: {
     major_status: INVALID_PHANTOM_TYPE_PARAM_POSITION,
     sub_status: None,
     location: 0x1::M1,
@@ -10,7 +10,7 @@ Error: Unable to publish module '00000000000000000000000000000001::M1'. Got VMEr
 }
 
 task 1 'publish'. lines 13-19:
-Error: Unable to publish module '00000000000000000000000000000001::M2'. Got VMError: {
+Error: Unable to publish module '0x1::M2'. Got VMError: {
     major_status: INVALID_PHANTOM_TYPE_PARAM_POSITION,
     sub_status: None,
     location: 0x1::M2,
@@ -19,7 +19,7 @@ Error: Unable to publish module '00000000000000000000000000000001::M2'. Got VMEr
 }
 
 task 2 'publish'. lines 21-28:
-Error: Unable to publish module '00000000000000000000000000000001::M3'. Got VMError: {
+Error: Unable to publish module '0x1::M3'. Got VMError: {
     major_status: INVALID_PHANTOM_TYPE_PARAM_POSITION,
     sub_status: None,
     location: 0x1::M3,
@@ -28,7 +28,7 @@ Error: Unable to publish module '00000000000000000000000000000001::M3'. Got VMEr
 }
 
 task 3 'publish'. lines 30-39:
-Error: Unable to publish module '00000000000000000000000000000001::M4'. Got VMError: {
+Error: Unable to publish module '0x1::M4'. Got VMError: {
     major_status: INVALID_PHANTOM_TYPE_PARAM_POSITION,
     sub_status: None,
     location: 0x1::M4,
@@ -37,7 +37,7 @@ Error: Unable to publish module '00000000000000000000000000000001::M4'. Got VMEr
 }
 
 task 4 'publish'. lines 41-47:
-Error: Unable to publish module '00000000000000000000000000000001::M5'. Got VMError: {
+Error: Unable to publish module '0x1::M5'. Got VMError: {
     major_status: INVALID_PHANTOM_TYPE_PARAM_POSITION,
     sub_status: None,
     location: 0x1::M5,
@@ -46,7 +46,7 @@ Error: Unable to publish module '00000000000000000000000000000001::M5'. Got VMEr
 }
 
 task 5 'publish'. lines 49-56:
-Error: Unable to publish module '00000000000000000000000000000001::M6'. Got VMError: {
+Error: Unable to publish module '0x1::M6'. Got VMError: {
     major_status: CONSTRAINT_NOT_SATISFIED,
     sub_status: None,
     location: 0x1::M6,

--- a/language/move-bytecode-verifier/transactional-tests/tests/type_safety/procedure_return_invalid_subtype.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/type_safety/procedure_return_invalid_subtype.exp
@@ -1,7 +1,7 @@
 processed 1 task
 
 task 0 'publish'. lines 1-9:
-Error: Unable to publish module '00000000000000000000000000000042::Test'. Got VMError: {
+Error: Unable to publish module '0x42::Test'. Got VMError: {
     major_status: RET_TYPE_MISMATCH_ERROR,
     sub_status: None,
     location: 0x42::Test,

--- a/language/move-bytecode-verifier/transactional-tests/tests/type_safety/procedure_return_invalid_type.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/type_safety/procedure_return_invalid_type.exp
@@ -1,7 +1,7 @@
 processed 1 task
 
 task 0 'publish'. lines 1-9:
-Error: Unable to publish module '00000000000000000000000000000042::Test'. Got VMError: {
+Error: Unable to publish module '0x42::Test'. Got VMError: {
     major_status: RET_TYPE_MISMATCH_ERROR,
     sub_status: None,
     location: 0x42::Test,

--- a/language/move-bytecode-verifier/transactional-tests/tests/type_safety/release.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/type_safety/release.exp
@@ -1,7 +1,7 @@
 processed 1 task
 
 task 0 'publish'. lines 1-10:
-Error: Unable to publish module '00000000000000000000000000000001::M'. Got VMError: {
+Error: Unable to publish module '0x1::M'. Got VMError: {
     major_status: NEGATIVE_STACK_SIZE_WITHIN_BLOCK,
     sub_status: None,
     location: 0x1::M,

--- a/language/move-bytecode-verifier/transactional-tests/tests/type_safety/resource_instantiate_bad_type.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/type_safety/resource_instantiate_bad_type.exp
@@ -1,7 +1,7 @@
 processed 1 task
 
 task 0 'publish'. lines 1-14:
-Error: Unable to publish module '00000000000000000000000000000042::Test'. Got VMError: {
+Error: Unable to publish module '0x42::Test'. Got VMError: {
     major_status: PACK_TYPE_MISMATCH_ERROR,
     sub_status: None,
     location: 0x42::Test,

--- a/language/move-bytecode-verifier/transactional-tests/tests/type_safety/return_type_mismatch_and_unused_resource.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/type_safety/return_type_mismatch_and_unused_resource.exp
@@ -1,7 +1,7 @@
 processed 4 tasks
 
 task 0 'publish'. lines 1-13:
-Error: Unable to publish module '00000000000000000000000000000001::M'. Got VMError: {
+Error: Unable to publish module '0x1::M'. Got VMError: {
     major_status: RET_TYPE_MISMATCH_ERROR,
     sub_status: None,
     location: 0x1::M,
@@ -10,7 +10,7 @@ Error: Unable to publish module '00000000000000000000000000000001::M'. Got VMErr
 }
 
 task 1 'publish'. lines 15-27:
-Error: Unable to publish module '00000000000000000000000000000001::M2'. Got VMError: {
+Error: Unable to publish module '0x1::M2'. Got VMError: {
     major_status: RET_TYPE_MISMATCH_ERROR,
     sub_status: None,
     location: 0x1::M2,
@@ -19,7 +19,7 @@ Error: Unable to publish module '00000000000000000000000000000001::M2'. Got VMEr
 }
 
 task 2 'publish'. lines 29-40:
-Error: Unable to publish module '00000000000000000000000000000001::M'. Got VMError: {
+Error: Unable to publish module '0x1::M'. Got VMError: {
     major_status: UNSAFE_RET_UNUSED_VALUES_WITHOUT_DROP,
     sub_status: None,
     location: 0x1::M,
@@ -28,7 +28,7 @@ Error: Unable to publish module '00000000000000000000000000000001::M'. Got VMErr
 }
 
 task 3 'publish'. lines 42-53:
-Error: Unable to publish module '00000000000000000000000000000001::M2'. Got VMError: {
+Error: Unable to publish module '0x1::M2'. Got VMError: {
     major_status: UNSAFE_RET_LOCAL_OR_RESOURCE_STILL_BORROWED,
     sub_status: None,
     location: 0x1::M2,

--- a/language/move-bytecode-verifier/transactional-tests/tests/type_safety/signer_copy_loc.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/type_safety/signer_copy_loc.exp
@@ -1,7 +1,7 @@
 processed 1 task
 
 task 0 'publish'. lines 1-8:
-Error: Unable to publish module '00000000000000000000000000000042::M'. Got VMError: {
+Error: Unable to publish module '0x42::M'. Got VMError: {
     major_status: COPYLOC_WITHOUT_COPY_ABILITY,
     sub_status: None,
     location: 0x42::M,

--- a/language/move-bytecode-verifier/transactional-tests/tests/type_safety/signer_copy_loc_transitive.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/type_safety/signer_copy_loc_transitive.exp
@@ -1,7 +1,7 @@
 processed 1 task
 
 task 0 'publish'. lines 1-11:
-Error: Unable to publish module '00000000000000000000000000000042::M'. Got VMError: {
+Error: Unable to publish module '0x42::M'. Got VMError: {
     major_status: COPYLOC_WITHOUT_COPY_ABILITY,
     sub_status: None,
     location: 0x42::M,

--- a/language/move-bytecode-verifier/transactional-tests/tests/type_safety/signer_does_not_have_store.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/type_safety/signer_does_not_have_store.exp
@@ -1,7 +1,7 @@
 processed 1 task
 
 task 0 'publish'. lines 1-13:
-Error: Unable to publish module '00000000000000000000000000000042::M'. Got VMError: {
+Error: Unable to publish module '0x42::M'. Got VMError: {
     major_status: MOVETO_WITHOUT_KEY_ABILITY,
     sub_status: None,
     location: 0x42::M,

--- a/language/move-bytecode-verifier/transactional-tests/tests/type_safety/signer_move_to_mutable_signer.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/type_safety/signer_move_to_mutable_signer.exp
@@ -1,7 +1,7 @@
 processed 2 tasks
 
 task 0 'publish'. lines 1-12:
-Error: Unable to publish module '00000000000000000000000000000042::M'. Got VMError: {
+Error: Unable to publish module '0x42::M'. Got VMError: {
     major_status: MOVETO_TYPE_MISMATCH_ERROR,
     sub_status: None,
     location: 0x42::M,
@@ -10,7 +10,7 @@ Error: Unable to publish module '00000000000000000000000000000042::M'. Got VMErr
 }
 
 task 1 'publish'. lines 14-23:
-Error: Unable to publish module '00000000000000000000000000000042::N'. Got VMError: {
+Error: Unable to publish module '0x42::N'. Got VMError: {
     major_status: MOVETO_TYPE_MISMATCH_ERROR,
     sub_status: None,
     location: 0x42::N,

--- a/language/move-bytecode-verifier/transactional-tests/tests/type_safety/signer_move_to_non_resource.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/type_safety/signer_move_to_non_resource.exp
@@ -1,7 +1,7 @@
 processed 2 tasks
 
 task 0 'publish'. lines 1-12:
-Error: Unable to publish module '00000000000000000000000000000042::M'. Got VMError: {
+Error: Unable to publish module '0x42::M'. Got VMError: {
     major_status: MOVETO_WITHOUT_KEY_ABILITY,
     sub_status: None,
     location: 0x42::M,
@@ -10,7 +10,7 @@ Error: Unable to publish module '00000000000000000000000000000042::M'. Got VMErr
 }
 
 task 1 'publish'. lines 14-23:
-Error: Unable to publish module '00000000000000000000000000000042::N'. Got VMError: {
+Error: Unable to publish module '0x42::N'. Got VMError: {
     major_status: MOVETO_WITHOUT_KEY_ABILITY,
     sub_status: None,
     location: 0x42::N,

--- a/language/move-bytecode-verifier/transactional-tests/tests/type_safety/signer_move_to_non_signer.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/type_safety/signer_move_to_non_signer.exp
@@ -1,7 +1,7 @@
 processed 2 tasks
 
 task 0 'publish'. lines 1-12:
-Error: Unable to publish module '00000000000000000000000000000042::M'. Got VMError: {
+Error: Unable to publish module '0x42::M'. Got VMError: {
     major_status: MOVETO_TYPE_MISMATCH_ERROR,
     sub_status: None,
     location: 0x42::M,
@@ -10,7 +10,7 @@ Error: Unable to publish module '00000000000000000000000000000042::M'. Got VMErr
 }
 
 task 1 'publish'. lines 14-23:
-Error: Unable to publish module '00000000000000000000000000000042::N'. Got VMError: {
+Error: Unable to publish module '0x42::N'. Got VMError: {
     major_status: MOVETO_TYPE_MISMATCH_ERROR,
     sub_status: None,
     location: 0x42::N,

--- a/language/move-bytecode-verifier/transactional-tests/tests/type_safety/signer_move_to_non_struct.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/type_safety/signer_move_to_non_struct.exp
@@ -1,7 +1,7 @@
 processed 1 task
 
 task 0 'publish'. lines 1-10:
-Error: Unable to publish module '00000000000000000000000000000042::N'. Got VMError: {
+Error: Unable to publish module '0x42::N'. Got VMError: {
     major_status: MOVETO_TYPE_MISMATCH_ERROR,
     sub_status: None,
     location: 0x42::N,

--- a/language/move-bytecode-verifier/transactional-tests/tests/type_safety/signer_move_to_reference_to_args_flipped.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/type_safety/signer_move_to_reference_to_args_flipped.exp
@@ -1,7 +1,7 @@
 processed 2 tasks
 
 task 0 'publish'. lines 1-12:
-Error: Unable to publish module '00000000000000000000000000000042::M'. Got VMError: {
+Error: Unable to publish module '0x42::M'. Got VMError: {
     major_status: MOVETO_TYPE_MISMATCH_ERROR,
     sub_status: None,
     location: 0x42::M,
@@ -10,7 +10,7 @@ Error: Unable to publish module '00000000000000000000000000000042::M'. Got VMErr
 }
 
 task 1 'publish'. lines 14-23:
-Error: Unable to publish module '00000000000000000000000000000042::N'. Got VMError: {
+Error: Unable to publish module '0x42::N'. Got VMError: {
     major_status: MOVETO_TYPE_MISMATCH_ERROR,
     sub_status: None,
     location: 0x42::N,

--- a/language/move-bytecode-verifier/transactional-tests/tests/type_safety/signer_move_to_reference_to_resource.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/type_safety/signer_move_to_reference_to_resource.exp
@@ -1,7 +1,7 @@
 processed 2 tasks
 
 task 0 'publish'. lines 1-12:
-Error: Unable to publish module '00000000000000000000000000000042::M'. Got VMError: {
+Error: Unable to publish module '0x42::M'. Got VMError: {
     major_status: MOVETO_TYPE_MISMATCH_ERROR,
     sub_status: None,
     location: 0x42::M,
@@ -10,7 +10,7 @@ Error: Unable to publish module '00000000000000000000000000000042::M'. Got VMErr
 }
 
 task 1 'publish'. lines 14-23:
-Error: Unable to publish module '00000000000000000000000000000042::N'. Got VMError: {
+Error: Unable to publish module '0x42::N'. Got VMError: {
     major_status: MOVETO_TYPE_MISMATCH_ERROR,
     sub_status: None,
     location: 0x42::N,

--- a/language/move-bytecode-verifier/transactional-tests/tests/type_safety/signer_move_to_reference_to_wrong_resource.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/type_safety/signer_move_to_reference_to_wrong_resource.exp
@@ -1,7 +1,7 @@
 processed 2 tasks
 
 task 0 'publish'. lines 1-13:
-Error: Unable to publish module '00000000000000000000000000000042::M'. Got VMError: {
+Error: Unable to publish module '0x42::M'. Got VMError: {
     major_status: MOVETO_TYPE_MISMATCH_ERROR,
     sub_status: None,
     location: 0x42::M,
@@ -10,7 +10,7 @@ Error: Unable to publish module '00000000000000000000000000000042::M'. Got VMErr
 }
 
 task 1 'publish'. lines 15-25:
-Error: Unable to publish module '00000000000000000000000000000042::N'. Got VMError: {
+Error: Unable to publish module '0x42::N'. Got VMError: {
     major_status: MOVETO_TYPE_MISMATCH_ERROR,
     sub_status: None,
     location: 0x42::N,

--- a/language/move-bytecode-verifier/transactional-tests/tests/type_safety/signer_read_ref.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/type_safety/signer_read_ref.exp
@@ -1,7 +1,7 @@
 processed 1 task
 
 task 0 'publish'. lines 1-8:
-Error: Unable to publish module '00000000000000000000000000000042::M'. Got VMError: {
+Error: Unable to publish module '0x42::M'. Got VMError: {
     major_status: READREF_WITHOUT_COPY_ABILITY,
     sub_status: None,
     location: 0x42::M,

--- a/language/move-bytecode-verifier/transactional-tests/tests/type_safety/signer_read_ref_transitive.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/type_safety/signer_read_ref_transitive.exp
@@ -1,7 +1,7 @@
 processed 2 tasks
 
 task 0 'publish'. lines 1-11:
-Error: Unable to publish module '00000000000000000000000000000042::M'. Got VMError: {
+Error: Unable to publish module '0x42::M'. Got VMError: {
     major_status: READREF_WITHOUT_COPY_ABILITY,
     sub_status: None,
     location: 0x42::M,
@@ -10,7 +10,7 @@ Error: Unable to publish module '00000000000000000000000000000042::M'. Got VMErr
 }
 
 task 1 'publish'. lines 13-23:
-Error: Unable to publish module '00000000000000000000000000000042::M'. Got VMError: {
+Error: Unable to publish module '0x42::M'. Got VMError: {
     major_status: READREF_WITHOUT_COPY_ABILITY,
     sub_status: None,
     location: 0x42::M,

--- a/language/move-bytecode-verifier/transactional-tests/tests/type_safety/struct_kind_inference.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/type_safety/struct_kind_inference.exp
@@ -1,7 +1,7 @@
 processed 5 tasks
 
 task 0 'publish'. lines 1-12:
-Error: Unable to publish module '00000000000000000000000000000001::M1'. Got VMError: {
+Error: Unable to publish module '0x1::M1'. Got VMError: {
     major_status: UNSAFE_RET_UNUSED_VALUES_WITHOUT_DROP,
     sub_status: None,
     location: 0x1::M1,
@@ -10,7 +10,7 @@ Error: Unable to publish module '00000000000000000000000000000001::M1'. Got VMEr
 }
 
 task 1 'publish'. lines 14-25:
-Error: Unable to publish module '00000000000000000000000000000001::M2'. Got VMError: {
+Error: Unable to publish module '0x1::M2'. Got VMError: {
     major_status: STLOC_UNSAFE_TO_DESTROY_ERROR,
     sub_status: None,
     location: 0x1::M2,
@@ -19,7 +19,7 @@ Error: Unable to publish module '00000000000000000000000000000001::M2'. Got VMEr
 }
 
 task 2 'publish'. lines 27-37:
-Error: Unable to publish module '00000000000000000000000000000001::M3'. Got VMError: {
+Error: Unable to publish module '0x1::M3'. Got VMError: {
     major_status: READREF_WITHOUT_COPY_ABILITY,
     sub_status: None,
     location: 0x1::M3,
@@ -28,7 +28,7 @@ Error: Unable to publish module '00000000000000000000000000000001::M3'. Got VMEr
 }
 
 task 3 'publish'. lines 39-50:
-Error: Unable to publish module '00000000000000000000000000000001::M4'. Got VMError: {
+Error: Unable to publish module '0x1::M4'. Got VMError: {
     major_status: WRITEREF_WITHOUT_DROP_ABILITY,
     sub_status: None,
     location: 0x1::M4,
@@ -37,7 +37,7 @@ Error: Unable to publish module '00000000000000000000000000000001::M4'. Got VMEr
 }
 
 task 4 'publish'. lines 52-62:
-Error: Unable to publish module '00000000000000000000000000000001::M5'. Got VMError: {
+Error: Unable to publish module '0x1::M5'. Got VMError: {
     major_status: COPYLOC_WITHOUT_COPY_ABILITY,
     sub_status: None,
     location: 0x1::M5,

--- a/language/move-bytecode-verifier/transactional-tests/tests/type_safety/unpack_wrong_type.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/type_safety/unpack_wrong_type.exp
@@ -1,7 +1,7 @@
 processed 1 task
 
 task 0 'publish'. lines 1-19:
-Error: Unable to publish module '00000000000000000000000000000001::Test'. Got VMError: {
+Error: Unable to publish module '0x1::Test'. Got VMError: {
     major_status: UNPACK_TYPE_MISMATCH_ERROR,
     sub_status: None,
     location: 0x1::Test,

--- a/language/move-bytecode-verifier/transactional-tests/tests/type_safety/unrestricted_instantiate_bad_type.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/type_safety/unrestricted_instantiate_bad_type.exp
@@ -1,7 +1,7 @@
 processed 1 task
 
 task 0 'publish'. lines 1-10:
-Error: Unable to publish module '00000000000000000000000000000042::Test'. Got VMError: {
+Error: Unable to publish module '0x42::Test'. Got VMError: {
     major_status: PACK_TYPE_MISMATCH_ERROR,
     sub_status: None,
     location: 0x42::Test,

--- a/language/move-core/types/src/language_storage.rs
+++ b/language/move-core/types/src/language_storage.rs
@@ -142,11 +142,24 @@ impl ModuleId {
 
 impl Display for ModuleId {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
-        write!(f, "{}::{}", self.address, self.name)
+        self.short_str_lossless().fmt(f)
     }
 }
 
 impl ModuleId {
+    /// Returns a human-readable representation of the module id; that is,
+    /// with a shortened address.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use move_core_types::{ident_str, language_storage::ModuleId, account_address::AccountAddress};
+    /// let my_module_id = ModuleId::new(
+    ///   AccountAddress::from_hex_literal("0xAbCd123").unwrap(),
+    ///   ident_str!("abc").into(),
+    /// );
+    /// assert_eq!(my_module_id.short_str_lossless(), "0xabcd123::abc");
+    /// ```
     pub fn short_str_lossless(&self) -> String {
         format!("0x{}::{}", self.address.short_str_lossless(), self.name)
     }

--- a/language/move-vm/transactional-tests/tests/module_publishing/republish_module_incompatible_change_friend_fn.exp
+++ b/language/move-vm/transactional-tests/tests/module_publishing/republish_module_incompatible_change_friend_fn.exp
@@ -1,7 +1,7 @@
 processed 4 tasks
 
 task 3 'publish'. lines 28-36:
-Error: Unable to publish module '00000000000000000000000000000042::M'. Got VMError: {
+Error: Unable to publish module '0x42::M'. Got VMError: {
     major_status: BACKWARD_INCOMPATIBLE_MODULE_UPDATE,
     sub_status: None,
     location: undefined,

--- a/language/move-vm/transactional-tests/tests/module_publishing/republish_module_incompatible_change_unused_friend_fn.exp
+++ b/language/move-vm/transactional-tests/tests/module_publishing/republish_module_incompatible_change_unused_friend_fn.exp
@@ -1,7 +1,7 @@
 processed 3 tasks
 
 task 2 'publish'. lines 14-22:
-Error: Unable to publish module '00000000000000000000000000000042::M'. Got VMError: {
+Error: Unable to publish module '0x42::M'. Got VMError: {
     major_status: BACKWARD_INCOMPATIBLE_MODULE_UPDATE,
     sub_status: None,
     location: undefined,

--- a/language/move-vm/transactional-tests/tests/module_publishing/republish_module_incompatible_delete_friend_fn.exp
+++ b/language/move-vm/transactional-tests/tests/module_publishing/republish_module_incompatible_delete_friend_fn.exp
@@ -1,7 +1,7 @@
 processed 4 tasks
 
 task 3 'publish'. lines 28-33:
-Error: Unable to publish module '00000000000000000000000000000042::M'. Got VMError: {
+Error: Unable to publish module '0x42::M'. Got VMError: {
     major_status: BACKWARD_INCOMPATIBLE_MODULE_UPDATE,
     sub_status: None,
     location: undefined,

--- a/language/move-vm/transactional-tests/tests/module_publishing/republish_module_incompatible_delete_unused_friend_fn.exp
+++ b/language/move-vm/transactional-tests/tests/module_publishing/republish_module_incompatible_delete_unused_friend_fn.exp
@@ -1,7 +1,7 @@
 processed 3 tasks
 
 task 2 'publish'. lines 14-18:
-Error: Unable to publish module '00000000000000000000000000000042::M'. Got VMError: {
+Error: Unable to publish module '0x42::M'. Got VMError: {
     major_status: BACKWARD_INCOMPATIBLE_MODULE_UPDATE,
     sub_status: None,
     location: undefined,

--- a/language/move-vm/transactional-tests/tests/module_publishing/republish_module_incompatible_drop_friend.exp
+++ b/language/move-vm/transactional-tests/tests/module_publishing/republish_module_incompatible_drop_friend.exp
@@ -1,7 +1,7 @@
 processed 4 tasks
 
 task 3 'publish'. lines 28-35:
-Error: Unable to publish module '00000000000000000000000000000042::M'. Got VMError: {
+Error: Unable to publish module '0x42::M'. Got VMError: {
     major_status: BACKWARD_INCOMPATIBLE_MODULE_UPDATE,
     sub_status: None,
     location: undefined,

--- a/language/move-vm/transactional-tests/tests/module_publishing/republish_module_incompatible_drop_unlinked_friend.exp
+++ b/language/move-vm/transactional-tests/tests/module_publishing/republish_module_incompatible_drop_unlinked_friend.exp
@@ -1,7 +1,7 @@
 processed 3 tasks
 
 task 2 'publish'. lines 14-21:
-Error: Unable to publish module '00000000000000000000000000000042::M'. Got VMError: {
+Error: Unable to publish module '0x42::M'. Got VMError: {
     major_status: BACKWARD_INCOMPATIBLE_MODULE_UPDATE,
     sub_status: None,
     location: undefined,

--- a/language/move-vm/transactional-tests/tests/module_publishing/republish_module_incompatible_entry_removed.exp
+++ b/language/move-vm/transactional-tests/tests/module_publishing/republish_module_incompatible_entry_removed.exp
@@ -1,7 +1,7 @@
 processed 6 tasks
 
 task 1 'publish'. lines 11-17:
-Error: Unable to publish module '00000000000000000000000000000042::Priv'. Got VMError: {
+Error: Unable to publish module '0x42::Priv'. Got VMError: {
     major_status: BACKWARD_INCOMPATIBLE_MODULE_UPDATE,
     sub_status: None,
     location: undefined,
@@ -10,7 +10,7 @@ Error: Unable to publish module '00000000000000000000000000000042::Priv'. Got VM
 }
 
 task 3 'publish'. lines 27-33:
-Error: Unable to publish module '00000000000000000000000000000042::Pub'. Got VMError: {
+Error: Unable to publish module '0x42::Pub'. Got VMError: {
     major_status: BACKWARD_INCOMPATIBLE_MODULE_UPDATE,
     sub_status: None,
     location: undefined,
@@ -19,7 +19,7 @@ Error: Unable to publish module '00000000000000000000000000000042::Pub'. Got VME
 }
 
 task 5 'publish'. lines 43-49:
-Error: Unable to publish module '00000000000000000000000000000042::Fr'. Got VMError: {
+Error: Unable to publish module '0x42::Fr'. Got VMError: {
     major_status: BACKWARD_INCOMPATIBLE_MODULE_UPDATE,
     sub_status: None,
     location: undefined,

--- a/language/move-vm/transactional-tests/tests/module_publishing/republish_module_incompatible_friend_fn_to_private.exp
+++ b/language/move-vm/transactional-tests/tests/module_publishing/republish_module_incompatible_friend_fn_to_private.exp
@@ -1,7 +1,7 @@
 processed 4 tasks
 
 task 3 'publish'. lines 28-36:
-Error: Unable to publish module '00000000000000000000000000000042::M'. Got VMError: {
+Error: Unable to publish module '0x42::M'. Got VMError: {
     major_status: BACKWARD_INCOMPATIBLE_MODULE_UPDATE,
     sub_status: None,
     location: undefined,

--- a/language/move-vm/transactional-tests/tests/module_publishing/republish_module_incompatible_layout.exp
+++ b/language/move-vm/transactional-tests/tests/module_publishing/republish_module_incompatible_layout.exp
@@ -1,7 +1,7 @@
 processed 2 tasks
 
 task 1 'publish'. lines 6-10:
-Error: Unable to publish module '00000000000000000000000000000042::Duplicate'. Got VMError: {
+Error: Unable to publish module '0x42::Duplicate'. Got VMError: {
     major_status: BACKWARD_INCOMPATIBLE_MODULE_UPDATE,
     sub_status: None,
     location: undefined,

--- a/language/move-vm/transactional-tests/tests/module_publishing/republish_module_incompatible_linking.exp
+++ b/language/move-vm/transactional-tests/tests/module_publishing/republish_module_incompatible_linking.exp
@@ -1,7 +1,7 @@
 processed 2 tasks
 
 task 1 'publish'. lines 7-11:
-Error: Unable to publish module '00000000000000000000000000000042::Duplicate'. Got VMError: {
+Error: Unable to publish module '0x42::Duplicate'. Got VMError: {
     major_status: BACKWARD_INCOMPATIBLE_MODULE_UPDATE,
     sub_status: None,
     location: undefined,

--- a/language/move-vm/transactional-tests/tests/native_functions/clever_non_existant_native_function.exp
+++ b/language/move-vm/transactional-tests/tests/native_functions/clever_non_existant_native_function.exp
@@ -1,7 +1,7 @@
 processed 3 tasks
 
 task 0 'publish'. lines 1-5:
-Error: Unable to publish module '00000000000000000000000000000042::Hash'. Got VMError: {
+Error: Unable to publish module '0x42::Hash'. Got VMError: {
     major_status: MISSING_DEPENDENCY,
     sub_status: None,
     location: 0x42::Hash,
@@ -10,7 +10,7 @@ Error: Unable to publish module '00000000000000000000000000000042::Hash'. Got VM
 }
 
 task 1 'publish'. lines 7-10:
-Error: Unable to publish module '00000000000000000000000000000043::Hash'. Got VMError: {
+Error: Unable to publish module '0x43::Hash'. Got VMError: {
     major_status: MISSING_DEPENDENCY,
     sub_status: None,
     location: 0x43::Hash,
@@ -19,7 +19,7 @@ Error: Unable to publish module '00000000000000000000000000000043::Hash'. Got VM
 }
 
 task 2 'publish'. lines 12-15:
-Error: Unable to publish module '00000000000000000000000000000044::Hash'. Got VMError: {
+Error: Unable to publish module '0x44::Hash'. Got VMError: {
     major_status: MISSING_DEPENDENCY,
     sub_status: None,
     location: 0x44::Hash,

--- a/language/move-vm/transactional-tests/tests/native_functions/non_existant_native_function.exp
+++ b/language/move-vm/transactional-tests/tests/native_functions/non_existant_native_function.exp
@@ -1,7 +1,7 @@
 processed 1 task
 
 task 0 'publish'. lines 1-5:
-Error: Unable to publish module '00000000000000000000000000000042::No'. Got VMError: {
+Error: Unable to publish module '0x42::No'. Got VMError: {
     major_status: MISSING_DEPENDENCY,
     sub_status: None,
     location: 0x42::No,

--- a/language/move-vm/transactional-tests/tests/native_functions/vector_resource_not_destroyed_at_return.exp
+++ b/language/move-vm/transactional-tests/tests/native_functions/vector_resource_not_destroyed_at_return.exp
@@ -1,7 +1,7 @@
 processed 1 task
 
 task 0 'publish'. lines 1-14:
-Error: Unable to publish module '00000000000000000000000000000042::M'. Got VMError: {
+Error: Unable to publish module '0x42::M'. Got VMError: {
     major_status: UNSAFE_RET_UNUSED_VALUES_WITHOUT_DROP,
     sub_status: None,
     location: 0x42::M,

--- a/language/move-vm/transactional-tests/tests/native_structs/non_existant_native_struct.exp
+++ b/language/move-vm/transactional-tests/tests/native_structs/non_existant_native_struct.exp
@@ -1,7 +1,7 @@
 processed 1 task
 
 task 0 'publish'. lines 1-6:
-Error: Unable to publish module '00000000000000000000000000000042::M'. Got VMError: {
+Error: Unable to publish module '0x42::M'. Got VMError: {
     major_status: MISSING_DEPENDENCY,
     sub_status: None,
     location: 0x42::M,

--- a/language/tools/move-cli/tests/sandbox_tests/build_modules_and_scripts/args.exp
+++ b/language/tools/move-cli/tests/sandbox_tests/build_modules_and_scripts/args.exp
@@ -1,4 +1,4 @@
 Command `-v sandbox publish`:
 Found 1 modules
-Publishing a new module 00000000000000000000000000000042::M (wrote 56 bytes)
+Publishing a new module 0x42::M (wrote 56 bytes)
 Wrote 56 bytes of module ID's and code

--- a/language/tools/move-cli/tests/sandbox_tests/cyclic_multi_module_publish/args.exp
+++ b/language/tools/move-cli/tests/sandbox_tests/cyclic_multi_module_publish/args.exp
@@ -1,8 +1,8 @@
 Command `-p p1 sandbox publish --bundle --override-ordering A --override-ordering B -v`:
 Found 2 modules
-Publishing a new module 00000000000000000000000000000003::A (wrote 82 bytes)
-Publishing a new module 00000000000000000000000000000003::B (wrote 93 bytes)
+Publishing a new module 0x3::A (wrote 82 bytes)
+Publishing a new module 0x3::B (wrote 93 bytes)
 Wrote 175 bytes of module ID's and code
 Command `-p p2 sandbox publish --bundle --override-ordering A --override-ordering C -v`:
 Found 3 modules
-Invalid multi-module publishing: VMError with status INVALID_FRIEND_DECL_WITH_MODULES_IN_DEPENDENCIES at location Module ModuleId { address: 00000000000000000000000000000003, name: Identifier("C") } and message At least one module, 00000000000000000000000000000003::A, appears in both the dependency set and the friend set
+Invalid multi-module publishing: VMError with status INVALID_FRIEND_DECL_WITH_MODULES_IN_DEPENDENCIES at location Module ModuleId { address: 00000000000000000000000000000003, name: Identifier("C") } and message At least one module, 0x3::A, appears in both the dependency set and the friend set

--- a/language/tools/move-cli/tests/sandbox_tests/examples_published_dev_mode/args.exp
+++ b/language/tools/move-cli/tests/sandbox_tests/examples_published_dev_mode/args.exp
@@ -1,9 +1,9 @@
 Command `sandbox publish -v`:
 Found 1 modules
-Publishing a new module 00000000000000000000000000000001::Module (wrote 66 bytes)
+Publishing a new module 0x1::Module (wrote 66 bytes)
 Wrote 66 bytes of module ID's and code
 Command `-d sandbox publish -v`:
 Found 2 modules
-Publishing a new module 00000000000000000000000000000001::Example (wrote 68 bytes)
-Updating an existing module 00000000000000000000000000000001::Module (wrote 66 bytes)
+Publishing a new module 0x1::Example (wrote 68 bytes)
+Updating an existing module 0x1::Module (wrote 66 bytes)
 Wrote 134 bytes of module ID's and code

--- a/language/tools/move-cli/tests/sandbox_tests/explain_missing_resource/args.exp
+++ b/language/tools/move-cli/tests/sandbox_tests/explain_missing_resource/args.exp
@@ -1,3 +1,3 @@
 Command `sandbox publish`:
 Command `sandbox run scripts/missing_resource.move`:
-Execution failed because of a RESOURCE_DOES_NOT_EXIST error (i.e., `move_from<T>(a)`, `borrow_global<T>(a)`, or `borrow_global_mut<T>(a)` when there is no resource of type `T` at address `a`) in 00000000000000000000000000000002::MissingResource::f at code offset 1
+Execution failed because of a RESOURCE_DOES_NOT_EXIST error (i.e., `move_from<T>(a)`, `borrow_global<T>(a)`, or `borrow_global_mut<T>(a)` when there is no resource of type `T` at address `a`) in 0x2::MissingResource::f at code offset 1

--- a/language/tools/move-cli/tests/sandbox_tests/explain_resource_already_exists/args.exp
+++ b/language/tools/move-cli/tests/sandbox_tests/explain_resource_already_exists/args.exp
@@ -1,3 +1,3 @@
 Command `sandbox publish`:
 Command `sandbox run scripts/resource_already_exists.move --signers 0xA`:
-Execution failed because of a RESOURCE_ALREADY_EXISTS error (i.e., `move_to<T>(account)` when there is already a resource of type `T` under `account`) in 00000000000000000000000000000002::ResourceExists::f at code offset 7
+Execution failed because of a RESOURCE_ALREADY_EXISTS error (i.e., `move_to<T>(account)` when there is already a resource of type `T` under `account`) in 0x2::ResourceExists::f at code offset 7

--- a/language/tools/move-cli/tests/sandbox_tests/explain_user_module_abort/args.exp
+++ b/language/tools/move-cli/tests/sandbox_tests/explain_user_module_abort/args.exp
@@ -1,3 +1,3 @@
 Command `sandbox publish`:
 Command `sandbox run scripts/fail_script.move`:
-Execution aborted with code 77 in module 00000000000000000000000000000002::Fail.
+Execution aborted with code 77 in module 0x2::Fail.

--- a/language/tools/move-cli/tests/sandbox_tests/generate_struct_layout/args.exp
+++ b/language/tools/move-cli/tests/sandbox_tests/generate_struct_layout/args.exp
@@ -1,7 +1,7 @@
 Command `sandbox publish`:
 Command `sandbox generate struct-layouts --module storage/0x00000000000000000000000000000001/modules/M2.mv --struct C --type-args u64`:
 ---
-"00000000000000000000000000000001::M2::C<u64>":
+"0x1::M2::C<u64>":
   STRUCT:
     - t: U64
     - b: BOOL
@@ -18,7 +18,7 @@ Signer:
 
 Command `sandbox generate struct-layouts --module storage/0x00000000000000000000000000000001/modules/M2.mv --struct C --type-args address`:
 ---
-"00000000000000000000000000000001::M2::C<AccountAddress>":
+"0x1::M2::C<AccountAddress>":
   STRUCT:
     - t:
         TYPENAME: AccountAddress
@@ -36,7 +36,7 @@ Signer:
 
 Command `sandbox generate struct-layouts --module storage/0x00000000000000000000000000000001/modules/M2.mv --struct C --type-args vector<u8>`:
 ---
-"00000000000000000000000000000001::M2::C<vector<u8>>":
+"0x1::M2::C<vector<u8>>":
   STRUCT:
     - t: BYTES
     - b: BOOL
@@ -53,14 +53,14 @@ Signer:
 
 Command `sandbox generate struct-layouts --module storage/0x00000000000000000000000000000001/modules/M1.mv --struct B --type-args bool`:
 ---
-"00000000000000000000000000000001::M1::B<bool>":
+"0x1::M1::B<bool>":
   STRUCT:
     - a:
         TYPENAME: AccountAddress
     - c:
-        TYPENAME: "00000000000000000000000000000001::M2::C<bool>"
+        TYPENAME: "0x1::M2::C<bool>"
     - t: BOOL
-"00000000000000000000000000000001::M2::C<bool>":
+"0x1::M2::C<bool>":
   STRUCT:
     - t: BOOL
     - b: BOOL
@@ -77,37 +77,37 @@ Signer:
 
 Command `sandbox generate struct-layouts --module storage/0x00000000000000000000000000000001/modules/M1.mv --struct B --type-args bool --shallow`:
 ---
-"00000000000000000000000000000001::M1::B<bool>":
+"0x1::M1::B<bool>":
   STRUCT:
     - a:
         TYPENAME: AccountAddress
     - c:
-        TYPENAME: "00000000000000000000000000000001::M2::C<bool>"
+        TYPENAME: "0x1::M2::C<bool>"
     - t: BOOL
 
 Command `sandbox generate struct-layouts --module storage/0x00000000000000000000000000000001/modules/M1.mv --struct A --type-args 0x1::M1::S<u64>`:
 ---
-"00000000000000000000000000000001::M1::A<00000000000000000000000000000001::M1::S<u64>>":
+"0x1::M1::A<0x1::M1::S<u64>>":
   STRUCT:
     - f: U64
     - v: BYTES
     - b:
-        TYPENAME: "00000000000000000000000000000001::M1::B<00000000000000000000000000000001::M1::S<u64>>"
-"00000000000000000000000000000001::M1::B<00000000000000000000000000000001::M1::S<u64>>":
+        TYPENAME: "0x1::M1::B<0x1::M1::S<u64>>"
+"0x1::M1::B<0x1::M1::S<u64>>":
   STRUCT:
     - a:
         TYPENAME: AccountAddress
     - c:
-        TYPENAME: "00000000000000000000000000000001::M2::C<00000000000000000000000000000001::M1::S<u64>>"
+        TYPENAME: "0x1::M2::C<0x1::M1::S<u64>>"
     - t:
-        TYPENAME: "00000000000000000000000000000001::M1::S<u64>"
-"00000000000000000000000000000001::M1::S<u64>":
+        TYPENAME: "0x1::M1::S<u64>"
+"0x1::M1::S<u64>":
   STRUCT:
     - t: U64
-"00000000000000000000000000000001::M2::C<00000000000000000000000000000001::M1::S<u64>>":
+"0x1::M2::C<0x1::M1::S<u64>>":
   STRUCT:
     - t:
-        TYPENAME: "00000000000000000000000000000001::M1::S<u64>"
+        TYPENAME: "0x1::M1::S<u64>"
     - b: BOOL
 AccountAddress:
   NEWTYPESTRUCT:
@@ -122,29 +122,29 @@ Signer:
 
 Command `sandbox generate struct-layouts --module storage/0x00000000000000000000000000000001/modules/M1.mv --struct A --type-args vector<0x1::M1::S<u64>>`:
 ---
-"00000000000000000000000000000001::M1::A<vector<00000000000000000000000000000001::M1::S<u64>>>":
+"0x1::M1::A<vector<0x1::M1::S<u64>>>":
   STRUCT:
     - f: U64
     - v: BYTES
     - b:
-        TYPENAME: "00000000000000000000000000000001::M1::B<vector<00000000000000000000000000000001::M1::S<u64>>>"
-"00000000000000000000000000000001::M1::B<vector<00000000000000000000000000000001::M1::S<u64>>>":
+        TYPENAME: "0x1::M1::B<vector<0x1::M1::S<u64>>>"
+"0x1::M1::B<vector<0x1::M1::S<u64>>>":
   STRUCT:
     - a:
         TYPENAME: AccountAddress
     - c:
-        TYPENAME: "00000000000000000000000000000001::M2::C<vector<00000000000000000000000000000001::M1::S<u64>>>"
+        TYPENAME: "0x1::M2::C<vector<0x1::M1::S<u64>>>"
     - t:
         SEQ:
-          TYPENAME: "00000000000000000000000000000001::M1::S<u64>"
-"00000000000000000000000000000001::M1::S<u64>":
+          TYPENAME: "0x1::M1::S<u64>"
+"0x1::M1::S<u64>":
   STRUCT:
     - t: U64
-"00000000000000000000000000000001::M2::C<vector<00000000000000000000000000000001::M1::S<u64>>>":
+"0x1::M2::C<vector<0x1::M1::S<u64>>>":
   STRUCT:
     - t:
         SEQ:
-          TYPENAME: "00000000000000000000000000000001::M1::S<u64>"
+          TYPENAME: "0x1::M1::S<u64>"
     - b: BOOL
 AccountAddress:
   NEWTYPESTRUCT:
@@ -159,30 +159,30 @@ Signer:
 
 Command `sandbox generate struct-layouts --module storage/0x00000000000000000000000000000001/modules/M1.mv --struct A --type-args 0x1::M1::S<u64> --shallow`:
 ---
-"00000000000000000000000000000001::M1::A<00000000000000000000000000000001::M1::S<u64>>":
+"0x1::M1::A<0x1::M1::S<u64>>":
   STRUCT:
     - f: U64
     - v: BYTES
     - b:
-        TYPENAME: "00000000000000000000000000000001::M1::B<00000000000000000000000000000001::M1::S<u64>>"
+        TYPENAME: "0x1::M1::B<0x1::M1::S<u64>>"
 
 Command `sandbox generate struct-layouts --module storage/0x00000000000000000000000000000001/modules/M1.mv --struct A --type-args vector<0x1::M1::S<u64>> --shallow`:
 ---
-"00000000000000000000000000000001::M1::A<vector<00000000000000000000000000000001::M1::S<u64>>>":
+"0x1::M1::A<vector<0x1::M1::S<u64>>>":
   STRUCT:
     - f: U64
     - v: BYTES
     - b:
-        TYPENAME: "00000000000000000000000000000001::M1::B<vector<00000000000000000000000000000001::M1::S<u64>>>"
+        TYPENAME: "0x1::M1::B<vector<0x1::M1::S<u64>>>"
 
 Command `sandbox generate struct-layouts --module storage/0x00000000000000000000000000000001/modules/M2.mv --struct C --type-args 0x1::M2::C<u64>`:
 ---
-"00000000000000000000000000000001::M2::C<00000000000000000000000000000001::M2::C<u64>>":
+"0x1::M2::C<0x1::M2::C<u64>>":
   STRUCT:
     - t:
-        TYPENAME: "00000000000000000000000000000001::M2::C<u64>"
+        TYPENAME: "0x1::M2::C<u64>"
     - b: BOOL
-"00000000000000000000000000000001::M2::C<u64>":
+"0x1::M2::C<u64>":
   STRUCT:
     - t: U64
     - b: BOOL
@@ -199,12 +199,12 @@ Signer:
 
 Command `sandbox generate struct-layouts --module storage/0x00000000000000000000000000000001/modules/M1.mv --struct G`:
 ---
-"00000000000000000000000000000001::M1::G<>":
+"0x1::M1::G<>":
   STRUCT:
     - x: U64
     - s:
-        TYPENAME: "00000000000000000000000000000001::M1::S<bool>"
-"00000000000000000000000000000001::M1::S<bool>":
+        TYPENAME: "0x1::M1::S<bool>"
+"0x1::M1::S<bool>":
   STRUCT:
     - t: BOOL
 AccountAddress:

--- a/language/tools/move-cli/tests/sandbox_tests/module_publish_view/args.exp
+++ b/language/tools/move-cli/tests/sandbox_tests/module_publish_view/args.exp
@@ -1,6 +1,6 @@
 Command `sandbox publish -v`:
 Found 1 modules
-Publishing a new module 00000000000000000000000000000042::Module (wrote 120 bytes)
+Publishing a new module 0x42::Module (wrote 120 bytes)
 Wrote 120 bytes of module ID's and code
 Command `sandbox view storage/0x00000000000000000000000000000042/modules/Module.mv`:
 // Move bytecode v5

--- a/language/tools/move-cli/tests/sandbox_tests/multi_module_publish/args.exp
+++ b/language/tools/move-cli/tests/sandbox_tests/multi_module_publish/args.exp
@@ -9,8 +9,8 @@ Found 2 modules
 Invalid multi-module publishing: VMError with status LINKER_ERROR at location UNDEFINED and message Cannot find ModuleId { address: 00000000000000000000000000000002, name: Identifier("A") } in data cache
 Command `sandbox publish --bundle --override-ordering A --override-ordering B -v`:
 Found 2 modules
-Publishing a new module 00000000000000000000000000000002::A (wrote 89 bytes)
-Publishing a new module 00000000000000000000000000000002::B (wrote 97 bytes)
+Publishing a new module 0x2::A (wrote 89 bytes)
+Publishing a new module 0x2::B (wrote 97 bytes)
 Wrote 186 bytes of module ID's and code
 Command `sandbox view storage/0x00000000000000000000000000000002/modules/A.mv`:
 // Move bytecode v5

--- a/language/tools/move-cli/tests/sandbox_tests/offer_smoke/args.exp
+++ b/language/tools/move-cli/tests/sandbox_tests/offer_smoke/args.exp
@@ -1,14 +1,14 @@
 Command `sandbox publish`:
 Command `sandbox run scripts/create_offer.move --signers 0xA11CE`:
 Command `sandbox run scripts/redeem_offer.move --signers 0xCA21`:
-Execution aborted with code 65536 in module 00000000000000000000000000000001::offer.
+Execution aborted with code 65536 in module 0x1::offer.
 Command `sandbox run scripts/redeem_offer_bob.move --signers 0xB0B`:
 Command `sandbox run scripts/reclaim_offer.move --signers 0xB0B`:
 Command `sandbox clean`:
 Command `sandbox run scripts/self_offer_create.move --signers 0xA11CE`:
 Command `sandbox clean`:
 Command `sandbox run scripts/multi_offer.move --signers 0xA11CE`:
-Execution aborted with code 524289 in module 00000000000000000000000000000001::offer.
+Execution aborted with code 524289 in module 0x1::offer.
 Command `sandbox clean`:
 Command `sandbox run scripts/non_existent_offer.move --signers 0xA11CE`:
-Execution aborted with code 393218 in module 00000000000000000000000000000001::offer.
+Execution aborted with code 393218 in module 0x1::offer.

--- a/language/tools/move-cli/tests/sandbox_tests/republish/args.exp
+++ b/language/tools/move-cli/tests/sandbox_tests/republish/args.exp
@@ -1,7 +1,7 @@
 Command `sandbox publish -v`:
 Found 2 modules
-Publishing a new module 00000000000000000000000000000042::M (wrote 56 bytes)
-Publishing a new module 00000000000000000000000000000043::N (wrote 56 bytes)
+Publishing a new module 0x42::M (wrote 56 bytes)
+Publishing a new module 0x43::N (wrote 56 bytes)
 Wrote 112 bytes of module ID's and code
 Command `sandbox view storage/0x00000000000000000000000000000042/modules/M.mv`:
 // Move bytecode v5
@@ -19,8 +19,8 @@ module 43.N {
 }
 Command `sandbox publish -v`:
 Found 2 modules
-Updating an existing module 00000000000000000000000000000042::M (wrote 56 bytes)
-Updating an existing module 00000000000000000000000000000043::N (wrote 56 bytes)
+Updating an existing module 0x42::M (wrote 56 bytes)
+Updating an existing module 0x43::N (wrote 56 bytes)
 Wrote 112 bytes of module ID's and code
 Command `sandbox view storage/0x00000000000000000000000000000042/modules/M.mv`:
 // Move bytecode v5
@@ -38,4 +38,4 @@ module 43.N {
 }
 Command `sandbox publish -v --no-republish`:
 Found 2 modules
-Failed to republish modules since the --no-republish flag is set. Tried to republish the following modules: 00000000000000000000000000000042::M, 00000000000000000000000000000043::N
+Failed to republish modules since the --no-republish flag is set. Tried to republish the following modules: 0x42::M, 0x43::N


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Move Language.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

The current `Display` impl for `ModuleId` is ugly.

This was covered by https://github.com/move-language/move/pull/416, but this version has no breaking changes to the serialized representation.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes

## Test Plan

Ran Cargo tests

