### PR TITLE
[move-model] intrinsic declarations in struct spec

### DIFF
--- a/language/extensions/move-table-extension/sources/Table.spec.move
+++ b/language/extensions/move-table-extension/sources/Table.spec.move
@@ -5,7 +5,20 @@ spec extensions::table {
 
     spec Table {
         pragma intrinsic = map,
-            map_borrow_mut = borrow_mut;
+            map_new = new,
+            map_destroy_empty = destroy_empty,
+            map_len = length,
+            map_is_empty = empty,
+            map_has_key = contains,
+            map_add_no_override = add,
+            map_del_must_exist = remove,
+            map_borrow = borrow,
+            map_borrow_mut = borrow_mut,
+            map_spec_get = spec_get,
+            map_spec_set = spec_add,
+            map_spec_del = spec_remove,
+            map_spec_len = spec_len,
+            map_spec_has_key = spec_contains;
     }
 
     spec new {
@@ -46,7 +59,6 @@ spec extensions::table {
 
     // Specification functions for tables
 
-    spec native fun spec_table<K, V>(): Table<K, V>;
     spec native fun spec_len<K, V>(t: Table<K, V>): num;
     spec native fun spec_contains<K, V>(t: Table<K, V>, k: K): bool;
     spec native fun spec_add<K, V>(t: Table<K, V>, k: K, v: V): Table<K, V>;

--- a/language/extensions/move-table-extension/sources/Table.spec.move
+++ b/language/extensions/move-table-extension/sources/Table.spec.move
@@ -4,7 +4,8 @@ spec extensions::table {
     // Make most of the public API intrinsic. Those functions have custom specifications in the prover.
 
     spec Table {
-        pragma intrinsic;
+        pragma intrinsic = map,
+            map_borrow_mut = borrow_mut;
     }
 
     spec new {

--- a/language/move-model/src/builder/module_builder.rs
+++ b/language/move-model/src/builder/module_builder.rs
@@ -38,6 +38,7 @@ use crate::{
         model_builder::{ConstEntry, LocalVarEntry, ModelBuilder, SpecFunEntry},
     },
     exp_rewriter::{ExpRewriter, ExpRewriterFunctions, RewriteTarget},
+    intrinsics::process_intrinsic_declaration,
     model::{
         AbilityConstraint, FieldId, FunId, FunctionData, FunctionVisibility, Loc, ModuleId,
         MoveIrLoc, NamedConstantData, NamedConstantId, NodeId, QualifiedId, QualifiedInstId,
@@ -165,7 +166,7 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
 
 impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
     /// Shortcut for accessing the symbol pool.
-    fn symbol_pool(&self) -> &SymbolPool {
+    pub fn symbol_pool(&self) -> &SymbolPool {
         self.parent.env.symbol_pool()
     }
 
@@ -743,7 +744,7 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
                             );
                             if let Some(kind) = self.convert_condition_kind(kind, &context) {
                                 let properties =
-                                    self.translate_properties(properties, &|_, prop| {
+                                    self.translate_properties(properties, &|_, _, prop| {
                                         if !is_property_valid_for_condition(&kind, prop) {
                                             Some(loc.clone())
                                         } else {
@@ -1030,7 +1031,7 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
                 additional_exps,
             } => {
                 if let Some(kind) = self.convert_condition_kind(kind, context) {
-                    let properties = self.translate_properties(properties, &|_, prop| {
+                    let properties = self.translate_properties(properties, &|_, _, prop| {
                         if !is_property_valid_for_condition(&kind, prop) {
                             Some(loc.clone())
                         } else {
@@ -1049,7 +1050,7 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
                 def,
             } => self.def_ana_let(context, loc, *post_state, name, def),
             Include { properties, exp } => {
-                let properties = self.translate_properties(properties, &|_, _| None);
+                let properties = self.translate_properties(properties, &|_, _, _| None);
                 self.def_ana_schema_inclusion_outside_schema(loc, context, None, properties, exp)
             }
             Apply {
@@ -1130,13 +1131,17 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
         context: &SpecBlockContext,
         properties: &[EA::PragmaProperty],
     ) {
-        let properties = self.translate_properties(properties, &|_, prop| {
-            if !is_pragma_valid_for_block(context, prop) {
+        let mut properties = self.translate_properties(properties, &|symbols, bag, prop| {
+            if !is_pragma_valid_for_block(symbols, bag, context, prop) {
                 Some(loc.clone())
             } else {
                 None
             }
         });
+
+        // extra processing on concrete pragma declarations
+        process_intrinsic_declaration(self, loc, context, &mut properties);
+
         self.update_spec(context, move |spec| {
             spec.properties.extend(properties);
         });
@@ -1151,7 +1156,7 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
     ) -> PropertyBag
     where
         // Returns the location if not valid
-        F: Fn(&PropertyBag, &str) -> Option<Loc>,
+        F: Fn(&SymbolPool, &PropertyBag, &str) -> Option<Loc>,
     {
         let mut props = PropertyBag::default();
         for prop in properties {
@@ -1167,10 +1172,10 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
         check_prop: &F,
     ) where
         // Returns the location if not valid
-        F: Fn(&PropertyBag, &str) -> Option<Loc>,
+        F: Fn(&SymbolPool, &PropertyBag, &str) -> Option<Loc>,
     {
         let prop_str = prop.value.name.value.as_str();
-        if let Some(loc) = check_prop(bag, prop_str) {
+        if let Some(loc) = check_prop(self.symbol_pool(), bag, prop_str) {
             self.parent.error(
                 &loc,
                 &format!("property `{}` is not valid in this context", prop_str),
@@ -2085,7 +2090,7 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
         // Process all schema includes. We need to do this before we type check expressions to have
         // all variables from includes in the environment.
         for (_, included_props, included_exp) in self.iter_schema_includes(&block.value.members) {
-            let included_props = self.translate_properties(included_props, &|_, _| None);
+            let included_props = self.translate_properties(included_props, &|_, _, _| None);
             self.def_ana_schema_exp(
                 &type_params,
                 &mut all_vars,
@@ -2123,7 +2128,7 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
                 } => {
                     let context = SpecBlockContext::Schema(name.clone());
                     if let Some(kind) = self.convert_condition_kind(kind, &context) {
-                        let properties = self.translate_properties(properties, &|_, prop| {
+                        let properties = self.translate_properties(properties, &|_, _, prop| {
                             if !is_property_valid_for_condition(&kind, prop) {
                                 Some(member_loc.clone())
                             } else {

--- a/language/move-model/src/intrinsics.rs
+++ b/language/move-model/src/intrinsics.rs
@@ -1,0 +1,247 @@
+// Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{collections::BTreeMap, ops::Deref};
+
+use crate::{
+    ast::{Operation, PropertyBag, PropertyValue, QualifiedSymbol},
+    builder::module_builder::SpecBlockContext,
+    model::{IntrinsicId, QualifiedId, SpecFunId},
+    pragmas::{INTRINSIC_PRAGMA, INTRINSIC_TYPE_MAP, INTRINSIC_TYPE_MAP_ASSOC_FUNCTIONS},
+    symbol::Symbol,
+    FunId, Loc, ModuleBuilder, StructId,
+};
+
+/// An information pack that holds the intrinsic declaration
+#[derive(Clone, Debug)]
+pub struct IntrinsicDecl {
+    move_type: QualifiedId<StructId>,
+    #[allow(dead_code)]
+    intrinsic_type: Symbol,
+    intrinsic_to_move_fun: BTreeMap<Symbol, QualifiedId<FunId>>,
+    move_fun_to_intrinsic: BTreeMap<QualifiedId<FunId>, Symbol>,
+    intrinsic_to_spec_fun: BTreeMap<Symbol, QualifiedId<SpecFunId>>,
+    spec_fun_to_intrinsic: BTreeMap<QualifiedId<SpecFunId>, Symbol>,
+}
+
+pub(crate) fn process_intrinsic_declaration(
+    builder: &mut ModuleBuilder,
+    loc: &Loc,
+    context: &SpecBlockContext,
+    props: &mut PropertyBag,
+) {
+    // intrinsic declarations only appears in struct spec block
+    let type_qsym = match context {
+        SpecBlockContext::Struct(qsym) => qsym.clone(),
+        _ => {
+            return;
+        }
+    };
+
+    // search for intrinsic declarations
+    let symbol_pool = builder.symbol_pool();
+    let pragma_symbol = symbol_pool.make(INTRINSIC_PRAGMA);
+    let target = match props.get_mut(&pragma_symbol) {
+        None => {
+            // this is not an intrinsic declaration
+            return;
+        }
+        Some(val) => {
+            match val {
+                PropertyValue::Symbol(sym) => symbol_pool.string(*sym),
+                PropertyValue::QualifiedSymbol(_) => {
+                    builder
+                        .parent
+                        .error(loc, "expect a boolean value or a valid intrinsic type");
+                    return;
+                }
+                _ => {
+                    // this is the true/false pragma
+                    return;
+                }
+            }
+        }
+    };
+
+    // obtain the associated functions map
+    let associated_funs = match target.as_str() {
+        INTRINSIC_TYPE_MAP => INTRINSIC_TYPE_MAP_ASSOC_FUNCTIONS.deref(),
+        _ => {
+            builder
+                .parent
+                .error(loc, &format!("unknown intrinsic type: {}", target.as_str()));
+            return;
+        }
+    };
+
+    // prepare the decl
+    let type_entry = builder.parent.struct_table.get(&type_qsym).expect("struct");
+    let move_type = type_entry.module_id.qualified(type_entry.struct_id);
+
+    let mut decl = IntrinsicDecl {
+        move_type,
+        intrinsic_type: symbol_pool.make(target.as_str()),
+        intrinsic_to_move_fun: BTreeMap::new(),
+        move_fun_to_intrinsic: BTreeMap::new(),
+        intrinsic_to_spec_fun: BTreeMap::new(),
+        spec_fun_to_intrinsic: BTreeMap::new(),
+    };
+
+    // construct the pack
+    populate_intrinsic_decl(builder, loc, associated_funs, props, &mut decl);
+
+    // add the decl back
+    builder.parent.intrinsics.push(decl);
+}
+
+fn populate_intrinsic_decl(
+    builder: &mut ModuleBuilder,
+    loc: &Loc,
+    associated_funs: &BTreeMap<&str, bool>,
+    props: &mut PropertyBag,
+    decl: &mut IntrinsicDecl,
+) {
+    let symbol_pool = builder.symbol_pool();
+    for (&name, &is_move_fun) in associated_funs {
+        let key_sym = symbol_pool.make(name);
+
+        // look-up the target of the declaration, if present
+        let target_sym = match props.remove(&key_sym) {
+            None => {
+                continue;
+            }
+            Some(PropertyValue::Value(_)) => {
+                builder.parent.error(
+                    loc,
+                    &format!("invalid intrinsic function mapping: {}", name),
+                );
+                continue;
+            }
+            Some(PropertyValue::Symbol(val_sym)) => val_sym,
+            Some(PropertyValue::QualifiedSymbol(qual_sym)) => {
+                if qual_sym.module_name != builder.module_name {
+                    builder.parent.error(
+                        loc,
+                        &format!(
+                            "an intrinsic function mapping can only refer to functions \
+                            declared in the same module while `{}` is not",
+                            qual_sym.display(symbol_pool)
+                        ),
+                    );
+                    continue;
+                }
+                qual_sym.symbol
+            }
+        };
+        let qualified_sym = QualifiedSymbol {
+            module_name: builder.module_name.clone(),
+            symbol: target_sym,
+        };
+
+        // check presence
+        if is_move_fun {
+            match builder.parent.fun_table.get(&qualified_sym) {
+                None => {
+                    builder.parent.error(
+                        loc,
+                        &format!(
+                            "unable to find move function for intrinsic mapping: {}",
+                            qualified_sym.display(symbol_pool)
+                        ),
+                    );
+                    continue;
+                }
+                Some(entry) => {
+                    // TODO: in theory, we should also do some type checking on the function
+                    // signature. This is implicitly done by Boogie right now, but we may want to
+                    // make it more explicit and do the checking ourselves.
+                    let qid = entry.module_id.qualified(entry.fun_id);
+                    decl.intrinsic_to_move_fun.insert(key_sym, qid);
+                    if decl.move_fun_to_intrinsic.insert(qid, key_sym).is_some() {
+                        builder.parent.error(
+                            loc,
+                            &format!(
+                                "duplicated intrinsic mapping for move function: {}",
+                                qualified_sym.display(symbol_pool)
+                            ),
+                        );
+                        continue;
+                    }
+                }
+            }
+        } else {
+            match builder.parent.spec_fun_table.get(&qualified_sym) {
+                None => {
+                    builder.parent.error(
+                        loc,
+                        &format!(
+                            "unable to find spec function for intrinsic mapping: {}",
+                            qualified_sym.display(symbol_pool)
+                        ),
+                    );
+                    continue;
+                }
+                Some(entries) => {
+                    if entries.len() != 1 {
+                        builder.parent.error(
+                            loc,
+                            &format!(
+                                "unable to find a unique spec function for intrinsic mapping: {}",
+                                qualified_sym.display(symbol_pool)
+                            ),
+                        );
+                        continue;
+                    }
+                    let entry = &entries[0];
+
+                    // TODO: in theory, we should also do some type checking on the function
+                    // signature. This is implicitly done by Boogie right now, but we may want to
+                    // make it more explicit and do the checking ourselves.
+                    if let Operation::Function(mid, fid, ..) = &entry.oper {
+                        let qid = mid.qualified(*fid);
+                        decl.intrinsic_to_spec_fun.insert(key_sym, qid);
+                        if decl.spec_fun_to_intrinsic.insert(qid, key_sym).is_some() {
+                            builder.parent.error(
+                                loc,
+                                &format!(
+                                    "duplicated intrinsic mapping for spec function: {}",
+                                    qualified_sym.display(symbol_pool)
+                                ),
+                            );
+                            continue;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Hosts all intrinsic declarations
+#[derive(Clone, Debug, Default)]
+pub struct IntrinsicsAnnotation {
+    /// Intrinsic declarations
+    decls: BTreeMap<IntrinsicId, IntrinsicDecl>,
+    /// A map from intrinsic types to intrinsic decl
+    intrinsic_structs: BTreeMap<QualifiedId<StructId>, IntrinsicId>,
+    /// A map from intrinsic move functions to intrinsic decl
+    intrinsic_move_funs: BTreeMap<QualifiedId<FunId>, IntrinsicId>,
+    /// A map from intrinsic spec functions to intrinsic decl
+    intrinsic_spec_funs: BTreeMap<QualifiedId<SpecFunId>, IntrinsicId>,
+}
+
+impl IntrinsicsAnnotation {
+    /// Add a declaration pack into the annotation set
+    pub fn add_decl(&mut self, decl: &IntrinsicDecl) {
+        let id = IntrinsicId::new(self.decls.len());
+        self.intrinsic_structs.insert(decl.move_type, id);
+        for move_fid in decl.move_fun_to_intrinsic.keys() {
+            self.intrinsic_move_funs.insert(*move_fid, id);
+        }
+        for spec_fid in decl.spec_fun_to_intrinsic.keys() {
+            self.intrinsic_spec_funs.insert(*spec_fid, id);
+        }
+        self.decls.insert(id, decl.clone());
+    }
+}

--- a/language/move-model/src/lib.rs
+++ b/language/move-model/src/lib.rs
@@ -53,6 +53,7 @@ mod builder;
 pub mod code_writer;
 pub mod exp_generator;
 pub mod exp_rewriter;
+pub mod intrinsics;
 pub mod model;
 pub mod options;
 pub mod pragmas;
@@ -588,6 +589,10 @@ fn run_spec_checker(env: &mut GlobalEnv, units: Vec<AnnotatedCompiledUnit>, mut 
             function_infos,
         );
     }
+
+    // Populate GlobalEnv with model-level information
+    builder.populate_env();
+
     // After all specs have been processed, warn about any unused schemas.
     builder.warn_unused_schemas();
 

--- a/language/move-model/src/model.rs
+++ b/language/move-model/src/model.rs
@@ -32,15 +32,15 @@ use codespan_reporting::{
 use itertools::Itertools;
 #[allow(unused_imports)]
 use log::{info, warn};
-use move_command_line_common::files::FileHash;
 use num::{BigUint, One, ToPrimitive};
 use serde::{Deserialize, Serialize};
 
+pub use move_binary_format::file_format::{AbilitySet, Visibility as FunctionVisibility};
 use move_binary_format::{
     access::ModuleAccess,
     binary_views::BinaryIndexedView,
     file_format::{
-        AddressIdentifierIndex, Bytecode, Constant as VMConstant, ConstantPoolIndex,
+        AddressIdentifierIndex, Bytecode, CodeOffset, Constant as VMConstant, ConstantPoolIndex,
         FunctionDefinitionIndex, FunctionHandleIndex, SignatureIndex, SignatureToken,
         StructDefinitionIndex, StructFieldInformation, StructHandleIndex, Visibility,
     },
@@ -52,6 +52,7 @@ use move_binary_format::{
     CompiledModule,
 };
 use move_bytecode_source_map::{mapping::SourceMapping, source_map::SourceMap};
+use move_command_line_common::{address::NumericalAddress, files::FileHash};
 use move_core_types::{
     account_address::AccountAddress,
     identifier::{IdentStr, Identifier},
@@ -62,9 +63,10 @@ use move_disassembler::disassembler::{Disassembler, DisassemblerOptions};
 
 use crate::{
     ast::{
-        ConditionKind, Exp, ExpData, GlobalInvariant, ModuleName, PropertyBag, PropertyValue, Spec,
-        SpecBlockInfo, SpecFunDecl, SpecVarDecl, Value,
+        Attribute, ConditionKind, Exp, ExpData, GlobalInvariant, ModuleName, PropertyBag,
+        PropertyValue, Spec, SpecBlockInfo, SpecFunDecl, SpecVarDecl, Value,
     },
+    intrinsics::IntrinsicsAnnotation,
     pragmas::{
         DELEGATE_INVARIANTS_TO_CALLER_PRAGMA, DISABLE_INVARIANTS_IN_BODY_PRAGMA, FRIEND_PRAGMA,
         INTRINSIC_PRAGMA, OPAQUE_PRAGMA, VERIFY_PRAGMA,
@@ -72,12 +74,6 @@ use crate::{
     symbol::{Symbol, SymbolPool},
     ty::{PrimitiveType, Type, TypeDisplayContext, TypeUnificationAdapter, Variance},
 };
-
-// import and re-expose symbols
-use crate::ast::Attribute;
-use move_binary_format::file_format::CodeOffset;
-pub use move_binary_format::file_format::{AbilitySet, Visibility as FunctionVisibility};
-use move_command_line_common::address::NumericalAddress;
 
 // =================================================================================================
 /// # Constants
@@ -225,6 +221,10 @@ pub struct NodeId(usize);
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy)]
 pub struct GlobalId(usize);
 
+/// Identifier for an intrinsic declaration, relative globally in `GlobalEnv`.
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy)]
+pub struct IntrinsicId(usize);
+
 /// Some identifier qualified by a module.
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy)]
 pub struct QualifiedId<Id> {
@@ -330,16 +330,6 @@ impl ModuleId {
     }
 }
 
-impl GlobalId {
-    pub fn new(idx: usize) -> Self {
-        Self(idx)
-    }
-
-    pub fn as_usize(self) -> usize {
-        self.0
-    }
-}
-
 impl ModuleId {
     pub fn qualified<Id>(self, id: Id) -> QualifiedId<Id> {
         QualifiedId {
@@ -354,6 +344,26 @@ impl ModuleId {
             inst,
             id,
         }
+    }
+}
+
+impl GlobalId {
+    pub fn new(idx: usize) -> Self {
+        Self(idx)
+    }
+
+    pub fn as_usize(self) -> usize {
+        self.0
+    }
+}
+
+impl IntrinsicId {
+    pub fn new(idx: usize) -> Self {
+        Self(idx)
+    }
+
+    pub fn as_usize(self) -> usize {
+        self.0
     }
 }
 
@@ -500,6 +510,8 @@ pub struct GlobalEnv {
     /// are represented without type instantiation because we assume the backend can handle
     /// generics in the expression language.
     pub used_spec_funs: BTreeSet<QualifiedId<SpecFunId>>,
+    /// An annotation of all intrinsic declarations
+    pub intrinsics: IntrinsicsAnnotation,
     /// A type-indexed container for storing extension data in the environment.
     extensions: RefCell<BTreeMap<TypeId, Box<dyn Any>>>,
     /// The address of the standard and extension libaries.
@@ -555,6 +567,7 @@ impl GlobalEnv {
             global_invariants: Default::default(),
             global_invariants_for_memory: Default::default(),
             used_spec_funs: BTreeSet::new(),
+            intrinsics: Default::default(),
             extensions: Default::default(),
             stdlib_address: None,
             extlib_address: None,
@@ -2510,7 +2523,7 @@ impl<'env> StructEnv<'env> {
     /// Returns true if this is the well-known native or intrinsic struct of the given name.
     pub fn is_well_known(&self, name: &str) -> bool {
         let env = self.module_env.env;
-        if !self.is_native() && !self.is_intrinsic() {
+        if !self.is_native_or_intrinsic() {
             return false;
         }
         let addr = self.module_env.get_name().addr();
@@ -2717,7 +2730,7 @@ impl<'env> StructEnv<'env> {
 
     /// Returns true if this struct is native or marked as intrinsic.
     pub fn is_native_or_intrinsic(&self) -> bool {
-        self.is_native() || self.is_pragma_true(INTRINSIC_PRAGMA, || false)
+        self.is_native() || self.is_intrinsic()
     }
 }
 

--- a/language/move-model/src/model.rs
+++ b/language/move-model/src/model.rs
@@ -2520,22 +2520,13 @@ impl<'env> StructEnv<'env> {
         self.is_pragma_true(INTRINSIC_PRAGMA, || false)
     }
 
-    /// Returns true if this is the well-known native or intrinsic struct of the given name.
-    pub fn is_well_known(&self, name: &str) -> bool {
-        let env = self.module_env.env;
-        if !self.is_native_or_intrinsic() {
-            return false;
-        }
-        let addr = self.module_env.get_name().addr();
-        (addr == &env.get_stdlib_address() || addr == &env.get_extlib_address())
-            && self.get_full_name_str() == name
-    }
-
-    /// Determines whether this struct is the well-known vector type.
-    pub fn is_vector(&self) -> bool {
-        let name = self.symbol_pool().string(self.module_env.get_name().name());
-        let addr = self.module_env.get_name().addr();
-        name.as_ref() == "vector" && addr == &BigUint::from(0_u64)
+    /// Returns true if this is an intrinsic struct of a given name
+    pub fn is_intrinsic_of(&self, name: &str) -> bool {
+        self.module_env.env.intrinsics.is_intrinsic_of_for_struct(
+            self.symbol_pool(),
+            &self.get_qualified_id(),
+            name,
+        )
     }
 
     /// Returns true if this struct is ghost memory for a specification variable.
@@ -3184,6 +3175,15 @@ impl<'env> FunctionEnv<'env> {
     /// Returns true if function is either native or intrinsic.
     pub fn is_native_or_intrinsic(&self) -> bool {
         self.is_native() || self.is_intrinsic()
+    }
+
+    /// Returns true if this is an intrinsic struct of a given name
+    pub fn is_intrinsic_of(&self, name: &str) -> bool {
+        self.module_env.env.intrinsics.is_intrinsic_of_for_move_fun(
+            self.symbol_pool(),
+            &self.get_qualified_id(),
+            name,
+        )
     }
 
     /// Returns true if this is the well-known native or intrinsic function of the given name.

--- a/language/move-model/src/pragmas.rs
+++ b/language/move-model/src/pragmas.rs
@@ -105,9 +105,17 @@ pub const INTRINSIC_FUN_MAP_SPEC_DEL: &str = "map_spec_del";
 /// `[spec] fun map_len<K, V>(m: Map<K, V>): num`
 pub const INTRINSIC_FUN_MAP_SPEC_LEN: &str = "map_spec_len";
 
+/// Check whether the map is empty (the spec version)
+/// `[move] fun map_is_empty<K, V>(m: Map<K, V>): bool`
+pub const INTRINSIC_FUN_MAP_SPEC_IS_EMPTY: &str = "map_spec_is_empty";
+
 /// Get the number of entries in the map
 /// `[move] fun map_len<K, V>(m: &Map<K, V>): u64`
 pub const INTRINSIC_FUN_MAP_LEN: &str = "map_len";
+
+/// Check whether the map is empty
+/// `[move] fun map_is_empty<K, V>(m: &Map<K, V>): bool`
+pub const INTRINSIC_FUN_MAP_IS_EMPTY: &str = "map_is_empty";
 
 /// Check if the map has an entry associated with key `k` (the spec version)
 /// `[spec] fun map_has_key<K, V>(m: Map<K, V>, k: K): bool`
@@ -146,8 +154,10 @@ pub static INTRINSIC_TYPE_MAP_ASSOC_FUNCTIONS: Lazy<BTreeMap<&'static str, bool>
             (INTRINSIC_FUN_MAP_SPEC_SET, false),
             (INTRINSIC_FUN_MAP_SPEC_DEL, false),
             (INTRINSIC_FUN_MAP_SPEC_LEN, false),
+            (INTRINSIC_FUN_MAP_SPEC_IS_EMPTY, false),
             (INTRINSIC_FUN_MAP_SPEC_HAS_KEY, false),
             (INTRINSIC_FUN_MAP_LEN, true),
+            (INTRINSIC_FUN_MAP_IS_EMPTY, true),
             (INTRINSIC_FUN_MAP_HAS_KEY, true),
             (INTRINSIC_FUN_MAP_DESTROY_EMPTY, true),
             (INTRINSIC_FUN_MAP_ADD_NO_OVERRIDE, true),

--- a/language/move-model/src/well_known.rs
+++ b/language/move-model/src/well_known.rs
@@ -8,9 +8,7 @@
 //! declarations. It can be extended on the go.
 
 pub const VECTOR_BORROW_MUT: &str = "vector::borrow_mut";
-pub const TABLE_BORROW_MUT: &str = "table::borrow_mut";
 pub const EVENT_EMIT_EVENT: &str = "event::emit_event";
-pub const TABLE_TABLE: &str = "table::Table";
 
 pub const TYPE_NAME_MOVE: &str = "type_info::type_name";
 pub const TYPE_NAME_SPEC: &str = "type_info::$type_name";

--- a/language/move-model/tests/sources/intrinsic_decl_err.exp
+++ b/language/move-model/tests/sources/intrinsic_decl_err.exp
@@ -1,0 +1,69 @@
+error: expect a boolean value or a valid intrinsic type
+   ┌─ tests/sources/intrinsic_decl_err.move:16:9
+   │
+16 │         pragma intrinsic = 0x42::M::MyTable;
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: unknown intrinsic type: no_such_map
+   ┌─ tests/sources/intrinsic_decl_err.move:19:9
+   │
+19 │         pragma intrinsic = no_such_map;
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: property `map_no_such_fun` is not valid in this context
+   ┌─ tests/sources/intrinsic_decl_err.move:22:9
+   │
+22 │ ╭         pragma intrinsic = map,
+23 │ │             map_no_such_fun = new;
+   │ ╰──────────────────────────────────^
+
+error: invalid intrinsic function mapping: map_len
+   ┌─ tests/sources/intrinsic_decl_err.move:26:9
+   │
+26 │ ╭         pragma intrinsic = map,
+27 │ │             map_len = true;
+   │ ╰───────────────────────────^
+
+error: an intrinsic function mapping can only refer to functions declared in the same module while `signer::address_of` is not
+   ┌─ tests/sources/intrinsic_decl_err.move:30:9
+   │
+30 │ ╭         pragma intrinsic = map,
+31 │ │             map_len = 0x1::signer::address_of;
+   │ ╰──────────────────────────────────────────────^
+
+error: unable to find move function for intrinsic mapping: M::no_such_move_fun
+   ┌─ tests/sources/intrinsic_decl_err.move:34:9
+   │
+34 │ ╭         pragma intrinsic = map,
+35 │ │             map_len = no_such_move_fun;
+   │ ╰───────────────────────────────────────^
+
+error: unable to find spec function for intrinsic mapping: M::no_such_spec_fun
+   ┌─ tests/sources/intrinsic_decl_err.move:38:9
+   │
+38 │ ╭         pragma intrinsic = map,
+39 │ │             map_spec_len = no_such_spec_fun;
+   │ ╰────────────────────────────────────────────^
+
+error: unable to find move function for intrinsic mapping: M::spec_len
+   ┌─ tests/sources/intrinsic_decl_err.move:42:9
+   │
+42 │ ╭         pragma intrinsic = map,
+43 │ │             map_len = spec_len;
+   │ ╰───────────────────────────────^
+
+error: duplicated intrinsic mapping for move function: M::length
+   ┌─ tests/sources/intrinsic_decl_err.move:46:9
+   │
+46 │ ╭         pragma intrinsic = map,
+47 │ │             map_len = length,
+48 │ │             map_borrow_mut = length;
+   │ ╰────────────────────────────────────^
+
+error: duplicated intrinsic mapping for spec function: M::spec_len
+   ┌─ tests/sources/intrinsic_decl_err.move:51:9
+   │
+51 │ ╭         pragma intrinsic = map,
+52 │ │             map_spec_len = spec_len,
+53 │ │             map_spec_set = spec_len;
+   │ ╰────────────────────────────────────^

--- a/language/move-model/tests/sources/intrinsic_decl_err.move
+++ b/language/move-model/tests/sources/intrinsic_decl_err.move
@@ -1,0 +1,55 @@
+module 0x42::M {
+    struct MyTable<phantom K, phantom V> {}
+    struct MyTable1<phantom K, phantom V> {}
+
+    native fun new<K, V>(): MyTable1<K, V>;
+    native fun destroy_empty<K, V>(t: MyTable1<K, V>);
+    native fun borrow_mut<K, V>(t: &mut MyTable1<K, V>, k: K): &mut V;
+    native fun length<K, V>(t: &MyTable1<K, V>): u64;
+
+    spec native fun spec_len<K, V>(t: MyTable1<K, V>): num;
+    spec native fun spec_set<K, V>(t: MyTable1<K, V>, k: K, v: V): MyTable1<K, V>;
+    spec native fun spec_get<K, V>(t: MyTable1<K, V>, k: K): V;
+
+    spec MyTable1 {
+        // expect failure
+        pragma intrinsic = 0x42::M::MyTable;
+
+        // expect failure
+        pragma intrinsic = no_such_map;
+
+        // expect failure
+        pragma intrinsic = map,
+            map_no_such_fun = new;
+
+        // expect failure
+        pragma intrinsic = map,
+            map_len = true;
+
+        // expect failure
+        pragma intrinsic = map,
+            map_len = 0x1::signer::address_of;
+
+        // expect failure
+        pragma intrinsic = map,
+            map_len = no_such_move_fun;
+
+        // expect failure
+        pragma intrinsic = map,
+            map_spec_len = no_such_spec_fun;
+
+        // expect failure
+        pragma intrinsic = map,
+            map_len = spec_len;
+
+        // expect failure
+        pragma intrinsic = map,
+            map_len = length,
+            map_borrow_mut = length;
+
+        // expect failure
+        pragma intrinsic = map,
+            map_spec_len = spec_len,
+            map_spec_set = spec_len;
+    }
+}

--- a/language/move-model/tests/sources/intrinsic_decl_ok.exp
+++ b/language/move-model/tests/sources/intrinsic_decl_ok.exp
@@ -1,0 +1,1 @@
+All good, no errors!

--- a/language/move-model/tests/sources/intrinsic_decl_ok.move
+++ b/language/move-model/tests/sources/intrinsic_decl_ok.move
@@ -1,0 +1,45 @@
+module 0x42::M {
+    struct MyTable1<phantom K, phantom V> {}
+
+    native fun new<K, V>(): MyTable1<K, V>;
+    native fun destroy_empty<K, V>(t: MyTable1<K, V>);
+    native fun borrow_mut<K, V>(t: &mut MyTable1<K, V>, k: K): &mut V;
+    native fun length<K, V>(t: &MyTable1<K, V>): u64;
+
+    spec native fun spec_len<K, V>(t: MyTable1<K, V>): num;
+    spec native fun spec_set<K, V>(t: MyTable1<K, V>, k: K, v: V): MyTable1<K, V>;
+    spec native fun spec_get<K, V>(t: MyTable1<K, V>, k: K): V;
+
+    spec MyTable1 {
+        pragma intrinsic = map,
+            map_new = new,
+            map_destroy_empty = destroy_empty,
+            map_borrow_mut = borrow_mut,
+            map_len = length,
+            map_spec_len = spec_len,
+            map_spec_get = spec_get,
+            map_spec_set = spec_set;
+    }
+
+    struct MyTable2<phantom K, phantom V> {}
+
+    native fun new2<K, V>(): MyTable2<K, V>;
+    native fun contains<K, V>(t: &MyTable2<K, V>, k: K): bool;
+    native fun borrow<K, V>(t: &MyTable2<K, V>, k: K): &V;
+    native fun remove<K, V>(t: &mut MyTable2<K, V>, k: K): V;
+
+    spec native fun spec_len2<K, V>(t: MyTable2<K, V>): num;
+    spec native fun spec_del<K, V>(t: MyTable2<K, V>): num;
+    spec native fun spec_has_key<K, V>(t: MyTable2<K, V>, k: K): bool;
+
+    spec MyTable2 {
+        pragma intrinsic = map,
+            map_new = new2,
+            map_has_key = contains,
+            map_borrow = borrow,
+            map_del_must_exist = remove,
+            map_spec_len = spec_len2,
+            map_spec_del = spec_del,
+            map_spec_has_key = spec_has_key;
+    }
+}

--- a/language/move-model/tests/sources/pragmas_err.exp
+++ b/language/move-model/tests/sources/pragmas_err.exp
@@ -3,3 +3,9 @@ error: property `bar` is not valid in this context
   │
 7 │         pragma bar = true;
   │         ^^^^^^^^^^^^^^^^^^
+
+error: property `verify` specified more than once in the same pragma declaration
+   ┌─ tests/sources/pragmas_err.move:19:24
+   │
+19 │         pragma verify, verify;
+   │                        ^^^^^^

--- a/language/move-model/tests/sources/pragmas_err.move
+++ b/language/move-model/tests/sources/pragmas_err.move
@@ -15,6 +15,9 @@ module 0x42::M {
         // Should be ok (we do not check types of values)
         pragma verify = Self::a_valid_id;
 
+        // Should produce an error that the same property is defined twice on the same line
+        pragma verify, verify;
+
         // The below produces an error from move_compiler because the relative module name cannot be resolved.
         // We leave it here for illustration.
         // pragma verify = M::a_valid_id;

--- a/language/move-prover/boogie-backend/src/boogie_helpers.rs
+++ b/language/move-prover/boogie-backend/src/boogie_helpers.rs
@@ -242,9 +242,13 @@ pub fn boogie_type_suffix(env: &GlobalEnv, ty: &Type) -> String {
 }
 
 pub fn boogie_type_suffix_for_struct(struct_env: &StructEnv<'_>, inst: &[Type]) -> String {
-    let env = struct_env.module_env.env;
     if struct_env.is_intrinsic_of(INTRINSIC_TYPE_MAP) {
-        format!("table{}", boogie_inst_suffix(env, inst))
+        format!(
+            "${}_{}{}",
+            boogie_module_name(&struct_env.module_env),
+            struct_env.get_name().display(struct_env.symbol_pool()),
+            boogie_inst_suffix(struct_env.module_env.env, inst)
+        )
     } else {
         boogie_struct_name(struct_env, inst)
     }

--- a/language/move-prover/boogie-backend/src/boogie_helpers.rs
+++ b/language/move-prover/boogie-backend/src/boogie_helpers.rs
@@ -14,9 +14,9 @@ use move_model::{
         FieldEnv, FunctionEnv, GlobalEnv, ModuleEnv, QualifiedInstId, SpecFunId, StructEnv,
         StructId, SCRIPT_MODULE_NAME,
     },
+    pragmas::INTRINSIC_TYPE_MAP,
     symbol::Symbol,
     ty::{PrimitiveType, Type},
-    well_known::TABLE_TABLE,
 };
 use move_stackless_bytecode::function_target::FunctionTarget;
 
@@ -39,7 +39,7 @@ pub fn boogie_module_name(env: &ModuleEnv<'_>) -> String {
 
 /// Return boogie name of given structure.
 pub fn boogie_struct_name(struct_env: &StructEnv<'_>, inst: &[Type]) -> String {
-    if struct_env.is_well_known(TABLE_TABLE) {
+    if struct_env.is_intrinsic_of(INTRINSIC_TYPE_MAP) {
         // Map to the theory type representation, which is `Table int V`. The key
         // is encoded as an integer to avoid extensionality problems, and to support
         // $Mutation paths, which are sequences of ints.
@@ -243,7 +243,7 @@ pub fn boogie_type_suffix(env: &GlobalEnv, ty: &Type) -> String {
 
 pub fn boogie_type_suffix_for_struct(struct_env: &StructEnv<'_>, inst: &[Type]) -> String {
     let env = struct_env.module_env.env;
-    if struct_env.is_well_known(TABLE_TABLE) {
+    if struct_env.is_intrinsic_of(INTRINSIC_TYPE_MAP) {
         format!("table{}", boogie_inst_suffix(env, inst))
     } else {
         boogie_struct_name(struct_env, inst)

--- a/language/move-prover/boogie-backend/src/boogie_wrapper.rs
+++ b/language/move-prover/boogie-backend/src/boogie_wrapper.rs
@@ -26,8 +26,8 @@ use move_model::{
     ast::TempIndex,
     code_writer::CodeWriter,
     model::{FunId, GlobalEnv, Loc, ModuleId, NodeId, QualifiedId, StructEnv},
+    pragmas::INTRINSIC_TYPE_MAP,
     ty::{PrimitiveType, Type},
-    well_known::TABLE_TABLE,
 };
 use move_stackless_bytecode::function_target_pipeline::{FunctionTargetsHolder, FunctionVariant};
 
@@ -1417,7 +1417,7 @@ impl ModelValue {
             Type::Vector(param) => self.pretty_vector(wrapper, model, param),
             Type::Struct(module_id, struct_id, params) => {
                 let struct_env = wrapper.env.get_struct_qid(module_id.qualified(*struct_id));
-                if struct_env.is_well_known(TABLE_TABLE) {
+                if struct_env.is_intrinsic_of(INTRINSIC_TYPE_MAP) {
                     self.pretty_table(wrapper, model, &params[0], &params[1])
                 } else {
                     self.pretty_struct(wrapper, model, &struct_env, params)

--- a/language/move-prover/boogie-backend/src/lib.rs
+++ b/language/move-prover/boogie-backend/src/lib.rs
@@ -9,19 +9,28 @@ use std::collections::BTreeSet;
 use itertools::Itertools;
 #[allow(unused_imports)]
 use log::{debug, info, warn};
+use num::BigUint;
 use serde::{Deserialize, Serialize};
 use tera::{Context, Tera};
 
 use move_model::{
     code_writer::CodeWriter,
     emit, emitln,
-    model::GlobalEnv,
+    model::{GlobalEnv, QualifiedId, StructId},
+    pragmas::{
+        INTRINSIC_FUN_MAP_ADD_NO_OVERRIDE, INTRINSIC_FUN_MAP_BORROW, INTRINSIC_FUN_MAP_BORROW_MUT,
+        INTRINSIC_FUN_MAP_DEL_MUST_EXIST, INTRINSIC_FUN_MAP_DESTROY_EMPTY,
+        INTRINSIC_FUN_MAP_HAS_KEY, INTRINSIC_FUN_MAP_IS_EMPTY, INTRINSIC_FUN_MAP_LEN,
+        INTRINSIC_FUN_MAP_NEW, INTRINSIC_FUN_MAP_SPEC_DEL, INTRINSIC_FUN_MAP_SPEC_GET,
+        INTRINSIC_FUN_MAP_SPEC_HAS_KEY, INTRINSIC_FUN_MAP_SPEC_IS_EMPTY,
+        INTRINSIC_FUN_MAP_SPEC_LEN, INTRINSIC_FUN_MAP_SPEC_SET,
+    },
     ty::{PrimitiveType, Type},
 };
 use move_stackless_bytecode::mono_analysis;
 
 use crate::{
-    boogie_helpers::{boogie_type, boogie_type_suffix},
+    boogie_helpers::{boogie_module_name, boogie_type, boogie_type_suffix},
     bytecode_translator::has_native_equality,
     options::{BoogieOptions, VectorTheory},
 };
@@ -53,6 +62,29 @@ struct TypeInfo {
     name: String,
     suffix: String,
     has_native_equality: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, Default)]
+struct MapImpl {
+    struct_name: String,
+    insts: Vec<(TypeInfo, TypeInfo)>,
+    // move functions
+    fun_new: String,
+    fun_destroy_empty: String,
+    fun_len: String,
+    fun_is_empty: String,
+    fun_has_key: String,
+    fun_add_no_override: String,
+    fun_del_must_exist: String,
+    fun_borrow: String,
+    fun_borrow_mut: String,
+    // spec functions
+    fun_spec_get: String,
+    fun_spec_set: String,
+    fun_spec_del: String,
+    fun_spec_len: String,
+    fun_spec_is_empty: String,
+    fun_spec_has_key: String,
 }
 
 /// Adds the prelude to the generated output.
@@ -106,21 +138,16 @@ pub fn add_prelude(
     let table_instances = mono_info
         .table_inst
         .iter()
-        .map(|(kty, vty)| {
-            (
-                TypeInfo::new(env, options, kty),
-                TypeInfo::new(env, options, vty),
-            )
-        })
+        .map(|(qid, ty_args)| MapImpl::new(env, options, *qid, ty_args))
         .collect_vec();
+    context.insert("table_instances", &table_instances);
     let table_key_instances = mono_info
         .table_inst
         .iter()
-        .map(|(kty, _)| kty)
+        .flat_map(|(_, ty_args)| ty_args.iter().map(|(kty, _)| kty))
         .unique()
         .map(|ty| TypeInfo::new(env, options, ty))
         .collect_vec();
-    context.insert("table_instances", &table_instances);
     context.insert("table_key_instances", &table_key_instances);
     let filter_native = |module: &str| {
         mono_info
@@ -174,6 +201,92 @@ impl TypeInfo {
             name: boogie_type(env, ty),
             suffix: boogie_type_suffix(env, ty),
             has_native_equality: has_native_equality(env, options, ty),
+        }
+    }
+}
+
+impl MapImpl {
+    fn new(
+        env: &GlobalEnv,
+        options: &BoogieOptions,
+        struct_qid: QualifiedId<StructId>,
+        ty_args: &BTreeSet<(Type, Type)>,
+    ) -> Self {
+        let insts = ty_args
+            .iter()
+            .map(|(kty, vty)| {
+                (
+                    TypeInfo::new(env, options, kty),
+                    TypeInfo::new(env, options, vty),
+                )
+            })
+            .collect();
+
+        let struct_env = env.get_struct(struct_qid);
+        let struct_name = format!(
+            "${}_{}",
+            boogie_module_name(&struct_env.module_env),
+            struct_env.get_name().display(struct_env.symbol_pool()),
+        );
+
+        let decl = env
+            .intrinsics
+            .get_decl_for_struct(&struct_qid)
+            .expect("intrinsic decl");
+
+        MapImpl {
+            struct_name,
+            insts,
+            fun_new: Self::triple_opt_to_name(decl.get_fun_triple(env, INTRINSIC_FUN_MAP_NEW)),
+            fun_destroy_empty: Self::triple_opt_to_name(
+                decl.get_fun_triple(env, INTRINSIC_FUN_MAP_DESTROY_EMPTY),
+            ),
+            fun_len: Self::triple_opt_to_name(decl.get_fun_triple(env, INTRINSIC_FUN_MAP_LEN)),
+            fun_is_empty: Self::triple_opt_to_name(
+                decl.get_fun_triple(env, INTRINSIC_FUN_MAP_IS_EMPTY),
+            ),
+            fun_has_key: Self::triple_opt_to_name(
+                decl.get_fun_triple(env, INTRINSIC_FUN_MAP_HAS_KEY),
+            ),
+            fun_add_no_override: Self::triple_opt_to_name(
+                decl.get_fun_triple(env, INTRINSIC_FUN_MAP_ADD_NO_OVERRIDE),
+            ),
+            fun_del_must_exist: Self::triple_opt_to_name(
+                decl.get_fun_triple(env, INTRINSIC_FUN_MAP_DEL_MUST_EXIST),
+            ),
+            fun_borrow: Self::triple_opt_to_name(
+                decl.get_fun_triple(env, INTRINSIC_FUN_MAP_BORROW),
+            ),
+            fun_borrow_mut: Self::triple_opt_to_name(
+                decl.get_fun_triple(env, INTRINSIC_FUN_MAP_BORROW_MUT),
+            ),
+            fun_spec_get: Self::triple_opt_to_name(
+                decl.get_fun_triple(env, INTRINSIC_FUN_MAP_SPEC_GET),
+            ),
+            fun_spec_set: Self::triple_opt_to_name(
+                decl.get_fun_triple(env, INTRINSIC_FUN_MAP_SPEC_SET),
+            ),
+            fun_spec_del: Self::triple_opt_to_name(
+                decl.get_fun_triple(env, INTRINSIC_FUN_MAP_SPEC_DEL),
+            ),
+            fun_spec_len: Self::triple_opt_to_name(
+                decl.get_fun_triple(env, INTRINSIC_FUN_MAP_SPEC_LEN),
+            ),
+            fun_spec_is_empty: Self::triple_opt_to_name(
+                decl.get_fun_triple(env, INTRINSIC_FUN_MAP_SPEC_IS_EMPTY),
+            ),
+            fun_spec_has_key: Self::triple_opt_to_name(
+                decl.get_fun_triple(env, INTRINSIC_FUN_MAP_SPEC_HAS_KEY),
+            ),
+        }
+    }
+
+    fn triple_opt_to_name(triple_opt: Option<(BigUint, String, String)>) -> String {
+        match triple_opt {
+            None => String::new(),
+            Some((addr, mod_name, fun_name)) => {
+                format!("${}_{}_{}", addr.to_str_radix(16), mod_name, fun_name)
+            }
         }
     }
 }

--- a/language/move-prover/boogie-backend/src/prelude/prelude.bpl
+++ b/language/move-prover/boogie-backend/src/prelude/prelude.bpl
@@ -508,18 +508,19 @@ function {:inline} $SliceVecByRange<T>(v: Vec T, r: $Range): Vec T {
 {%- for instance in table_key_instances %}
 
 // ----------------------------------------------------------------------------------
-// Native Table key encoding for type `({{instance.suffix}}`
+// Native Table key encoding for type `{{instance.suffix}}`
 
 {{ native::table_key_encoding(instance=instance) -}}
 {%- endfor %}
 
-{%- for instance in table_instances %}
+{%- for impl in table_instances %}
+{%- for instance in impl.insts %}
 
 // ----------------------------------------------------------------------------------
 // Native Table implementation for type `({{instance.0.suffix}},{{instance.1.suffix}})`
 
-
-{{ native::table_module(instance=instance) -}}
+{{ native::table_module(impl=impl, instance=instance) -}}
+{%- endfor %}
 {%- endfor %}
 
 // ==================================================================================

--- a/language/move-prover/bytecode/src/clean_and_optimize.rs
+++ b/language/move-prover/bytecode/src/clean_and_optimize.rs
@@ -4,23 +4,24 @@
 
 // Final phase of cleanup and optimization.
 
+use std::collections::BTreeSet;
+
+use move_binary_format::file_format::CodeOffset;
+use move_model::{
+    model::FunctionEnv,
+    pragmas::INTRINSIC_FUN_MAP_BORROW_MUT,
+    well_known::{EVENT_EMIT_EVENT, VECTOR_BORROW_MUT},
+};
+
 use crate::{
     dataflow_analysis::{DataflowAnalysis, TransferFunctions},
+    dataflow_domains::{AbstractDomain, JoinResult},
     function_target::{FunctionData, FunctionTarget},
     function_target_pipeline::{FunctionTargetProcessor, FunctionTargetsHolder},
     options::ProverOptions,
     stackless_bytecode::{BorrowNode, Bytecode, Operation},
     stackless_control_flow_graph::StacklessControlFlowGraph,
 };
-use move_binary_format::file_format::CodeOffset;
-use move_model::{
-    model::FunctionEnv,
-    well_known::{EVENT_EMIT_EVENT, VECTOR_BORROW_MUT},
-};
-
-use crate::dataflow_domains::{AbstractDomain, JoinResult};
-use move_model::well_known::TABLE_BORROW_MUT;
-use std::collections::BTreeSet;
 
 pub struct CleanAndOptimizeProcessor();
 
@@ -115,7 +116,7 @@ impl<'a> TransferFunctions for Optimizer<'a> {
                         // Exploit knowledge about builtin functions
                         !(callee_env.is_well_known(VECTOR_BORROW_MUT)
                             || callee_env.is_well_known(EVENT_EMIT_EVENT)
-                            || callee_env.is_well_known(TABLE_BORROW_MUT))
+                            || callee_env.is_intrinsic_of(INTRINSIC_FUN_MAP_BORROW_MUT))
                     } else {
                         true
                     };

--- a/language/move-prover/bytecode/src/function_target.rs
+++ b/language/move-prover/bytecode/src/function_target.rs
@@ -152,16 +152,6 @@ impl<'env> FunctionTarget<'env> {
         self.data.vc_infos.get(&attr_id)
     }
 
-    /// Returns true if this function is native.
-    pub fn is_native(&self) -> bool {
-        self.func_env.is_native()
-    }
-
-    /// Returns true if this function is marked as intrinsic
-    pub fn is_intrinsic(&self) -> bool {
-        self.func_env.is_intrinsic()
-    }
-
     /// Returns true if this function is opaque.
     pub fn is_opaque(&self) -> bool {
         self.func_env.is_opaque()

--- a/language/move-prover/bytecode/src/mono_analysis.rs
+++ b/language/move-prover/bytecode/src/mono_analysis.rs
@@ -41,7 +41,7 @@ pub struct MonoInfo {
     pub spec_vars: BTreeMap<QualifiedId<SpecVarId>, BTreeSet<Vec<Type>>>,
     pub type_params: BTreeSet<u16>,
     pub vec_inst: BTreeSet<Type>,
-    pub table_inst: BTreeSet<(Type, Type)>,
+    pub table_inst: BTreeMap<QualifiedId<StructId>, BTreeSet<(Type, Type)>>,
     pub native_inst: BTreeMap<ModuleId, BTreeSet<Vec<Type>>>,
     pub axioms: Vec<Condition>,
 }
@@ -480,6 +480,8 @@ impl<'a> Analyzer<'a> {
         if struct_.is_intrinsic_of(INTRINSIC_TYPE_MAP) {
             self.info
                 .table_inst
+                .entry(struct_.get_qualified_id())
+                .or_default()
                 .insert((targs[0].clone(), targs[1].clone()));
         } else if struct_.is_native_or_intrinsic() && !targs.is_empty() {
             self.info

--- a/language/move-prover/bytecode/src/mono_analysis.rs
+++ b/language/move-prover/bytecode/src/mono_analysis.rs
@@ -20,8 +20,9 @@ use move_model::{
         FunId, FunctionEnv, GlobalEnv, ModuleId, QualifiedId, QualifiedInstId, SpecFunId,
         SpecVarId, StructEnv, StructId,
     },
+    pragmas::INTRINSIC_TYPE_MAP,
     ty::{Type, TypeDisplayContext, TypeInstantiationDerivation, TypeUnificationAdapter, Variance},
-    well_known::{TABLE_TABLE, TYPE_INFO_MOVE, TYPE_INFO_SPEC, TYPE_NAME_MOVE, TYPE_NAME_SPEC},
+    well_known::{TYPE_INFO_MOVE, TYPE_INFO_SPEC, TYPE_NAME_MOVE, TYPE_NAME_SPEC},
 };
 
 use crate::{
@@ -476,7 +477,7 @@ impl<'a> Analyzer<'a> {
     }
 
     fn add_struct(&mut self, struct_: StructEnv<'_>, targs: &[Type]) {
-        if struct_.is_well_known(TABLE_TABLE) {
+        if struct_.is_intrinsic_of(INTRINSIC_TYPE_MAP) {
             self.info
                 .table_inst
                 .insert((targs[0].clone(), targs[1].clone()));

--- a/language/move-prover/tests/sources/functional/verify_custom_table.exp
+++ b/language/move-prover/tests/sources/functional/verify_custom_table.exp
@@ -1,0 +1,43 @@
+Move prover returns: exiting with verification errors
+error: post-condition does not hold
+    ┌─ tests/sources/functional/verify_custom_table.move:170:9
+    │
+170 │         ensures spec_get(result.t, k1) == 23;
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    =     at tests/sources/functional/verify_custom_table.move:166: add_R_fail (spec)
+    =     at tests/sources/functional/verify_custom_table.move:167: add_R_fail (spec)
+    =     at tests/sources/functional/verify_custom_table.move:163: add_R_fail
+    =     at tests/sources/functional/verify_custom_table.move:144: make_R
+    =         t = <redacted>
+    =     at tests/sources/functional/verify_custom_table.move:145: make_R
+    =         t = <redacted>
+    =     at tests/sources/functional/verify_custom_table.move:146: make_R
+    =         t = <redacted>
+    =     at tests/sources/functional/verify_custom_table.move:147: make_R
+    =         result = <redacted>
+    =     at tests/sources/functional/verify_custom_table.move:148: make_R
+    =         result = <redacted>
+    =     at tests/sources/functional/verify_custom_table.move:164: add_R_fail
+    =     at tests/sources/functional/verify_custom_table.move:168: add_R_fail (spec)
+    =     at tests/sources/functional/verify_custom_table.move:169: add_R_fail (spec)
+    =     at tests/sources/functional/verify_custom_table.move:170: add_R_fail (spec)
+
+error: post-condition does not hold
+   ┌─ tests/sources/functional/verify_custom_table.move:68:9
+   │
+68 │         ensures spec_get(result, 1) == 1;
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   =     at tests/sources/functional/verify_custom_table.move:61: add_fail
+   =         t = <redacted>
+   =     at tests/sources/functional/verify_custom_table.move:62: add_fail
+   =         t = <redacted>
+   =     at tests/sources/functional/verify_custom_table.move:63: add_fail
+   =         t = <redacted>
+   =     at tests/sources/functional/verify_custom_table.move:64: add_fail
+   =         t = <redacted>
+   =     at tests/sources/functional/verify_custom_table.move:65: add_fail
+   =         result = <redacted>
+   =     at tests/sources/functional/verify_custom_table.move:66: add_fail
+   =     at tests/sources/functional/verify_custom_table.move:68: add_fail (spec)

--- a/language/move-prover/tests/sources/functional/verify_custom_table.move
+++ b/language/move-prover/tests/sources/functional/verify_custom_table.move
@@ -1,0 +1,187 @@
+// Similar to `verify_table.move`, but against a custom implementation.
+module 0x42::table {
+    struct Table<phantom K: copy + drop, phantom V> has store {}
+    spec Table {
+        pragma intrinsic = map,
+        map_new = new,
+        map_destroy_empty = destroy_empty,
+        map_len = length,
+        map_is_empty = empty,
+        map_has_key = contains,
+        map_add_no_override = add,
+        map_del_must_exist = remove,
+        map_borrow = borrow,
+        map_borrow_mut = borrow_mut,
+        map_spec_get = spec_get,
+        map_spec_set = spec_add,
+        map_spec_del = spec_remove,
+        map_spec_len = spec_len,
+        map_spec_has_key = spec_contains;
+    }
+
+    public native fun new<K: copy + drop, V: store>(): Table<K, V>;
+    public native fun destroy_empty<K: copy + drop, V>(table: Table<K, V>);
+    public native fun add<K: copy + drop, V>(table: &mut Table<K, V>, key: K, val: V);
+    public native fun borrow<K: copy + drop, V>(table: &Table<K, V>, key: K): &V;
+    public native fun borrow_mut<K: copy + drop, V>(table: &mut Table<K, V>, key: K): &mut V;
+    public native fun length<K: copy + drop, V>(table: &Table<K, V>): u64;
+    public native fun empty<K: copy + drop, V>(table: &Table<K, V>): bool;
+    public native fun remove<K: copy + drop, V>(table: &mut Table<K, V>, key: K): V;
+    public native fun contains<K: copy + drop, V>(table: &Table<K, V>, key: K): bool;
+
+    spec native fun spec_len<K, V>(t: Table<K, V>): num;
+    spec native fun spec_contains<K, V>(t: Table<K, V>, k: K): bool;
+    spec native fun spec_add<K, V>(t: Table<K, V>, k: K, v: V): Table<K, V>;
+    spec native fun spec_remove<K, V>(t: Table<K, V>, k: K): Table<K, V>;
+    spec native fun spec_get<K, V>(t: Table<K, V>, k: K): V;
+}
+
+module 0x42::VerifyTable {
+    use 0x42::table::{Self, Table};
+    use 0x42::table::{spec_get, spec_len, spec_contains};
+
+    // TODO: test precise aborts behavior of all table functions
+
+    fun add(): Table<u8, u64> {
+        let t = table::new<u8, u64>();
+        table::add(&mut t, 1, 2);
+        table::add(&mut t, 2, 3);
+        table::add(&mut t, 3, 4);
+        t
+    }
+    spec add {
+        ensures spec_contains(result, 1) && spec_contains(result, 2) && spec_contains(result, 3);
+        ensures spec_len(result) == 3;
+        ensures spec_get(result, 1) == 2;
+        ensures spec_get(result, 2) == 3;
+        ensures spec_get(result, 3) == 4;
+    }
+
+    fun add_fail(): Table<u8, u64> {
+        let t = table::new<u8, u64>();
+        table::add(&mut t, 1, 2);
+        table::add(&mut t, 2, 3);
+        table::add(&mut t, 3, 4);
+        t
+    }
+    spec add_fail {
+        ensures spec_get(result, 1) == 1;
+    }
+
+    fun add_fail_exists(k1: u8, k2: u8): Table<u8, u64> {
+        let t = table::new<u8, u64>();
+        table::add(&mut t, k1, 2);
+        table::add(&mut t, k2, 3);
+        t
+    }
+    spec add_fail_exists {
+        aborts_if k1 == k2;
+    }
+
+    fun remove(): Table<u8, u64> {
+        let t = add();
+        table::remove(&mut t, 2);
+        t
+    }
+    spec remove {
+        ensures spec_contains(result, 1) && spec_contains(result, 3);
+        ensures spec_len(result) == 2;
+        ensures spec_get(result, 1) == 2;
+        ensures spec_get(result, 3) == 4;
+    }
+
+    fun contains_and_length(): (bool, bool, u64, Table<u8, u64>) {
+        let t = table::new<u8, u64>();
+        table::add(&mut t, 1, 2);
+        table::add(&mut t, 2, 3);
+        (table::contains(&t, 1), table::contains(&t, 3), table::length(&t), t)
+    }
+    spec contains_and_length {
+        ensures result_1 == true;
+        ensures result_2 == false;
+        ensures result_3 == 2;
+    }
+
+    fun borrow(): (u64, Table<u8, u64>) {
+        let t = table::new<u8, u64>();
+        table::add(&mut t, 1, 2);
+        let r = table::borrow(&t, 1);
+        (*r, t)
+    }
+    spec borrow {
+        ensures result_1 == 2;
+        ensures spec_len(result_2) == 1;
+        ensures spec_get(result_2, 1) == 2;
+    }
+
+    fun borrow_mut(): Table<u8, u64> {
+        let t = table::new<u8, u64>();
+        table::add(&mut t, 1, 2);
+        table::add(&mut t, 2, 3);
+        let r = table::borrow_mut(&mut t, 1);
+        *r = 4;
+        t
+    }
+    spec borrow_mut {
+        ensures spec_contains(result, 1) && spec_contains(result, 2);
+        ensures spec_len(result) == 2;
+        ensures spec_get(result, 1) == 4;
+        ensures spec_get(result, 2) == 3;
+    }
+
+    // ====================================================================================================
+    // Tables with structured keys
+
+    struct Key has copy, drop {
+        v: vector<u8>       // Use a vector so we do not have extensional equality
+    }
+
+    struct R {
+        t: Table<Key, u64>
+    }
+
+    fun make_R(): R {
+        let t = table::new<Key, u64>();
+        table::add(&mut t, Key{v: vector[1, 2]}, 22);
+        table::add(&mut t, Key{v: vector[2, 3]}, 23);
+        R{t}
+    }
+
+    fun add_R(): R {
+        make_R()
+    }
+    spec add_R {
+        let k1 = Key{v: concat(vec(1u8), vec(2u8))};
+        let k2 = Key{v: concat(vec(2u8), vec(3u8))};
+        ensures spec_len(result.t) == 2;
+        ensures spec_contains(result.t, k1) && spec_contains(result.t, k2);
+        ensures spec_get(result.t, k1) == 22;
+        ensures spec_get(result.t, k2) == 23;
+    }
+
+    fun add_R_fail(): R {
+        make_R()
+    }
+    spec add_R_fail {
+        let k1 = Key{v: concat(vec(1u8), vec(2u8))};
+        let k2 = Key{v: concat(vec(2u8), vec(3u8))};
+        ensures spec_len(result.t) == 2;
+        ensures spec_contains(result.t, k1) && spec_contains(result.t, k2);
+        ensures spec_get(result.t, k1) == 23;
+        ensures spec_get(result.t, k2) == 22;
+    }
+
+    fun borrow_mut_R(): R {
+        let r = make_R();
+        let x = table::borrow_mut(&mut r.t, Key{v: vector[1, 2]});
+        *x = *x * 2;
+        r
+    }
+    spec borrow_mut_R {
+        let k1 = Key{v: concat(vec(1u8), vec(2u8))};
+        let k2 = Key{v: concat(vec(2u8), vec(3u8))};
+        ensures spec_len(result.t) == 2;
+        ensures spec_get(result.t, k1) == 44;
+        ensures spec_get(result.t, k2) == 23;
+    }
+}


### PR DESCRIPTION
This PR allows intrinsic types and functions to be declared in struct spec block.

This feature is best highlighted in the following code:

```move
module 0x42::M {
    struct MyTable1<phantom K, phantom V> {}

    native fun new<K, V>(): MyTable1<K, V>;
    native fun destroy_empty<K, V>(t: MyTable1<K, V>);
    native fun borrow_mut<K, V>(t: &mut MyTable1<K, V>, k: K): &mut V;
    native fun length<K, V>(t: &MyTable1<K, V>): u64;

    spec native fun spec_len<K, V>(t: MyTable1<K, V>): num;
    spec native fun spec_set<K, V>(t: MyTable1<K, V>, k: K, v: V): MyTable1<K, V>;
    spec native fun spec_get<K, V>(t: MyTable1<K, V>, k: K): V;

    spec MyTable1 {
        pragma intrinsic = map,
            map_new = new,
            map_destroy_empty = destroy_empty,
            map_borrow_mut = borrow_mut,
            map_len = length,
            map_spec_len = spec_len,
            map_spec_get = spec_get,
            map_spec_set = spec_set;
    }
}
```

Pay attention to the spec block of  `MyTable1`. Instead of having
`pragma intrinsic = true;`, we now have
```move
    spec MyTable1 {
        pragma intrinsic = map,  // type mapping
            // a series of function mappings
            map_new = new,
            map_destroy_empty = destroy_empty,
            map_borrow_mut = borrow_mut,
            map_len = length,
            map_spec_len = spec_len,
            map_spec_get = spec_get,
            map_spec_set = spec_set;
    }
```

The move-model is clever enough to detect that the intrinsic declarations
are reasonable, e.g., no unrecognized functions, no duplication, etc,
(except for type checking, which is deferred to boogie).

This is the first step of implementing a better support for intrinsic types.
With this record, we can instantiate the Boogie templates into different
sets of preludes, each prelude maps for an intrinsic declaration.

To illustrate:

if we have two tables, `MyTable1` and `MyTable2` both declared to be
`pragma intrinsic = map, .....`

Then, we will instantiate the `Table.boogie` template twice, one for the type
`MyTable1` and the other for `MyTable2` and include both instantiations in the
prelude.

To be even more specific, this template will be instantiated into two prelude code:
- `map := MyTable1, fun_new := new_tb1, ...`
- `map := MyTable2, fun_new := new_tb2, ...`

```
type {:datatype} {{map}} _ _;

function {:constructor} {{map}}<K, V>(v: [K]V, e: [K]bool, l: int): {{map}} K V;

function {:inline} {{fun_new}}<K, V>(): {{map}} K V {
    {{map}}(DefaultTableArray(), DefaultTableKeyExistsArray(), 0)
}

function {:inline} {{fun_map_get}}<K,V>(t: {{map}} K V, k: K): V {
    v#{{map}}(t)[k]
}
```

This is a way simpler solution that #442.

And, not related to this PR, but features like `trait` can be supported
in a similar way in the prover.

## Motivation

Better support for intrinsic types

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes

## Test Plan

CI