### PR TITLE
[move-package] Make git fetch dependencies refresh on by default

### DIFF
--- a/language/tools/move-package/src/lib.rs
+++ b/language/tools/move-package/src/lib.rs
@@ -132,8 +132,8 @@ pub struct BuildConfig {
     pub fetch_deps_only: bool,
 
     /// Skip fetching latest git dependencies
-    #[clap(long = "fetch-latest-git-deps", global = true)]
-    pub fetch_latest_git_deps: bool,
+    #[clap(long = "skip-fetch-latest-git-deps", global = true)]
+    pub skip_fetch_latest_git_deps: bool,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, PartialOrd)]

--- a/language/tools/move-package/tests/test_sources/compilation/basic_no_deps/Move.exp
+++ b/language/tools/move-package/tests/test_sources/compilation/basic_no_deps/Move.exp
@@ -16,6 +16,6 @@ CompiledPackageInfo {
         additional_named_addresses: {},
         architecture: None,
         fetch_deps_only: false,
-        fetch_latest_git_deps: false,
+        skip_fetch_latest_git_deps: false,
     },
 }

--- a/language/tools/move-package/tests/test_sources/compilation/basic_no_deps_address_assigned/Move.exp
+++ b/language/tools/move-package/tests/test_sources/compilation/basic_no_deps_address_assigned/Move.exp
@@ -18,6 +18,6 @@ CompiledPackageInfo {
         additional_named_addresses: {},
         architecture: None,
         fetch_deps_only: false,
-        fetch_latest_git_deps: false,
+        skip_fetch_latest_git_deps: false,
     },
 }

--- a/language/tools/move-package/tests/test_sources/compilation/basic_no_deps_address_not_assigned_with_dev_assignment/Move.exp
+++ b/language/tools/move-package/tests/test_sources/compilation/basic_no_deps_address_not_assigned_with_dev_assignment/Move.exp
@@ -18,6 +18,6 @@ CompiledPackageInfo {
         additional_named_addresses: {},
         architecture: None,
         fetch_deps_only: false,
-        fetch_latest_git_deps: false,
+        skip_fetch_latest_git_deps: false,
     },
 }

--- a/language/tools/move-package/tests/test_sources/compilation/basic_no_deps_test_mode/Move.exp
+++ b/language/tools/move-package/tests/test_sources/compilation/basic_no_deps_test_mode/Move.exp
@@ -18,6 +18,6 @@ CompiledPackageInfo {
         additional_named_addresses: {},
         architecture: None,
         fetch_deps_only: false,
-        fetch_latest_git_deps: false,
+        skip_fetch_latest_git_deps: false,
     },
 }

--- a/language/tools/move-package/tests/test_sources/compilation/diamond_problem_backflow_resolution/Move.exp
+++ b/language/tools/move-package/tests/test_sources/compilation/diamond_problem_backflow_resolution/Move.exp
@@ -19,6 +19,6 @@ CompiledPackageInfo {
         additional_named_addresses: {},
         architecture: None,
         fetch_deps_only: false,
-        fetch_latest_git_deps: false,
+        skip_fetch_latest_git_deps: false,
     },
 }

--- a/language/tools/move-package/tests/test_sources/compilation/diamond_problem_no_conflict/Move.exp
+++ b/language/tools/move-package/tests/test_sources/compilation/diamond_problem_no_conflict/Move.exp
@@ -19,6 +19,6 @@ CompiledPackageInfo {
         additional_named_addresses: {},
         architecture: None,
         fetch_deps_only: false,
-        fetch_latest_git_deps: false,
+        skip_fetch_latest_git_deps: false,
     },
 }

--- a/language/tools/move-package/tests/test_sources/compilation/multiple_deps_rename/Move.exp
+++ b/language/tools/move-package/tests/test_sources/compilation/multiple_deps_rename/Move.exp
@@ -20,6 +20,6 @@ CompiledPackageInfo {
         additional_named_addresses: {},
         architecture: None,
         fetch_deps_only: false,
-        fetch_latest_git_deps: false,
+        skip_fetch_latest_git_deps: false,
     },
 }

--- a/language/tools/move-package/tests/test_sources/compilation/multiple_deps_rename_one/Move.exp
+++ b/language/tools/move-package/tests/test_sources/compilation/multiple_deps_rename_one/Move.exp
@@ -20,6 +20,6 @@ CompiledPackageInfo {
         additional_named_addresses: {},
         architecture: None,
         fetch_deps_only: false,
-        fetch_latest_git_deps: false,
+        skip_fetch_latest_git_deps: false,
     },
 }

--- a/language/tools/move-package/tests/test_sources/compilation/one_dep/Move.exp
+++ b/language/tools/move-package/tests/test_sources/compilation/one_dep/Move.exp
@@ -18,6 +18,6 @@ CompiledPackageInfo {
         additional_named_addresses: {},
         architecture: None,
         fetch_deps_only: false,
-        fetch_latest_git_deps: false,
+        skip_fetch_latest_git_deps: false,
     },
 }

--- a/language/tools/move-package/tests/test_sources/compilation/one_dep_assigned_address/Move.exp
+++ b/language/tools/move-package/tests/test_sources/compilation/one_dep_assigned_address/Move.exp
@@ -18,6 +18,6 @@ CompiledPackageInfo {
         additional_named_addresses: {},
         architecture: None,
         fetch_deps_only: false,
-        fetch_latest_git_deps: false,
+        skip_fetch_latest_git_deps: false,
     },
 }

--- a/language/tools/move-package/tests/test_sources/compilation/one_dep_renamed/Move.exp
+++ b/language/tools/move-package/tests/test_sources/compilation/one_dep_renamed/Move.exp
@@ -18,6 +18,6 @@ CompiledPackageInfo {
         additional_named_addresses: {},
         architecture: None,
         fetch_deps_only: false,
-        fetch_latest_git_deps: false,
+        skip_fetch_latest_git_deps: false,
     },
 }

--- a/language/tools/move-package/tests/test_sources/compilation/one_dep_with_scripts/Move.exp
+++ b/language/tools/move-package/tests/test_sources/compilation/one_dep_with_scripts/Move.exp
@@ -18,6 +18,6 @@ CompiledPackageInfo {
         additional_named_addresses: {},
         architecture: None,
         fetch_deps_only: false,
-        fetch_latest_git_deps: false,
+        skip_fetch_latest_git_deps: false,
     },
 }

--- a/language/tools/move-package/tests/test_sources/compilation/test_symlinks/Move.exp
+++ b/language/tools/move-package/tests/test_sources/compilation/test_symlinks/Move.exp
@@ -18,6 +18,6 @@ CompiledPackageInfo {
         additional_named_addresses: {},
         architecture: None,
         fetch_deps_only: false,
-        fetch_latest_git_deps: false,
+        skip_fetch_latest_git_deps: false,
     },
 }

--- a/language/tools/move-package/tests/test_sources/parsing/invalid_identifier_package_name/Move.exp
+++ b/language/tools/move-package/tests/test_sources/parsing/invalid_identifier_package_name/Move.exp
@@ -12,7 +12,7 @@ ResolutionGraph {
         additional_named_addresses: {},
         architecture: None,
         fetch_deps_only: false,
-        fetch_latest_git_deps: false,
+        skip_fetch_latest_git_deps: false,
     },
     root_package: SourceManifest {
         package: PackageInfo {

--- a/language/tools/move-package/tests/test_sources/parsing/minimal_manifest/Move.exp
+++ b/language/tools/move-package/tests/test_sources/parsing/minimal_manifest/Move.exp
@@ -12,7 +12,7 @@ ResolutionGraph {
         additional_named_addresses: {},
         architecture: None,
         fetch_deps_only: false,
-        fetch_latest_git_deps: false,
+        skip_fetch_latest_git_deps: false,
     },
     root_package: SourceManifest {
         package: PackageInfo {

--- a/language/tools/move-package/tests/test_sources/resolution/basic_no_deps/Move.exp
+++ b/language/tools/move-package/tests/test_sources/resolution/basic_no_deps/Move.exp
@@ -12,7 +12,7 @@ ResolutionGraph {
         additional_named_addresses: {},
         architecture: None,
         fetch_deps_only: false,
-        fetch_latest_git_deps: false,
+        skip_fetch_latest_git_deps: false,
     },
     root_package: SourceManifest {
         package: PackageInfo {

--- a/language/tools/move-package/tests/test_sources/resolution/basic_no_deps_address_assigned/Move.exp
+++ b/language/tools/move-package/tests/test_sources/resolution/basic_no_deps_address_assigned/Move.exp
@@ -12,7 +12,7 @@ ResolutionGraph {
         additional_named_addresses: {},
         architecture: None,
         fetch_deps_only: false,
-        fetch_latest_git_deps: false,
+        skip_fetch_latest_git_deps: false,
     },
     root_package: SourceManifest {
         package: PackageInfo {

--- a/language/tools/move-package/tests/test_sources/resolution/basic_no_deps_address_not_assigned_with_dev_assignment/Move.exp
+++ b/language/tools/move-package/tests/test_sources/resolution/basic_no_deps_address_not_assigned_with_dev_assignment/Move.exp
@@ -12,7 +12,7 @@ ResolutionGraph {
         additional_named_addresses: {},
         architecture: None,
         fetch_deps_only: false,
-        fetch_latest_git_deps: false,
+        skip_fetch_latest_git_deps: false,
     },
     root_package: SourceManifest {
         package: PackageInfo {

--- a/language/tools/move-package/tests/test_sources/resolution/dep_good_digest/Move.exp
+++ b/language/tools/move-package/tests/test_sources/resolution/dep_good_digest/Move.exp
@@ -12,7 +12,7 @@ ResolutionGraph {
         additional_named_addresses: {},
         architecture: None,
         fetch_deps_only: false,
-        fetch_latest_git_deps: false,
+        skip_fetch_latest_git_deps: false,
     },
     root_package: SourceManifest {
         package: PackageInfo {

--- a/language/tools/move-package/tests/test_sources/resolution/diamond_problem_backflow_resolution/Move.exp
+++ b/language/tools/move-package/tests/test_sources/resolution/diamond_problem_backflow_resolution/Move.exp
@@ -12,7 +12,7 @@ ResolutionGraph {
         additional_named_addresses: {},
         architecture: None,
         fetch_deps_only: false,
-        fetch_latest_git_deps: false,
+        skip_fetch_latest_git_deps: false,
     },
     root_package: SourceManifest {
         package: PackageInfo {

--- a/language/tools/move-package/tests/test_sources/resolution/diamond_problem_no_conflict/Move.exp
+++ b/language/tools/move-package/tests/test_sources/resolution/diamond_problem_no_conflict/Move.exp
@@ -12,7 +12,7 @@ ResolutionGraph {
         additional_named_addresses: {},
         architecture: None,
         fetch_deps_only: false,
-        fetch_latest_git_deps: false,
+        skip_fetch_latest_git_deps: false,
     },
     root_package: SourceManifest {
         package: PackageInfo {

--- a/language/tools/move-package/tests/test_sources/resolution/multiple_deps_rename/Move.exp
+++ b/language/tools/move-package/tests/test_sources/resolution/multiple_deps_rename/Move.exp
@@ -12,7 +12,7 @@ ResolutionGraph {
         additional_named_addresses: {},
         architecture: None,
         fetch_deps_only: false,
-        fetch_latest_git_deps: false,
+        skip_fetch_latest_git_deps: false,
     },
     root_package: SourceManifest {
         package: PackageInfo {

--- a/language/tools/move-package/tests/test_sources/resolution/one_dep/Move.exp
+++ b/language/tools/move-package/tests/test_sources/resolution/one_dep/Move.exp
@@ -12,7 +12,7 @@ ResolutionGraph {
         additional_named_addresses: {},
         architecture: None,
         fetch_deps_only: false,
-        fetch_latest_git_deps: false,
+        skip_fetch_latest_git_deps: false,
     },
     root_package: SourceManifest {
         package: PackageInfo {

--- a/language/tools/move-package/tests/test_sources/resolution/one_dep_assigned_address/Move.exp
+++ b/language/tools/move-package/tests/test_sources/resolution/one_dep_assigned_address/Move.exp
@@ -12,7 +12,7 @@ ResolutionGraph {
         additional_named_addresses: {},
         architecture: None,
         fetch_deps_only: false,
-        fetch_latest_git_deps: false,
+        skip_fetch_latest_git_deps: false,
     },
     root_package: SourceManifest {
         package: PackageInfo {

--- a/language/tools/move-package/tests/test_sources/resolution/one_dep_multiple_of_same_name/Move.exp
+++ b/language/tools/move-package/tests/test_sources/resolution/one_dep_multiple_of_same_name/Move.exp
@@ -12,7 +12,7 @@ ResolutionGraph {
         additional_named_addresses: {},
         architecture: None,
         fetch_deps_only: false,
-        fetch_latest_git_deps: false,
+        skip_fetch_latest_git_deps: false,
     },
     root_package: SourceManifest {
         package: PackageInfo {

--- a/language/tools/move-package/tests/test_sources/resolution/one_dep_reassigned_address/Move.exp
+++ b/language/tools/move-package/tests/test_sources/resolution/one_dep_reassigned_address/Move.exp
@@ -12,7 +12,7 @@ ResolutionGraph {
         additional_named_addresses: {},
         architecture: None,
         fetch_deps_only: false,
-        fetch_latest_git_deps: false,
+        skip_fetch_latest_git_deps: false,
     },
     root_package: SourceManifest {
         package: PackageInfo {

--- a/language/tools/move-package/tests/test_sources/resolution/one_dep_unification_across_local_renamings/Move.exp
+++ b/language/tools/move-package/tests/test_sources/resolution/one_dep_unification_across_local_renamings/Move.exp
@@ -12,7 +12,7 @@ ResolutionGraph {
         additional_named_addresses: {},
         architecture: None,
         fetch_deps_only: false,
-        fetch_latest_git_deps: false,
+        skip_fetch_latest_git_deps: false,
     },
     root_package: SourceManifest {
         package: PackageInfo {


### PR DESCRIPTION
## Motivation
This fixes the issues with the fetch refresher that wasn't doing it correctly.  Now it does properly fetch.


### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes

## Test Plan

I've tested manually, I will copy some outputs here soon
