### PR TITLE
[tests] add type safety tests for vec_pack_n and vec_unpack_n for n > 0

### DIFF
--- a/language/move-bytecode-verifier/transactional-tests/tests/type_safety/vector_ops_type_mismatch.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/type_safety/vector_ops_type_mismatch.exp
@@ -1,4 +1,4 @@
-processed 6 tasks
+processed 8 tasks
 
 task 0 'run'. lines 1-7:
 Error: Script execution failed with VMError: {
@@ -45,11 +45,29 @@ Error: Script execution failed with VMError: {
     offsets: [(FunctionDefinitionIndex(0), 6)],
 }
 
-task 5 'run'. lines 61-75:
+task 5 'run'. lines 61-77:
 Error: Script execution failed with VMError: {
     major_status: STLOC_TYPE_MISMATCH_ERROR,
     sub_status: None,
     location: script,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 1)],
+}
+
+task 6 'run'. lines 78-86:
+Error: Script execution failed with VMError: {
+    major_status: TYPE_MISMATCH,
+    sub_status: None,
+    location: script,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 1)],
+}
+
+task 7 'run'. lines 87-96:
+Error: Script execution failed with VMError: {
+    major_status: TYPE_MISMATCH,
+    sub_status: None,
+    location: script,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 5)],
 }

--- a/language/move-bytecode-verifier/transactional-tests/tests/type_safety/vector_ops_type_mismatch.mvir
+++ b/language/move-bytecode-verifier/transactional-tests/tests/type_safety/vector_ops_type_mismatch.mvir
@@ -73,3 +73,24 @@ label b0:
 
     return;
 }
+
+// push int on the stack, then try to pack into vector of the wrong type
+//# run
+main() {
+    let v: vector<bool>;
+label b0:
+    v = vec_pack_1<bool>(28u8);
+    return;
+}
+
+// create vector<T>, try to unpack into different type
+//# run
+main() {
+    let v: vector<u8>;
+    let x: bool;
+    let y: bool;
+label b0:
+    v = vec_pack_2<u8>(1u8, 0u8);
+    x, y = vec_unpack_2<bool>(move(v));
+    return;
+}


### PR DESCRIPTION
We only have type safety tests for `vec_pack_0` and `vec_unpack_0`
