### PR TITLE
[cherry-pick] Safe type tags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2759,9 +2759,9 @@ checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 
 [[package]]
 name = "memchr"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
+checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memoffset"

--- a/language/extensions/async/move-async-vm/src/async_vm.rs
+++ b/language/extensions/async/move-async-vm/src/async_vm.rs
@@ -179,7 +179,7 @@ impl<'r, 'l, S: MoveResolver> AsyncSession<'r, 'l, S> {
             .actor_metadata
             .get(module_id)
             .ok_or_else(|| async_extension_error(format!("actor `{}` unknown", module_id)))?;
-        let state_type_tag = TypeTag::Struct(actor.state_tag.clone());
+        let state_type_tag = TypeTag::Struct(Box::new(actor.state_tag.clone()));
         let state_type = self
             .vm_session
             .load_type(&state_type_tag)
@@ -275,7 +275,7 @@ impl<'r, 'l, S: MoveResolver> AsyncSession<'r, 'l, S> {
         })?;
 
         // Load the resource representing the actor state and add to arguments.
-        let state_type_tag = TypeTag::Struct(actor.state_tag.clone());
+        let state_type_tag = TypeTag::Struct(Box::new(actor.state_tag.clone()));
         let state_type = self
             .vm_session
             .load_type(&state_type_tag)

--- a/language/move-binary-format/src/normalized.rs
+++ b/language/move-binary-format/src/normalized.rs
@@ -208,7 +208,7 @@ impl Type {
                     module,
                     name,
                     type_arguments,
-                } => TypeTag::Struct(StructTag {
+                } => TypeTag::Struct(Box::new(StructTag {
                     address,
                     module,
                     name,
@@ -220,7 +220,7 @@ impl Type {
                             )
                         })
                         .collect(),
-                }),
+                })),
                 TypeParameter(_) => unreachable!(),
             }
         } else {
@@ -230,7 +230,7 @@ impl Type {
 
     pub fn into_struct_tag(self) -> Option<StructTag> {
         match self.into_type_tag()? {
-            TypeTag::Struct(s) => Some(s),
+            TypeTag::Struct(s) => Some(*s),
             _ => None,
         }
     }

--- a/language/move-command-line-common/src/types.rs
+++ b/language/move-command-line-common/src/types.rs
@@ -147,7 +147,7 @@ impl ParsedType {
             ParsedType::Address => TypeTag::Address,
             ParsedType::Signer => TypeTag::Signer,
             ParsedType::Vector(inner) => TypeTag::Vector(Box::new(inner.into_type_tag(mapping)?)),
-            ParsedType::Struct(s) => TypeTag::Struct(s.into_struct_tag(mapping)?),
+            ParsedType::Struct(s) => TypeTag::Struct(Box::new(s.into_struct_tag(mapping)?)),
         })
     }
 }

--- a/language/move-core/types/src/language_storage.rs
+++ b/language/move-core/types/src/language_storage.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 #[cfg(any(test, feature = "fuzzing"))]
 use proptest_derive::Arbitrary;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, Serializer};
 use std::{
     fmt::{Display, Formatter},
     str::FromStr,
@@ -18,10 +18,12 @@ use std::{
 pub const CODE_TAG: u8 = 0;
 pub const RESOURCE_TAG: u8 = 1;
 
+const MAX_TYPE_TAG_NESTING: u8 = 8;
+
 /// Hex address: 0x1
 pub const CORE_CODE_ADDRESS: AccountAddress = AccountAddress::ONE;
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Hash, Eq, Clone, PartialOrd, Ord)]
+#[derive(Deserialize, Debug, PartialEq, Hash, Eq, Clone, PartialOrd, Ord)]
 pub enum TypeTag {
     // alias for compatibility with old json serialized data.
     #[serde(rename = "bool", alias = "Bool")]
@@ -42,6 +44,82 @@ pub enum TypeTag {
     Struct(StructTag),
 }
 
+#[derive(Serialize)]
+enum SafeTypeTag<'a> {
+    #[serde(rename = "bool", alias = "Bool")]
+    Bool,
+    #[serde(rename = "u8", alias = "U8")]
+    U8,
+    #[serde(rename = "u64", alias = "U64")]
+    U64,
+    #[serde(rename = "u128", alias = "U128")]
+    U128,
+    #[serde(rename = "address", alias = "Address")]
+    Address,
+    #[serde(rename = "signer", alias = "Signer")]
+    Signer,
+    #[serde(rename = "vector", alias = "Vector")]
+    Vector(Box<SafeTypeTag<'a>>),
+    #[serde(rename = "struct", alias = "Struct")]
+    Struct(SafeStructTag<'a>),
+}
+
+impl<'a> From<&'a TypeTag> for SafeTypeTag<'a> {
+    fn from(type_tag: &'a TypeTag) -> Self {
+        match &type_tag {
+            TypeTag::Bool => SafeTypeTag::Bool,
+            TypeTag::U8 => SafeTypeTag::U8,
+            TypeTag::U64 => SafeTypeTag::U64,
+            TypeTag::U128 => SafeTypeTag::U128,
+            TypeTag::Address => SafeTypeTag::Address,
+            TypeTag::Signer => SafeTypeTag::Signer,
+            TypeTag::Vector(value) => SafeTypeTag::Vector(Box::new((&**value).into())),
+            TypeTag::Struct(value) => SafeTypeTag::Struct(value.into()),
+        }
+    }
+}
+
+impl Serialize for TypeTag {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match &self {
+            TypeTag::Vector(type_tag) => {
+                validate_type_tag_recursion(vec![(**type_tag).clone()].as_slice(), 1)
+            }
+            TypeTag::Struct(value) => validate_type_tag_recursion(&value.type_params, 1),
+            _ => Ok(()),
+        }
+        .map_err(serde::ser::Error::custom)?;
+
+        serializer.serialize_newtype_struct("TypeTag", &SafeTypeTag::from(self))
+    }
+}
+
+fn validate_type_tag_recursion(
+    type_tags: &[TypeTag],
+    count: u8,
+) -> std::result::Result<(), String> {
+    if count >= MAX_TYPE_TAG_NESTING {
+        return Err(format!(
+            "Hit TypeTag nesting limit during serialization: {}",
+            count
+        ));
+    }
+
+    for type_tag in type_tags {
+        match type_tag {
+            TypeTag::Vector(type_tag) => {
+                validate_type_tag_recursion(vec![(**type_tag).clone()].as_slice(), count + 1)
+            }
+            TypeTag::Struct(value) => validate_type_tag_recursion(&value.type_params, count + 1),
+            _ => Ok(()),
+        }?;
+    }
+    Ok(())
+}
+
 impl FromStr for TypeTag {
     type Err = anyhow::Error;
 
@@ -58,6 +136,31 @@ pub struct StructTag {
     // alias for compatibility with old json serialized data.
     #[serde(rename = "type_args", alias = "type_params")]
     pub type_params: Vec<TypeTag>,
+}
+
+#[derive(Serialize)]
+struct SafeStructTag<'a> {
+    address: AccountAddress,
+    module: &'a Identifier,
+    name: &'a Identifier,
+    // alias for compatibility with old json serialized data.
+    #[serde(rename = "type_args", alias = "type_params")]
+    type_params: Vec<SafeTypeTag<'a>>,
+}
+
+impl<'a> From<&'a StructTag> for SafeStructTag<'a> {
+    fn from(struct_tag: &'a StructTag) -> Self {
+        Self {
+            address: struct_tag.address,
+            module: &struct_tag.module,
+            name: &struct_tag.name,
+            type_params: struct_tag
+                .type_params
+                .iter()
+                .map(|ty_arg| ty_arg.into())
+                .collect::<Vec<_>>(),
+        }
+    }
 }
 
 impl StructTag {
@@ -211,12 +314,55 @@ mod tests {
     fn test_type_tag_serde() {
         let a = TypeTag::Struct(StructTag {
             address: AccountAddress::ONE,
-            module: Identifier::from_utf8(("abc".as_bytes()).to_vec()).unwrap(),
-            name: Identifier::from_utf8(("abc".as_bytes()).to_vec()).unwrap(),
+            module: Identifier::new("abc").unwrap(),
+            name: Identifier::new("abc").unwrap(),
             type_params: vec![TypeTag::U8],
         });
         let b = serde_json::to_string(&a).unwrap();
         let c: TypeTag = serde_json::from_str(&b).unwrap();
         assert!(a.eq(&c), "Typetag serde error")
+    }
+
+    #[test]
+    fn test_nested_type_tag_struct_serde() {
+        let mut type_tags = vec![make_type_tag_struct(TypeTag::U8)];
+
+        let limit = super::MAX_TYPE_TAG_NESTING - 1;
+        while type_tags.len() < limit.into() {
+            type_tags.push(make_type_tag_struct(type_tags.last().unwrap().clone()));
+        }
+
+        bcs::to_bytes(type_tags.last().unwrap()).unwrap();
+
+        let nest_limit = make_type_tag_struct(type_tags.last().unwrap().clone());
+        bcs::to_bytes(&nest_limit).unwrap_err();
+    }
+
+    #[test]
+    fn test_nested_type_tag_vector_serde() {
+        let mut type_tags = vec![make_type_tag_struct(TypeTag::U8)];
+
+        let limit = super::MAX_TYPE_TAG_NESTING - 1;
+        while type_tags.len() < limit.into() {
+            type_tags.push(make_type_tag_vector(type_tags.last().unwrap().clone()));
+        }
+
+        bcs::to_bytes(type_tags.last().unwrap()).unwrap();
+
+        let nest_limit = make_type_tag_vector(type_tags.last().unwrap().clone());
+        bcs::to_bytes(&nest_limit).unwrap_err();
+    }
+
+    fn make_type_tag_vector(type_param: TypeTag) -> TypeTag {
+        TypeTag::Vector(Box::new(type_param))
+    }
+
+    fn make_type_tag_struct(type_param: TypeTag) -> TypeTag {
+        TypeTag::Struct(StructTag {
+            address: AccountAddress::ONE,
+            module: Identifier::new("a").unwrap(),
+            name: Identifier::new("a").unwrap(),
+            type_params: vec![type_param],
+        })
     }
 }

--- a/language/move-core/types/src/lib.rs
+++ b/language/move-core/types/src/lib.rs
@@ -17,6 +17,7 @@ pub mod parser;
 #[cfg(any(test, feature = "fuzzing"))]
 pub mod proptest_types;
 pub mod resolver;
+mod safe_serialize;
 pub mod transaction_argument;
 #[cfg(test)]
 mod unit_tests;

--- a/language/move-core/types/src/parser.rs
+++ b/language/move-core/types/src/parser.rs
@@ -254,7 +254,11 @@ impl<I: Iterator<Item = Token>> Parser<I> {
         })
     }
 
-    fn parse_type_tag(&mut self) -> Result<TypeTag> {
+    fn parse_type_tag(&mut self, depth: u8) -> Result<TypeTag> {
+        if depth >= crate::safe_serialize::MAX_TYPE_TAG_NESTING {
+            bail!("Exceeded TypeTag nesting limit during parsing: {}", depth);
+        }
+
         Ok(match self.next()? {
             Token::U8Type => TypeTag::U8,
             Token::U64Type => TypeTag::U64,
@@ -264,7 +268,7 @@ impl<I: Iterator<Item = Token>> Parser<I> {
             Token::SignerType => TypeTag::Signer,
             Token::VectorType => {
                 self.consume(Token::Lt)?;
-                let ty = self.parse_type_tag()?;
+                let ty = self.parse_type_tag(depth + 1)?;
                 self.consume(Token::Gt)?;
                 TypeTag::Vector(Box::new(ty))
             }
@@ -278,7 +282,7 @@ impl<I: Iterator<Item = Token>> Parser<I> {
                                 let ty_args = if self.peek() == Some(&Token::Lt) {
                                     self.next()?;
                                     let ty_args = self.parse_comma_list(
-                                        |parser| parser.parse_type_tag(),
+                                        |parser| parser.parse_type_tag(depth + 1),
                                         Token::Gt,
                                         true,
                                     )?;
@@ -343,12 +347,12 @@ pub fn parse_string_list(s: &str) -> Result<Vec<String>> {
 
 pub fn parse_type_tags(s: &str) -> Result<Vec<TypeTag>> {
     parse(s, |parser| {
-        parser.parse_comma_list(|parser| parser.parse_type_tag(), Token::EOF, true)
+        parser.parse_comma_list(|parser| parser.parse_type_tag(0), Token::EOF, true)
     })
 }
 
 pub fn parse_type_tag(s: &str) -> Result<TypeTag> {
-    parse(s, |parser| parser.parse_type_tag())
+    parse(s, |parser| parser.parse_type_tag(0))
 }
 
 pub fn parse_transaction_arguments(s: &str) -> Result<Vec<TransactionArgument>> {
@@ -366,7 +370,7 @@ pub fn parse_transaction_argument(s: &str) -> Result<TransactionArgument> {
 }
 
 pub fn parse_struct_tag(s: &str) -> Result<StructTag> {
-    let type_tag = parse(s, |parser| parser.parse_type_tag())
+    let type_tag = parse(s, |parser| parser.parse_type_tag(0))
         .map_err(|e| format_err!("invalid struct tag: {}, {}", s, e))?;
     if let TypeTag::Struct(struct_tag) = type_tag {
         Ok(*struct_tag)
@@ -489,6 +493,7 @@ mod tests {
             "bool",
             "vector<u8>",
             "vector<vector<u64>>",
+            "vector<vector<vector<vector<vector<vector<vector<u64>>>>>>>",
             "signer",
             "0x1::M::S",
             "0x2::M::S_",
@@ -504,6 +509,14 @@ mod tests {
         ] {
             assert!(parse_type_tag(s).is_ok(), "Failed to parse tag {}", s);
         }
+
+        let s =
+            "vector<vector<vector<vector<vector<vector<vector<vector<vector<vector<u64>>>>>>>>>>";
+        assert!(
+            parse_type_tag(s).is_err(),
+            "Should have failed to parse type tag {}",
+            s
+        );
     }
 
     #[test]
@@ -529,6 +542,7 @@ mod tests {
             "0x1::Diem::Diem<u8 , bool  ,    vector<u8>,address,signer>",
             "0x1::Diem::Diem<vector<0x1::Diem::Struct<0x1::XUS::XUS>>>",
             "0x1::Diem::Diem<0x1::Diem::Struct<vector<0x1::XUS::XUS>, 0x1::Diem::Diem<vector<0x1::Diem::Struct<0x1::XUS::XUS>>>>>",
+            "0x1::Diem::Diem<vector<0x1::XDX::XDX<vector<vector<vector<0x1::XDX::XDX<vector<u64>>>>>>>>",
         ];
         for text in valid {
             let st = parse_struct_tag(text).expect("valid StructTag");
@@ -540,5 +554,12 @@ mod tests {
                 st
             );
         }
+
+        let s = "0x1::Diem::Diem<vector<0x1::XDX::XDX<vector<vector<vector<0x1::XDX::XDX<vector<vector<u64>>>>>>>>>";
+        assert!(
+            parse_struct_tag(s).is_err(),
+            "Should have failed to parse type tag {}",
+            s
+        );
     }
 }

--- a/language/move-core/types/src/parser.rs
+++ b/language/move-core/types/src/parser.rs
@@ -511,7 +511,7 @@ mod tests {
         }
 
         let s =
-            "vector<vector<vector<vector<vector<vector<vector<vector<vector<vector<u64>>>>>>>>>>";
+            "vector<vector<vector<vector<vector<vector<vector<vector<vector<vector<vector<vector<vector<vector<u64>>>>>>>>>>>>>>";
         assert!(
             parse_type_tag(s).is_err(),
             "Should have failed to parse type tag {}",
@@ -542,7 +542,7 @@ mod tests {
             "0x1::Diem::Diem<u8 , bool  ,    vector<u8>,address,signer>",
             "0x1::Diem::Diem<vector<0x1::Diem::Struct<0x1::XUS::XUS>>>",
             "0x1::Diem::Diem<0x1::Diem::Struct<vector<0x1::XUS::XUS>, 0x1::Diem::Diem<vector<0x1::Diem::Struct<0x1::XUS::XUS>>>>>",
-            "0x1::Diem::Diem<vector<0x1::XDX::XDX<vector<vector<vector<0x1::XDX::XDX<vector<u64>>>>>>>>",
+            "0x1::Diem::Diem<vector<vector<vector<vector<vector<0x1::XDX::XDX<vector<vector<vector<0x1::XDX::XDX<vector<u64>>>>>>>>>>>>",
         ];
         for text in valid {
             let st = parse_struct_tag(text).expect("valid StructTag");
@@ -555,7 +555,7 @@ mod tests {
             );
         }
 
-        let s = "0x1::Diem::Diem<vector<0x1::XDX::XDX<vector<vector<vector<0x1::XDX::XDX<vector<vector<u64>>>>>>>>>";
+        let s = "vector<vector<vector<vector<0x1::Diem::Diem<vector<0x1::XDX::XDX<vector<vector<vector<0x1::XDX::XDX<vector<vector<u64>>>>>>>>>>>>>";
         assert!(
             parse_struct_tag(s).is_err(),
             "Should have failed to parse type tag {}",

--- a/language/move-core/types/src/parser.rs
+++ b/language/move-core/types/src/parser.rs
@@ -287,12 +287,12 @@ impl<I: Iterator<Item = Token>> Parser<I> {
                                 } else {
                                     vec![]
                                 };
-                                TypeTag::Struct(StructTag {
+                                TypeTag::Struct(Box::new(StructTag {
                                     address: AccountAddress::from_hex_literal(&addr)?,
                                     module: Identifier::new(module)?,
                                     name: Identifier::new(name)?,
                                     type_params: ty_args,
-                                })
+                                }))
                             }
                             t => bail!("expected name, got {:?}", t),
                         }
@@ -369,7 +369,7 @@ pub fn parse_struct_tag(s: &str) -> Result<StructTag> {
     let type_tag = parse(s, |parser| parser.parse_type_tag())
         .map_err(|e| format_err!("invalid struct tag: {}, {}", s, e))?;
     if let TypeTag::Struct(struct_tag) = type_tag {
-        Ok(struct_tag)
+        Ok(*struct_tag)
     } else {
         bail!("invalid struct tag: {}", s)
     }

--- a/language/move-core/types/src/proptest_types.rs
+++ b/language/move-core/types/src/proptest_types.rs
@@ -35,12 +35,12 @@ impl Arbitrary for TypeTag {
                     vec(inner, 0..4),
                 )
                     .prop_map(|(address, module, name, type_params)| {
-                        Struct(StructTag {
+                        Struct(Box::new(StructTag {
                             address,
                             module,
                             name,
                             type_params,
-                        })
+                        }))
                     })
             },
         )

--- a/language/move-core/types/src/safe_serialize.rs
+++ b/language/move-core/types/src/safe_serialize.rs
@@ -1,0 +1,69 @@
+// Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Custom serializers which track recursion nesting with a thread local,
+//! and otherwise delegate to the derived serializers.
+//!
+//! This is currently only implemented for type tags, but can be easily
+//! generalized, as the the only type-tag specific thing is the allowed nesting.
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::cell::RefCell;
+
+pub(crate) const MAX_TYPE_TAG_NESTING: u8 = 9;
+
+thread_local! {
+    static TYPE_TAG_DEPTH: RefCell<u8> = RefCell::new(0);
+}
+
+pub(crate) fn type_tag_recursive_serialize<S, T>(t: &T, s: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+    T: Serialize,
+{
+    use serde::ser::Error;
+
+    TYPE_TAG_DEPTH.with(|depth| {
+        let mut r = depth.borrow_mut();
+        if *r >= MAX_TYPE_TAG_NESTING {
+            // for testability, we allow one level more
+            return Err(S::Error::custom(
+                "type tag nesting exceeded during serialization",
+            ));
+        }
+        *r += 1;
+        Ok(())
+    })?;
+    let res = t.serialize(s);
+    TYPE_TAG_DEPTH.with(|depth| {
+        let mut r = depth.borrow_mut();
+        *r -= 1;
+    });
+    res
+}
+
+pub(crate) fn type_tag_recursive_deserialize<'de, D, T>(d: D) -> Result<T, D::Error>
+where
+    D: Deserializer<'de>,
+    T: Deserialize<'de>,
+{
+    use serde::de::Error;
+    TYPE_TAG_DEPTH.with(|depth| {
+        let mut r = depth.borrow_mut();
+        // For testability, we allow to serialize one more level than deserialize.
+        if *r >= MAX_TYPE_TAG_NESTING - 1 {
+            return Err(D::Error::custom(
+                "type tag nesting exceeded during deserialization",
+            ));
+        }
+        *r += 1;
+        Ok(())
+    })?;
+    let res = T::deserialize(d);
+    TYPE_TAG_DEPTH.with(|depth| {
+        let mut r = depth.borrow_mut();
+        *r -= 1;
+    });
+    res
+}

--- a/language/move-core/types/src/safe_serialize.rs
+++ b/language/move-core/types/src/safe_serialize.rs
@@ -11,7 +11,7 @@
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::cell::RefCell;
 
-pub(crate) const MAX_TYPE_TAG_NESTING: u8 = 9;
+pub(crate) const MAX_TYPE_TAG_NESTING: u8 = 13;
 
 thread_local! {
     static TYPE_TAG_DEPTH: RefCell<u8> = RefCell::new(0);

--- a/language/move-core/types/src/value.rs
+++ b/language/move-core/types/src/value.rs
@@ -525,7 +525,7 @@ impl TryInto<TypeTag> for &MoveTypeLayout {
                 let inner_type = &**v;
                 TypeTag::Vector(Box::new(inner_type.try_into()?))
             }
-            MoveTypeLayout::Struct(v) => TypeTag::Struct(v.try_into()?),
+            MoveTypeLayout::Struct(v) => TypeTag::Struct(Box::new(v.try_into()?)),
         })
     }
 }

--- a/language/move-prover/bytecode/src/packed_types_analysis.rs
+++ b/language/move-prover/bytecode/src/packed_types_analysis.rs
@@ -56,7 +56,7 @@ pub fn get_packed_types(
                             for coin_ty in &coin_types {
                                 match open_ty.instantiate(vec![coin_ty.clone()].as_slice()).into_type_tag(env) {
                                     Some(TypeTag::Struct(s)) =>     {
-                                        packed_types.insert(s);
+                                        packed_types.insert(*s);
                                     }
                                     _ => panic!("Invariant violation: failed to specialize tx script open type {:?} into struct", open_ty),
                                 }
@@ -137,7 +137,7 @@ impl<'a> TransferFunctions for PackedTypesAnalysis<'a> {
                             } else if let Some(TypeTag::Struct(s)) =
                                 specialized_ty.into_type_tag(self.cache.global_env())
                             {
-                                state.closed_types.insert(s);
+                                state.closed_types.insert(*s);
                             } else {
                                 panic!("Invariant violation: struct type {:?} became non-struct type after substitution", open_ty)
                             }

--- a/language/move-prover/interpreter/src/concrete/ty.rs
+++ b/language/move-prover/interpreter/src/concrete/ty.rs
@@ -428,7 +428,7 @@ impl BaseType {
             BaseType::Primitive(PrimitiveType::Address) => TypeTag::Address,
             BaseType::Primitive(PrimitiveType::Signer) => TypeTag::Signer,
             BaseType::Vector(elem) => TypeTag::Vector(Box::new(elem.to_move_type_tag())),
-            BaseType::Struct(inst) => TypeTag::Struct(inst.to_move_struct_tag()),
+            BaseType::Struct(inst) => TypeTag::Struct(Box::new(inst.to_move_struct_tag())),
         }
     }
 

--- a/language/move-prover/move-abigen/src/abigen.rs
+++ b/language/move-prover/move-abigen/src/abigen.rs
@@ -289,7 +289,7 @@ impl<'env> Abigen<'env> {
                 let struct_module_env = module_env.env.get_module(*module_id);
                 let abilities = struct_module_env.get_struct(*struct_id).get_abilities();
                 if abilities.has_ability(Ability::Copy) && !abilities.has_ability(Ability::Key) {
-                    TypeTag::Struct(StructTag {
+                    TypeTag::Struct(Box::new(StructTag {
                         address: *struct_module_env.self_address(),
                         module: struct_module_env.get_identifier(),
                         name: struct_module_env
@@ -304,7 +304,7 @@ impl<'env> Abigen<'env> {
                             })
                             .map(|e| e.unwrap_or_else(|| panic!("{}", expect_msg)))
                             .collect(),
-                    })
+                    }))
                 } else {
                     return Ok(None);
                 }

--- a/language/move-vm/runtime/src/data_cache.rs
+++ b/language/move-vm/runtime/src/data_cache.rs
@@ -93,7 +93,7 @@ impl<'r, 'l, S: MoveResolver> TransactionDataCache<'r, 'l, S> {
                 };
 
                 let struct_tag = match self.loader.type_to_type_tag(&ty)? {
-                    TypeTag::Struct(struct_tag) => struct_tag,
+                    TypeTag::Struct(struct_tag) => *struct_tag,
                     _ => return Err(PartialVMError::new(StatusCode::INTERNAL_TYPE_ERROR)),
                 };
 

--- a/language/move-vm/runtime/src/loader.rs
+++ b/language/move-vm/runtime/src/loader.rs
@@ -2244,9 +2244,11 @@ impl Loader {
             Type::Address => TypeTag::Address,
             Type::Signer => TypeTag::Signer,
             Type::Vector(ty) => TypeTag::Vector(Box::new(self.type_to_type_tag(ty)?)),
-            Type::Struct(gidx) => TypeTag::Struct(self.struct_gidx_to_type_tag(*gidx, &[])?),
+            Type::Struct(gidx) => {
+                TypeTag::Struct(Box::new(self.struct_gidx_to_type_tag(*gidx, &[])?))
+            }
             Type::StructInstantiation(gidx, ty_args) => {
-                TypeTag::Struct(self.struct_gidx_to_type_tag(*gidx, ty_args)?)
+                TypeTag::Struct(Box::new(self.struct_gidx_to_type_tag(*gidx, ty_args)?))
             }
             Type::Reference(_) | Type::MutableReference(_) | Type::TyParam(_) => {
                 return Err(

--- a/language/tools/move-cli/src/sandbox/utils/on_disk_state_view.rs
+++ b/language/tools/move-cli/src/sandbox/utils/on_disk_state_view.rs
@@ -452,7 +452,7 @@ struct Generics(Vec<TypeTag>);
 impl ToString for TypeID {
     fn to_string(&self) -> String {
         match &self.0 {
-            TypeTag::Struct(s) => StructID(s.clone()).to_string(),
+            TypeTag::Struct(s) => StructID(*s.clone()).to_string(),
             TypeTag::Vector(t) => format!("vector<{}>", TypeID(*t.clone()).to_string()),
             t => t.to_string(),
         }

--- a/language/tools/move-resource-viewer/src/fat_type.rs
+++ b/language/tools/move-resource-viewer/src/fat_type.rs
@@ -148,7 +148,7 @@ impl FatType {
             Address => TypeTag::Address,
             Signer => TypeTag::Signer,
             Vector(ty) => TypeTag::Vector(Box::new(ty.type_tag()?)),
-            Struct(struct_ty) => TypeTag::Struct(struct_ty.struct_tag()?),
+            Struct(struct_ty) => TypeTag::Struct(Box::new(struct_ty.struct_tag()?)),
 
             Reference(_) | MutableReference(_) | TyParam(_) => {
                 return Err(

--- a/language/tools/move-resource-viewer/src/lib.rs
+++ b/language/tools/move-resource-viewer/src/lib.rs
@@ -66,7 +66,7 @@ impl AnnotatedMoveValue {
             Address(_) => TypeTag::Address,
             Vector(t, _) => t.clone(),
             Bytes(_) => TypeTag::Vector(Box::new(TypeTag::U8)),
-            Struct(s) => TypeTag::Struct(s.type_.clone()),
+            Struct(s) => TypeTag::Struct(Box::new(s.type_.clone())),
         }
     }
 }

--- a/language/tools/read-write-set/dynamic/src/dynamic_analysis.rs
+++ b/language/tools/read-write-set/dynamic/src/dynamic_analysis.rs
@@ -219,8 +219,11 @@ impl ConcretizedFormals {
                 .get_resource(g, &tag)
                 .map_err(|_| anyhow!("Failed to get resource for {:?}::{:?}", g, tag))?
             {
-                let layout = TypeLayoutBuilder::build_runtime(&TypeTag::Struct(tag), module_cache)
-                    .map_err(|_| anyhow!("Failed to resolve type: {:?}", access_path.root.type_))?;
+                let layout =
+                    TypeLayoutBuilder::build_runtime(&TypeTag::Struct(Box::new(tag)), module_cache)
+                        .map_err(|_| {
+                            anyhow!("Failed to resolve type: {:?}", access_path.root.type_)
+                        })?;
 
                 let resource =
                     MoveValue::simple_deserialize(&resource_bytes, &layout).map_err(|_| {


### PR DESCRIPTION
## Motivation

This cherry picks a series of PRs from the `aptos` branch to secure recursive type tags. Type tags are limited in serialization and parsing to not exceed a nesting depth of 8. In addition, it significantly reduces size of TypeTag by boxing the content of a larger enum variant.

For details see the individual commits

## Test Plan

Tests added in the commits
