### PR TITLE
[1/2][binary/cfg] Relax backward-jump == loop back-edge requirement

### DIFF
--- a/language/move-binary-format/src/binary_views.rs
+++ b/language/move-binary-format/src/binary_views.rs
@@ -336,8 +336,6 @@ pub struct FunctionView<'a> {
 
 impl<'a> FunctionView<'a> {
     // Creates a `FunctionView` for a module function.
-    // Creates a `FunctionView` for a module function.
-    // Requires control flow verifier (control_flow.rs)
     pub fn function(
         module: &'a CompiledModule,
         index: FunctionDefinitionIndex,

--- a/language/move-binary-format/src/control_flow_graph.rs
+++ b/language/move-binary-format/src/control_flow_graph.rs
@@ -147,8 +147,8 @@ impl VMControlFlowGraph {
                     // Already traversed the sub-graph reachable from this block, so skip it.
                     Exploration::Done => continue,
 
-                    // Finish up the traversal by adding this block to the reverse traversal after
-                    // its sub-graph (modulo cycles).
+                    // Finish up the traversal by adding this block to the post-order traversal
+                    // after its sub-graph (modulo cycles).
                     Exploration::InProgress => {
                         post_order.push(block);
                         entry.insert(Exploration::Done);

--- a/language/move-binary-format/src/control_flow_graph.rs
+++ b/language/move-binary-format/src/control_flow_graph.rs
@@ -4,8 +4,7 @@
 
 //! This module defines the control-flow graph uses for bytecode verification.
 use crate::file_format::{Bytecode, CodeOffset};
-use std::collections::btree_map::Entry;
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{btree_map::Entry, BTreeMap, BTreeSet};
 
 // BTree/Hash agnostic type wrappers
 type Map<K, V> = BTreeMap<K, V>;

--- a/language/move-binary-format/src/unit_tests/control_flow_graph_tests.rs
+++ b/language/move-binary-format/src/unit_tests/control_flow_graph_tests.rs
@@ -1,18 +1,20 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::control_flow_graph::{BlockId, ControlFlowGraph, VMControlFlowGraph};
-use crate::file_format::Bytecode;
+use crate::{
+    control_flow_graph::{BlockId, ControlFlowGraph, VMControlFlowGraph},
+    file_format::Bytecode,
+};
 
 #[test]
 fn traversal_no_loops() {
     let cfg = {
         use Bytecode::*;
         VMControlFlowGraph::new(&[
-            LdTrue,    // L0
-            BrTrue(3),
-            Branch(3), // L2
-            Ret,       // L3
+            /* L0 */ LdTrue,
+            /*    */ BrTrue(3),
+            /* L2 */ Branch(3),
+            /* L3 */ Ret,
         ])
     };
 
@@ -26,13 +28,13 @@ fn traversal_loops() {
     let cfg = {
         use Bytecode::*;
         VMControlFlowGraph::new(&[
-            LdTrue,    // L0: Outer head
-            BrTrue(6), //     Outer break
-            LdTrue,    // L2: Inner head
-            BrTrue(5), //     Inner break
-            Branch(2), // L4: Inner continue
-            Branch(0), // L5: Outer continue
-            Ret,       // L6
+            /* L0: Outer head     */ LdTrue,
+            /*     Outer break    */ BrTrue(6),
+            /* L2: Inner head     */ LdTrue,
+            /*     Inner break    */ BrTrue(5),
+            /* L4: Inner continue */ Branch(2),
+            /*     Outer continue */ Branch(0),
+            /* L6:                */ Ret,
         ])
     };
 
@@ -46,9 +48,9 @@ fn traversal_non_loop_back_branch() {
     let cfg = {
         use Bytecode::*;
         VMControlFlowGraph::new(&[
-            Branch(2), // L0
-            Ret,       // L1
-            Branch(1), // L2
+            /* L0 */ Branch(2),
+            /* L1 */ Ret,
+            /* L2 */ Branch(1),
         ])
     };
 

--- a/language/move-binary-format/src/unit_tests/control_flow_graph_tests.rs
+++ b/language/move-binary-format/src/unit_tests/control_flow_graph_tests.rs
@@ -59,7 +59,7 @@ fn traversal_non_loop_back_branch() {
     assert_eq!(traversal(&cfg), vec![0, 2, 1]);
 }
 
-/// Return a vector containing the `BlockId`s from `cfg` in the order suggested by successiely
+/// Return a vector containing the `BlockId`s from `cfg` in the order suggested by successively
 /// calling `ControlFlowGraph::next_block` starting from the entry block.
 fn traversal(cfg: &dyn ControlFlowGraph) -> Vec<BlockId> {
     let mut order = Vec::with_capacity(cfg.num_blocks() as usize);

--- a/language/move-binary-format/src/unit_tests/control_flow_graph_tests.rs
+++ b/language/move-binary-format/src/unit_tests/control_flow_graph_tests.rs
@@ -1,0 +1,72 @@
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::control_flow_graph::{BlockId, ControlFlowGraph, VMControlFlowGraph};
+use crate::file_format::Bytecode;
+
+#[test]
+fn traversal_no_loops() {
+    let cfg = {
+        use Bytecode::*;
+        VMControlFlowGraph::new(&[
+            LdTrue,    // L0
+            BrTrue(3),
+            Branch(3), // L2
+            Ret,       // L3
+        ])
+    };
+
+    cfg.display();
+    assert_eq!(cfg.num_blocks(), 3);
+    assert_eq!(traversal(&cfg), vec![0, 2, 3]);
+}
+
+#[test]
+fn traversal_loops() {
+    let cfg = {
+        use Bytecode::*;
+        VMControlFlowGraph::new(&[
+            LdTrue,    // L0: Outer head
+            BrTrue(6), //     Outer break
+            LdTrue,    // L2: Inner head
+            BrTrue(5), //     Inner break
+            Branch(2), // L4: Inner continue
+            Branch(0), // L5: Outer continue
+            Ret,       // L6
+        ])
+    };
+
+    cfg.display();
+    assert_eq!(cfg.num_blocks(), 5);
+    assert_eq!(traversal(&cfg), vec![0, 2, 4, 5, 6]);
+}
+
+#[test]
+fn traversal_non_loop_back_branch() {
+    let cfg = {
+        use Bytecode::*;
+        VMControlFlowGraph::new(&[
+            Branch(2), // L0
+            Ret,       // L1
+            Branch(1), // L2
+        ])
+    };
+
+    cfg.display();
+    assert_eq!(cfg.num_blocks(), 3);
+    assert_eq!(traversal(&cfg), vec![0, 2, 1]);
+}
+
+/// Return a vector containing the `BlockId`s from `cfg` in the order suggested by successiely
+/// calling `ControlFlowGraph::next_block` starting from the entry block.
+fn traversal(cfg: &dyn ControlFlowGraph) -> Vec<BlockId> {
+    let mut order = Vec::with_capacity(cfg.num_blocks() as usize);
+    let mut next = Some(cfg.entry_block_id());
+
+    while let Some(block) = next {
+        order.push(block);
+        next = cfg.next_block(block);
+    }
+
+    order
+}

--- a/language/move-binary-format/src/unit_tests/mod.rs
+++ b/language/move-binary-format/src/unit_tests/mod.rs
@@ -4,6 +4,7 @@
 
 mod binary_tests;
 mod compatibility_tests;
+mod control_flow_graph_tests;
 mod deserializer_tests;
 mod number_tests;
 mod signature_token_tests;


### PR DESCRIPTION
## Motivation

When generating a `VMControlFlowGraph`, identify loop heads and back-edges by finding back-edges in the depth-first traversal from the entry block.  This ensures that all the blocks in the CFG that are reachable at runtime are reachable during abstract interpretation.

This is roughly the algorithm proposed for finding widening points in Section 4.1 (Depth-first numbering) of "Efficient chaotic iteration strategies with widenings", Bourdoncle 1993.

Replaces the previous strategy of assuming a backward (in code offset) jump corresponds to a back-edge, which is something the Control Flow verifier was ensuring.  This assumption is no longer required, so this commit also removes references to that dependency.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes

## Test Plan

Newly introduced unit tests check that a CFG can be generated, even when the verifier would fail on the bytecode:

```
move/language/move-binary-format$ cargo test
```