### PR TITLE
[bytecode-verifier] fix an off-by-one error

### DIFF
--- a/language/move-binary-format/src/file_format.rs
+++ b/language/move-binary-format/src/file_format.rs
@@ -1672,6 +1672,12 @@ impl Bytecode {
             pc < u16::MAX && (pc as usize) < code.len(),
             "Program counter out of bounds"
         );
+
+        // Return early to prevent overflow if pc is hiting the end of max number of instructions allowed (u16::MAX).
+        if pc > u16::max_value() - 2 {
+            return vec![];
+        }
+
         let bytecode = &code[pc as usize];
         let mut v = vec![];
 

--- a/language/move-binary-format/src/file_format.rs
+++ b/language/move-binary-format/src/file_format.rs
@@ -1668,9 +1668,8 @@ impl Bytecode {
     /// Return the successor offsets of this bytecode instruction.
     pub fn get_successors(pc: CodeOffset, code: &[Bytecode]) -> Vec<CodeOffset> {
         assert!(
-            // The program counter could be added to at most twice and must remain
-            // within the bounds of the code.
-            pc <= u16::max_value() - 2 && (pc as usize) < code.len(),
+            // The program counter must remain within the bounds of the code
+            pc < u16::MAX && (pc as usize) < code.len(),
             "Program counter out of bounds"
         );
         let bytecode = &code[pc as usize];

--- a/language/move-binary-format/src/unit_tests/binary_tests.rs
+++ b/language/move-binary-format/src/unit_tests/binary_tests.rs
@@ -2,7 +2,7 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::file_format_common::*;
+use crate::{file_format::Bytecode, file_format_common::*};
 use proptest::prelude::*;
 
 #[test]
@@ -12,6 +12,18 @@ fn binary_len() {
         binary_data.push(1).unwrap();
     }
     assert_eq!(binary_data.len(), 100);
+}
+
+#[test]
+fn test_max_number_of_bytecode() {
+    let mut nops = vec![];
+    for _ in 0..u16::MAX - 1 {
+        nops.push(Bytecode::Nop);
+    }
+    nops.push(Bytecode::Ret);
+
+    let result = Bytecode::get_successors(u16::MAX - 1, &nops);
+    assert!(result.is_empty());
 }
 
 proptest! {

--- a/language/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/code_unit_tests.rs
+++ b/language/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/code_unit_tests.rs
@@ -58,3 +58,16 @@ fn valid_fallthrough_abort() {
     let result = CodeUnitVerifier::verify_module(&Default::default(), &module);
     assert!(result.is_ok());
 }
+
+#[test]
+fn test_max_number_of_bytecode() {
+    let mut nops = vec![];
+    for _ in 0..u16::MAX - 1 {
+        nops.push(Bytecode::Nop);
+    }
+    nops.push(Bytecode::Ret);
+    let module = dummy_procedure_module(nops);
+
+    let result = CodeUnitVerifier::verify_module(&Default::default(), &module);
+    assert!(result.is_ok());
+}


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Move Language.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

This is a duplicate of #524. Just to make sure the changes on the aptos branch could be included in upstream as much as possible if the community agrees.

There is an off-by-one error in the assertion on 
`assert!(pc <= u16::max_value() - 2 && (pc as usize) < code.len())`

While the RHS, i.e., `(pc as usize) < code.len()` is correct, the LHS has the off-by-one issue.

The deserializer guarantees that code unit length is at max `u16::MAX`, i.e., `code.len() <= u16::MAX`. Therefore, it is possible to construct a code unit with length `u16::MAX` which is filled by `u16::MAX - 1` `nop` operations and one `ret` operation, as shown in the added test case `test_max_number_of_bytecode`.

In this test case:
- The whole `nop + ret` code unit will be considered as a single basic block and the bytecode verifier, when running control-flow sensitive passes, will attempt to get the successor of this basic block, and will hence call the `get_successor` function.
- When calling the function, the `pc` value is guaranteed to be pointing to the last `nop`, right before the `ret`, which is at offset `u16::MAX - 1`. This is in violation of the wrongful assertion that `pc <= u16::max_value() - 2`. This is a proof that the LHS of the assertion is wrong.

In fact, it may be even argued that the `pc < u16::MAX` part in the assertion is redundant.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes

## Test Plan

Added test
