### PR TITLE
[bug fix] Fixed bug with natives in instantiation loop checker

### DIFF
--- a/language/move-bytecode-verifier/src/instantiation_loops.rs
+++ b/language/move-bytecode-verifier/src/instantiation_loops.rs
@@ -233,8 +233,8 @@ impl<'a> InstantiationLoopChecker<'a> {
             .module
             .function_defs()
             .iter()
-            .filter(|def| !def.is_native())
             .enumerate()
+            .filter(|(_, def)| !def.is_native())
         {
             self.build_graph_function_def(FunctionDefinitionIndex::new(def_idx as u16), func_def)
         }


### PR DESCRIPTION
- Fixed bug with instantiation loop checker that filtered before enumerating

## Motivation

- Found this annoying bug when adding some native functions

## Test Plan

- I do not think it can be tested without lazy native loading