### PR TITLE
[move-prover] model `type_of` which returns the struct tag triple

### DIFF
--- a/language/move-model/src/well_known.rs
+++ b/language/move-model/src/well_known.rs
@@ -14,3 +14,5 @@ pub const TABLE_TABLE: &str = "table::Table";
 
 pub const TYPE_NAME_MOVE: &str = "type_info::type_name";
 pub const TYPE_NAME_SPEC: &str = "type_info::$type_name";
+pub const TYPE_INFO_MOVE: &str = "type_info::type_of";
+pub const TYPE_INFO_SPEC: &str = "type_info::$type_of";

--- a/language/move-prover/boogie-backend/src/bytecode_translator.rs
+++ b/language/move-prover/boogie-backend/src/bytecode_translator.rs
@@ -18,7 +18,7 @@ use move_model::{
     model::{GlobalEnv, Loc, NodeId, QualifiedInstId, StructEnv, StructId},
     pragmas::{ADDITION_OVERFLOW_UNCHECKED_PRAGMA, SEED_PRAGMA, TIMEOUT_PRAGMA},
     ty::{PrimitiveType, Type, TypeDisplayContext, BOOL_TYPE},
-    well_known::TYPE_NAME_MOVE,
+    well_known::{TYPE_INFO_MOVE, TYPE_NAME_MOVE},
 };
 use move_stackless_bytecode::{
     function_target::FunctionTarget,
@@ -34,9 +34,9 @@ use crate::{
         boogie_address_blob, boogie_byte_blob, boogie_debug_track_abort, boogie_debug_track_local,
         boogie_debug_track_return, boogie_equality_for_type, boogie_field_sel, boogie_field_update,
         boogie_function_name, boogie_make_vec_from_strings, boogie_modifies_memory_name,
-        boogie_reflection_type_name, boogie_resource_memory_name, boogie_struct_name, boogie_temp,
-        boogie_type, boogie_type_param, boogie_type_suffix, boogie_type_suffix_for_struct,
-        boogie_well_formed_check, boogie_well_formed_expr,
+        boogie_reflection_type_info, boogie_reflection_type_name, boogie_resource_memory_name,
+        boogie_struct_name, boogie_temp, boogie_type, boogie_type_param, boogie_type_suffix,
+        boogie_type_suffix_for_struct, boogie_well_formed_check, boogie_well_formed_expr,
     },
     options::BoogieOptions,
     spec_translator::SpecTranslator,
@@ -112,6 +112,10 @@ impl<'env> BoogieTranslator<'env> {
 
             // declare free variables to represent the type info for this type
             emitln!(writer, "var {}_name: Vec int;", param_type);
+            emitln!(writer, "var {}_is_struct: bool;", param_type);
+            emitln!(writer, "var {}_account_address: int;", param_type);
+            emitln!(writer, "var {}_module_name: Vec int;", param_type);
+            emitln!(writer, "var {}_struct_name: Vec int;", param_type);
         }
         emitln!(writer);
 
@@ -968,6 +972,8 @@ impl<'env> FunctionTranslator<'env> {
                             .join(",");
 
                         // special casing for type reflection
+                        let mut processed = false;
+
                         // TODO(mengxu): change it to a better address name instead of extlib
                         if env.get_extlib_address() == *module_env.get_name().addr() {
                             let qualified_name = format!(
@@ -991,27 +997,44 @@ impl<'env> FunctionTranslator<'env> {
                                         boogie_reflection_type_name(env, &inst[0])
                                     );
                                 }
-                                return;
+                                processed = true;
+                            } else if qualified_name == TYPE_INFO_MOVE {
+                                assert_eq!(inst.len(), 1);
+                                let (flag, info) = boogie_reflection_type_info(env, &inst[0]);
+                                emitln!(writer, "if (!{}) {{", flag);
+                                writer.with_indent(|| emitln!(writer, "call $ExecFailureAbort();"));
+                                emitln!(writer, "}");
+                                if !dest_str.is_empty() {
+                                    emitln!(writer, "else {");
+                                    writer.with_indent(|| {
+                                        emitln!(writer, "{} := {};", dest_str, info)
+                                    });
+                                    emitln!(writer, "}");
+                                }
+                                processed = true;
                             }
                         }
 
                         // regular path
-                        if dest_str.is_empty() {
-                            emitln!(
-                                writer,
-                                "call {}({});",
-                                boogie_function_name(&callee_env, inst),
-                                args_str
-                            );
-                        } else {
-                            emitln!(
-                                writer,
-                                "call {} := {}({});",
-                                dest_str,
-                                boogie_function_name(&callee_env, inst),
-                                args_str
-                            );
+                        if !processed {
+                            if dest_str.is_empty() {
+                                emitln!(
+                                    writer,
+                                    "call {}({});",
+                                    boogie_function_name(&callee_env, inst),
+                                    args_str
+                                );
+                            } else {
+                                emitln!(
+                                    writer,
+                                    "call {} := {}({});",
+                                    dest_str,
+                                    boogie_function_name(&callee_env, inst),
+                                    args_str
+                                );
+                            }
                         }
+
                         // Clear the last track location after function call, as the call inserted
                         // location tracks before it returns.
                         *last_tracked_loc = None;

--- a/language/move-prover/bytecode/src/mono_analysis.rs
+++ b/language/move-prover/bytecode/src/mono_analysis.rs
@@ -21,7 +21,7 @@ use move_model::{
         SpecVarId, StructEnv, StructId,
     },
     ty::{Type, TypeDisplayContext, TypeInstantiationDerivation, TypeUnificationAdapter, Variance},
-    well_known::TABLE_TABLE,
+    well_known::{TABLE_TABLE, TYPE_INFO_MOVE, TYPE_INFO_SPEC, TYPE_NAME_MOVE, TYPE_NAME_SPEC},
 };
 
 use crate::{
@@ -328,18 +328,32 @@ impl<'a> Analyzer<'a> {
         // elsewhere.
         match bc {
             Call(_, _, Function(mid, fid, targs), ..) => {
-                let callee = &self.env.get_module(*mid).into_function(*fid);
+                let module_env = &self.env.get_module(*mid);
+                let callee_env = module_env.get_function(*fid);
                 let actuals = self.instantiate_vec(targs);
-                if callee.is_native_or_intrinsic() && !actuals.is_empty() {
+
+                // the type reflection functions are specially handled here
+                if self.env.get_extlib_address() == *module_env.get_name().addr() {
+                    let qualified_name = format!(
+                        "{}::{}",
+                        module_env.get_name().name().display(self.env.symbol_pool()),
+                        callee_env.get_name().display(self.env.symbol_pool()),
+                    );
+                    if qualified_name == TYPE_NAME_MOVE || qualified_name == TYPE_INFO_MOVE {
+                        self.add_type(&actuals[0]);
+                    }
+                }
+
+                if callee_env.is_native_or_intrinsic() && !actuals.is_empty() {
                     // Mark the associated module to be instantiated with the given actuals.
                     // This will instantiate all functions in the module with matching number
                     // of type parameters.
                     self.info
                         .native_inst
-                        .entry(callee.module_env.get_id())
+                        .entry(callee_env.module_env.get_id())
                         .or_default()
                         .insert(actuals);
-                } else if !callee.is_opaque() {
+                } else if !callee_env.is_opaque() {
                     // This call needs to be inlined, with targs instantiated by self.inst_opt.
                     // Schedule for later processing if this instance has not been processed yet.
                     let entry = (mid.qualified(*fid), FunctionVariant::Baseline, actuals);
@@ -398,9 +412,21 @@ impl<'a> Analyzer<'a> {
             }
             if let ExpData::Call(node_id, ast::Operation::Function(mid, fid, _), _) = e {
                 let actuals = self.instantiate_vec(&self.env.get_node_instantiation(*node_id));
-                // Only if this call has not been processed yet, queue it for future processing.
                 let module = self.env.get_module(*mid);
                 let spec_fun = module.get_spec_fun(*fid);
+
+                // the type reflection functions are specially handled here
+                if self.env.get_extlib_address() == *module.get_name().addr() {
+                    let qualified_name = format!(
+                        "{}::{}",
+                        module.get_name().name().display(self.env.symbol_pool()),
+                        spec_fun.name.display(self.env.symbol_pool()),
+                    );
+                    if qualified_name == TYPE_NAME_SPEC || qualified_name == TYPE_INFO_SPEC {
+                        self.add_type(&actuals[0]);
+                    }
+                }
+
                 if spec_fun.is_native && !actuals.is_empty() {
                     // Add module to native modules
                     self.info
@@ -410,6 +436,7 @@ impl<'a> Analyzer<'a> {
                         .insert(actuals);
                 } else {
                     let entry = (mid.qualified(*fid), actuals);
+                    // Only if this call has not been processed yet, queue it for future processing.
                     if !self.done_spec_funs.contains(&entry) {
                         self.todo_spec_funs.push(entry);
                     }

--- a/language/move-prover/tests/sources/functional/type_reflection.exp
+++ b/language/move-prover/tests/sources/functional/type_reflection.exp
@@ -1,0 +1,15 @@
+Move prover returns: exiting with verification errors
+error: abort not covered by any of the `aborts_if` clauses
+    ┌─ tests/sources/functional/type_reflection.move:98:5
+    │
+ 96 │           type_info::type_of<T>()
+    │           ----------------------- abort happened here with execution failure
+ 97 │       }
+ 98 │ ╭     spec test_type_info_can_abort {
+ 99 │ │         // this should not pass
+100 │ │         aborts_if false;
+101 │ │     }
+    │ ╰─────^
+    │
+    =     at tests/sources/functional/type_reflection.move:96: test_type_info_can_abort
+    =         ABORTED

--- a/language/move-prover/tests/sources/functional/type_reflection.move
+++ b/language/move-prover/tests/sources/functional/type_reflection.move
@@ -1,8 +1,27 @@
 module extensions::type_info {
     use std::string;
 
-    // this is a mock of the type reflection scheme
+    struct TypeInfo has copy, drop, store {
+        account_address: address,
+        module_name: vector<u8>,
+        struct_name: vector<u8>,
+    }
+
+    // these are mocks of the type reflection scheme
+    public native fun type_of<T>(): TypeInfo;
     public native fun type_name<T>(): string::String;
+
+    public fun account_address(type_info: &TypeInfo): address {
+        type_info.account_address
+    }
+
+    public fun module_name(type_info: &TypeInfo): vector<u8> {
+        type_info.module_name
+    }
+
+    public fun struct_name(type_info: &TypeInfo): vector<u8> {
+        type_info.struct_name
+    }
 }
 
 module 0x42::test {
@@ -32,5 +51,52 @@ module 0x42::test {
         // TODO(mengxu): however, this ensures fails to verify.
         // Further investigation needed, could be issues with ConcatVec.
         // ensures result != type_info::type_name<vector<T>>();
+    }
+
+    fun test_type_info_concrete(): type_info::TypeInfo {
+        spec {
+            assert type_info::type_of<MyTable<address, u128>>().account_address == @0x42;
+            assert type_info::type_of<MyTable<address, u128>>().module_name == b"test";
+            assert type_info::type_of<MyTable<address, u128>>().struct_name == b"MyTable";
+        };
+        type_info::type_of<MyTable<vector<bool>, address>>()
+    }
+    spec test_type_info_concrete {
+        ensures result.account_address == @0x42;
+        ensures result.module_name == b"test";
+        ensures result.struct_name == b"MyTable";
+    }
+
+    fun test_type_info_symbolic<T>(): type_info::TypeInfo {
+        spec {
+            assert type_info::type_of<T>().account_address == type_info::type_of<T>().account_address;
+            assert type_info::type_of<T>().module_name == type_info::type_of<T>().module_name;
+            assert type_info::type_of<T>().struct_name == type_info::type_of<T>().struct_name;
+        };
+        let info = type_info::type_of<T>();
+        assert!(type_info::account_address(&info) == @0x42, 1);
+        assert!(type_info::module_name(&info) == b"test", 2);
+        assert!(type_info::struct_name(&info) == b"MyTable", 2);
+        info
+    }
+    spec test_type_info_symbolic {
+        ensures result.account_address == @0x42;
+        ensures result.module_name == b"test";
+        ensures result.struct_name == b"MyTable";
+    }
+
+    fun test_type_info_ignores_type_param<T>(): type_info::TypeInfo {
+        type_info::type_of<MyTable<T, address>>()
+    }
+    spec test_type_info_ignores_type_param {
+        ensures result == type_info::type_of<MyTable<address, T>>();
+    }
+
+    fun test_type_info_can_abort<T>(): type_info::TypeInfo {
+        type_info::type_of<T>()
+    }
+    spec test_type_info_can_abort {
+        // this should not pass
+        aborts_if false;
     }
 }


### PR DESCRIPTION
The `type_of` primitive is another type reflection feature supported by the move prover:

At its core, the `type_of` function returns information about a user-defined struct type:

```move
struct TypeInfo has copy, drop, store {
    account_address: address,
    module_name: vector<u8>,
    struct_name: vector<u8>,
}

public native fun type_of<T>: TypeInfo;
```

This is similar to the `type_name` feature with the following complication:
- `type_of<T>` will panic if `T` is not a user-defined struct type. `type_of<vector<bool>>` will cause the Move VM to abort. This needs to be captured by the prover as well. On the other hand, `type_name` will never panic and will always return a canonical representation of the passed in type tag.
- `type_of<T>` does not care about the type arguments of the struct type. E.g., if there is a struct `Foo<K, V>`, then both `type_of<Foo<bool, int>>` and `type_of<Foo<int, bool>>` will return exactly the same information.

With that said, `type_of` is handled in a similar way to `type_name`:

- If the type argument `T` is statically known, all fields of the `TypeInfo` struct will be pre-determined as constants. However, there is a caveat when `T` is not a user-defined type in spec function context.
- If the type argument `T` is symbolic in the verification context, we rely on the following newly introduced fresh variables to model the information of `T`, including
  - `#T_is_struct: bool;` to model whether `T` is a user-defined struct
  - `#T_account_address: int;`
  - `#T_module_name: Vec int;`
  - `#T_struct_name: Vec int;`, for these variables, the name says all

In the bytecode context (i.e., Move function context), a `type_of<T>` function call is translated as:

```
if (!<predicate_is_struct>) {
    call $ExecFailureAbort();
} else {
    retval := <struct_info_variable>;
}
```

In this way, we still capture the fact that `type_of<T>()` may abort when `T` is not a struct type.

However, in spec function context, due to the fact that a spec function is essentially an expression. The rewriting mechanism does not allow us (or at least it is not easy) to instrument an additional check that `T` must be a struct type. In light of this, the `<is_struct>` flag is ignored and we assume `T` passed in is a struct.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Move Language.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Support type reflection

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes

## Test Plan

- CI
- New test case added