### PR TITLE
[compatibility] Relax compatibility for friends

### DIFF
--- a/language/move-binary-format/src/unit_tests/compatibility_tests.rs
+++ b/language/move-binary-format/src/unit_tests/compatibility_tests.rs
@@ -82,7 +82,7 @@ const COMPATIBLE: Compatibility = Compatibility {
 fn deprecated_unchanged_script_visibility() {
     let script_module = mk_module(Visibility::DEPRECATED_SCRIPT);
     assert_eq!(
-        Compatibility::check(&script_module, &script_module,),
+        Compatibility::check(false, &script_module, &script_module,),
         COMPATIBLE
     );
 }
@@ -93,19 +93,19 @@ fn deprecated_remove_script_visibility() {
     // script -> private, not allowed
     let private_module = mk_module(Visibility::Private as u8);
     assert_eq!(
-        Compatibility::check(&script_module, &private_module),
+        Compatibility::check(false, &script_module, &private_module),
         NON_COMPATIBLE
     );
     // script -> public, not allowed
     let public_module = mk_module(Visibility::Public as u8);
     assert_eq!(
-        Compatibility::check(&script_module, &public_module),
+        Compatibility::check(false, &script_module, &public_module),
         NON_COMPATIBLE
     );
     // script -> friend, not allowed
     let friend_module = mk_module(Visibility::Friend as u8);
     assert_eq!(
-        Compatibility::check(&script_module, &friend_module),
+        Compatibility::check(false, &script_module, &friend_module),
         NON_COMPATIBLE
     );
 }
@@ -116,19 +116,19 @@ fn deprecated_add_script_visibility() {
     // private -> script, allowed
     let private_module = mk_module(Visibility::Private as u8);
     assert_eq!(
-        Compatibility::check(&private_module, &script_module,),
+        Compatibility::check(false, &private_module, &script_module,),
         COMPATIBLE
     );
     // public -> script, not allowed
     let public_module = mk_module(Visibility::Public as u8);
     assert_eq!(
-        Compatibility::check(&public_module, &script_module),
+        Compatibility::check(false, &public_module, &script_module),
         NON_COMPATIBLE
     );
     // friend -> script, not allowed
     let friend_module = mk_module(Visibility::Friend as u8);
     assert_eq!(
-        Compatibility::check(&friend_module, &script_module),
+        Compatibility::check(false, &friend_module, &script_module),
         NON_COMPATIBLE
     );
 }

--- a/language/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/control_flow_tests.rs
+++ b/language/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/control_flow_tests.rs
@@ -98,6 +98,7 @@ fn nested_loops_max_depth() {
     let result = verify_module(
         &VerifierConfig {
             max_loop_depth: Some(2),
+            ..VerifierConfig::default()
         },
         &module,
     );
@@ -118,6 +119,7 @@ fn nested_loops_exceed_max_depth() {
     let result = verify_module(
         &VerifierConfig {
             max_loop_depth: Some(2),
+            ..VerifierConfig::default()
         },
         &module,
     );

--- a/language/move-bytecode-verifier/src/verifier.rs
+++ b/language/move-bytecode-verifier/src/verifier.rs
@@ -19,6 +19,7 @@ use move_binary_format::{
 #[derive(Debug, Clone, Default)]
 pub struct VerifierConfig {
     pub max_loop_depth: Option<usize>,
+    pub treat_friend_as_private: bool,
 }
 
 /// Helper for a "canonical" verification of a module.

--- a/language/move-vm/integration-tests/src/tests/nested_loop_tests.rs
+++ b/language/move-vm/integration-tests/src/tests/nested_loop_tests.rs
@@ -45,6 +45,7 @@ fn test_publish_module_with_nested_loops() {
             ),
             VerifierConfig {
                 max_loop_depth: Some(2),
+                ..VerifierConfig::default()
             },
         )
         .unwrap();
@@ -64,6 +65,7 @@ fn test_publish_module_with_nested_loops() {
             ),
             VerifierConfig {
                 max_loop_depth: Some(1),
+                ..VerifierConfig::default()
             },
         )
         .unwrap();
@@ -109,6 +111,7 @@ fn test_run_script_with_nested_loops() {
             ),
             VerifierConfig {
                 max_loop_depth: Some(2),
+                ..VerifierConfig::default()
             },
         )
         .unwrap();
@@ -129,6 +132,7 @@ fn test_run_script_with_nested_loops() {
             ),
             VerifierConfig {
                 max_loop_depth: Some(1),
+                ..VerifierConfig::default()
             },
         )
         .unwrap();

--- a/language/tools/move-cli/src/sandbox/utils/mod.rs
+++ b/language/tools/move-cli/src/sandbox/utils/mod.rs
@@ -347,7 +347,7 @@ pub(crate) fn explain_publish_error(
             let old_module = state.get_module_by_id(&module_id)?.unwrap();
             let old_api = normalized::Module::new(&old_module);
             let new_api = normalized::Module::new(module);
-            let compat = Compatibility::check(&old_api, &new_api);
+            let compat = Compatibility::check(false, &old_api, &new_api);
             // the only way we get this error code is compatibility checking failed, so assert here
             assert!(!compat.is_fully_compatible());
 


### PR DESCRIPTION
This adds a dynamic global flag which if set, lets the compatibility check treat friend functions like private functions. The feature is not on by default because it assumes that modules are compiled and published on package granularity level. On package level, we can assume that each call site of the friend function has been updated to the changed friend function as well.


### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

NA