### PR TITLE
[move-test] Inclusion of debug module no longer gated by the testing feature

### DIFF
--- a/language/move-stdlib/src/natives/mod.rs
+++ b/language/move-stdlib/src/natives/mod.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod bcs;
+pub mod debug;
 pub mod event;
 pub mod hash;
 pub mod signer;
@@ -10,9 +11,6 @@ pub mod string;
 #[cfg(feature = "testing")]
 pub mod unit_test;
 pub mod vector;
-
-#[cfg(feature = "testing")]
-pub mod debug;
 
 mod helpers;
 
@@ -126,8 +124,6 @@ pub fn all_natives(
 #[derive(Debug, Clone)]
 pub struct NurseryGasParameters {
     event: event::GasParameters,
-
-    #[cfg(feature = "testing")]
     debug: debug::GasParameters,
 }
 
@@ -139,7 +135,6 @@ impl NurseryGasParameters {
                     unit_cost: 0.into(),
                 },
             },
-            #[cfg(feature = "testing")]
             debug: debug::GasParameters {
                 print: debug::PrintGasParameters {
                     base_cost: 0.into(),
@@ -167,10 +162,7 @@ pub fn nursery_natives(
     }
 
     add_natives!("event", event::make_all(gas_params.event));
-    #[cfg(feature = "testing")]
-    {
-        add_natives!("debug", debug::make_all(gas_params.debug));
-    }
+    add_natives!("debug", debug::make_all(gas_params.debug));
 
     make_table_from_iter(move_std_addr, natives)
 }


### PR DESCRIPTION
## Motivation

As discussed during one of the recent community meetings, it would be convenient to allow developers (temporarily) keep their debug printing code around in published modules while debugging their code on chain.

The intention is to keep be able to link with the `debug` module but have its (native) functions do something useful (that is actually print some info) only when testing. This is why the code of the debug native functions is gated on the "testing" feature. Unfortunately, inclusion of the `debug` module (or rather its native methods) is also gated on the "testing" feature which will throw an error during native function verification (as the Move-level functions will not have their Rust equivalents that are currently compiled away outside testing). This PR removes this restriction.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yet
