### PR TITLE
[types] limit nesting of types via state

### DIFF
--- a/language/move-core/types/src/lib.rs
+++ b/language/move-core/types/src/lib.rs
@@ -17,6 +17,7 @@ pub mod parser;
 #[cfg(any(test, feature = "fuzzing"))]
 pub mod proptest_types;
 pub mod resolver;
+mod safe_serialize;
 pub mod transaction_argument;
 #[cfg(test)]
 mod unit_tests;

--- a/language/move-core/types/src/safe_serialize.rs
+++ b/language/move-core/types/src/safe_serialize.rs
@@ -1,0 +1,69 @@
+// Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Custom serializers which track recursion nesting with a thread local,
+//! and otherwise delegate to the derived serializers.
+//!
+//! This is currently only implemented for type tags, but can be easily
+//! generalized, as the the only type-tag specific thing is the allowed nesting.
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::cell::RefCell;
+
+pub(crate) const MAX_TYPE_TAG_NESTING: u8 = 9;
+
+thread_local! {
+    static TYPE_TAG_DEPTH: RefCell<u8> = RefCell::new(0);
+}
+
+pub(crate) fn type_tag_recursive_serialize<S, T>(t: &T, s: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+    T: Serialize,
+{
+    use serde::ser::Error;
+
+    TYPE_TAG_DEPTH.with(|depth| {
+        let mut r = depth.borrow_mut();
+        if *r >= MAX_TYPE_TAG_NESTING {
+            // for testability, we allow one level more
+            return Err(S::Error::custom(
+                "type tag nesting exceeded during serialization",
+            ));
+        }
+        *r += 1;
+        Ok(())
+    })?;
+    let res = t.serialize(s);
+    TYPE_TAG_DEPTH.with(|depth| {
+        let mut r = depth.borrow_mut();
+        *r -= 1;
+    });
+    res
+}
+
+pub(crate) fn type_tag_recursive_deserialize<'de, D, T>(d: D) -> Result<T, D::Error>
+where
+    D: Deserializer<'de>,
+    T: Deserialize<'de>,
+{
+    use serde::de::Error;
+    TYPE_TAG_DEPTH.with(|depth| {
+        let mut r = depth.borrow_mut();
+        // For testability, we allow to serialize one more level than deserialize.
+        if *r >= MAX_TYPE_TAG_NESTING - 1 {
+            return Err(D::Error::custom(
+                "type tag nesting exceeded during deserialization",
+            ));
+        }
+        *r += 1;
+        Ok(())
+    })?;
+    let res = T::deserialize(d);
+    TYPE_TAG_DEPTH.with(|depth| {
+        let mut r = depth.borrow_mut();
+        *r -= 1;
+    });
+    res
+}


### PR DESCRIPTION
Cherry picked from #529.

## Motivation

This is an alternative version of what #528 and the previous for limitation of nesting provides, having a significant lower footprint.

This approach installs custom serializers at the recursion points of the `TypeTag` enum. Those serializer use a thread local to track the nesting of the type tag, both for serialization and deserialization.

The usage of a thread local is safe and a common technique to provide extra state for implementations which miss it (e.g. serde). A given thread has a single execution stack and this will always count the depth counter consistently up and down. Because Rust has no exceptions are other exit points, this cannot be corrupted. Possibly, thread locals may cause inefficiency. However, we expect TypeTags to be small (a few constructors, limited nestings).

The technique used for type tags can be generalized for any other recursive type if needed. Eventually, we hope serde will support per-type nesting, and possibly we should talk with the author if we can add it ourselves.



### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes

## Test Plan

This uses and passes the tests from #528.
