### PR TITLE
[types] limit nesting of types via state

### DIFF
--- a/language/move-core/types/src/language_storage.rs
+++ b/language/move-core/types/src/language_storage.rs
@@ -6,6 +6,7 @@ use crate::{
     account_address::AccountAddress,
     identifier::{IdentStr, Identifier},
     parser::{parse_struct_tag, parse_type_tag},
+    safe_serialize,
 };
 #[cfg(any(test, feature = "fuzzing"))]
 use proptest_derive::Arbitrary;
@@ -37,9 +38,21 @@ pub enum TypeTag {
     #[serde(rename = "signer", alias = "Signer")]
     Signer,
     #[serde(rename = "vector", alias = "Vector")]
-    Vector(Box<TypeTag>),
+    Vector(
+        #[serde(
+            serialize_with = "safe_serialize::type_tag_recursive_serialize",
+            deserialize_with = "safe_serialize::type_tag_recursive_deserialize"
+        )]
+        Box<TypeTag>,
+    ),
     #[serde(rename = "struct", alias = "Struct")]
-    Struct(StructTag),
+    Struct(
+        #[serde(
+            serialize_with = "safe_serialize::type_tag_recursive_serialize",
+            deserialize_with = "safe_serialize::type_tag_recursive_deserialize"
+        )]
+        StructTag,
+    ),
 }
 
 impl FromStr for TypeTag {
@@ -205,6 +218,7 @@ mod tests {
     use super::TypeTag;
     use crate::{
         account_address::AccountAddress, identifier::Identifier, language_storage::StructTag,
+        safe_serialize::MAX_TYPE_TAG_NESTING,
     };
 
     #[test]
@@ -218,5 +232,66 @@ mod tests {
         let b = serde_json::to_string(&a).unwrap();
         let c: TypeTag = serde_json::from_str(&b).unwrap();
         assert!(a.eq(&c), "Typetag serde error")
+    }
+
+    #[test]
+    fn test_nested_type_tag_struct_serde() {
+        let mut type_tags = vec![make_type_tag_struct(TypeTag::U8)];
+
+        let limit = MAX_TYPE_TAG_NESTING - 1;
+        while type_tags.len() < limit.into() {
+            type_tags.push(make_type_tag_struct(type_tags.last().unwrap().clone()));
+        }
+
+        // Note for this test serialize can handle one more nesting than deserialize
+        // Both directions work
+        let output = bcs::to_bytes(type_tags.last().unwrap()).unwrap();
+        bcs::from_bytes::<TypeTag>(&output).unwrap();
+
+        // One more, both should fail
+        type_tags.push(make_type_tag_struct(type_tags.last().unwrap().clone()));
+        let output = bcs::to_bytes(type_tags.last().unwrap()).unwrap();
+        bcs::from_bytes::<TypeTag>(&output).unwrap_err();
+
+        // One more and serialize fails
+        type_tags.push(make_type_tag_struct(type_tags.last().unwrap().clone()));
+        bcs::to_bytes(type_tags.last().unwrap()).unwrap_err();
+    }
+
+    #[test]
+    fn test_nested_type_tag_vector_serde() {
+        let mut type_tags = vec![make_type_tag_struct(TypeTag::U8)];
+
+        let limit = MAX_TYPE_TAG_NESTING - 1;
+        while type_tags.len() < limit.into() {
+            type_tags.push(make_type_tag_vector(type_tags.last().unwrap().clone()));
+        }
+
+        // Note for this test serialize can handle one more nesting than deserialize
+        // Both directions work
+        let output = bcs::to_bytes(type_tags.last().unwrap()).unwrap();
+        bcs::from_bytes::<TypeTag>(&output).unwrap();
+
+        // One more, serialize passes, deserialize fails
+        type_tags.push(make_type_tag_vector(type_tags.last().unwrap().clone()));
+        let output = bcs::to_bytes(type_tags.last().unwrap()).unwrap();
+        bcs::from_bytes::<TypeTag>(&output).unwrap_err();
+
+        // One more and serialize fails
+        type_tags.push(make_type_tag_vector(type_tags.last().unwrap().clone()));
+        bcs::to_bytes(type_tags.last().unwrap()).unwrap_err();
+    }
+
+    fn make_type_tag_vector(type_param: TypeTag) -> TypeTag {
+        TypeTag::Vector(Box::new(type_param))
+    }
+
+    fn make_type_tag_struct(type_param: TypeTag) -> TypeTag {
+        TypeTag::Struct(StructTag {
+            address: AccountAddress::ONE,
+            module: Identifier::new("a").unwrap(),
+            name: Identifier::new("a").unwrap(),
+            type_params: vec![type_param],
+        })
     }
 }

--- a/language/move-core/types/src/lib.rs
+++ b/language/move-core/types/src/lib.rs
@@ -17,6 +17,7 @@ pub mod parser;
 #[cfg(any(test, feature = "fuzzing"))]
 pub mod proptest_types;
 pub mod resolver;
+mod safe_serialize;
 pub mod transaction_argument;
 #[cfg(test)]
 mod unit_tests;

--- a/language/move-core/types/src/safe_serialize.rs
+++ b/language/move-core/types/src/safe_serialize.rs
@@ -1,0 +1,69 @@
+// Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Custom serializers which track recursion nesting with a thread local,
+//! and otherwise delegate to the derived serializers.
+//!
+//! This is currently only implemented for type tags, but can be easily
+//! generalized, as the the only type-tag specific thing is the allowed nesting.
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::cell::RefCell;
+
+pub(crate) const MAX_TYPE_TAG_NESTING: u8 = 9;
+
+thread_local! {
+    static TYPE_TAG_DEPTH: RefCell<u8> = RefCell::new(0);
+}
+
+pub(crate) fn type_tag_recursive_serialize<S, T>(t: &T, s: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+    T: Serialize,
+{
+    use serde::ser::Error;
+
+    TYPE_TAG_DEPTH.with(|depth| {
+        let mut r = depth.borrow_mut();
+        if *r >= MAX_TYPE_TAG_NESTING {
+            // for testability, we allow one level more
+            return Err(S::Error::custom(
+                "type tag nesting exceeded during serialization",
+            ));
+        }
+        *r += 1;
+        Ok(())
+    })?;
+    let res = t.serialize(s);
+    TYPE_TAG_DEPTH.with(|depth| {
+        let mut r = depth.borrow_mut();
+        *r -= 1;
+    });
+    res
+}
+
+pub(crate) fn type_tag_recursive_deserialize<'de, D, T>(d: D) -> Result<T, D::Error>
+where
+    D: Deserializer<'de>,
+    T: Deserialize<'de>,
+{
+    use serde::de::Error;
+    TYPE_TAG_DEPTH.with(|depth| {
+        let mut r = depth.borrow_mut();
+        // For testability, we allow to serialize one more level than deserialize.
+        if *r >= MAX_TYPE_TAG_NESTING - 1 {
+            return Err(D::Error::custom(
+                "type tag nesting exceeded during deserialization",
+            ));
+        }
+        *r += 1;
+        Ok(())
+    })?;
+    let res = T::deserialize(d);
+    TYPE_TAG_DEPTH.with(|depth| {
+        let mut r = depth.borrow_mut();
+        *r -= 1;
+    });
+    res
+}


### PR DESCRIPTION
## Motivation

This is an alternative version of what #528 and the previous PR for limitation of nesting of type tags provides.

This approach installs custom serializers at the recursion points of the `TypeTag` enum. Those serializer use a thread local to track the nesting of the type tag, both for serialization and deserialization.

The usage of a thread local is safe and a common technique to provide extra state for implementations which miss it (e.g. serde). A given thread has a single execution stack and this will always count the depth counter consistently up and down. Because Rust has no exceptions are other exit points, this cannot be corrupted. Possibly, thread locals may cause inefficiency. However, we expect TypeTags to be small (a few constructors, limited nestings).

The technique used for type tags can be generalized for any other recursive type if needed. Eventually, we hope serde will support per-type nesting, and possibly we should talk with the author if we can add it ourselves.


(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes

## Test Plan

This uses and passes the tests from #528.
