### PR TITLE
[move-compiler] Fix optimizations blocked by warnings

### DIFF
--- a/language/evm/move-to-yul/tests/TestABINative.exp
+++ b/language/evm/move-to-yul/tests/TestABINative.exp
@@ -153,25 +153,20 @@ object "test_A2_M_test_decode_two_bytes1" {
                     $t26 := 1
                     // $t27 := ==($t25, $t26)
                     $t27 := $Eq($t25, $t26)
-                    // if ($t27) goto L8 else goto L10
+                    // if ($t27) goto L8 else goto L9
                     switch $t27
-                    case 0  { $block := 10 }
-                    default { $block := 9 }
+                    case 0  { $block := 9 }
+                    default { $block := 10 }
                 }
                 case 9 {
-                    // label L8
-                    // goto L11
-                    $block := 11
-                }
-                case 10 {
-                    // label L10
+                    // label L9
                     // $t28 := 101
                     $t28 := 101
                     // abort($t28)
                     $Abort($t28)
                 }
-                case 11 {
-                    // label L11
+                case 10 {
+                    // label L8
                     // $t29 := borrow_local($t4)
                     $t29 := $MakePtr(false, add($locals, 64))
                     // $t30 := vector::length<u8>($t29)
@@ -180,25 +175,20 @@ object "test_A2_M_test_decode_two_bytes1" {
                     $t31 := 1
                     // $t32 := ==($t30, $t31)
                     $t32 := $Eq($t30, $t31)
-                    // if ($t32) goto L12 else goto L14
+                    // if ($t32) goto L10 else goto L11
                     switch $t32
-                    case 0  { $block := 13 }
+                    case 0  { $block := 11 }
                     default { $block := 12 }
                 }
-                case 12 {
-                    // label L12
-                    // goto L15
-                    $block := 14
-                }
-                case 13 {
-                    // label L14
+                case 11 {
+                    // label L11
                     // $t33 := 102
                     $t33 := 102
                     // abort($t33)
                     $Abort($t33)
                 }
-                case 14 {
-                    // label L15
+                case 12 {
+                    // label L10
                     // $t34 := borrow_local($t3)
                     $t34 := $MakePtr(false, add($locals, 32))
                     // $t35 := 0
@@ -211,25 +201,20 @@ object "test_A2_M_test_decode_two_bytes1" {
                     $t38 := 42
                     // $t39 := ==($t37, $t38)
                     $t39 := $Eq($t37, $t38)
-                    // if ($t39) goto L16 else goto L18
+                    // if ($t39) goto L12 else goto L13
                     switch $t39
-                    case 0  { $block := 16 }
-                    default { $block := 15 }
+                    case 0  { $block := 13 }
+                    default { $block := 14 }
                 }
-                case 15 {
-                    // label L16
-                    // goto L19
-                    $block := 17
-                }
-                case 16 {
-                    // label L18
+                case 13 {
+                    // label L13
                     // $t40 := 103
                     $t40 := 103
                     // abort($t40)
                     $Abort($t40)
                 }
-                case 17 {
-                    // label L19
+                case 14 {
+                    // label L12
                     // $t41 := borrow_local($t4)
                     $t41 := $MakePtr(false, add($locals, 64))
                     // $t42 := 0
@@ -242,25 +227,20 @@ object "test_A2_M_test_decode_two_bytes1" {
                     $t45 := 43
                     // $t46 := ==($t44, $t45)
                     $t46 := $Eq($t44, $t45)
-                    // if ($t46) goto L20 else goto L22
+                    // if ($t46) goto L14 else goto L15
                     switch $t46
-                    case 0  { $block := 19 }
-                    default { $block := 18 }
+                    case 0  { $block := 15 }
+                    default { $block := 16 }
                 }
-                case 18 {
-                    // label L20
-                    // goto L23
-                    $block := 20
-                }
-                case 19 {
-                    // label L22
+                case 15 {
+                    // label L15
                     // $t47 := 104
                     $t47 := 104
                     // abort($t47)
                     $Abort($t47)
                 }
-                case 20 {
-                    // label L23
+                case 16 {
+                    // label L14
                     // return ()
                     $Free($locals, 96)
                     leave
@@ -604,7 +584,7 @@ object "test_A2_M_test_decode_two_bytes1" {
         }
     }
 }
-===> Test result of M::test_decode_two_bytes1: Succeed(Stopped) (used_gas=66864): []
+===> Test result of M::test_decode_two_bytes1: Succeed(Stopped) (used_gas=65452): []
 
 // test of M::test_decode_two_u8
 /* =======================================
@@ -716,48 +696,38 @@ object "test_A2_M_test_decode_two_u8" {
                     $t24 := 42
                     // $t25 := ==($t22, $t24)
                     $t25 := $Eq($t22, $t24)
-                    // if ($t25) goto L8 else goto L10
+                    // if ($t25) goto L8 else goto L9
                     switch $t25
-                    case 0  { $block := 10 }
-                    default { $block := 9 }
+                    case 0  { $block := 9 }
+                    default { $block := 10 }
                 }
                 case 9 {
-                    // label L8
-                    // goto L11
-                    $block := 11
-                }
-                case 10 {
-                    // label L10
+                    // label L9
                     // $t26 := 101
                     $t26 := 101
                     // abort($t26)
                     $Abort($t26)
                 }
-                case 11 {
-                    // label L11
+                case 10 {
+                    // label L8
                     // $t27 := 43
                     $t27 := 43
                     // $t28 := ==($t23, $t27)
                     $t28 := $Eq($t23, $t27)
-                    // if ($t28) goto L12 else goto L14
+                    // if ($t28) goto L10 else goto L11
                     switch $t28
-                    case 0  { $block := 13 }
+                    case 0  { $block := 11 }
                     default { $block := 12 }
                 }
-                case 12 {
-                    // label L12
-                    // goto L15
-                    $block := 14
-                }
-                case 13 {
-                    // label L14
+                case 11 {
+                    // label L11
                     // $t29 := 102
                     $t29 := 102
                     // abort($t29)
                     $Abort($t29)
                 }
-                case 14 {
-                    // label L15
+                case 12 {
+                    // label L10
                     // return ()
                     $Free($locals, 32)
                     leave
@@ -1041,7 +1011,7 @@ object "test_A2_M_test_decode_two_u8" {
         }
     }
 }
-===> Test result of M::test_decode_two_u8: Succeed(Stopped) (used_gas=64646): []
+===> Test result of M::test_decode_two_u8: Succeed(Stopped) (used_gas=64116): []
 
 // test of M::test_encode_packed_string
 /* =======================================
@@ -1060,16 +1030,37 @@ object "test_A2_M_test_encode_packed_string" {
             for {} true {} {
                 switch $block
                 case 2 {
-                    // label L0
-                    // goto L3
-                    $block := 5
-                }
-                case 3 {
-                    // label L2
+                    // label L1
                     // $t5 := 100
                     $t5 := 100
                     // abort($t5)
                     $Abort($t5)
+                }
+                case 3 {
+                    // label L0
+                    // $t6 := [49]
+                    $t6 := $Malloc(add(32, $ClosestGreaterPowerOfTwo(1)))
+                    $MemoryStoreU64($t6, 1)
+                    $MemoryStoreU64(add($t6, 8), $ClosestGreaterPowerOfTwo(1))
+                    copy_literal_string_to_memory_2868747976(add($t6, 32))
+                    // $t7 := [50]
+                    $t7 := $Malloc(add(32, $ClosestGreaterPowerOfTwo(1)))
+                    $MemoryStoreU64($t7, 1)
+                    $MemoryStoreU64(add($t7, 8), $ClosestGreaterPowerOfTwo(1))
+                    copy_literal_string_to_memory_4015750317(add($t7, 32))
+                    // $t8 := M::encode_packed_string($t6, $t7)
+                    $t8 := A2_M_encode_packed_string($t6, $t7)
+                    // $t9 := [49, 50]
+                    $t9 := $Malloc(add(32, $ClosestGreaterPowerOfTwo(2)))
+                    $MemoryStoreU64($t9, 2)
+                    $MemoryStoreU64(add($t9, 8), $ClosestGreaterPowerOfTwo(2))
+                    copy_literal_string_to_memory_141265791(add($t9, 32))
+                    // $t10 := ==($t8, $t9)
+                    $t10 := $Eq_$vec$u8$$($t8, $t9)
+                    // if ($t10) goto L2 else goto L3
+                    switch $t10
+                    case 0  { $block := 5 }
+                    default { $block := 6 }
                 }
                 case 4 {
                     // $t0 := []
@@ -1091,51 +1082,20 @@ object "test_A2_M_test_encode_packed_string" {
                     copy_literal_string_to_memory_21418693(add($t3, 32))
                     // $t4 := ==($t2, $t3)
                     $t4 := $Eq_$vec$u8$$($t2, $t3)
-                    // if ($t4) goto L0 else goto L2
+                    // if ($t4) goto L0 else goto L1
                     switch $t4
-                    case 0  { $block := 3 }
-                    default { $block := 2 }
+                    case 0  { $block := 2 }
+                    default { $block := 3 }
                 }
                 case 5 {
                     // label L3
-                    // $t6 := [49]
-                    $t6 := $Malloc(add(32, $ClosestGreaterPowerOfTwo(1)))
-                    $MemoryStoreU64($t6, 1)
-                    $MemoryStoreU64(add($t6, 8), $ClosestGreaterPowerOfTwo(1))
-                    copy_literal_string_to_memory_2868747976(add($t6, 32))
-                    // $t7 := [50]
-                    $t7 := $Malloc(add(32, $ClosestGreaterPowerOfTwo(1)))
-                    $MemoryStoreU64($t7, 1)
-                    $MemoryStoreU64(add($t7, 8), $ClosestGreaterPowerOfTwo(1))
-                    copy_literal_string_to_memory_4015750317(add($t7, 32))
-                    // $t8 := M::encode_packed_string($t6, $t7)
-                    $t8 := A2_M_encode_packed_string($t6, $t7)
-                    // $t9 := [49, 50]
-                    $t9 := $Malloc(add(32, $ClosestGreaterPowerOfTwo(2)))
-                    $MemoryStoreU64($t9, 2)
-                    $MemoryStoreU64(add($t9, 8), $ClosestGreaterPowerOfTwo(2))
-                    copy_literal_string_to_memory_141265791(add($t9, 32))
-                    // $t10 := ==($t8, $t9)
-                    $t10 := $Eq_$vec$u8$$($t8, $t9)
-                    // if ($t10) goto L4 else goto L6
-                    switch $t10
-                    case 0  { $block := 7 }
-                    default { $block := 6 }
-                }
-                case 6 {
-                    // label L4
-                    // goto L7
-                    $block := 8
-                }
-                case 7 {
-                    // label L6
                     // $t11 := 101
                     $t11 := 101
                     // abort($t11)
                     $Abort($t11)
                 }
-                case 8 {
-                    // label L7
+                case 6 {
+                    // label L2
                     // $t12 := []
                     $t12 := $Malloc(add(32, $ClosestGreaterPowerOfTwo(0)))
                     $MemoryStoreU64($t12, 0)
@@ -1155,25 +1115,20 @@ object "test_A2_M_test_encode_packed_string" {
                     copy_literal_string_to_memory_2053440334(add($t15, 32))
                     // $t16 := ==($t14, $t15)
                     $t16 := $Eq_$vec$u8$$($t14, $t15)
-                    // if ($t16) goto L8 else goto L10
+                    // if ($t16) goto L4 else goto L5
                     switch $t16
-                    case 0  { $block := 10 }
-                    default { $block := 9 }
+                    case 0  { $block := 7 }
+                    default { $block := 8 }
                 }
-                case 9 {
-                    // label L8
-                    // goto L11
-                    $block := 11
-                }
-                case 10 {
-                    // label L10
+                case 7 {
+                    // label L5
                     // $t17 := 102
                     $t17 := 102
                     // abort($t17)
                     $Abort($t17)
                 }
-                case 11 {
-                    // label L11
+                case 8 {
+                    // label L4
                     // $t18 := [97]
                     $t18 := $Malloc(add(32, $ClosestGreaterPowerOfTwo(1)))
                     $MemoryStoreU64($t18, 1)
@@ -1200,25 +1155,20 @@ object "test_A2_M_test_encode_packed_string" {
                     copy_literal_string_to_memory_3871831907(add($t23, 32))
                     // $t24 := ==($t22, $t23)
                     $t24 := $Eq_$vec$u8$$($t22, $t23)
-                    // if ($t24) goto L12 else goto L14
+                    // if ($t24) goto L6 else goto L7
                     switch $t24
-                    case 0  { $block := 13 }
-                    default { $block := 12 }
+                    case 0  { $block := 9 }
+                    default { $block := 10 }
                 }
-                case 12 {
-                    // label L12
-                    // goto L15
-                    $block := 14
-                }
-                case 13 {
-                    // label L14
+                case 9 {
+                    // label L7
                     // $t25 := 103
                     $t25 := 103
                     // abort($t25)
                     $Abort($t25)
                 }
-                case 14 {
-                    // label L15
+                case 10 {
+                    // label L6
                     // $t26 := [116, 101, 115, 116]
                     $t26 := $Malloc(add(32, $ClosestGreaterPowerOfTwo(4)))
                     $MemoryStoreU64($t26, 4)
@@ -1238,25 +1188,20 @@ object "test_A2_M_test_encode_packed_string" {
                     copy_literal_string_to_memory_1610556060(add($t29, 32))
                     // $t30 := ==($t28, $t29)
                     $t30 := $Eq_$vec$u8$$($t28, $t29)
-                    // if ($t30) goto L16 else goto L18
+                    // if ($t30) goto L8 else goto L9
                     switch $t30
-                    case 0  { $block := 16 }
-                    default { $block := 15 }
+                    case 0  { $block := 11 }
+                    default { $block := 12 }
                 }
-                case 15 {
-                    // label L16
-                    // goto L19
-                    $block := 17
-                }
-                case 16 {
-                    // label L18
+                case 11 {
+                    // label L9
                     // $t31 := 104
                     $t31 := 104
                     // abort($t31)
                     $Abort($t31)
                 }
-                case 17 {
-                    // label L19
+                case 12 {
+                    // label L8
                     // return ()
                     leave
                 }
@@ -1443,7 +1388,7 @@ object "test_A2_M_test_encode_packed_string" {
         }
     }
 }
-===> Test result of M::test_encode_packed_string: Succeed(Stopped) (used_gas=10647): []
+===> Test result of M::test_encode_packed_string: Succeed(Stopped) (used_gas=9310): []
 
 // test of M::test_encode_packed_uint16
 /* =======================================
@@ -1463,16 +1408,17 @@ object "test_A2_M_test_encode_packed_uint16" {
             for {} true {} {
                 switch $block
                 case 2 {
-                    // label L0
-                    // goto L3
-                    $block := 5
-                }
-                case 3 {
-                    // label L2
+                    // label L1
                     // $t9 := 101
                     $t9 := 101
                     // abort($t9)
                     $Abort($t9)
+                }
+                case 3 {
+                    // label L0
+                    // return ()
+                    $Free($locals, 32)
+                    leave
                 }
                 case 4 {
                     // $t3 := 41
@@ -1489,16 +1435,10 @@ object "test_A2_M_test_encode_packed_uint16" {
                     $t7 := 4
                     // $t8 := ==($t6, $t7)
                     $t8 := $Eq($t6, $t7)
-                    // if ($t8) goto L0 else goto L2
+                    // if ($t8) goto L0 else goto L1
                     switch $t8
-                    case 0  { $block := 3 }
-                    default { $block := 2 }
-                }
-                case 5 {
-                    // label L3
-                    // return ()
-                    $Free($locals, 32)
-                    leave
+                    case 0  { $block := 2 }
+                    default { $block := 3 }
                 }
             }
         }
@@ -1668,7 +1608,7 @@ object "test_A2_M_test_encode_packed_uint16" {
         }
     }
 }
-===> Test result of M::test_encode_packed_uint16: Succeed(Stopped) (used_gas=776): []
+===> Test result of M::test_encode_packed_uint16: Succeed(Stopped) (used_gas=693): []
 
 // test of M::test_marshalling_two_bytes1
 /* =======================================
@@ -1782,25 +1722,20 @@ object "test_A2_M_test_marshalling_two_bytes1" {
                     $t26 := mload($locals)
                     // $t27 := ==($t26, $t25)
                     $t27 := $Eq_$vec$u8$$($t26, $t25)
-                    // if ($t27) goto L8 else goto L10
+                    // if ($t27) goto L8 else goto L9
                     switch $t27
-                    case 0  { $block := 10 }
-                    default { $block := 9 }
+                    case 0  { $block := 9 }
+                    default { $block := 10 }
                 }
                 case 9 {
-                    // label L8
-                    // goto L11
-                    $block := 11
-                }
-                case 10 {
-                    // label L10
+                    // label L9
                     // $t28 := 101
                     $t28 := 101
                     // abort($t28)
                     $Abort($t28)
                 }
-                case 11 {
-                    // label L11
+                case 10 {
+                    // label L8
                     // return ()
                     $Free($locals, 32)
                     leave
@@ -2161,7 +2096,7 @@ object "test_A2_M_test_marshalling_two_bytes1" {
         }
     }
 }
-===> Test result of M::test_marshalling_two_bytes1: Succeed(Stopped) (used_gas=66247): []
+===> Test result of M::test_marshalling_two_bytes1: Succeed(Stopped) (used_gas=66026): []
 
 // test of M::test_marshalling_two_u8
 /* =======================================
@@ -2273,73 +2208,58 @@ object "test_A2_M_test_marshalling_two_u8" {
                     $t25 := 42
                     // $t26 := ==($t23, $t25)
                     $t26 := $Eq($t23, $t25)
-                    // if ($t26) goto L8 else goto L10
+                    // if ($t26) goto L8 else goto L9
                     switch $t26
-                    case 0  { $block := 10 }
-                    default { $block := 9 }
+                    case 0  { $block := 9 }
+                    default { $block := 10 }
                 }
                 case 9 {
-                    // label L8
-                    // goto L11
-                    $block := 11
-                }
-                case 10 {
-                    // label L10
+                    // label L9
                     // $t27 := 101
                     $t27 := 101
                     // abort($t27)
                     $Abort($t27)
                 }
-                case 11 {
-                    // label L11
+                case 10 {
+                    // label L8
                     // $t28 := 43
                     $t28 := 43
                     // $t29 := ==($t24, $t28)
                     $t29 := $Eq($t24, $t28)
-                    // if ($t29) goto L12 else goto L14
+                    // if ($t29) goto L10 else goto L11
                     switch $t29
-                    case 0  { $block := 13 }
+                    case 0  { $block := 11 }
                     default { $block := 12 }
                 }
-                case 12 {
-                    // label L12
-                    // goto L15
-                    $block := 14
-                }
-                case 13 {
-                    // label L14
+                case 11 {
+                    // label L11
                     // $t30 := 102
                     $t30 := 102
                     // abort($t30)
                     $Abort($t30)
                 }
-                case 14 {
-                    // label L15
+                case 12 {
+                    // label L10
                     // $t31 := M::encode_two_u8($t23, $t24)
                     $t31 := A2_M_encode_two_u8($t23, $t24)
                     // $t32 := move($t2)
                     $t32 := mload($locals)
                     // $t33 := ==($t32, $t31)
                     $t33 := $Eq_$vec$u8$$($t32, $t31)
-                    // if ($t33) goto L16 else goto L18
+                    // if ($t33) goto L12 else goto L13
                     switch $t33
-                    case 0  { $block := 16 }
-                    default { $block := 15 }
+                    case 0  { $block := 13 }
+                    default { $block := 14 }
                 }
-                case 15 {
-                    // label L16
-                    // goto L19
-                    $block := 17
-                }
-                case 16 {
-                    // label L18
+                case 13 {
+                    // label L13
                     // $t34 := 103
                     $t34 := 103
                     // abort($t34)
                     $Abort($t34)
                 }
-                case 17 {
-                    // label L19
+                case 14 {
+                    // label L12
                     // return ()
                     $Free($locals, 32)
                     leave
@@ -2681,7 +2601,7 @@ object "test_A2_M_test_marshalling_two_u8" {
         }
     }
 }
-===> Test result of M::test_marshalling_two_u8: Succeed(Stopped) (used_gas=66157): []
+===> Test result of M::test_marshalling_two_u8: Succeed(Stopped) (used_gas=65230): []
 
 
 

--- a/language/extensions/async/move-async-vm/tests/sources/AccountStateMachine.exp
+++ b/language/extensions/async/move-async-vm/tests/sources/AccountStateMachine.exp
@@ -52,4 +52,4 @@ actor 0x4 handling 0x3::AccountStateMachine::verify (hash=0x3450A8717C6383FF)
 actor 0x5 handling 0x3::AccountStateMachine::verify (hash=0x3450A8717C6383FF)
   SUCCESS
 actor 0x5 handling 0x3::AccountStateMachine::verify (hash=0x3450A8717C6383FF)
-  FAIL  VMError with status ABORTED with sub status 2 at location Module ModuleId { address: 00000000000000000000000000000003, name: Identifier("AccountStateMachine") } and message 0x00000000000000000000000000000003::AccountStateMachine::verify at offset 9 at code offset 9 in function definition 16
+  FAIL  VMError with status ABORTED with sub status 2 at location Module ModuleId { address: 00000000000000000000000000000003, name: Identifier("AccountStateMachine") } and message 0x00000000000000000000000000000003::AccountStateMachine::verify at offset 7 at code offset 7 in function definition 16

--- a/language/move-compiler/src/cfgir/borrows/mod.rs
+++ b/language/move-compiler/src/cfgir/borrows/mod.rs
@@ -6,7 +6,7 @@ mod state;
 
 use super::absint::*;
 use crate::{
-    diagnostics::Diagnostics,
+    diagnostics::{codes::Severity, Diagnostics},
     hlir::ast::*,
     parser::ast::{BinOp_, StructName, Var},
     shared::{unique_map::UniqueMap, CompilationEnv},
@@ -86,8 +86,9 @@ pub fn verify(
     locals: &UniqueMap<Var, SingleType>,
     cfg: &super::cfg::BlockCFG,
 ) -> BTreeMap<Label, BorrowState> {
-    let mut initial_state =
-        BorrowState::initial(locals, acquires.clone(), compilation_env.has_diags());
+    // check for existing errors
+    let has_errors = compilation_env.has_diags_at_or_above_severity(Severity::NonblockingError);
+    let mut initial_state = BorrowState::initial(locals, acquires.clone(), has_errors);
     initial_state.bind_arguments(&signature.parameters);
     let mut safety = BorrowSafety::new(locals);
     initial_state.canonicalize_locals(&safety.local_numbers);

--- a/language/move-compiler/src/cfgir/borrows/mod.rs
+++ b/language/move-compiler/src/cfgir/borrows/mod.rs
@@ -87,7 +87,7 @@ pub fn verify(
     cfg: &super::cfg::BlockCFG,
 ) -> BTreeMap<Label, BorrowState> {
     // check for existing errors
-    let has_errors = compilation_env.has_diags_at_or_above_severity(Severity::NonblockingError);
+    let has_errors = compilation_env.has_errors();
     let mut initial_state = BorrowState::initial(locals, acquires.clone(), has_errors);
     initial_state.bind_arguments(&signature.parameters);
     let mut safety = BorrowSafety::new(locals);

--- a/language/move-compiler/src/cfgir/borrows/mod.rs
+++ b/language/move-compiler/src/cfgir/borrows/mod.rs
@@ -6,7 +6,7 @@ mod state;
 
 use super::absint::*;
 use crate::{
-    diagnostics::{codes::Severity, Diagnostics},
+    diagnostics::Diagnostics,
     hlir::ast::*,
     parser::ast::{BinOp_, StructName, Var},
     shared::{unique_map::UniqueMap, CompilationEnv},

--- a/language/move-compiler/src/cfgir/translate.rs
+++ b/language/move-compiler/src/cfgir/translate.rs
@@ -9,7 +9,6 @@ use crate::{
         cfg::BlockCFG,
     },
     diag,
-    diagnostics::codes::Severity,
     expansion::ast::{AbilitySet, ModuleIdent},
     hlir::ast::{self as H, Label, Value, Value_},
     parser::ast::{ConstantName, FunctionName, StructName, Var},

--- a/language/move-compiler/src/cfgir/translate.rs
+++ b/language/move-compiler/src/cfgir/translate.rs
@@ -436,10 +436,7 @@ fn function_body(
                 &infinite_loop_starts,
             );
             // do not optimize if there are errors, warnings are okay
-            if !context
-                .env
-                .has_diags_at_or_above_severity(Severity::NonblockingError)
-            {
+            if !context.env.has_errors() {
                 cfgir::optimize(signature, &locals, &mut cfg);
             }
 

--- a/language/move-compiler/src/cfgir/translate.rs
+++ b/language/move-compiler/src/cfgir/translate.rs
@@ -9,6 +9,7 @@ use crate::{
         cfg::BlockCFG,
     },
     diag,
+    diagnostics::codes::Severity,
     expansion::ast::{AbilitySet, ModuleIdent},
     hlir::ast::{self as H, Label, Value, Value_},
     parser::ast::{ConstantName, FunctionName, StructName, Var},
@@ -434,7 +435,11 @@ fn function_body(
                 &mut cfg,
                 &infinite_loop_starts,
             );
-            if !context.env.has_diags() {
+            // do not optimize if there are errors, warnings are okay
+            if context
+                .env
+                .has_diags_at_or_above_severity(Severity::NonblockingError)
+            {
                 cfgir::optimize(signature, &locals, &mut cfg);
             }
 

--- a/language/move-compiler/src/cfgir/translate.rs
+++ b/language/move-compiler/src/cfgir/translate.rs
@@ -436,7 +436,7 @@ fn function_body(
                 &infinite_loop_starts,
             );
             // do not optimize if there are errors, warnings are okay
-            if context
+            if !context
                 .env
                 .has_diags_at_or_above_severity(Severity::NonblockingError)
             {

--- a/language/move-compiler/src/command_line/compiler.rs
+++ b/language/move-compiler/src/command_line/compiler.rs
@@ -447,16 +447,10 @@ pub fn construct_pre_compiled_lib<Paths: Into<Symbol>, NamedAddress: Into<Symbol
             parser = Some(prog.clone())
         }
         PassResult::Expansion(eprog) => {
-            if env.has_diags_at_or_above_severity(Severity::BlockingError) {
-                return;
-            }
             assert!(expansion.is_none());
             expansion = Some(eprog.clone())
         }
         PassResult::Naming(nprog) => {
-            if env.has_diags_at_or_above_severity(Severity::BlockingError) {
-                return;
-            }
             assert!(naming.is_none());
             naming = Some(nprog.clone())
         }
@@ -465,9 +459,6 @@ pub fn construct_pre_compiled_lib<Paths: Into<Symbol>, NamedAddress: Into<Symbol
             typing = Some(tprog.clone())
         }
         PassResult::HLIR(hprog) => {
-            if env.has_diags_at_or_above_severity(Severity::NonblockingError) {
-                return;
-            }
             assert!(hlir.is_none());
             hlir = Some(hprog.clone());
         }

--- a/language/move-compiler/src/command_line/compiler.rs
+++ b/language/move-compiler/src/command_line/compiler.rs
@@ -441,7 +441,7 @@ pub fn construct_pre_compiled_lib<Paths: Into<Symbol>, NamedAddress: Into<Symbol
     let mut cfgir = None;
     let mut compiled = None;
 
-    let save_result = |cur: &PassResult, env: &CompilationEnv| match cur {
+    let save_result = |cur: &PassResult, _env: &CompilationEnv| match cur {
         PassResult::Parser(prog) => {
             assert!(parser.is_none());
             parser = Some(prog.clone())

--- a/language/move-compiler/src/command_line/compiler.rs
+++ b/language/move-compiler/src/command_line/compiler.rs
@@ -447,14 +447,14 @@ pub fn construct_pre_compiled_lib<Paths: Into<Symbol>, NamedAddress: Into<Symbol
             parser = Some(prog.clone())
         }
         PassResult::Expansion(eprog) => {
-            if env.has_diags() {
+            if env.has_diags_at_or_above_severity(Severity::BlockingError) {
                 return;
             }
             assert!(expansion.is_none());
             expansion = Some(eprog.clone())
         }
         PassResult::Naming(nprog) => {
-            if env.has_diags() {
+            if env.has_diags_at_or_above_severity(Severity::BlockingError) {
                 return;
             }
             assert!(naming.is_none());
@@ -465,7 +465,7 @@ pub fn construct_pre_compiled_lib<Paths: Into<Symbol>, NamedAddress: Into<Symbol
             typing = Some(tprog.clone())
         }
         PassResult::HLIR(hprog) => {
-            if env.has_diags() {
+            if env.has_diags_at_or_above_severity(Severity::NonblockingError) {
                 return;
             }
             assert!(hlir.is_none());

--- a/language/move-compiler/src/expansion/translate.rs
+++ b/language/move-compiler/src/expansion/translate.rs
@@ -1187,7 +1187,7 @@ fn visibility(context: &mut Context, pvisibility: P::Visibility) -> E::Visibilit
     match pvisibility {
         P::Visibility::Public(loc) => E::Visibility::Public(loc),
         P::Visibility::Script(loc) => {
-            assert!(context.env.has_errors());
+            assert!(!context.env.has_errors());
             E::Visibility::Public(loc)
         }
         P::Visibility::Friend(loc) => E::Visibility::Friend(loc),

--- a/language/move-compiler/src/expansion/translate.rs
+++ b/language/move-compiler/src/expansion/translate.rs
@@ -992,7 +992,7 @@ fn struct_def(
 ) {
     let (sname, sdef) = struct_def_(context, pstruct);
     if let Err(_old_loc) = structs.add(sname, sdef) {
-        assert!(context.env.has_diags())
+        assert!(context.env.has_errors())
     }
 }
 
@@ -1080,7 +1080,7 @@ fn friend(
                 ));
             }
         },
-        None => assert!(context.env.has_diags()),
+        None => assert!(context.env.has_errors()),
     };
 }
 
@@ -1107,7 +1107,7 @@ fn constant(
 ) {
     let (name, constant) = constant_(context, pconstant);
     if let Err(_old_loc) = constants.add(name, constant) {
-        assert!(context.env.has_diags())
+        assert!(context.env.has_errors())
     }
 }
 
@@ -1144,7 +1144,7 @@ fn function(
 ) {
     let (fname, fdef) = function_(context, pfunction);
     if let Err(_old_loc) = functions.add(fname, fdef) {
-        assert!(context.env.has_diags())
+        assert!(context.env.has_errors())
     }
 }
 
@@ -1187,7 +1187,7 @@ fn visibility(context: &mut Context, pvisibility: P::Visibility) -> E::Visibilit
     match pvisibility {
         P::Visibility::Public(loc) => E::Visibility::Public(loc),
         P::Visibility::Script(loc) => {
-            debug_assert!(context.env.has_diags());
+            assert!(context.env.has_errors());
             E::Visibility::Public(loc)
         }
         P::Visibility::Friend(loc) => E::Visibility::Friend(loc),
@@ -1534,7 +1534,7 @@ fn type_(context: &mut Context, sp!(loc, pt_): P::Type) -> E::Type {
             let tyargs = types(context, ptyargs);
             match name_access_chain(context, Access::Type, *pn) {
                 None => {
-                    assert!(context.env.has_diags());
+                    assert!(context.env.has_errors());
                     ET::UnresolvedError
                 }
                 Some(n) => ET::Apply(n, tyargs),
@@ -1720,7 +1720,7 @@ fn sequence_item(context: &mut Context, sp!(loc, pitem_): P::SequenceItem) -> E:
             let ty_opt = pty_opt.map(|t| type_(context, t));
             match b_opt {
                 None => {
-                    assert!(context.env.has_diags());
+                    assert!(context.env.has_errors());
                     ES::Seq(sp(loc, E::Exp_::UnresolvedError))
                 }
                 Some(b) => ES::Declare(b, ty_opt),
@@ -1736,7 +1736,7 @@ fn sequence_item(context: &mut Context, sp!(loc, pitem_): P::SequenceItem) -> E:
             };
             match b_opt {
                 None => {
-                    assert!(context.env.has_diags());
+                    assert!(context.env.has_errors());
                     ES::Seq(sp(loc, E::Exp_::UnresolvedError))
                 }
                 Some(b) => ES::Bind(b, e),
@@ -1762,7 +1762,7 @@ fn exp_(context: &mut Context, sp!(loc, pe_): P::Exp) -> E::Exp {
         PE::Value(pv) => match value(context, pv) {
             Some(v) => EE::Value(v),
             None => {
-                assert!(context.env.has_diags());
+                assert!(context.env.has_errors());
                 EE::UnresolvedError
             }
         },
@@ -1785,7 +1785,7 @@ fn exp_(context: &mut Context, sp!(loc, pe_): P::Exp) -> E::Exp {
             match en_opt {
                 Some(en) => EE::Name(en, tys_opt),
                 None => {
-                    assert!(context.env.has_diags());
+                    assert!(context.env.has_errors());
                     EE::UnresolvedError
                 }
             }
@@ -1797,7 +1797,7 @@ fn exp_(context: &mut Context, sp!(loc, pe_): P::Exp) -> E::Exp {
             match en_opt {
                 Some(en) => EE::Call(en, is_macro, tys_opt, ers),
                 None => {
-                    assert!(context.env.has_diags());
+                    assert!(context.env.has_errors());
                     EE::UnresolvedError
                 }
             }
@@ -1813,7 +1813,7 @@ fn exp_(context: &mut Context, sp!(loc, pe_): P::Exp) -> E::Exp {
             match en_opt {
                 Some(en) => EE::Pack(en, tys_opt, efields),
                 None => {
-                    assert!(context.env.has_diags());
+                    assert!(context.env.has_errors());
                     EE::UnresolvedError
                 }
             }
@@ -1848,7 +1848,7 @@ fn exp_(context: &mut Context, sp!(loc, pe_): P::Exp) -> E::Exp {
                 match bs_opt {
                     Some(bs) => EE::Lambda(bs, Box::new(e)),
                     None => {
-                        assert!(context.env.has_diags());
+                        assert!(context.env.has_errors());
                         EE::UnresolvedError
                     }
                 }
@@ -1872,7 +1872,7 @@ fn exp_(context: &mut Context, sp!(loc, pe_): P::Exp) -> E::Exp {
                 match rs_opt {
                     Some(rs) => EE::Quant(k, rs, rtrs, rc, Box::new(re)),
                     None => {
-                        assert!(context.env.has_diags());
+                        assert!(context.env.has_errors());
                         EE::UnresolvedError
                     }
                 }
@@ -1888,7 +1888,7 @@ fn exp_(context: &mut Context, sp!(loc, pe_): P::Exp) -> E::Exp {
             let er = exp(context, *rhs);
             match l_opt {
                 None => {
-                    assert!(context.env.has_diags());
+                    assert!(context.env.has_errors());
                     EE::UnresolvedError
                 }
                 Some(LValue::Assigns(al)) => EE::Assign(al, er),
@@ -1926,7 +1926,7 @@ fn exp_(context: &mut Context, sp!(loc, pe_): P::Exp) -> E::Exp {
         pdotted_ @ PE::Dot(_, _) => match exp_dotted(context, sp(loc, pdotted_)) {
             Some(edotted) => EE::ExpDotted(Box::new(edotted)),
             None => {
-                assert!(context.env.has_diags());
+                assert!(context.env.has_errors());
                 EE::UnresolvedError
             }
         },

--- a/language/move-compiler/src/hlir/translate.rs
+++ b/language/move-compiler/src/hlir/translate.rs
@@ -140,7 +140,7 @@ impl<'env> Context<'env> {
         let fields = self.structs.get(struct_name);
         // if fields are none, the struct must be defined in another module,
         // in that case, there should be errors
-        assert!(fields.is_some() || self.env.has_diags());
+        assert!(fields.is_some() || self.env.has_errors());
         fields
     }
 

--- a/language/move-compiler/src/hlir/translate.rs
+++ b/language/move-compiler/src/hlir/translate.rs
@@ -1241,7 +1241,7 @@ fn exp_impl(
                 for (decl_idx, f, _exp_idx, bt, tf) in texp_fields {
                     // Might have too many arguments, there will be an error from typing
                     if decl_idx > fields.len() {
-                        debug_assert!(context.env.has_diags());
+                        debug_assert!(context.env.has_errors());
                         break;
                     }
                     let bt = base_type(context, bt);
@@ -1256,7 +1256,7 @@ fn exp_impl(
                     .into_iter()
                     .filter_map(|o| {
                         // if o is None, context should have errors
-                        debug_assert!(o.is_some() || context.env.has_diags());
+                        debug_assert!(o.is_some() || context.env.has_errors());
                         o
                     })
                     .collect()
@@ -1338,7 +1338,7 @@ fn exp_impl(
             HE::Spec(u, used_locals)
         }
         TE::UnresolvedError => {
-            assert!(context.env.has_diags());
+            assert!(context.env.has_errors());
             HE::UnresolvedError
         }
 
@@ -1578,7 +1578,7 @@ fn needs_freeze(context: &Context, sp!(_, actual): &H::Type, sp!(_, expected): &
             }
         }
         (_actual, _expected) => {
-            assert!(context.env.has_diags());
+            assert!(context.env.has_errors());
             Freeze::NotNeeded
         }
     }

--- a/language/move-compiler/src/naming/translate.rs
+++ b/language/move-compiler/src/naming/translate.rs
@@ -250,7 +250,7 @@ impl<'env> Context<'env> {
         match ma_ {
             EA::Name(n) => match self.resolve_unscoped_type(&n) {
                 None => {
-                    assert!(self.env.has_diags());
+                    assert!(self.env.has_errors());
                     None
                 }
                 Some(rt) => {
@@ -264,7 +264,7 @@ impl<'env> Context<'env> {
             },
             EA::ModuleAccess(m, n) => match self.resolve_module_type(nloc, &m, &n) {
                 None => {
-                    assert!(self.env.has_diags());
+                    assert!(self.env.has_errors());
                     None
                 }
                 Some((_, _, _, arity)) => {
@@ -297,7 +297,7 @@ impl<'env> Context<'env> {
             },
             EA::ModuleAccess(m, n) => match self.resolve_module_constant(loc, &m, n) {
                 None => {
-                    assert!(self.env.has_diags());
+                    assert!(self.env.has_errors());
                     None
                 }
                 Some(cname) => Some((Some(m), cname)),

--- a/language/move-compiler/src/naming/translate.rs
+++ b/language/move-compiler/src/naming/translate.rs
@@ -470,7 +470,7 @@ fn friend(context: &mut Context, mident: ModuleIdent, friend: E::Friend) -> Opti
     } else if context.resolve_module(&mident) {
         Some(friend)
     } else {
-        assert!(context.env.has_diags());
+        assert!(context.env.has_errors());
         None
     }
 }
@@ -751,12 +751,12 @@ fn type_(context: &mut Context, sp!(loc, ety_): E::Type) -> N::Type {
         }
         ET::Ref(mut_, inner) => NT::Ref(mut_, Box::new(type_(context, *inner))),
         ET::UnresolvedError => {
-            assert!(context.env.has_diags());
+            assert!(context.env.has_errors());
             NT::UnresolvedError
         }
         ET::Apply(sp!(_, EN::Name(n)), tys) => match context.resolve_unscoped_type(&n) {
             None => {
-                assert!(context.env.has_diags());
+                assert!(context.env.has_errors());
                 NT::UnresolvedError
             }
             Some(RT::BuiltinType) => {
@@ -782,7 +782,7 @@ fn type_(context: &mut Context, sp!(loc, ety_): E::Type) -> N::Type {
         ET::Apply(sp!(nloc, EN::ModuleAccess(m, n)), tys) => {
             match context.resolve_module_type(nloc, &m, &n) {
                 None => {
-                    assert!(context.env.has_diags());
+                    assert!(context.env.has_errors());
                     NT::UnresolvedError
                 }
                 Some((_, _, _, arity)) => {
@@ -852,7 +852,7 @@ fn sequence_item(context: &mut Context, sp!(loc, ns_): E::SequenceItem) -> N::Se
             let tys = ty_opt.map(|t| type_(context, t));
             match bind_opt {
                 None => {
-                    assert!(context.env.has_diags());
+                    assert!(context.env.has_errors());
                     NS::Seq(sp(loc, N::Exp_::UnresolvedError))
                 }
                 Some(bind) => NS::Declare(bind, tys),
@@ -863,7 +863,7 @@ fn sequence_item(context: &mut Context, sp!(loc, ns_): E::SequenceItem) -> N::Se
             let e = exp_(context, e);
             match bind_opt {
                 None => {
-                    assert!(context.env.has_diags());
+                    assert!(context.env.has_errors());
                     NS::Seq(sp(loc, N::Exp_::UnresolvedError))
                 }
                 Some(bind) => NS::Bind(bind, e),
@@ -915,7 +915,7 @@ fn exp_(context: &mut Context, e: E::Exp) -> N::Exp {
             let ne = exp(context, *e);
             match na_opt {
                 None => {
-                    assert!(context.env.has_diags());
+                    assert!(context.env.has_errors());
                     NE::UnresolvedError
                 }
                 Some(na) => NE::Assign(na, ne),
@@ -926,7 +926,7 @@ fn exp_(context: &mut Context, e: E::Exp) -> N::Exp {
             let ner = exp(context, *er);
             match ndot_opt {
                 None => {
-                    assert!(context.env.has_diags());
+                    assert!(context.env.has_errors());
                     NE::UnresolvedError
                 }
                 Some(ndot) => NE::FieldMutate(ndot, ner),
@@ -950,7 +950,7 @@ fn exp_(context: &mut Context, e: E::Exp) -> N::Exp {
         EE::Pack(tn, etys_opt, efields) => {
             match context.resolve_struct_name(eloc, "construction", tn, etys_opt) {
                 None => {
-                    assert!(context.env.has_diags());
+                    assert!(context.env.has_errors());
                     NE::UnresolvedError
                 }
                 Some((m, sn, tys_opt)) => NE::Pack(
@@ -969,7 +969,7 @@ fn exp_(context: &mut Context, e: E::Exp) -> N::Exp {
         EE::Borrow(mut_, inner) => match *inner {
             sp!(_, EE::ExpDotted(edot)) => match dotted(context, *edot) {
                 None => {
-                    assert!(context.env.has_diags());
+                    assert!(context.env.has_errors());
                     NE::UnresolvedError
                 }
                 Some(d) => NE::Borrow(mut_, d),
@@ -982,7 +982,7 @@ fn exp_(context: &mut Context, e: E::Exp) -> N::Exp {
 
         EE::ExpDotted(edot) => match dotted(context, *edot) {
             None => {
-                assert!(context.env.has_diags());
+                assert!(context.env.has_errors());
                 NE::UnresolvedError
             }
             Some(d) => NE::DerefBorrow(d),
@@ -1017,7 +1017,7 @@ fn exp_(context: &mut Context, e: E::Exp) -> N::Exp {
                 EA::Name(n) if N::BuiltinFunction_::all_names().contains(&n.value) => {
                     match resolve_builtin_function(context, eloc, &n, ty_args) {
                         None => {
-                            assert!(context.env.has_diags());
+                            assert!(context.env.has_errors());
                             NE::UnresolvedError
                         }
                         Some(f) => NE::Builtin(sp(mloc, f), nes),
@@ -1033,7 +1033,7 @@ fn exp_(context: &mut Context, e: E::Exp) -> N::Exp {
                 }
                 EA::ModuleAccess(m, n) => match context.resolve_module_function(mloc, &m, &n) {
                     None => {
-                        assert!(context.env.has_diags());
+                        assert!(context.env.has_errors());
                         NE::UnresolvedError
                     }
                     Some(_) => NE::ModuleCall(m, FunctionName(n), ty_args, nes),
@@ -1064,7 +1064,7 @@ fn exp_(context: &mut Context, e: E::Exp) -> N::Exp {
             NE::Spec(u, used_locals)
         }
         EE::UnresolvedError => {
-            assert!(context.env.has_diags());
+            assert!(context.env.has_errors());
             NE::UnresolvedError
         }
         // `Name` matches name variants only allowed in specs (we handle the allowed ones above)
@@ -1078,7 +1078,7 @@ fn exp_(context: &mut Context, e: E::Exp) -> N::Exp {
 fn access_constant(context: &mut Context, ma: E::ModuleAccess) -> N::Exp_ {
     match context.resolve_constant(ma) {
         None => {
-            assert!(context.env.has_diags());
+            assert!(context.env.has_errors());
             N::Exp_::UnresolvedError
         }
         Some((m, c)) => N::Exp_::Constant(m, c),

--- a/language/move-compiler/src/shared/mod.rs
+++ b/language/move-compiler/src/shared/mod.rs
@@ -193,8 +193,13 @@ impl CompilationEnv {
         self.diags.extend(diags)
     }
 
-    pub fn has_diags(&self) -> bool {
+    pub fn has_warnings_or_errors(&self) -> bool {
         !self.diags.is_empty()
+    }
+
+    pub fn has_errors(&self) -> bool {
+        // Non-blocking Error is the min level considered an error
+        self.has_diags_at_or_above_severity(Severity::NonblockingError)
     }
 
     pub fn count_diags(&self) -> usize {

--- a/language/move-compiler/src/shared/mod.rs
+++ b/language/move-compiler/src/shared/mod.rs
@@ -201,13 +201,21 @@ impl CompilationEnv {
         self.diags.len()
     }
 
+    pub fn has_diags_at_or_above_severity(&self, threshold: Severity) -> bool {
+        match self.diags.max_severity() {
+            Some(max) if max >= threshold => true,
+            Some(_) | None => false,
+        }
+    }
+
     pub fn check_diags_at_or_above_severity(
         &mut self,
         threshold: Severity,
     ) -> Result<(), Diagnostics> {
-        match self.diags.max_severity() {
-            Some(max) if max >= threshold => Err(std::mem::take(&mut self.diags)),
-            Some(_) | None => Ok(()),
+        if self.has_diags_at_or_above_severity(threshold) {
+            Err(std::mem::take(&mut self.diags))
+        } else {
+            Ok(())
         }
     }
 

--- a/language/move-compiler/src/typing/globals.rs
+++ b/language/move-compiler/src/typing/globals.rs
@@ -270,14 +270,14 @@ where
         }
         T::Ref(_, _) | T::Unit => {
             // Key ability is checked by constraints, and these types do not have Key
-            assert!(context.env.has_diags());
+            assert!(context.env.has_errors());
             return None;
         }
         T::Apply(Some(abilities), sp!(_, TN::Multiple(_)), _)
         | T::Apply(Some(abilities), sp!(_, TN::Builtin(_)), _) => {
             // Key ability is checked by constraints
             assert!(!abilities.has_ability_(Ability_::Key));
-            assert!(context.env.has_diags());
+            assert!(context.env.has_errors());
             return None;
         }
         T::Param(_) => {

--- a/language/move-compiler/src/typing/translate.rs
+++ b/language/move-compiler/src/typing/translate.rs
@@ -1489,7 +1489,7 @@ fn exp_inner(context: &mut Context, sp!(eloc, ne_): N::Exp) -> T::Exp {
             (sp(eloc, Type_::Unit), TE::Spec(u, used_local_types))
         }
         NE::UnresolvedError => {
-            assert!(context.env.has_diags());
+            assert!(context.env.has_errors());
             (context.error_type(eloc), TE::UnresolvedError)
         }
 

--- a/language/move-compiler/transactional-tests/tests/evaluation_order/lazy_assert.exp
+++ b/language/move-compiler/transactional-tests/tests/evaluation_order/lazy_assert.exp
@@ -15,5 +15,5 @@ Error: Script execution failed with VMError: {
     sub_status: None,
     location: script,
     indices: [],
-    offsets: [(FunctionDefinitionIndex(0), 3)],
+    offsets: [(FunctionDefinitionIndex(0), 2)],
 }

--- a/language/tools/move-cli/tests/build_tests/build_with_warnings/Move.toml
+++ b/language/tools/move-cli/tests/build_tests/build_with_warnings/Move.toml
@@ -1,0 +1,3 @@
+[package]
+name = "Test"
+version = "0.0.0"

--- a/language/tools/move-cli/tests/build_tests/build_with_warnings/args.exp
+++ b/language/tools/move-cli/tests/build_tests/build_with_warnings/args.exp
@@ -1,0 +1,25 @@
+Command `build`:
+BUILDING Test
+warning[W09002]: unused variable
+  ┌─ ./sources/m.move:2:16
+  │
+2 │ public fun foo(x: u64): u64 {
+  │                ^ Unused parameter 'x'. Consider removing or prefixing with an underscore: '_x'
+
+Command `disassemble --package Test --name m`:
+// Move bytecode v5
+module 42.m {
+
+
+public foo(x: u64): u64 {
+B0:
+	0: LdU64(2)
+	1: Ret
+}
+}
+warning[W09002]: unused variable
+  ┌─ ./sources/m.move:2:16
+  │
+2 │ public fun foo(x: u64): u64 {
+  │                ^ Unused parameter 'x'. Consider removing or prefixing with an underscore: '_x'
+

--- a/language/tools/move-cli/tests/build_tests/build_with_warnings/args.txt
+++ b/language/tools/move-cli/tests/build_tests/build_with_warnings/args.txt
@@ -1,0 +1,2 @@
+build
+disassemble --package Test --name m

--- a/language/tools/move-cli/tests/build_tests/build_with_warnings/modules/m.move
+++ b/language/tools/move-cli/tests/build_tests/build_with_warnings/modules/m.move
@@ -1,0 +1,5 @@
+module 0x42::m {
+public fun foo(x: u64): u64 {
+    1 + 1
+}
+}

--- a/language/tools/move-cli/tests/build_tests/build_with_warnings/sources/m.move
+++ b/language/tools/move-cli/tests/build_tests/build_with_warnings/sources/m.move
@@ -1,0 +1,5 @@
+module 0x42::m {
+public fun foo(x: u64): u64 {
+    1 + 1
+}
+}


### PR DESCRIPTION
- Fix compiler optimizations being erroneously blocked by all diagnostics, not just errors
- Fix internal ICE checks for the compiler's reference safety checks

## Motivation

- @awelc found a bug where optimizations weren't done in the presence of warnings.

## Test Plan

- Optimizations are not currently observable in the test suite
