### PR TITLE
[move] Restrict size of type terms

### DIFF
--- a/language/move-binary-format/src/normalized.rs
+++ b/language/move-binary-format/src/normalized.rs
@@ -280,7 +280,10 @@ impl Struct {
     pub fn new(m: &CompiledModule, def: &StructDefinition) -> (Identifier, Self) {
         let handle = m.struct_handle_at(def.struct_handle);
         let fields = match &def.field_information {
-            StructFieldInformation::Native => panic!("Can't extract for native struct"),
+            StructFieldInformation::Native => {
+                // Pretend for compatibility checking no fields
+                vec![]
+            }
             StructFieldInformation::Declared(fields) => {
                 fields.iter().map(|f| Field::new(m, f)).collect()
             }

--- a/language/move-core/types/src/vm_status.rs
+++ b/language/move-core/types/src/vm_status.rs
@@ -668,6 +668,7 @@ pub enum StatusCode {
     VM_EXTENSION_ERROR = 4026,
     STORAGE_WRITE_LIMIT_REACHED = 4027,
     MEMORY_LIMIT_EXCEEDED = 4028,
+    VM_MAX_TYPE_NODES_REACHED = 4029,
 
     // A reserved status to represent an unknown vm status.
     // this is std::u64::MAX, but we can't pattern match on that, so put the hardcoded value in

--- a/language/move-vm/transactional-tests/tests/recursion/runtime_type_many_nodes.exp
+++ b/language/move-vm/transactional-tests/tests/recursion/runtime_type_many_nodes.exp
@@ -1,0 +1,10 @@
+processed 2 tasks
+
+task 1 'run'. lines 17-53:
+Error: Script execution failed with VMError: {
+    major_status: VM_MAX_TYPE_DEPTH_REACHED,
+    sub_status: None,
+    location: 0x42::M,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(1), 1)],
+}

--- a/language/move-vm/transactional-tests/tests/recursion/runtime_type_many_nodes.exp
+++ b/language/move-vm/transactional-tests/tests/recursion/runtime_type_many_nodes.exp
@@ -2,7 +2,7 @@ processed 2 tasks
 
 task 1 'run'. lines 17-53:
 Error: Script execution failed with VMError: {
-    major_status: VM_MAX_TYPE_DEPTH_REACHED,
+    major_status: VM_MAX_TYPE_NODES_REACHED,
     sub_status: None,
     location: 0x42::M,
     indices: [],

--- a/language/move-vm/transactional-tests/tests/recursion/runtime_type_many_nodes.mvir
+++ b/language/move-vm/transactional-tests/tests/recursion/runtime_type_many_nodes.mvir
@@ -1,0 +1,53 @@
+//# publish
+module 0x42.M {
+    struct Foo<phantom T, phantom R, phantom S> has key, store, drop { x: bool }
+    public f<X>() acquires Foo {
+      label b0:
+        Self.g<X, X, X>();
+        return;
+    }
+    public g<X, Y, Z>() acquires Foo {
+      label b0:
+      _ = move_from<Foo<X, Y, Z>>(0x1);
+      return;
+    }
+}
+// check: "Keep(EXECUTED)"
+
+//# run
+import 0x42.M;
+
+main() {
+label b0:
+    M.f<
+    M.Foo<
+    M.Foo<
+    M.Foo<
+    M.Foo<
+    M.Foo<
+    M.Foo<
+    M.Foo<
+    M.Foo<
+    M.Foo<
+    M.Foo<
+    M.Foo<
+    M.Foo<
+    M.Foo<
+    M.Foo<
+    M.Foo<u64, u64, u64>,
+    u64, u64>,
+    u64, u64>,
+    u64, u64>,
+    u64, u64>,
+    u64, u64>,
+    u64, u64>,
+    u64, u64>,
+    u64, u64>,
+    u64, u64>,
+    u64, u64>,
+    u64, u64>,
+    u64, u64>,
+    u64, u64>,
+    u64, u64>>();
+    return;
+}


### PR DESCRIPTION
Restrict the number of allowed type terms in instantiation to 128. This should prevent that malicious code produces OOM attacks via type instantiation.
