### PR TITLE
[gas] pass more info to the gas meter when calling functions

### DIFF
--- a/language/move-vm/test-utils/src/gas_schedule.rs
+++ b/language/move-vm/test-utils/src/gas_schedule.rs
@@ -260,7 +260,11 @@ impl<'b> GasMeter for GasStatus<'b> {
         self.charge_instr(get_simple_instruction_opcode(instr))
     }
 
-    fn charge_native_function(&mut self, amount: InternalGas) -> PartialVMResult<()> {
+    fn charge_native_function(
+        &mut self,
+        amount: InternalGas,
+        _ret_vals: Option<impl ExactSizeIterator<Item = impl ValueView>>,
+    ) -> PartialVMResult<()> {
         self.deduct_gas(amount)
     }
 
@@ -269,6 +273,7 @@ impl<'b> GasMeter for GasStatus<'b> {
         _module_id: &ModuleId,
         _func_name: &str,
         args: impl ExactSizeIterator<Item = impl ValueView>,
+        _num_locals: NumArgs,
     ) -> PartialVMResult<()> {
         self.charge_instr_with_size(Opcodes::CALL, (args.len() as u64 + 1).into())
     }
@@ -279,6 +284,7 @@ impl<'b> GasMeter for GasStatus<'b> {
         _func_name: &str,
         ty_args: impl ExactSizeIterator<Item = impl TypeView>,
         args: impl ExactSizeIterator<Item = impl ValueView>,
+        _num_locals: NumArgs,
     ) -> PartialVMResult<()> {
         self.charge_instr_with_size(
             Opcodes::CALL_GENERIC,

--- a/language/move-vm/types/src/gas.rs
+++ b/language/move-vm/types/src/gas.rs
@@ -72,6 +72,7 @@ pub trait GasMeter {
         module_id: &ModuleId,
         func_name: &str,
         args: impl ExactSizeIterator<Item = impl ValueView>,
+        num_locals: NumArgs,
     ) -> PartialVMResult<()>;
 
     fn charge_call_generic(
@@ -80,6 +81,7 @@ pub trait GasMeter {
         func_name: &str,
         ty_args: impl ExactSizeIterator<Item = impl TypeView>,
         args: impl ExactSizeIterator<Item = impl ValueView>,
+        num_locals: NumArgs,
     ) -> PartialVMResult<()>;
 
     fn charge_ld_const(&mut self, size: NumBytes) -> PartialVMResult<()>;
@@ -193,7 +195,11 @@ pub trait GasMeter {
     ///
     /// In the future, we may want to remove this and directly pass a reference to the GasMeter
     /// instance to the native functions to allow gas to be deducted during computation.
-    fn charge_native_function(&mut self, amount: InternalGas) -> PartialVMResult<()>;
+    fn charge_native_function(
+        &mut self,
+        amount: InternalGas,
+        ret_vals: Option<impl ExactSizeIterator<Item = impl ValueView>>,
+    ) -> PartialVMResult<()>;
 }
 
 /// A dummy gas meter that does not meter anything.
@@ -210,6 +216,7 @@ impl GasMeter for UnmeteredGasMeter {
         _module_id: &ModuleId,
         _func_name: &str,
         _args: impl IntoIterator<Item = impl ValueView>,
+        _num_locals: NumArgs,
     ) -> PartialVMResult<()> {
         Ok(())
     }
@@ -220,6 +227,7 @@ impl GasMeter for UnmeteredGasMeter {
         _func_name: &str,
         _ty_args: impl ExactSizeIterator<Item = impl TypeView>,
         _args: impl ExactSizeIterator<Item = impl ValueView>,
+        _num_locals: NumArgs,
     ) -> PartialVMResult<()> {
         Ok(())
     }
@@ -363,7 +371,11 @@ impl GasMeter for UnmeteredGasMeter {
         Ok(())
     }
 
-    fn charge_native_function(&mut self, _amount: InternalGas) -> PartialVMResult<()> {
+    fn charge_native_function(
+        &mut self,
+        _amount: InternalGas,
+        _ret_vals: Option<impl ExactSizeIterator<Item = impl ValueView>>,
+    ) -> PartialVMResult<()> {
         Ok(())
     }
 }


### PR DESCRIPTION
This passes some additional info to the gas meter when calling functions to make gas metering more robust
- Number of locals
- (Natives only) Views into the return values