### PR TITLE
[move-prover] preliminary support for type reflection

### DIFF
--- a/language/move-model/src/well_known.rs
+++ b/language/move-model/src/well_known.rs
@@ -11,3 +11,6 @@ pub const VECTOR_BORROW_MUT: &str = "vector::borrow_mut";
 pub const TABLE_BORROW_MUT: &str = "table::borrow_mut";
 pub const EVENT_EMIT_EVENT: &str = "event::emit_event";
 pub const TABLE_TABLE: &str = "table::Table";
+
+pub const TYPE_NAME_MOVE: &str = "type_info::type_name";
+pub const TYPE_NAME_SPEC: &str = "type_info::$type_name";

--- a/language/move-prover/tests/sources/functional/type_reflection.move
+++ b/language/move-prover/tests/sources/functional/type_reflection.move
@@ -1,0 +1,36 @@
+module extensions::type_info {
+    use std::string;
+
+    // this is a mock of the type reflection scheme
+    public native fun type_name<T>(): string::String;
+}
+
+module 0x42::test {
+    use extensions::type_info;
+    use std::string;
+
+    struct MyTable<phantom K, phantom V> {}
+
+    fun test_type_name_concrete(): string::String {
+        spec {
+            assert type_info::type_name<bool>().bytes == b"bool";
+        };
+        type_info::type_name<MyTable<vector<bool>, address>>()
+    }
+    spec test_type_name_concrete {
+        ensures result.bytes == b"0x42::test::MyTable<vector<bool>, address>";
+    }
+
+    fun test_type_name_symbolic<T>(): string::String {
+        spec {
+            assert type_info::type_name<T>().bytes == type_info::type_name<T>().bytes;
+        };
+        type_info::type_name<MyTable<T, T>>()
+    }
+    spec test_type_name_symbolic {
+        ensures result.bytes != b"vector<bool>";
+        // TODO(mengxu): however, this ensures fails to verify.
+        // Further investigation needed, could be issues with ConcatVec.
+        // ensures result != type_info::type_name<vector<T>>();
+    }
+}


### PR DESCRIPTION
This commit introduces preliminary support on verifying code that uses reflection to obtain type information at runtime.

We use a hyperthetical (and intrinsic) call
`fun extension::type_info::type_name<T>(): String` that returns the type name of `T`.

Being a pure function, this reflection function can be called from the spec context as well.

In handling reflection, the high-level idea is:
- if `T` is statically known when `type_name<T>` is called, replace this call with a constant
- if `T` is unknown, full or partially, when this call is invoked, replace the `type_name` for `T` with a fresh variable `var #T_name: Vec int`, in particular:
  - if `T` is fully unknown, `type_name<T>` will be `#T_name`
  - if `T` is partially unknown (e.g., `type_name<vector<T>>`), then the `type_name` call will be replaced as `ConcatVec(ConcatVec("vector<", #T_name), ">")`

This instrumentation happens at the translation phase, on the way to Boogie.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Move Language.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Reasoning with a reflection context

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes

## Test Plan

- CI
- new test case added