### PR TITLE
[fuzzing] Add fuzzing infra for bytecode verifier + fix bug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,6 +117,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84450d0b4a8bd1ba4144ce8ce718fbc5d071358b1e5384bace6536b3d1f2d5b3"
 
 [[package]]
+name = "arbitrary"
+version = "1.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d86fd10d912cab78764cc44307d9cd5f164e09abbeb87fb19fb6d95937e8da5f"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -566,6 +575,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "bytecode-verifier-libfuzzer"
+version = "0.0.0"
+dependencies = [
+ "arbitrary",
+ "libfuzzer-sys",
+ "move-binary-format",
+ "move-bytecode-verifier",
+ "move-core-types",
+]
+
+[[package]]
 name = "bytecode-verifier-tests"
 version = "0.1.0"
 dependencies = [
@@ -660,6 +680,9 @@ name = "cc"
 version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c69b077ad434294d3ce9f1f6143a2a4b89a8a2d54ef813d85003a4fd1137fd"
+dependencies = [
+ "jobserver",
+]
 
 [[package]]
 name = "cfg-expr"
@@ -1227,6 +1250,17 @@ name = "derivative"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2 1.0.43",
+ "quote 1.0.9",
+ "syn 1.0.99",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "226ad66541d865d7a7173ad6a9e691c33fdb910ac723f4bc734b3e5294a1f931"
 dependencies = [
  "proc-macro2 1.0.43",
  "quote 1.0.9",
@@ -2552,6 +2586,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
+name = "jobserver"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "068b1ee6743e4d11fb9c6a1e6064b3693a1b600e7f5f5988047d98b3dc9fb90b"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2662,6 +2705,17 @@ name = "libc"
 version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
+
+[[package]]
+name = "libfuzzer-sys"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae185684fe19814afd066da15a7cc41e126886c21282934225d9fc847582da58"
+dependencies = [
+ "arbitrary",
+ "cc",
+ "once_cell",
+]
 
 [[package]]
 name = "libnghttp2-sys"
@@ -2905,6 +2959,7 @@ name = "move-binary-format"
 version = "0.0.3"
 dependencies = [
  "anyhow",
+ "arbitrary",
  "move-core-types",
  "once_cell",
  "proptest",
@@ -3079,6 +3134,7 @@ name = "move-core-types"
 version = "0.0.4"
 dependencies = [
  "anyhow",
+ "arbitrary",
  "bcs",
  "hex",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ members = [
     "language/move-borrow-graph",
     "language/move-bytecode-verifier",
     "language/move-bytecode-verifier/bytecode-verifier-tests",
+    "language/move-bytecode-verifier/fuzz",
     "language/move-bytecode-verifier/invalid-mutations",
     "language/move-bytecode-verifier/transactional-tests",
     "language/move-command-line-common",

--- a/devtools/x-lint/src/runner.rs
+++ b/devtools/x-lint/src/runner.rs
@@ -245,7 +245,7 @@ impl<'cfg> LintEngine<'cfg> {
         // TODO: make global exclusions configurable
         Ok(tracked_files
             .iter()
-            .filter(|f| !f.starts_with("testsuite/diem-fuzzer/artifacts/")))
+            .filter(|f| !f.starts_with("testsuite/diem-bytecode-verifier-fuzzer/artifacts/")))
     }
 }
 

--- a/language/move-binary-format/Cargo.toml
+++ b/language/move-binary-format/Cargo.toml
@@ -16,15 +16,16 @@ proptest = { version = "1.0.0", optional = true }
 proptest-derive = { version = "0.3.0", optional = true }
 ref-cast = "1.0.6"
 variant_count = "1.1.0"
-move-core-types = { path = "../move-core/types", version = "0.0.4" }
+move-core-types = { path = "../move-core/types" }
 serde = { version = "1.0.124", default-features = false }
+arbitrary = { version = "1.1.7", optional = true, features = ["derive"] }
 
 [dev-dependencies]
 proptest = "1.0.0"
 proptest-derive = "0.3.0"
-move-core-types = { path = "../move-core/types", features = ["fuzzing"] }
+move-core-types = { path = "../move-core/types", features = ["fuzzing" ] }
 serde_json = "1.0.64"
 
 [features]
 default = []
-fuzzing = ["proptest", "proptest-derive", "move-core-types/fuzzing"]
+fuzzing = ["proptest", "proptest-derive", "arbitrary", "move-core-types/fuzzing"]

--- a/language/move-binary-format/src/check_bounds.rs
+++ b/language/move-binary-format/src/check_bounds.rs
@@ -11,14 +11,13 @@ use crate::{
     file_format::{
         AbilitySet, Bytecode, CodeOffset, CodeUnit, CompiledModule, CompiledScript, Constant,
         FieldHandle, FieldInstantiation, FunctionDefinition, FunctionDefinitionIndex,
-        FunctionHandle, FunctionInstantiation, ModuleHandle, Signature, SignatureToken,
+        FunctionHandle, FunctionInstantiation, LocalIndex, ModuleHandle, Signature, SignatureToken,
         StructDefInstantiation, StructDefinition, StructFieldInformation, StructHandle, TableIndex,
     },
     internals::ModuleIndex,
     IndexKind,
 };
 use move_core_types::vm_status::StatusCode;
-use std::u8;
 
 enum BoundsCheckingContext {
     Module,
@@ -347,7 +346,7 @@ impl<'a> BoundsChecker<'a> {
             .len()
             .saturating_add(parameters.len());
 
-        if locals_count > (u8::MAX as usize) + 1 {
+        if locals_count > LocalIndex::MAX as usize {
             return Err(verification_error(
                 StatusCode::TOO_MANY_LOCALS,
                 IndexKind::FunctionDefinition,
@@ -367,7 +366,7 @@ impl<'a> BoundsChecker<'a> {
         check_bounds_impl(self.view.signatures(), code_unit.locals)?;
 
         let locals = self.get_locals(code_unit)?;
-        // Use saturating add for stability; range checked above
+        // Use saturating add for stability
         let locals_count = locals.len().saturating_add(parameters.len());
 
         // if there are locals check that the type parameters in local signature are in bounds.

--- a/language/move-binary-format/src/file_format.rs
+++ b/language/move-binary-format/src/file_format.rs
@@ -43,8 +43,6 @@ use move_core_types::{
 };
 #[cfg(any(test, feature = "fuzzing"))]
 use proptest::{collection::vec, prelude::*, strategy::BoxedStrategy};
-#[cfg(any(test, feature = "fuzzing"))]
-use proptest_derive::Arbitrary;
 use ref_cast::RefCast;
 use serde::{Deserialize, Serialize};
 use std::ops::BitOr;
@@ -60,8 +58,9 @@ macro_rules! define_index {
         doc: $comment: literal,
     } => {
         #[derive(Clone, Copy, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
-        #[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
+        #[cfg_attr(any(test, feature = "fuzzing"), derive(proptest_derive::Arbitrary))]
         #[cfg_attr(any(test, feature = "fuzzing"), proptest(no_params))]
+        #[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
         #[doc=$comment]
         pub struct $name(pub TableIndex);
 
@@ -216,8 +215,9 @@ pub const NO_TYPE_ARGUMENTS: SignatureIndex = SignatureIndex(0);
 /// Type definitions (fields) are private to the module. Outside the module a
 /// Type is an opaque handle.
 #[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
-#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(proptest_derive::Arbitrary))]
 #[cfg_attr(any(test, feature = "fuzzing"), proptest(no_params))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 pub struct ModuleHandle {
     /// Index into the `AddressIdentifierIndex`. Identifies module-holding account's address.
     pub address: AddressIdentifierIndex,
@@ -239,8 +239,9 @@ pub struct ModuleHandle {
 /// At link time ability/constraint checking is performed and an error is reported if there is a
 /// mismatch with the definition.
 #[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
-#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(proptest_derive::Arbitrary))]
 #[cfg_attr(any(test, feature = "fuzzing"), proptest(no_params))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 pub struct StructHandle {
     /// The module that defines the type.
     pub module: ModuleHandleIndex,
@@ -262,8 +263,9 @@ impl StructHandle {
 
 /// A type parameter used in the declaration of a struct.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize, Deserialize)]
-#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(proptest_derive::Arbitrary))]
 #[cfg_attr(any(test, feature = "fuzzing"), proptest(no_params))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 pub struct StructTypeParameter {
     /// The type parameter constraints.
     pub constraints: AbilitySet,
@@ -279,8 +281,9 @@ pub struct StructTypeParameter {
 /// ensure the function reference is valid and it is also used by the verifier to type check
 /// function calls.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
-#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(proptest_derive::Arbitrary))]
 #[cfg_attr(any(test, feature = "fuzzing"), proptest(params = "usize"))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 pub struct FunctionHandle {
     /// The module that defines the function.
     pub module: ModuleHandleIndex,
@@ -296,8 +299,9 @@ pub struct FunctionHandle {
 
 /// A field access info (owner type and offset)
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
-#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(proptest_derive::Arbitrary))]
 #[cfg_attr(any(test, feature = "fuzzing"), proptest(no_params))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 pub struct FieldHandle {
     pub owner: StructDefinitionIndex,
     pub field: MemberCount,
@@ -308,8 +312,9 @@ pub struct FieldHandle {
 
 /// `StructFieldInformation` indicates whether a struct is native or has user-specified fields
 #[derive(Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(proptest_derive::Arbitrary))]
 #[cfg_attr(any(test, feature = "fuzzing"), proptest(no_params))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 pub enum StructFieldInformation {
     Native,
     Declared(Vec<FieldDefinition>),
@@ -325,8 +330,9 @@ pub enum StructFieldInformation {
 
 /// A complete or partial instantiation of a generic struct
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
-#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(proptest_derive::Arbitrary))]
 #[cfg_attr(any(test, feature = "fuzzing"), proptest(no_params))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 pub struct StructDefInstantiation {
     pub def: StructDefinitionIndex,
     pub type_parameters: SignatureIndex,
@@ -334,8 +340,9 @@ pub struct StructDefInstantiation {
 
 /// A complete or partial instantiation of a function
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
-#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(proptest_derive::Arbitrary))]
 #[cfg_attr(any(test, feature = "fuzzing"), proptest(no_params))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 pub struct FunctionInstantiation {
     pub handle: FunctionHandleIndex,
     pub type_parameters: SignatureIndex,
@@ -348,8 +355,9 @@ pub struct FunctionInstantiation {
 /// E.g. for `S<u8, bool>.f` where `f` is a field of any type, `instantiation`
 /// would be `[u8, boo]`
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
-#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(proptest_derive::Arbitrary))]
 #[cfg_attr(any(test, feature = "fuzzing"), proptest(no_params))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 pub struct FieldInstantiation {
     pub handle: FieldHandleIndex,
     pub type_parameters: SignatureIndex,
@@ -358,8 +366,9 @@ pub struct FieldInstantiation {
 /// A `StructDefinition` is a type definition. It either indicates it is native or defines all the
 /// user-specified fields declared on the type.
 #[derive(Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(proptest_derive::Arbitrary))]
 #[cfg_attr(any(test, feature = "fuzzing"), proptest(no_params))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 pub struct StructDefinition {
     /// The `StructHandle` for this `StructDefinition`. This has the name and the abilities
     /// for the type.
@@ -390,8 +399,9 @@ impl StructDefinition {
 
 /// A `FieldDefinition` is the definition of a field: its name and the field type.
 #[derive(Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(proptest_derive::Arbitrary))]
 #[cfg_attr(any(test, feature = "fuzzing"), proptest(no_params))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 pub struct FieldDefinition {
     /// The name of the field.
     pub name: IdentifierIndex,
@@ -402,8 +412,9 @@ pub struct FieldDefinition {
 /// `Visibility` restricts the accessibility of the associated entity.
 /// - For function visibility, it restricts who may call into the associated function.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Ord, Serialize, Deserialize)]
-#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(proptest_derive::Arbitrary))]
 #[cfg_attr(any(test, feature = "fuzzing"), proptest(no_params))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 #[repr(u8)]
 pub enum Visibility {
     /// Accessible within its defining module only.
@@ -443,8 +454,9 @@ impl std::convert::TryFrom<u8> for Visibility {
 /// A `FunctionDefinition` is the implementation of a function. It defines
 /// the *prototype* of the function and the function body.
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
-#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(proptest_derive::Arbitrary))]
 #[cfg_attr(any(test, feature = "fuzzing"), proptest(params = "usize"))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 pub struct FunctionDefinition {
     /// The prototype of the function (module, name, signature).
     pub function: FunctionHandleIndex,
@@ -495,16 +507,18 @@ impl FunctionDefinition {
 /// A type definition. `SignatureToken` allows the definition of the set of known types and their
 /// composition.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
-#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(proptest_derive::Arbitrary))]
 #[cfg_attr(any(test, feature = "fuzzing"), proptest(no_params))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 pub struct TypeSignature(pub SignatureToken);
 
 // TODO: remove at some point or move it in the front end (language/move-ir-compiler)
 /// A `FunctionSignature` in internally used to create a unique representation of the overall
 /// signature as need. Consider deprecated...
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
-#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(proptest_derive::Arbitrary))]
 #[cfg_attr(any(test, feature = "fuzzing"), proptest(params = "usize"))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 pub struct FunctionSignature {
     /// The list of return types.
     #[cfg_attr(
@@ -527,8 +541,9 @@ pub struct FunctionSignature {
 /// Locals include the arguments to the function from position `0` to argument `count - 1`.
 /// The remaining elements are the type of each local.
 #[derive(Clone, Debug, Default, Eq, Hash, PartialEq, Ord, PartialOrd)]
-#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(proptest_derive::Arbitrary))]
 #[cfg_attr(any(test, feature = "fuzzing"), proptest(params = "usize"))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 pub struct Signature(
     #[cfg_attr(
         any(test, feature = "fuzzing"),
@@ -558,7 +573,8 @@ pub type TypeParameterIndex = u16;
 /// An `Ability` classifies what operations are permitted for a given type
 #[repr(u8)]
 #[derive(Debug, Clone, Eq, Copy, Hash, Ord, PartialEq, PartialOrd)]
-#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(proptest_derive::Arbitrary))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 pub enum Ability {
     /// Allows values of types with this ability to be copied, via CopyLoc or ReadRef
     Copy = 0x1,
@@ -609,6 +625,7 @@ impl Ability {
 
 /// A set of `Ability`s
 #[derive(Clone, Eq, Copy, Hash, Ord, PartialEq, PartialOrd, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 pub struct AbilitySet(u8);
 
 impl AbilitySet {
@@ -816,6 +833,7 @@ impl Arbitrary for AbilitySet {
 /// A SignatureToken can express more types than the VM can handle safely, and correctness is
 /// enforced by the verifier.
 #[derive(Clone, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 pub enum SignatureToken {
     /// Boolean, `true` or `false`.
     Bool,
@@ -1076,6 +1094,7 @@ impl SignatureToken {
 /// A `Constant` is a serialized value along with its type. That type will be deserialized by the
 /// loader/evauluator
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 pub struct Constant {
     pub type_: SignatureToken,
     pub data: Vec<u8>,
@@ -1083,8 +1102,9 @@ pub struct Constant {
 
 /// A `CodeUnit` is the body of a function. It has the function header and the instruction stream.
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
-#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(proptest_derive::Arbitrary))]
 #[cfg_attr(any(test, feature = "fuzzing"), proptest(params = "usize"))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 pub struct CodeUnit {
     /// List of locals type. All locals are typed.
     pub locals: SignatureIndex,
@@ -1102,8 +1122,9 @@ pub struct CodeUnit {
 /// Bytecodes operate on a stack machine and each bytecode has side effect on the stack and the
 /// instruction stream.
 #[derive(Clone, Hash, Eq, VariantCount, PartialEq)]
-#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(proptest_derive::Arbitrary))]
 #[cfg_attr(any(test, feature = "fuzzing"), proptest(no_params))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 pub enum Bytecode {
     /// Pop and discard the value at the top of the stack.
     /// The value on the stack must be an copyable type.
@@ -1746,6 +1767,7 @@ impl CompiledScript {
 ///
 /// A module is published as a single entry and it is retrieved as a single blob.
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 pub struct CompiledModule {
     /// Version number found during deserialization
     pub version: u32,

--- a/language/move-bytecode-verifier/fuzz/.gitignore
+++ b/language/move-bytecode-verifier/fuzz/.gitignore
@@ -1,0 +1,3 @@
+target
+corpus
+artifacts

--- a/language/move-bytecode-verifier/fuzz/Cargo.toml
+++ b/language/move-bytecode-verifier/fuzz/Cargo.toml
@@ -1,0 +1,39 @@
+[package]
+name = "bytecode-verifier-libfuzzer"
+version = "0.0.0"
+authors = ["Diem Association <opensource@diem.com>"]
+license = "Apache-2.0"
+publish = false
+edition = "2018"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+arbitrary = "1.1.7"
+move-bytecode-verifier = { path = "../" }
+move-core-types = { path = "../../move-core/types", features = ["fuzzing"] }
+move-binary-format = { path = "../../move-binary-format", features = ["fuzzing"] }
+
+# Prevent this from interfering with workspaces
+#[workspace]
+#members = ["."]
+
+[[bin]]
+name = "code_unit"
+path = "fuzz_targets/code_unit.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "compiled_module"
+path = "fuzz_targets/compiled_module.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "mixed"
+path = "fuzz_targets/mixed.rs"
+test = false
+doc = false

--- a/language/move-bytecode-verifier/fuzz/README.md
+++ b/language/move-bytecode-verifier/fuzz/README.md
@@ -1,0 +1,4 @@
+See the [Rust fuzzing book](https://rust-fuzz.github.io/book/)
+for how to use the fuzz targets in this directory. Notice that
+`cargo +nightly fuzz run <target>` need to be executed in the parent
+directory; nightly is required.

--- a/language/move-bytecode-verifier/fuzz/fuzz_targets/code_unit.rs
+++ b/language/move-bytecode-verifier/fuzz/fuzz_targets/code_unit.rs
@@ -1,0 +1,83 @@
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#![no_main]
+use move_binary_format::file_format::{
+    empty_module, AbilitySet, CodeUnit, Constant, FieldDefinition, FunctionDefinition,
+    FunctionHandle, FunctionHandleIndex, IdentifierIndex, ModuleHandleIndex, Signature,
+    SignatureIndex,
+    SignatureToken::{Address, Bool, U128, U64},
+    StructDefinition, StructFieldInformation, StructHandle, StructHandleIndex, TypeSignature,
+    Visibility,
+};
+use move_core_types::{account_address::AccountAddress, identifier::Identifier};
+use std::str::FromStr;
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|code_unit: CodeUnit| {
+    let mut module = empty_module();
+    module.version = 5;
+
+    module.struct_handles.push(StructHandle {
+        module: ModuleHandleIndex(0),
+        name: IdentifierIndex(1),
+        abilities: AbilitySet::ALL,
+        type_parameters: vec![],
+    });
+
+    let fun_handle = FunctionHandle {
+        module: ModuleHandleIndex(0),
+        name: IdentifierIndex(2),
+        parameters: SignatureIndex(0),
+        return_: SignatureIndex(1),
+        type_parameters: vec![],
+    };
+
+    module.function_handles.push(fun_handle);
+
+    module.signatures.pop();
+    module.signatures.push(Signature(vec![
+        Address, U64, Address, Address, U128, Address, U64, U64, U64,
+    ]));
+    module.signatures.push(Signature(vec![]));
+    module
+        .signatures
+        .push(Signature(vec![Address, Bool, Address]));
+
+    module.identifiers.extend(
+        vec![
+            Identifier::from_str("zf_hello_world").unwrap(),
+            Identifier::from_str("awldFnU18mlDKQfh6qNfBGx8X").unwrap(),
+            Identifier::from_str("aQPwJNHyAHpvJ").unwrap(),
+            Identifier::from_str("aT7ZphKTrKcYCwCebJySrmrKlckmnL5").unwrap(),
+            Identifier::from_str("arYpsFa2fvrpPJ").unwrap(),
+        ]
+        .into_iter(),
+    );
+    module.address_identifiers.push(AccountAddress::random());
+
+    module.constant_pool.push(Constant {
+        type_: Address,
+        data: AccountAddress::ZERO.into_bytes().to_vec(),
+    });
+
+    module.struct_defs.push(StructDefinition {
+        struct_handle: StructHandleIndex(0),
+        field_information: StructFieldInformation::Declared(vec![FieldDefinition {
+            name: IdentifierIndex::new(3),
+            signature: TypeSignature(Address),
+        }]),
+    });
+
+    let fun_def = FunctionDefinition {
+        code: Some(code_unit),
+        function: FunctionHandleIndex(0),
+        visibility: Visibility::Public,
+        is_entry: false,
+        acquires_global_resources: vec![],
+    };
+
+    module.function_defs.push(fun_def);
+    let _ = move_bytecode_verifier::verify_module(&module);
+});

--- a/language/move-bytecode-verifier/fuzz/fuzz_targets/compiled_module.rs
+++ b/language/move-bytecode-verifier/fuzz/fuzz_targets/compiled_module.rs
@@ -1,0 +1,10 @@
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+use move_binary_format::file_format::CompiledModule;
+
+fuzz_target!(|module: CompiledModule| {
+    let _ = move_bytecode_verifier::verify_module(&module);
+});

--- a/language/move-bytecode-verifier/fuzz/fuzz_targets/mixed.rs
+++ b/language/move-bytecode-verifier/fuzz/fuzz_targets/mixed.rs
@@ -1,0 +1,97 @@
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#![no_main]
+use move_binary_format::file_format::{
+    empty_module, AbilitySet, Bytecode, CodeUnit, Constant, FieldDefinition, FunctionDefinition,
+    FunctionHandle, FunctionHandleIndex, IdentifierIndex, ModuleHandleIndex, Signature,
+    SignatureIndex, SignatureToken,
+    SignatureToken::{Address, Bool},
+    StructDefinition, StructFieldInformation, StructHandle, StructHandleIndex, TypeSignature,
+    Visibility,
+};
+use move_core_types::{account_address::AccountAddress, identifier::Identifier};
+use std::str::FromStr;
+
+use arbitrary::Arbitrary;
+use libfuzzer_sys::fuzz_target;
+
+#[derive(Arbitrary, Debug)]
+struct Mixed {
+    code: Vec<Bytecode>,
+    abilities: AbilitySet,
+    param_types: Vec<SignatureToken>,
+    return_type: Option<SignatureToken>,
+}
+
+fuzz_target!(|mix: Mixed| {
+    let mut module = empty_module();
+    module.version = 5;
+
+    module.struct_handles.push(StructHandle {
+        module: ModuleHandleIndex(0),
+        name: IdentifierIndex(1),
+        abilities: mix.abilities,
+        type_parameters: vec![],
+    });
+
+    let fun_handle = FunctionHandle {
+        module: ModuleHandleIndex(0),
+        name: IdentifierIndex(2),
+        parameters: SignatureIndex(0),
+        return_: SignatureIndex(1),
+        type_parameters: vec![],
+    };
+
+    module.function_handles.push(fun_handle);
+
+    module.signatures.pop();
+    module.signatures.push(Signature(mix.param_types));
+    module.signatures.push(Signature(
+        mix.return_type.map(|s| vec![s]).unwrap_or_default(),
+    ));
+    module
+        .signatures
+        .push(Signature(vec![Address, Bool, Address]));
+
+    module.identifiers.extend(
+        vec![
+            Identifier::from_str("zf_hello_world").unwrap(),
+            Identifier::from_str("awldFnU18mlDKQfh6qNfBGx8X").unwrap(),
+            Identifier::from_str("aQPwJNHyAHpvJ").unwrap(),
+            Identifier::from_str("aT7ZphKTrKcYCwCebJySrmrKlckmnL5").unwrap(),
+            Identifier::from_str("arYpsFa2fvrpPJ").unwrap(),
+        ]
+        .into_iter(),
+    );
+    module.address_identifiers.push(AccountAddress::random());
+
+    module.constant_pool.push(Constant {
+        type_: Address,
+        data: AccountAddress::ZERO.into_bytes().to_vec(),
+    });
+
+    module.struct_defs.push(StructDefinition {
+        struct_handle: StructHandleIndex(0),
+        field_information: StructFieldInformation::Declared(vec![FieldDefinition {
+            name: IdentifierIndex::new(3),
+            signature: TypeSignature(Address),
+        }]),
+    });
+
+    let code_unit = CodeUnit {
+        code: mix.code,
+        locals: SignatureIndex(0),
+    };
+
+    let fun_def = FunctionDefinition {
+        code: Some(code_unit),
+        function: FunctionHandleIndex(0),
+        visibility: Visibility::Public,
+        is_entry: false,
+        acquires_global_resources: vec![],
+    };
+
+    module.function_defs.push(fun_def);
+    let _ = move_bytecode_verifier::verify_module(&module);
+});

--- a/language/move-bytecode-verifier/src/regression_tests/reference_analysis.rs
+++ b/language/move-bytecode-verifier/src/regression_tests/reference_analysis.rs
@@ -1,106 +1,166 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#[test]
-fn reference_analysis_crash() {
-    use move_binary_format::file_format::{
-        empty_module, AbilitySet,
-        Bytecode::{BrTrue, LdFalse, MoveLoc, MutBorrowGlobal, Pop, Ret},
-        CodeUnit, Constant, FieldDefinition, FunctionDefinition, FunctionHandle,
-        FunctionHandleIndex, IdentifierIndex, ModuleHandleIndex, Signature, SignatureIndex,
-        SignatureToken::{Address, Bool, U128, U64},
-        StructDefinition, StructDefinitionIndex, StructFieldInformation, StructHandle,
-        StructHandleIndex, TypeSignature, Visibility,
+#[cfg(test)]
+mod tests {
+    use move_binary_format::{
+        file_format::{
+            empty_module, AbilitySet, AddressIdentifierIndex, Bytecode::*, CodeUnit, Constant,
+            FieldDefinition, FunctionDefinition, FunctionHandle, FunctionHandleIndex,
+            IdentifierIndex, ModuleHandle, ModuleHandleIndex, Signature, SignatureIndex,
+            SignatureToken::*, StructDefinition, StructDefinitionIndex, StructFieldInformation,
+            StructHandle, StructHandleIndex, TypeSignature, Visibility, Visibility::*,
+        },
+        CompiledModule,
     };
     use move_core_types::{
         account_address::AccountAddress, identifier::Identifier, vm_status::StatusCode,
     };
     use std::str::FromStr;
 
-    let mut module = empty_module();
-    module.version = 5;
+    #[test]
+    fn unbalanced_stack_crash() {
+        let mut module = empty_module();
+        module.version = 5;
 
-    module.struct_handles.push(StructHandle {
-        module: ModuleHandleIndex(0),
-        name: IdentifierIndex(1),
-        abilities: AbilitySet::ALL,
-        type_parameters: vec![],
-    });
+        module.struct_handles.push(StructHandle {
+            module: ModuleHandleIndex(0),
+            name: IdentifierIndex(1),
+            abilities: AbilitySet::ALL,
+            type_parameters: vec![],
+        });
 
-    let fun_handle = FunctionHandle {
-        module: ModuleHandleIndex(0),
-        name: IdentifierIndex(2),
-        parameters: SignatureIndex(0),
-        return_: SignatureIndex(1),
-        type_parameters: vec![],
-    };
+        let fun_handle = FunctionHandle {
+            module: ModuleHandleIndex(0),
+            name: IdentifierIndex(2),
+            parameters: SignatureIndex(0),
+            return_: SignatureIndex(1),
+            type_parameters: vec![],
+        };
 
-    module.function_handles.push(fun_handle);
+        module.function_handles.push(fun_handle);
 
-    module.signatures.pop();
-    module.signatures.push(Signature(vec![
-        Address, U64, Address, Address, U128, Address, U64, U64, U64,
-    ]));
-    module.signatures.push(Signature(vec![]));
-    module
-        .signatures
-        .push(Signature(vec![Address, Bool, Address]));
+        module.signatures.pop();
+        module.signatures.push(Signature(vec![
+            Address, U64, Address, Address, U128, Address, U64, U64, U64,
+        ]));
+        module.signatures.push(Signature(vec![]));
+        module
+            .signatures
+            .push(Signature(vec![Address, Bool, Address]));
 
-    module.identifiers.extend(
-        vec![
-            Identifier::from_str("zf_hello_world").unwrap(),
-            Identifier::from_str("awldFnU18mlDKQfh6qNfBGx8X").unwrap(),
-            Identifier::from_str("aQPwJNHyAHpvJ").unwrap(),
-            Identifier::from_str("aT7ZphKTrKcYCwCebJySrmrKlckmnL5").unwrap(),
-            Identifier::from_str("arYpsFa2fvrpPJ").unwrap(),
-        ]
-        .into_iter(),
-    );
-    module.address_identifiers.push(AccountAddress::random());
+        module.identifiers.extend(
+            vec![
+                Identifier::from_str("zf_hello_world").unwrap(),
+                Identifier::from_str("awldFnU18mlDKQfh6qNfBGx8X").unwrap(),
+                Identifier::from_str("aQPwJNHyAHpvJ").unwrap(),
+                Identifier::from_str("aT7ZphKTrKcYCwCebJySrmrKlckmnL5").unwrap(),
+                Identifier::from_str("arYpsFa2fvrpPJ").unwrap(),
+            ]
+            .into_iter(),
+        );
+        module.address_identifiers.push(AccountAddress::random());
 
-    module.constant_pool.push(Constant {
-        type_: Address,
-        data: AccountAddress::ZERO.into_bytes().to_vec(),
-    });
+        module.constant_pool.push(Constant {
+            type_: Address,
+            data: AccountAddress::ZERO.into_bytes().to_vec(),
+        });
 
-    module.struct_defs.push(StructDefinition {
-        struct_handle: StructHandleIndex(0),
-        field_information: StructFieldInformation::Declared(vec![FieldDefinition {
-            name: IdentifierIndex::new(3),
-            signature: TypeSignature(Address),
-        }]),
-    });
+        module.struct_defs.push(StructDefinition {
+            struct_handle: StructHandleIndex(0),
+            field_information: StructFieldInformation::Declared(vec![FieldDefinition {
+                name: IdentifierIndex::new(3),
+                signature: TypeSignature(Address),
+            }]),
+        });
 
-    let code_unit = CodeUnit {
-        code: vec![
-            LdFalse,
-            BrTrue(13),
-            MoveLoc(3),
-            MutBorrowGlobal(StructDefinitionIndex(0)),
-            MoveLoc(6),
-            Pop,
-            MoveLoc(5),
-            MutBorrowGlobal(StructDefinitionIndex(0)),
-            MoveLoc(0),
-            MutBorrowGlobal(StructDefinitionIndex(0)),
-            Pop,
-            Pop,
-            Pop,
-            Ret,
-        ],
-        locals: SignatureIndex::new(2),
-    };
-    let fun_def = FunctionDefinition {
-        code: Some(code_unit),
-        function: FunctionHandleIndex(0),
-        visibility: Visibility::Public,
-        is_entry: false,
-        acquires_global_resources: vec![],
-    };
+        let code_unit = CodeUnit {
+            code: vec![
+                LdFalse,
+                BrTrue(13),
+                MoveLoc(3),
+                MutBorrowGlobal(StructDefinitionIndex(0)),
+                MoveLoc(6),
+                Pop,
+                MoveLoc(5),
+                MutBorrowGlobal(StructDefinitionIndex(0)),
+                MoveLoc(0),
+                MutBorrowGlobal(StructDefinitionIndex(0)),
+                Pop,
+                Pop,
+                Pop,
+                Ret,
+            ],
+            locals: SignatureIndex::new(2),
+        };
+        let fun_def = FunctionDefinition {
+            code: Some(code_unit),
+            function: FunctionHandleIndex(0),
+            visibility: Visibility::Public,
+            is_entry: false,
+            acquires_global_resources: vec![],
+        };
 
-    module.function_defs.push(fun_def);
-    match crate::verify_module(&module) {
-        Ok(_) => {}
-        Err(e) => assert_eq!(e.major_status(), StatusCode::GLOBAL_REFERENCE_ERROR),
+        module.function_defs.push(fun_def);
+        match crate::verify_module(&module) {
+            Ok(_) => {}
+            Err(e) => assert_eq!(e.major_status(), StatusCode::GLOBAL_REFERENCE_ERROR),
+        }
+    }
+
+    #[test]
+    fn too_many_locals() {
+        // Create a signature of 128 elements. This will be used both for locals and parameters,
+        // thus the overall size will be 256. If this is not intercepted in bounds checks,
+        // as a result the following iterator in abstract state
+        // would be empty, breaking reference analysis: `0..self.num_locals as LocalIndex`
+        // (since LocalIndex is u8).
+        let sign_128 = (0..128)
+            .map(|_| Reference(Box::new(U64)))
+            .collect::<Vec<_>>();
+        let module = CompiledModule {
+            version: 5,
+            self_module_handle_idx: ModuleHandleIndex(0),
+            module_handles: vec![ModuleHandle {
+                address: AddressIdentifierIndex(0),
+                name: IdentifierIndex(0),
+            }],
+            struct_handles: vec![],
+            function_handles: vec![FunctionHandle {
+                module: ModuleHandleIndex(0),
+                name: IdentifierIndex(0),
+                parameters: SignatureIndex(0),
+                return_: SignatureIndex(0),
+                type_parameters: vec![AbilitySet::ALL],
+            }],
+            field_handles: vec![],
+            friend_decls: vec![],
+            struct_def_instantiations: vec![],
+            function_instantiations: vec![],
+            field_instantiations: vec![],
+            signatures: vec![Signature(sign_128)],
+            identifiers: vec![Identifier::new("x").unwrap()],
+            address_identifiers: vec![AccountAddress::ONE],
+            constant_pool: vec![],
+            metadata: vec![],
+            struct_defs: vec![],
+            function_defs: vec![FunctionDefinition {
+                function: FunctionHandleIndex(0),
+                visibility: Public,
+                is_entry: true,
+                acquires_global_resources: vec![],
+                code: Some(CodeUnit {
+                    locals: SignatureIndex(0),
+                    code: vec![CopyLoc(2), StLoc(33), Branch(0)],
+                }),
+            }],
+        };
+
+        let res = crate::verify_module(&module);
+
+        match res {
+            Ok(_) => {}
+            Err(e) => assert_eq!(e.major_status(), StatusCode::TOO_MANY_LOCALS),
+        }
     }
 }

--- a/language/move-bytecode-verifier/transactional-tests/tests/check_bounds/128_params_and_128_locals.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/check_bounds/128_params_and_128_locals.exp
@@ -1,1 +1,10 @@
 processed 1 task
+
+task 0 'publish'. lines 1-265:
+Error: Unable to publish module '00000000000000000000000000000001::M'. Got VMError: {
+    major_status: TOO_MANY_LOCALS,
+    sub_status: None,
+    location: undefined,
+    indices: [(FunctionDefinition, 0)],
+    offsets: [],
+}

--- a/language/move-bytecode-verifier/transactional-tests/tests/check_bounds/128_params_and_128_locals.mvir
+++ b/language/move-bytecode-verifier/transactional-tests/tests/check_bounds/128_params_and_128_locals.mvir
@@ -262,4 +262,4 @@ module 0x1.M {
         return;
     }
 }
-// check: "Keep(EXECUTED)"
+// check: TOO_MANY_LOCALS

--- a/language/move-bytecode-verifier/transactional-tests/tests/check_bounds/1_param_and_255_locals.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/check_bounds/1_param_and_255_locals.exp
@@ -1,1 +1,10 @@
 processed 1 task
+
+task 0 'publish'. lines 1-264:
+Error: Unable to publish module '00000000000000000000000000000001::M'. Got VMError: {
+    major_status: TOO_MANY_LOCALS,
+    sub_status: None,
+    location: undefined,
+    indices: [(FunctionDefinition, 0)],
+    offsets: [],
+}

--- a/language/move-bytecode-verifier/transactional-tests/tests/check_bounds/1_param_and_255_locals.mvir
+++ b/language/move-bytecode-verifier/transactional-tests/tests/check_bounds/1_param_and_255_locals.mvir
@@ -260,3 +260,5 @@ module 0x1.M {
         return;
     }
 }
+
+// check: TOO_MANY_LOCALS

--- a/language/move-core/types/Cargo.toml
+++ b/language/move-core/types/Cargo.toml
@@ -20,6 +20,7 @@ rand = "0.8.3"
 ref-cast = "1.0.6"
 serde = { version = "1.0.124", default-features = false }
 serde_bytes = "0.11.5"
+arbitrary = { version = "1.1.7", features = [ "derive_arbitrary"], optional = true }
 
 [dev-dependencies]
 proptest = "1.0.0"
@@ -31,4 +32,4 @@ serde_json = "1.0.64"
 address20 = []
 address32 = []
 default = []
-fuzzing = ["proptest", "proptest-derive"]
+fuzzing = ["proptest", "proptest-derive", "arbitrary"]

--- a/language/move-core/types/src/account_address.rs
+++ b/language/move-core/types/src/account_address.rs
@@ -10,6 +10,7 @@ use std::{convert::TryFrom, fmt, str::FromStr};
 /// A struct that represents an account address.
 #[derive(Ord, PartialOrd, Eq, PartialEq, Hash, Clone, Copy)]
 #[cfg_attr(any(test, feature = "fuzzing"), derive(proptest_derive::Arbitrary))]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(arbitrary::Arbitrary))]
 pub struct AccountAddress([u8; AccountAddress::LENGTH]);
 
 impl AccountAddress {

--- a/language/move-core/types/src/identifier.rs
+++ b/language/move-core/types/src/identifier.rs
@@ -89,6 +89,7 @@ pub(crate) static ALLOWED_NO_SELF_IDENTIFIERS: &str =
 ///
 /// For more details, see the module level documentation.
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 pub struct Identifier(Box<str>);
 // An identifier cannot be mutated so use Box<str> instead of String -- it is 1 word smaller.
 

--- a/language/move-core/types/src/metadata.rs
+++ b/language/move-core/types/src/metadata.rs
@@ -3,6 +3,7 @@
 
 /// Representation of metadata,
 #[derive(Clone, PartialEq, Eq, Debug)]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 pub struct Metadata {
     /// The key identifying the type of metadata.
     pub key: Vec<u8>,

--- a/x.toml
+++ b/x.toml
@@ -113,6 +113,7 @@ members = [
     # Please keep this list in alphabetical order!
 
     "bytecode-interpreter-testsuite",
+    "bytecode-verifier-libfuzzer",
     "bytecode-verifier-tests",
     "bytecode-verifier-transactional-tests",
     "df-cli",


### PR DESCRIPTION
This adds a fuzzing crate and a few targets for `CompileModule` to the bytecode verifier. The rather rudimentary `cargo-fuzz` is used ([see here](https://rust-fuzz.github.io/book)) as the more sophisticated tools like `honggfuzz` don't work on Apple silicon. Using this (and other fuzzing tools) requires to derive `arbitray::Arbitray` (not to be mistaken with proptests `Arbitrary`) which allows to derive values from bit images, as the fuzzer produces.

This fuzzer infra was capable to find a recent (already fixed) bug in stack balancing in reference analysis, caused by continuing analysis after an error occured. It also discovered (for now) the following new bug: if the number of locals + parameters is larger than 255 certain analysis will go wrong, as `type LocalIndex = u8`. This was discovered since reference analysis uses `0..self.locals as LocalIndex` to iterate over locals, which reduces to `0..0`. It appeared that bounds check actually does not check whether the number of locals + parameters in range, which was added in this PR.
