### PR TITLE
[move-package] Update cached git packages to latest state automatically

### DIFF
--- a/language/tools/move-package/src/lib.rs
+++ b/language/tools/move-package/src/lib.rs
@@ -132,8 +132,8 @@ pub struct BuildConfig {
     pub fetch_deps_only: bool,
 
     /// Skip fetching latest git dependencies
-    #[clap(long = "skip-fetch-latest-git-deps", global = true)]
-    pub skip_fetch_latest_git_deps: bool,
+    #[clap(long = "fetch-latest-git-deps", global = true)]
+    pub fetch_latest_git_deps: bool,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, PartialOrd)]

--- a/language/tools/move-package/src/lib.rs
+++ b/language/tools/move-package/src/lib.rs
@@ -130,6 +130,10 @@ pub struct BuildConfig {
     /// Only fetch dependency repos to MOVE_HOME
     #[clap(long = "fetch-deps-only", global = true)]
     pub fetch_deps_only: bool,
+
+    /// Skip fetching latest git dependencies
+    #[clap(long = "skip-fetch-latest-git-deps", global = true)]
+    pub skip_fetch_latest_git_deps: bool,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, PartialOrd)]

--- a/language/tools/move-package/src/resolution/resolution_graph.rs
+++ b/language/tools/move-package/src/resolution/resolution_graph.rs
@@ -391,7 +391,7 @@ impl ResolvingGraph {
         Self::download_and_update_if_remote(
             dep_name_in_pkg,
             &dep,
-            self.build_options.skip_fetch_latest_git_deps,
+            self.build_options.fetch_latest_git_deps,
         )?;
         let (dep_package, dep_package_dir) =
             Self::parse_package_manifest(&dep, &dep_name_in_pkg, root_path)
@@ -533,7 +533,7 @@ impl ResolvingGraph {
             Self::download_and_update_if_remote(
                 *dep_name,
                 dep,
-                build_options.skip_fetch_latest_git_deps,
+                build_options.fetch_latest_git_deps,
             )?;
 
             let (dep_manifest, _) =
@@ -548,7 +548,7 @@ impl ResolvingGraph {
     fn download_and_update_if_remote(
         dep_name: PackageName,
         dep: &Dependency,
-        skip_fetch_latest_git_deps: bool,
+        fetch_latest_git_deps: bool,
     ) -> Result<()> {
         if let Some(git_info) = &dep.git_info {
             if !git_info.download_to.exists() {
@@ -578,7 +578,7 @@ impl ResolvingGraph {
                             dep_name
                         )
                     })?;
-            } else if !skip_fetch_latest_git_deps {
+            } else if fetch_latest_git_deps {
                 // Check first that it isn't a git rev (if it doesn't work, just continue with the fetch)
                 if let Ok(rev) = Command::new("git")
                     .args([

--- a/language/tools/move-package/src/resolution/resolution_graph.rs
+++ b/language/tools/move-package/src/resolution/resolution_graph.rs
@@ -388,7 +388,11 @@ impl ResolvingGraph {
         dep: Dependency,
         root_path: PathBuf,
     ) -> Result<(Renaming, ResolvingTable)> {
-        Self::download_and_update_if_remote(dep_name_in_pkg, &dep)?;
+        Self::download_and_update_if_remote(
+            dep_name_in_pkg,
+            &dep,
+            self.build_options.skip_fetch_latest_git_deps,
+        )?;
         let (dep_package, dep_package_dir) =
             Self::parse_package_manifest(&dep, &dep_name_in_pkg, root_path)
                 .with_context(|| format!("While processing dependency '{}'", dep_name_in_pkg))?;
@@ -526,7 +530,11 @@ impl ResolvingGraph {
         };
 
         for (dep_name, dep) in manifest.dependencies.iter().chain(additional_deps.iter()) {
-            Self::download_and_update_if_remote(*dep_name, dep)?;
+            Self::download_and_update_if_remote(
+                *dep_name,
+                dep,
+                build_options.skip_fetch_latest_git_deps,
+            )?;
 
             let (dep_manifest, _) =
                 Self::parse_package_manifest(dep, dep_name, root_path.to_path_buf())
@@ -537,9 +545,14 @@ impl ResolvingGraph {
         Ok(())
     }
 
-    fn download_and_update_if_remote(dep_name: PackageName, dep: &Dependency) -> Result<()> {
+    fn download_and_update_if_remote(
+        dep_name: PackageName,
+        dep: &Dependency,
+        skip_fetch_latest_git_deps: bool,
+    ) -> Result<()> {
         if let Some(git_info) = &dep.git_info {
             if !git_info.download_to.exists() {
+                // If the cached folder does not exist, download and clone accordingly
                 Command::new("git")
                     .args([
                         "clone",
@@ -561,6 +574,59 @@ impl ResolvingGraph {
                     .map_err(|_| {
                         anyhow::anyhow!(
                             "Failed to checkout Git reference '{}' for package '{}'",
+                            &git_info.git_rev,
+                            dep_name
+                        )
+                    })?;
+            } else if !skip_fetch_latest_git_deps {
+                // Check first that it isn't a git rev (if it doesn't work, just continue with the fetch)
+                if let Ok(rev) = Command::new("git")
+                    .args([
+                        "--git-dir",
+                        &git_info.download_to.join(".git").display().to_string(),
+                        "rev-parse",
+                        "--verify",
+                        &git_info.git_rev,
+                    ])
+                    .output()
+                {
+                    if let Ok(parsable_version) = String::from_utf8(rev.stdout) {
+                        // If it's exactly the same, then it's a git rev
+                        if parsable_version.trim() == git_info.git_rev.as_str() {
+                            return Ok(());
+                        }
+                    }
+                }
+
+                // If the current folder exists, do a fetch and reset to ensure that the branch
+                // is up to date
+                // NOTE: this means that you must run the package system with a working network connection
+                Command::new("git")
+                    .args([
+                        "--git-dir",
+                        &git_info.download_to.join(".git").display().to_string(),
+                        "fetch",
+                        "origin",
+                    ])
+                    .output()
+                    .map_err(|_| {
+                        anyhow::anyhow!(
+                            "Failed to fetch latest Git state for package '{}', to skip set --skip-fetch-latest-git-deps",
+                            dep_name
+                        )
+                    })?;
+                Command::new("git")
+                    .args([
+                        "--git-dir",
+                        &git_info.download_to.join(".git").display().to_string(),
+                        "reset",
+                        "origin",
+                        "--hard",
+                    ])
+                    .output()
+                    .map_err(|_| {
+                        anyhow::anyhow!(
+                            "Failed to reset to latest Git state '{}' for package '{}', to skip set --skip-fetch-latest-git-deps",
                             &git_info.git_rev,
                             dep_name
                         )

--- a/language/tools/move-package/tests/test_sources/compilation/basic_no_deps/Move.exp
+++ b/language/tools/move-package/tests/test_sources/compilation/basic_no_deps/Move.exp
@@ -16,5 +16,6 @@ CompiledPackageInfo {
         additional_named_addresses: {},
         architecture: None,
         fetch_deps_only: false,
+        skip_fetch_latest_git_deps: false,
     },
 }

--- a/language/tools/move-package/tests/test_sources/compilation/basic_no_deps/Move.exp
+++ b/language/tools/move-package/tests/test_sources/compilation/basic_no_deps/Move.exp
@@ -16,6 +16,6 @@ CompiledPackageInfo {
         additional_named_addresses: {},
         architecture: None,
         fetch_deps_only: false,
-        skip_fetch_latest_git_deps: false,
+        fetch_latest_git_deps: false,
     },
 }

--- a/language/tools/move-package/tests/test_sources/compilation/basic_no_deps_address_assigned/Move.exp
+++ b/language/tools/move-package/tests/test_sources/compilation/basic_no_deps_address_assigned/Move.exp
@@ -18,6 +18,6 @@ CompiledPackageInfo {
         additional_named_addresses: {},
         architecture: None,
         fetch_deps_only: false,
-        skip_fetch_latest_git_deps: false,
+        fetch_latest_git_deps: false,
     },
 }

--- a/language/tools/move-package/tests/test_sources/compilation/basic_no_deps_address_assigned/Move.exp
+++ b/language/tools/move-package/tests/test_sources/compilation/basic_no_deps_address_assigned/Move.exp
@@ -18,5 +18,6 @@ CompiledPackageInfo {
         additional_named_addresses: {},
         architecture: None,
         fetch_deps_only: false,
+        skip_fetch_latest_git_deps: false,
     },
 }

--- a/language/tools/move-package/tests/test_sources/compilation/basic_no_deps_address_not_assigned_with_dev_assignment/Move.exp
+++ b/language/tools/move-package/tests/test_sources/compilation/basic_no_deps_address_not_assigned_with_dev_assignment/Move.exp
@@ -18,6 +18,6 @@ CompiledPackageInfo {
         additional_named_addresses: {},
         architecture: None,
         fetch_deps_only: false,
-        skip_fetch_latest_git_deps: false,
+        fetch_latest_git_deps: false,
     },
 }

--- a/language/tools/move-package/tests/test_sources/compilation/basic_no_deps_address_not_assigned_with_dev_assignment/Move.exp
+++ b/language/tools/move-package/tests/test_sources/compilation/basic_no_deps_address_not_assigned_with_dev_assignment/Move.exp
@@ -18,5 +18,6 @@ CompiledPackageInfo {
         additional_named_addresses: {},
         architecture: None,
         fetch_deps_only: false,
+        skip_fetch_latest_git_deps: false,
     },
 }

--- a/language/tools/move-package/tests/test_sources/compilation/basic_no_deps_test_mode/Move.exp
+++ b/language/tools/move-package/tests/test_sources/compilation/basic_no_deps_test_mode/Move.exp
@@ -18,6 +18,6 @@ CompiledPackageInfo {
         additional_named_addresses: {},
         architecture: None,
         fetch_deps_only: false,
-        skip_fetch_latest_git_deps: false,
+        fetch_latest_git_deps: false,
     },
 }

--- a/language/tools/move-package/tests/test_sources/compilation/basic_no_deps_test_mode/Move.exp
+++ b/language/tools/move-package/tests/test_sources/compilation/basic_no_deps_test_mode/Move.exp
@@ -18,5 +18,6 @@ CompiledPackageInfo {
         additional_named_addresses: {},
         architecture: None,
         fetch_deps_only: false,
+        skip_fetch_latest_git_deps: false,
     },
 }

--- a/language/tools/move-package/tests/test_sources/compilation/diamond_problem_backflow_resolution/Move.exp
+++ b/language/tools/move-package/tests/test_sources/compilation/diamond_problem_backflow_resolution/Move.exp
@@ -19,5 +19,6 @@ CompiledPackageInfo {
         additional_named_addresses: {},
         architecture: None,
         fetch_deps_only: false,
+        skip_fetch_latest_git_deps: false,
     },
 }

--- a/language/tools/move-package/tests/test_sources/compilation/diamond_problem_backflow_resolution/Move.exp
+++ b/language/tools/move-package/tests/test_sources/compilation/diamond_problem_backflow_resolution/Move.exp
@@ -19,6 +19,6 @@ CompiledPackageInfo {
         additional_named_addresses: {},
         architecture: None,
         fetch_deps_only: false,
-        skip_fetch_latest_git_deps: false,
+        fetch_latest_git_deps: false,
     },
 }

--- a/language/tools/move-package/tests/test_sources/compilation/diamond_problem_no_conflict/Move.exp
+++ b/language/tools/move-package/tests/test_sources/compilation/diamond_problem_no_conflict/Move.exp
@@ -19,5 +19,6 @@ CompiledPackageInfo {
         additional_named_addresses: {},
         architecture: None,
         fetch_deps_only: false,
+        skip_fetch_latest_git_deps: false,
     },
 }

--- a/language/tools/move-package/tests/test_sources/compilation/diamond_problem_no_conflict/Move.exp
+++ b/language/tools/move-package/tests/test_sources/compilation/diamond_problem_no_conflict/Move.exp
@@ -19,6 +19,6 @@ CompiledPackageInfo {
         additional_named_addresses: {},
         architecture: None,
         fetch_deps_only: false,
-        skip_fetch_latest_git_deps: false,
+        fetch_latest_git_deps: false,
     },
 }

--- a/language/tools/move-package/tests/test_sources/compilation/multiple_deps_rename/Move.exp
+++ b/language/tools/move-package/tests/test_sources/compilation/multiple_deps_rename/Move.exp
@@ -20,6 +20,6 @@ CompiledPackageInfo {
         additional_named_addresses: {},
         architecture: None,
         fetch_deps_only: false,
-        skip_fetch_latest_git_deps: false,
+        fetch_latest_git_deps: false,
     },
 }

--- a/language/tools/move-package/tests/test_sources/compilation/multiple_deps_rename/Move.exp
+++ b/language/tools/move-package/tests/test_sources/compilation/multiple_deps_rename/Move.exp
@@ -20,5 +20,6 @@ CompiledPackageInfo {
         additional_named_addresses: {},
         architecture: None,
         fetch_deps_only: false,
+        skip_fetch_latest_git_deps: false,
     },
 }

--- a/language/tools/move-package/tests/test_sources/compilation/multiple_deps_rename_one/Move.exp
+++ b/language/tools/move-package/tests/test_sources/compilation/multiple_deps_rename_one/Move.exp
@@ -20,6 +20,6 @@ CompiledPackageInfo {
         additional_named_addresses: {},
         architecture: None,
         fetch_deps_only: false,
-        skip_fetch_latest_git_deps: false,
+        fetch_latest_git_deps: false,
     },
 }

--- a/language/tools/move-package/tests/test_sources/compilation/multiple_deps_rename_one/Move.exp
+++ b/language/tools/move-package/tests/test_sources/compilation/multiple_deps_rename_one/Move.exp
@@ -20,5 +20,6 @@ CompiledPackageInfo {
         additional_named_addresses: {},
         architecture: None,
         fetch_deps_only: false,
+        skip_fetch_latest_git_deps: false,
     },
 }

--- a/language/tools/move-package/tests/test_sources/compilation/one_dep/Move.exp
+++ b/language/tools/move-package/tests/test_sources/compilation/one_dep/Move.exp
@@ -18,6 +18,6 @@ CompiledPackageInfo {
         additional_named_addresses: {},
         architecture: None,
         fetch_deps_only: false,
-        skip_fetch_latest_git_deps: false,
+        fetch_latest_git_deps: false,
     },
 }

--- a/language/tools/move-package/tests/test_sources/compilation/one_dep/Move.exp
+++ b/language/tools/move-package/tests/test_sources/compilation/one_dep/Move.exp
@@ -18,5 +18,6 @@ CompiledPackageInfo {
         additional_named_addresses: {},
         architecture: None,
         fetch_deps_only: false,
+        skip_fetch_latest_git_deps: false,
     },
 }

--- a/language/tools/move-package/tests/test_sources/compilation/one_dep_assigned_address/Move.exp
+++ b/language/tools/move-package/tests/test_sources/compilation/one_dep_assigned_address/Move.exp
@@ -18,6 +18,6 @@ CompiledPackageInfo {
         additional_named_addresses: {},
         architecture: None,
         fetch_deps_only: false,
-        skip_fetch_latest_git_deps: false,
+        fetch_latest_git_deps: false,
     },
 }

--- a/language/tools/move-package/tests/test_sources/compilation/one_dep_assigned_address/Move.exp
+++ b/language/tools/move-package/tests/test_sources/compilation/one_dep_assigned_address/Move.exp
@@ -18,5 +18,6 @@ CompiledPackageInfo {
         additional_named_addresses: {},
         architecture: None,
         fetch_deps_only: false,
+        skip_fetch_latest_git_deps: false,
     },
 }

--- a/language/tools/move-package/tests/test_sources/compilation/one_dep_renamed/Move.exp
+++ b/language/tools/move-package/tests/test_sources/compilation/one_dep_renamed/Move.exp
@@ -18,6 +18,6 @@ CompiledPackageInfo {
         additional_named_addresses: {},
         architecture: None,
         fetch_deps_only: false,
-        skip_fetch_latest_git_deps: false,
+        fetch_latest_git_deps: false,
     },
 }

--- a/language/tools/move-package/tests/test_sources/compilation/one_dep_renamed/Move.exp
+++ b/language/tools/move-package/tests/test_sources/compilation/one_dep_renamed/Move.exp
@@ -18,5 +18,6 @@ CompiledPackageInfo {
         additional_named_addresses: {},
         architecture: None,
         fetch_deps_only: false,
+        skip_fetch_latest_git_deps: false,
     },
 }

--- a/language/tools/move-package/tests/test_sources/compilation/one_dep_with_scripts/Move.exp
+++ b/language/tools/move-package/tests/test_sources/compilation/one_dep_with_scripts/Move.exp
@@ -18,6 +18,6 @@ CompiledPackageInfo {
         additional_named_addresses: {},
         architecture: None,
         fetch_deps_only: false,
-        skip_fetch_latest_git_deps: false,
+        fetch_latest_git_deps: false,
     },
 }

--- a/language/tools/move-package/tests/test_sources/compilation/one_dep_with_scripts/Move.exp
+++ b/language/tools/move-package/tests/test_sources/compilation/one_dep_with_scripts/Move.exp
@@ -18,5 +18,6 @@ CompiledPackageInfo {
         additional_named_addresses: {},
         architecture: None,
         fetch_deps_only: false,
+        skip_fetch_latest_git_deps: false,
     },
 }

--- a/language/tools/move-package/tests/test_sources/compilation/test_symlinks/Move.exp
+++ b/language/tools/move-package/tests/test_sources/compilation/test_symlinks/Move.exp
@@ -18,6 +18,6 @@ CompiledPackageInfo {
         additional_named_addresses: {},
         architecture: None,
         fetch_deps_only: false,
-        skip_fetch_latest_git_deps: false,
+        fetch_latest_git_deps: false,
     },
 }

--- a/language/tools/move-package/tests/test_sources/compilation/test_symlinks/Move.exp
+++ b/language/tools/move-package/tests/test_sources/compilation/test_symlinks/Move.exp
@@ -18,5 +18,6 @@ CompiledPackageInfo {
         additional_named_addresses: {},
         architecture: None,
         fetch_deps_only: false,
+        skip_fetch_latest_git_deps: false,
     },
 }

--- a/language/tools/move-package/tests/test_sources/parsing/invalid_identifier_package_name/Move.exp
+++ b/language/tools/move-package/tests/test_sources/parsing/invalid_identifier_package_name/Move.exp
@@ -12,6 +12,7 @@ ResolutionGraph {
         additional_named_addresses: {},
         architecture: None,
         fetch_deps_only: false,
+        skip_fetch_latest_git_deps: false,
     },
     root_package: SourceManifest {
         package: PackageInfo {

--- a/language/tools/move-package/tests/test_sources/parsing/invalid_identifier_package_name/Move.exp
+++ b/language/tools/move-package/tests/test_sources/parsing/invalid_identifier_package_name/Move.exp
@@ -12,7 +12,7 @@ ResolutionGraph {
         additional_named_addresses: {},
         architecture: None,
         fetch_deps_only: false,
-        skip_fetch_latest_git_deps: false,
+        fetch_latest_git_deps: false,
     },
     root_package: SourceManifest {
         package: PackageInfo {

--- a/language/tools/move-package/tests/test_sources/parsing/minimal_manifest/Move.exp
+++ b/language/tools/move-package/tests/test_sources/parsing/minimal_manifest/Move.exp
@@ -12,6 +12,7 @@ ResolutionGraph {
         additional_named_addresses: {},
         architecture: None,
         fetch_deps_only: false,
+        skip_fetch_latest_git_deps: false,
     },
     root_package: SourceManifest {
         package: PackageInfo {

--- a/language/tools/move-package/tests/test_sources/parsing/minimal_manifest/Move.exp
+++ b/language/tools/move-package/tests/test_sources/parsing/minimal_manifest/Move.exp
@@ -12,7 +12,7 @@ ResolutionGraph {
         additional_named_addresses: {},
         architecture: None,
         fetch_deps_only: false,
-        skip_fetch_latest_git_deps: false,
+        fetch_latest_git_deps: false,
     },
     root_package: SourceManifest {
         package: PackageInfo {

--- a/language/tools/move-package/tests/test_sources/resolution/basic_no_deps/Move.exp
+++ b/language/tools/move-package/tests/test_sources/resolution/basic_no_deps/Move.exp
@@ -12,6 +12,7 @@ ResolutionGraph {
         additional_named_addresses: {},
         architecture: None,
         fetch_deps_only: false,
+        skip_fetch_latest_git_deps: false,
     },
     root_package: SourceManifest {
         package: PackageInfo {

--- a/language/tools/move-package/tests/test_sources/resolution/basic_no_deps/Move.exp
+++ b/language/tools/move-package/tests/test_sources/resolution/basic_no_deps/Move.exp
@@ -12,7 +12,7 @@ ResolutionGraph {
         additional_named_addresses: {},
         architecture: None,
         fetch_deps_only: false,
-        skip_fetch_latest_git_deps: false,
+        fetch_latest_git_deps: false,
     },
     root_package: SourceManifest {
         package: PackageInfo {

--- a/language/tools/move-package/tests/test_sources/resolution/basic_no_deps_address_assigned/Move.exp
+++ b/language/tools/move-package/tests/test_sources/resolution/basic_no_deps_address_assigned/Move.exp
@@ -12,6 +12,7 @@ ResolutionGraph {
         additional_named_addresses: {},
         architecture: None,
         fetch_deps_only: false,
+        skip_fetch_latest_git_deps: false,
     },
     root_package: SourceManifest {
         package: PackageInfo {

--- a/language/tools/move-package/tests/test_sources/resolution/basic_no_deps_address_assigned/Move.exp
+++ b/language/tools/move-package/tests/test_sources/resolution/basic_no_deps_address_assigned/Move.exp
@@ -12,7 +12,7 @@ ResolutionGraph {
         additional_named_addresses: {},
         architecture: None,
         fetch_deps_only: false,
-        skip_fetch_latest_git_deps: false,
+        fetch_latest_git_deps: false,
     },
     root_package: SourceManifest {
         package: PackageInfo {

--- a/language/tools/move-package/tests/test_sources/resolution/basic_no_deps_address_not_assigned_with_dev_assignment/Move.exp
+++ b/language/tools/move-package/tests/test_sources/resolution/basic_no_deps_address_not_assigned_with_dev_assignment/Move.exp
@@ -12,6 +12,7 @@ ResolutionGraph {
         additional_named_addresses: {},
         architecture: None,
         fetch_deps_only: false,
+        skip_fetch_latest_git_deps: false,
     },
     root_package: SourceManifest {
         package: PackageInfo {

--- a/language/tools/move-package/tests/test_sources/resolution/basic_no_deps_address_not_assigned_with_dev_assignment/Move.exp
+++ b/language/tools/move-package/tests/test_sources/resolution/basic_no_deps_address_not_assigned_with_dev_assignment/Move.exp
@@ -12,7 +12,7 @@ ResolutionGraph {
         additional_named_addresses: {},
         architecture: None,
         fetch_deps_only: false,
-        skip_fetch_latest_git_deps: false,
+        fetch_latest_git_deps: false,
     },
     root_package: SourceManifest {
         package: PackageInfo {

--- a/language/tools/move-package/tests/test_sources/resolution/dep_good_digest/Move.exp
+++ b/language/tools/move-package/tests/test_sources/resolution/dep_good_digest/Move.exp
@@ -12,6 +12,7 @@ ResolutionGraph {
         additional_named_addresses: {},
         architecture: None,
         fetch_deps_only: false,
+        skip_fetch_latest_git_deps: false,
     },
     root_package: SourceManifest {
         package: PackageInfo {

--- a/language/tools/move-package/tests/test_sources/resolution/dep_good_digest/Move.exp
+++ b/language/tools/move-package/tests/test_sources/resolution/dep_good_digest/Move.exp
@@ -12,7 +12,7 @@ ResolutionGraph {
         additional_named_addresses: {},
         architecture: None,
         fetch_deps_only: false,
-        skip_fetch_latest_git_deps: false,
+        fetch_latest_git_deps: false,
     },
     root_package: SourceManifest {
         package: PackageInfo {

--- a/language/tools/move-package/tests/test_sources/resolution/diamond_problem_backflow_resolution/Move.exp
+++ b/language/tools/move-package/tests/test_sources/resolution/diamond_problem_backflow_resolution/Move.exp
@@ -12,6 +12,7 @@ ResolutionGraph {
         additional_named_addresses: {},
         architecture: None,
         fetch_deps_only: false,
+        skip_fetch_latest_git_deps: false,
     },
     root_package: SourceManifest {
         package: PackageInfo {

--- a/language/tools/move-package/tests/test_sources/resolution/diamond_problem_backflow_resolution/Move.exp
+++ b/language/tools/move-package/tests/test_sources/resolution/diamond_problem_backflow_resolution/Move.exp
@@ -12,7 +12,7 @@ ResolutionGraph {
         additional_named_addresses: {},
         architecture: None,
         fetch_deps_only: false,
-        skip_fetch_latest_git_deps: false,
+        fetch_latest_git_deps: false,
     },
     root_package: SourceManifest {
         package: PackageInfo {

--- a/language/tools/move-package/tests/test_sources/resolution/diamond_problem_no_conflict/Move.exp
+++ b/language/tools/move-package/tests/test_sources/resolution/diamond_problem_no_conflict/Move.exp
@@ -12,6 +12,7 @@ ResolutionGraph {
         additional_named_addresses: {},
         architecture: None,
         fetch_deps_only: false,
+        skip_fetch_latest_git_deps: false,
     },
     root_package: SourceManifest {
         package: PackageInfo {

--- a/language/tools/move-package/tests/test_sources/resolution/diamond_problem_no_conflict/Move.exp
+++ b/language/tools/move-package/tests/test_sources/resolution/diamond_problem_no_conflict/Move.exp
@@ -12,7 +12,7 @@ ResolutionGraph {
         additional_named_addresses: {},
         architecture: None,
         fetch_deps_only: false,
-        skip_fetch_latest_git_deps: false,
+        fetch_latest_git_deps: false,
     },
     root_package: SourceManifest {
         package: PackageInfo {

--- a/language/tools/move-package/tests/test_sources/resolution/multiple_deps_rename/Move.exp
+++ b/language/tools/move-package/tests/test_sources/resolution/multiple_deps_rename/Move.exp
@@ -12,6 +12,7 @@ ResolutionGraph {
         additional_named_addresses: {},
         architecture: None,
         fetch_deps_only: false,
+        skip_fetch_latest_git_deps: false,
     },
     root_package: SourceManifest {
         package: PackageInfo {

--- a/language/tools/move-package/tests/test_sources/resolution/multiple_deps_rename/Move.exp
+++ b/language/tools/move-package/tests/test_sources/resolution/multiple_deps_rename/Move.exp
@@ -12,7 +12,7 @@ ResolutionGraph {
         additional_named_addresses: {},
         architecture: None,
         fetch_deps_only: false,
-        skip_fetch_latest_git_deps: false,
+        fetch_latest_git_deps: false,
     },
     root_package: SourceManifest {
         package: PackageInfo {

--- a/language/tools/move-package/tests/test_sources/resolution/one_dep/Move.exp
+++ b/language/tools/move-package/tests/test_sources/resolution/one_dep/Move.exp
@@ -12,6 +12,7 @@ ResolutionGraph {
         additional_named_addresses: {},
         architecture: None,
         fetch_deps_only: false,
+        skip_fetch_latest_git_deps: false,
     },
     root_package: SourceManifest {
         package: PackageInfo {

--- a/language/tools/move-package/tests/test_sources/resolution/one_dep/Move.exp
+++ b/language/tools/move-package/tests/test_sources/resolution/one_dep/Move.exp
@@ -12,7 +12,7 @@ ResolutionGraph {
         additional_named_addresses: {},
         architecture: None,
         fetch_deps_only: false,
-        skip_fetch_latest_git_deps: false,
+        fetch_latest_git_deps: false,
     },
     root_package: SourceManifest {
         package: PackageInfo {

--- a/language/tools/move-package/tests/test_sources/resolution/one_dep_assigned_address/Move.exp
+++ b/language/tools/move-package/tests/test_sources/resolution/one_dep_assigned_address/Move.exp
@@ -12,6 +12,7 @@ ResolutionGraph {
         additional_named_addresses: {},
         architecture: None,
         fetch_deps_only: false,
+        skip_fetch_latest_git_deps: false,
     },
     root_package: SourceManifest {
         package: PackageInfo {

--- a/language/tools/move-package/tests/test_sources/resolution/one_dep_assigned_address/Move.exp
+++ b/language/tools/move-package/tests/test_sources/resolution/one_dep_assigned_address/Move.exp
@@ -12,7 +12,7 @@ ResolutionGraph {
         additional_named_addresses: {},
         architecture: None,
         fetch_deps_only: false,
-        skip_fetch_latest_git_deps: false,
+        fetch_latest_git_deps: false,
     },
     root_package: SourceManifest {
         package: PackageInfo {

--- a/language/tools/move-package/tests/test_sources/resolution/one_dep_multiple_of_same_name/Move.exp
+++ b/language/tools/move-package/tests/test_sources/resolution/one_dep_multiple_of_same_name/Move.exp
@@ -12,6 +12,7 @@ ResolutionGraph {
         additional_named_addresses: {},
         architecture: None,
         fetch_deps_only: false,
+        skip_fetch_latest_git_deps: false,
     },
     root_package: SourceManifest {
         package: PackageInfo {

--- a/language/tools/move-package/tests/test_sources/resolution/one_dep_multiple_of_same_name/Move.exp
+++ b/language/tools/move-package/tests/test_sources/resolution/one_dep_multiple_of_same_name/Move.exp
@@ -12,7 +12,7 @@ ResolutionGraph {
         additional_named_addresses: {},
         architecture: None,
         fetch_deps_only: false,
-        skip_fetch_latest_git_deps: false,
+        fetch_latest_git_deps: false,
     },
     root_package: SourceManifest {
         package: PackageInfo {

--- a/language/tools/move-package/tests/test_sources/resolution/one_dep_reassigned_address/Move.exp
+++ b/language/tools/move-package/tests/test_sources/resolution/one_dep_reassigned_address/Move.exp
@@ -12,6 +12,7 @@ ResolutionGraph {
         additional_named_addresses: {},
         architecture: None,
         fetch_deps_only: false,
+        skip_fetch_latest_git_deps: false,
     },
     root_package: SourceManifest {
         package: PackageInfo {

--- a/language/tools/move-package/tests/test_sources/resolution/one_dep_reassigned_address/Move.exp
+++ b/language/tools/move-package/tests/test_sources/resolution/one_dep_reassigned_address/Move.exp
@@ -12,7 +12,7 @@ ResolutionGraph {
         additional_named_addresses: {},
         architecture: None,
         fetch_deps_only: false,
-        skip_fetch_latest_git_deps: false,
+        fetch_latest_git_deps: false,
     },
     root_package: SourceManifest {
         package: PackageInfo {

--- a/language/tools/move-package/tests/test_sources/resolution/one_dep_unification_across_local_renamings/Move.exp
+++ b/language/tools/move-package/tests/test_sources/resolution/one_dep_unification_across_local_renamings/Move.exp
@@ -12,6 +12,7 @@ ResolutionGraph {
         additional_named_addresses: {},
         architecture: None,
         fetch_deps_only: false,
+        skip_fetch_latest_git_deps: false,
     },
     root_package: SourceManifest {
         package: PackageInfo {

--- a/language/tools/move-package/tests/test_sources/resolution/one_dep_unification_across_local_renamings/Move.exp
+++ b/language/tools/move-package/tests/test_sources/resolution/one_dep_unification_across_local_renamings/Move.exp
@@ -12,7 +12,7 @@ ResolutionGraph {
         additional_named_addresses: {},
         architecture: None,
         fetch_deps_only: false,
-        skip_fetch_latest_git_deps: false,
+        fetch_latest_git_deps: false,
     },
     root_package: SourceManifest {
         package: PackageInfo {


### PR DESCRIPTION

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Move Language.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Currently, the cached packages are never updated, even though they check out the corresponding git repo.  This will now just fetch and reset accordingly to update the local cached version.  Note, this will require a network connection for whenever the compiler is run with a git dependency (though, normally you need it if you don't have it cached).

https://github.com/move-language/move/issues/468

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes

## Test Plan

Tested with the Move CLI, it now properly downloads to the latest state.