### PR TITLE
[move-model] do not report errors when translating a non-pure fun to spec fun

### DIFF
--- a/language/move-model/src/builder/exp_translator.rs
+++ b/language/move-model/src/builder/exp_translator.rs
@@ -153,6 +153,15 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
         }
     }
 
+    /// Shortcut for reporting an error.
+    pub fn error_with_notes(&self, loc: &Loc, msg: &str, notes: Vec<String>) {
+        if self.translating_fun_as_spec_fun {
+            *self.errors_generated.borrow_mut() = true;
+        } else {
+            self.parent.parent.error_with_notes(loc, msg, notes);
+        }
+    }
+
     /// Creates a fresh type variable.
     fn fresh_type_var(&mut self) -> Type {
         let var = Type::Var(self.type_var_counter);
@@ -1443,7 +1452,7 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
                             )
                         })
                         .collect_vec();
-                    self.parent.parent.env.error_with_notes(
+                    self.error_with_notes(
                         loc,
                         &format!("no matching declaration of `{}`", display),
                         notes,

--- a/language/move-model/tests/sources/if_else_ok.exp
+++ b/language/move-model/tests/sources/if_else_ok.exp
@@ -1,0 +1,1 @@
+All good, no errors!

--- a/language/move-model/tests/sources/if_else_ok.move
+++ b/language/move-model/tests/sources/if_else_ok.move
@@ -1,0 +1,23 @@
+module 0x42::Test {
+    fun foo(cond: bool) {
+        // NOTE: `foo` will not be treated as a pure function because in
+        // move-model, the only thing allowed in an exp block is let-bindings
+        // (except for the last expression). This will cause the type unifier
+        // to treat the `addr` to have a type which is the same as the `dummy()`
+        // function call return type. This is clearly an erroneous state, but is
+        // okay because we have previously marked the spec fucntion translation
+        // as failure and subsequent errors can be ignored.
+        let addr = if (cond) {
+            dummy(0);
+            @0x1
+        } else {
+            dummy(42);
+            @0x2
+        };
+        bar(addr);
+    }
+
+    fun bar(_addr: address) {}
+
+    fun dummy(val: u8): u8 { val }
+}


### PR DESCRIPTION
During the process of translation, if an error already happened, i.e., the move function is already considered non-pure, the following-up errors can be misleading. As shown in the test case.

This commit stops showing an error on unable to find the correct spec fun candidate due to type unification failures (which is already messed up when there is a previous error).

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Move Language.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Improve UX

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes

## Test Plan

- CI
- A new test case