### PR TITLE
[clippy] Fix clippy rename warning

### DIFF
--- a/x.toml
+++ b/x.toml
@@ -30,7 +30,7 @@ features = [ "s3" ]
 allowed = [
     # Deriving Arbitrary often causes this warning to show up.
     "clippy::unit_arg",
-    "clippy::eval-order-dependence",
+    "clippy::mixed_read_write_in_expression",
     "clippy::new-without-default",
     "clippy::rc_buffer",
     "clippy::upper_case_acronyms",


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Move Language.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

There's a warning that says that this field has been renamed.  This fixes it.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes

## Test Plan

```
cargo x clippy
```
