### PR TITLE
[move-vm] eliminate use of `std::mem::take`

### DIFF
--- a/language/move-vm/runtime/src/interpreter.rs
+++ b/language/move-vm/runtime/src/interpreter.rs
@@ -30,7 +30,7 @@ use move_vm_types::{
 };
 
 use crate::native_extensions::NativeContextExtensions;
-use std::{cmp::min, collections::VecDeque, fmt::Write, mem, sync::Arc};
+use std::{cmp::min, collections::VecDeque, fmt::Write, sync::Arc};
 use tracing::error;
 
 macro_rules! debug_write {
@@ -139,7 +139,7 @@ impl Interpreter {
                         current_frame.pc += 1; // advance past the Call instruction in the caller
                     } else {
                         // end of execution. `self` should no longer be used afterward
-                        return Ok(mem::take(&mut self.operand_stack.0));
+                        return Ok(self.operand_stack.0);
                     }
                 }
                 ExitCode::Call(fh_idx) => {


### PR DESCRIPTION
No longer needed now that `execute_main` takes ownership of the interpreter.
