### PR TITLE
[binary format] fix signature token deserialization bug

### DIFF
--- a/language/move-binary-format/src/deserializer.rs
+++ b/language/move-binary-format/src/deserializer.rs
@@ -988,6 +988,10 @@ fn load_signature_token(cursor: &mut VersionedCursor) -> BinaryLoaderResult<Sign
                 S::STRUCT_INST => {
                     let sh_idx = load_struct_handle_index(cursor)?;
                     let arity = load_type_parameter_count(cursor)?;
+                    if arity == 0 {
+                        return Err(PartialVMError::new(StatusCode::MALFORMED)
+                            .with_message("Struct inst with arity 0".to_string()));
+                    }
                     T::StructInst {
                         sh_idx,
                         arity,

--- a/language/move-binary-format/src/unit_tests/signature_token_tests.rs
+++ b/language/move-binary-format/src/unit_tests/signature_token_tests.rs
@@ -5,7 +5,7 @@
 use crate::{
     deserializer::load_signature_token_test_entry,
     file_format::{SignatureToken, StructHandleIndex},
-    file_format_common::{BinaryData, SIGNATURE_TOKEN_DEPTH_MAX},
+    file_format_common::{BinaryData, SerializedType, SIGNATURE_TOKEN_DEPTH_MAX},
     serializer::{serialize_signature_token, serialize_signature_token_unchecked},
 };
 use std::io::Cursor;
@@ -43,4 +43,47 @@ fn serialize_nested_types_too_deep() {
         let cursor = Cursor::new(binary.as_inner());
         load_signature_token_test_entry(cursor).expect_err("deserialization should fail");
     }
+}
+
+#[test]
+fn deserialize_struct_inst_arity_0() {
+    let cursor = Cursor::new(
+        [
+            SerializedType::STRUCT_INST as u8,
+            0x0, /* struct handle idx */
+            0x0, /* arity */
+            SerializedType::BOOL as u8,
+        ]
+        .as_slice(),
+    );
+    load_signature_token_test_entry(cursor).expect_err("deserialization should fail");
+}
+
+#[test]
+fn deserialize_struct_inst_arity_1() {
+    let cursor = Cursor::new(
+        [
+            SerializedType::STRUCT_INST as u8,
+            0x0, /* struct handle idx */
+            0x1, /* arity */
+            SerializedType::BOOL as u8,
+        ]
+        .as_slice(),
+    );
+    load_signature_token_test_entry(cursor).expect("deserialization should succeed");
+}
+
+#[test]
+fn deserialize_struct_inst_arity_2() {
+    let cursor = Cursor::new(
+        [
+            SerializedType::STRUCT_INST as u8,
+            0x0, /* struct handle idx */
+            0x2, /* arity */
+            SerializedType::BOOL as u8,
+            SerializedType::BOOL as u8,
+        ]
+        .as_slice(),
+    );
+    load_signature_token_test_entry(cursor).expect("deserialization should succeed");
 }


### PR DESCRIPTION
This fixes a bug in the binary format deserializer regarding the handling of SignatureToken. The current implementation accepts a struct instantiation with arity 0 and will wrongfully apply the type constructor to the next argument.
```
        [
            SerializedType::STRUCT_INST as u8,
            0x0, /* struct handle idx */
            0x0, /* arity */
            SerializedType::BOOL as u8,
        ]
```

This gets it fixed by checking the arity and adds a few tests to ensure this case is covered. 