### PR TITLE
allow all codes under EXECUTION category for VmStatus::Error

### DIFF
--- a/language/move-core/types/src/vm_status.rs
+++ b/language/move-core/types/src/vm_status.rs
@@ -130,9 +130,6 @@ impl VMStatus {
                 let code = *code;
                 debug_assert!(code != StatusCode::EXECUTED);
                 debug_assert!(code != StatusCode::ABORTED);
-                debug_assert!(
-                    code.status_type() != StatusType::Execution || code == StatusCode::OUT_OF_GAS
-                );
                 code
             }
         }


### PR DESCRIPTION

## Motivation

We added a new error code STORAGE_WRITE_LIMIT_REACHED under the EXECUTION category and realized there's a debug_assert!() that prevents it from being part of a `VmStatus::Error()`. After discussion, it seems reasonable to allow all EXECUTION type of codes there.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

(Write your answer here.)

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)
