### PR TITLE
[rfc][interpreter] give each stack frame its own operand stack

### DIFF
--- a/language/move-vm/runtime/src/loader.rs
+++ b/language/move-vm/runtime/src/loader.rs
@@ -2043,6 +2043,10 @@ impl Function {
         self.parameters.len()
     }
 
+    pub(crate) fn return_type_count(&self) -> usize {
+        self.return_.len()
+    }
+
     pub(crate) fn name(&self) -> &str {
         self.name.as_str()
     }


### PR DESCRIPTION
In the current implementation of the VM, the operand stack is shared by all stack frames. However, the stack balancing pass of the verifier performs checks that prevent a callee frame from touching operand stack values that belong to the caller. Thus, each call stack frame conceptually has its own private operand stack, and an implementation that moves the operand stack into a call stack frame should work just fine.

This PR tries out such an implementation, mostly out of curiosity/sanity-checking that the verifier pass does indeed ensure what we think it does (at least on our e2e and smoke tests). It adds (redundant, paranoid) checks at function returns that ensure the number of values remaining on the callee operand stack is the same as the number of return types in the callee.

These redundant checks/this refactoring should be cheap (modulo extra allocations compared to a shared operand stack, which we should watch out for). But it has several advantages over the shared operand stack implementation in terms of defense in depth.

- A bug in the stack balancing verifier pass that allows the callee to reach into the caller's stack frame (aka the "Darion bug" from back in the day) will be caught at runtime--it will result in popping an empty stack in the callee and hitting a VM_INVARIANT_VIOLATION as a result
- A buggy native function that accidentally returns too many or too few values will *not* be caught by the verifier. But it will be caught at runtime by the paranoid checks. This seems like a fairly easy mistake for a native function implementer to make, particularly in refactoring.
- A bug in the type safety verifier pass that messes up the return type/return value arity will now be caught at runtime by the paranoid checks

I am putting this up as an experiment and a RFC to see if folks think the approach has value, but this would obviously need much more discussion and some perf measurement before going in.