### PR TITLE
[types] make type tag nesting limited

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2759,9 +2759,9 @@ checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 
 [[package]]
 name = "memchr"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
+checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memoffset"

--- a/language/move-core/types/src/language_storage.rs
+++ b/language/move-core/types/src/language_storage.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 #[cfg(any(test, feature = "fuzzing"))]
 use proptest_derive::Arbitrary;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, Serializer};
 use std::{
     fmt::{Display, Formatter},
     str::FromStr,
@@ -18,10 +18,12 @@ use std::{
 pub const CODE_TAG: u8 = 0;
 pub const RESOURCE_TAG: u8 = 1;
 
+const MAX_TYPE_TAG_NESTING: u8 = 8;
+
 /// Hex address: 0x1
 pub const CORE_CODE_ADDRESS: AccountAddress = AccountAddress::ONE;
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Hash, Eq, Clone, PartialOrd, Ord)]
+#[derive(Deserialize, Debug, PartialEq, Hash, Eq, Clone, PartialOrd, Ord)]
 pub enum TypeTag {
     // alias for compatibility with old json serialized data.
     #[serde(rename = "bool", alias = "Bool")]
@@ -42,6 +44,82 @@ pub enum TypeTag {
     Struct(StructTag),
 }
 
+#[derive(Serialize)]
+enum SafeTypeTag<'a> {
+    #[serde(rename = "bool", alias = "Bool")]
+    Bool,
+    #[serde(rename = "u8", alias = "U8")]
+    U8,
+    #[serde(rename = "u64", alias = "U64")]
+    U64,
+    #[serde(rename = "u128", alias = "U128")]
+    U128,
+    #[serde(rename = "address", alias = "Address")]
+    Address,
+    #[serde(rename = "signer", alias = "Signer")]
+    Signer,
+    #[serde(rename = "vector", alias = "Vector")]
+    Vector(Box<SafeTypeTag<'a>>),
+    #[serde(rename = "struct", alias = "Struct")]
+    Struct(SafeStructTag<'a>),
+}
+
+impl<'a> From<&'a TypeTag> for SafeTypeTag<'a> {
+    fn from(type_tag: &'a TypeTag) -> Self {
+        match &type_tag {
+            TypeTag::Bool => SafeTypeTag::Bool,
+            TypeTag::U8 => SafeTypeTag::U8,
+            TypeTag::U64 => SafeTypeTag::U64,
+            TypeTag::U128 => SafeTypeTag::U128,
+            TypeTag::Address => SafeTypeTag::Address,
+            TypeTag::Signer => SafeTypeTag::Signer,
+            TypeTag::Vector(value) => SafeTypeTag::Vector(Box::new((&**value).into())),
+            TypeTag::Struct(value) => SafeTypeTag::Struct(value.into()),
+        }
+    }
+}
+
+impl Serialize for TypeTag {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match &self {
+            TypeTag::Vector(type_tag) => {
+                validate_type_tag_recursion(vec![(**type_tag).clone()].as_slice(), 1)
+            }
+            TypeTag::Struct(value) => validate_type_tag_recursion(&value.type_params, 1),
+            _ => Ok(()),
+        }
+        .map_err(serde::ser::Error::custom)?;
+
+        serializer.serialize_newtype_struct("TypeTag", &SafeTypeTag::from(self))
+    }
+}
+
+fn validate_type_tag_recursion(
+    type_tags: &[TypeTag],
+    count: u8,
+) -> std::result::Result<(), String> {
+    if count >= MAX_TYPE_TAG_NESTING {
+        return Err(format!(
+            "Hit TypeTag nesting limit during serialization: {}",
+            count
+        ));
+    }
+
+    for type_tag in type_tags {
+        match type_tag {
+            TypeTag::Vector(type_tag) => {
+                validate_type_tag_recursion(vec![(**type_tag).clone()].as_slice(), count + 1)
+            }
+            TypeTag::Struct(value) => validate_type_tag_recursion(&value.type_params, count + 1),
+            _ => Ok(()),
+        }?;
+    }
+    Ok(())
+}
+
 impl FromStr for TypeTag {
     type Err = anyhow::Error;
 
@@ -58,6 +136,31 @@ pub struct StructTag {
     // alias for compatibility with old json serialized data.
     #[serde(rename = "type_args", alias = "type_params")]
     pub type_params: Vec<TypeTag>,
+}
+
+#[derive(Serialize)]
+struct SafeStructTag<'a> {
+    address: AccountAddress,
+    module: &'a Identifier,
+    name: &'a Identifier,
+    // alias for compatibility with old json serialized data.
+    #[serde(rename = "type_args", alias = "type_params")]
+    type_params: Vec<SafeTypeTag<'a>>,
+}
+
+impl<'a> From<&'a StructTag> for SafeStructTag<'a> {
+    fn from(struct_tag: &'a StructTag) -> Self {
+        Self {
+            address: struct_tag.address,
+            module: &struct_tag.module,
+            name: &struct_tag.name,
+            type_params: struct_tag
+                .type_params
+                .iter()
+                .map(|ty_arg| ty_arg.into())
+                .collect::<Vec<_>>(),
+        }
+    }
 }
 
 impl StructTag {
@@ -211,12 +314,55 @@ mod tests {
     fn test_type_tag_serde() {
         let a = TypeTag::Struct(StructTag {
             address: AccountAddress::ONE,
-            module: Identifier::from_utf8(("abc".as_bytes()).to_vec()).unwrap(),
-            name: Identifier::from_utf8(("abc".as_bytes()).to_vec()).unwrap(),
+            module: Identifier::new("abc").unwrap(),
+            name: Identifier::new("abc").unwrap(),
             type_params: vec![TypeTag::U8],
         });
         let b = serde_json::to_string(&a).unwrap();
         let c: TypeTag = serde_json::from_str(&b).unwrap();
         assert!(a.eq(&c), "Typetag serde error")
+    }
+
+    #[test]
+    fn test_nested_type_tag_struct_serde() {
+        let mut type_tags = vec![make_type_tag_struct(TypeTag::U8)];
+
+        let limit = super::MAX_TYPE_TAG_NESTING - 1;
+        while type_tags.len() < limit.into() {
+            type_tags.push(make_type_tag_struct(type_tags.last().unwrap().clone()));
+        }
+
+        bcs::to_bytes(type_tags.last().unwrap()).unwrap();
+
+        let nest_limit = make_type_tag_struct(type_tags.last().unwrap().clone());
+        bcs::to_bytes(&nest_limit).unwrap_err();
+    }
+
+    #[test]
+    fn test_nested_type_tag_vector_serde() {
+        let mut type_tags = vec![make_type_tag_struct(TypeTag::U8)];
+
+        let limit = super::MAX_TYPE_TAG_NESTING - 1;
+        while type_tags.len() < limit.into() {
+            type_tags.push(make_type_tag_vector(type_tags.last().unwrap().clone()));
+        }
+
+        bcs::to_bytes(type_tags.last().unwrap()).unwrap();
+
+        let nest_limit = make_type_tag_vector(type_tags.last().unwrap().clone());
+        bcs::to_bytes(&nest_limit).unwrap_err();
+    }
+
+    fn make_type_tag_vector(type_param: TypeTag) -> TypeTag {
+        TypeTag::Vector(Box::new(type_param))
+    }
+
+    fn make_type_tag_struct(type_param: TypeTag) -> TypeTag {
+        TypeTag::Struct(StructTag {
+            address: AccountAddress::ONE,
+            module: Identifier::new("a").unwrap(),
+            name: Identifier::new("a").unwrap(),
+            type_params: vec![type_param],
+        })
     }
 }


### PR DESCRIPTION
There's limited value and a lot of wasted resources by leaving this limited to serde's limits. Recursion is dangerous.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Move Language.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

(Write your answer here.)

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)
