### PR TITLE
[move-prover] allow recursive move function

### DIFF
--- a/language/move-prover/tests/sources/functional/recursive_move_fun.move
+++ b/language/move-prover/tests/sources/functional/recursive_move_fun.move
@@ -1,0 +1,18 @@
+module 0x1::test {
+    public fun pow(n: u64, e: u64): u64 {
+        if (e == 0) {
+            1
+        } else {
+            n * pow(n, e - 1)
+        }
+    }
+    spec pow {
+        // NOTE: opaque declaration is necessary for a recursive move function
+        pragma opaque;
+        ensures result == spec_pow(n, e);
+    }
+
+    spec fun spec_pow(n: num, e: num): num {
+        if (e == 0) { 1 } else { n * spec_pow(n, e - 1) }
+    }
+}


### PR DESCRIPTION
Recursive Move functions are not currently supported in Move prover.

This is because two passes in the transformation pipeline does not support it:
- borrow analysis does not support recursive functions that returns mutable references (`&mut`), and
- verification analysis does not know whether to mark a recursive function (or a mutually recursive function) inline or verify.

This commit does not add any functionality to support either analysis, but does allow the following situation to pass:

- if a recursive Move function does not return `&mut`, we allow it to pass the borrow analysis as it does not affect the borrow graph.
- Check that all recursive Move functions should be marked with `pragma opaque`. In this way, we essentially bypass the problem of whether to generate a Boogie `function` or `procedure` for a recursive Move function. We generate the VC for the recursive function by inlining its spec at the recursive call sites (like how we treat any other opaque function)

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Move Language.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Add very basic support recursive Move function

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes

## Test Plan

- CI
- new test case