### PR TITLE
[RFC][move-vm] Add a paranoid mode in the VM

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3646,6 +3646,7 @@ dependencies = [
  "move-binary-format",
  "move-bytecode-source-map",
  "move-bytecode-utils",
+ "move-bytecode-verifier",
  "move-cli",
  "move-command-line-common",
  "move-compiler",
@@ -3717,6 +3718,15 @@ dependencies = [
  "move-vm-test-utils",
  "move-vm-types",
  "tempfile",
+]
+
+[[package]]
+name = "move-vm-paranoid-tests"
+version = "0.1.0"
+dependencies = [
+ "datatest-stable",
+ "fail",
+ "move-transactional-test-runner",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ members = [
     "language/move-stdlib",
     "language/move-symbol-pool",
     "language/move-vm/integration-tests",
+    "language/move-vm/paranoid-tests",
     "language/move-vm/runtime",
     "language/move-vm/test-utils",
     "language/move-vm/transactional-tests",

--- a/language/extensions/async/move-async-vm/tests/sources/AccountStateMachine.move
+++ b/language/extensions/async/move-async-vm/tests/sources/AccountStateMachine.move
@@ -22,13 +22,13 @@ module Test::AccountStateMachine {
     // const MAX_TRANSFER_AGE: u128 = 100000000;
 
     #[state]
-    struct Account {
+    struct Account has key {
         value: u64,
         xfer_id_counter: u64,
         pending: vector<PendingTransfer>
     }
 
-    struct PendingTransfer has drop {
+    struct PendingTransfer has store, drop {
        xfer_id: u64,
        amount: u64,
        initiated_at: u128,

--- a/language/extensions/async/move-async-vm/tests/sources/Basic.move
+++ b/language/extensions/async/move-async-vm/tests/sources/Basic.move
@@ -6,7 +6,7 @@
 module Test::Basic {
 
     #[state]
-    struct State {
+    struct State has key {
         value: u64,
     }
 

--- a/language/move-binary-format/src/file_format.rs
+++ b/language/move-binary-format/src/file_format.rs
@@ -651,6 +651,10 @@ impl AbilitySet {
             | (Ability::Key as u8),
     );
 
+    pub fn singleton(ability: Ability) -> Self {
+        Self(ability as u8)
+    }
+
     pub fn has_ability(self, ability: Ability) -> bool {
         let a = ability as u8;
         (a & self.0) == a

--- a/language/move-core/types/src/value.rs
+++ b/language/move-core/types/src/value.rs
@@ -74,6 +74,12 @@ impl MoveFieldLayout {
 pub enum MoveStructLayout {
     /// The representation used by the MoveVM
     Runtime(Vec<MoveTypeLayout>),
+    /// The representation used by the MoveVM with extra unique identifier for distinct type.
+    CheckedRuntime {
+        fields: Vec<MoveTypeLayout>,
+        tag: u64,
+        ability: u8,
+    },
     /// A decorated representation with human-readable field names that can be used by clients
     WithFields(Vec<MoveFieldLayout>),
     /// An even more decorated representation with both types and human-readable field names
@@ -258,6 +264,11 @@ impl MoveStructLayout {
     pub fn fields(&self) -> &[MoveTypeLayout] {
         match self {
             Self::Runtime(vals) => vals,
+            Self::CheckedRuntime {
+                fields,
+                tag: _,
+                ability: _,
+            } => fields,
             Self::WithFields(_) | Self::WithTypes { .. } => {
                 // It's not possible to implement this without changing the return type, and some
                 // performance-critical VM serialization code uses the Runtime case of this.
@@ -270,9 +281,36 @@ impl MoveStructLayout {
     pub fn into_fields(self) -> Vec<MoveTypeLayout> {
         match self {
             Self::Runtime(vals) => vals,
+            Self::CheckedRuntime {
+                fields,
+                tag: _,
+                ability: _,
+            } => fields,
             Self::WithFields(fields) | Self::WithTypes { fields, .. } => {
                 fields.into_iter().map(|f| f.layout).collect()
             }
+        }
+    }
+
+    pub fn tag(&self) -> Option<u64> {
+        match self {
+            Self::CheckedRuntime {
+                fields: _,
+                tag,
+                ability: _,
+            } => Some(*tag),
+            Self::Runtime(_) | Self::WithFields(_) | Self::WithTypes { .. } => None,
+        }
+    }
+
+    pub fn ability(&self) -> Option<u8> {
+        match self {
+            Self::CheckedRuntime {
+                fields: _,
+                tag: _,
+                ability,
+            } => Some(*ability),
+            Self::Runtime(_) | Self::WithFields(_) | Self::WithTypes { .. } => None,
         }
     }
 }
@@ -393,7 +431,12 @@ impl<'d> serde::de::DeserializeSeed<'d> for &MoveStructLayout {
         deserializer: D,
     ) -> Result<Self::Value, D::Error> {
         match self {
-            MoveStructLayout::Runtime(layout) => {
+            MoveStructLayout::Runtime(layout)
+            | MoveStructLayout::CheckedRuntime {
+                fields: layout,
+                tag: _,
+                ability: _,
+            } => {
                 let fields =
                     deserializer.deserialize_tuple(layout.len(), StructFieldVisitor(layout))?;
                 Ok(MoveStruct::Runtime(fields))
@@ -510,7 +553,12 @@ impl fmt::Display for MoveStructLayout {
     fn fmt(&self, f: &mut fmt::Formatter) -> std::fmt::Result {
         write!(f, "{{ ")?;
         match self {
-            Self::Runtime(layouts) => {
+            Self::Runtime(layouts)
+            | Self::CheckedRuntime {
+                fields: layouts,
+                tag: _,
+                ability: _,
+            } => {
                 for (i, l) in layouts.iter().enumerate() {
                     write!(f, "{}: {}, ", i, l)?
                 }
@@ -561,7 +609,13 @@ impl TryInto<StructTag> for &MoveStructLayout {
     fn try_into(self) -> Result<StructTag, Self::Error> {
         use MoveStructLayout::*;
         match self {
-            Runtime(..) | WithFields(..) => bail!(
+            Runtime(..)
+            | CheckedRuntime {
+                fields: _,
+                tag: _,
+                ability: _,
+            }
+            | WithFields(..) => bail!(
                 "Invalid MoveTypeLayout -> StructTag conversion--needed MoveLayoutType::WithTypes"
             ),
             WithTypes { type_, .. } => Ok(type_.clone()),

--- a/language/move-prover/interpreter-testsuite/tests/concrete_check/destroy.move
+++ b/language/move-prover/interpreter-testsuite/tests/concrete_check/destroy.move
@@ -1,5 +1,5 @@
 module 0x2::A {
-    struct S {
+    struct S has drop {
         f1: bool,
         f2: u64,
     }

--- a/language/move-prover/interpreter-testsuite/tests/concrete_check/pack_unpack.move
+++ b/language/move-prover/interpreter-testsuite/tests/concrete_check/pack_unpack.move
@@ -1,5 +1,5 @@
 module 0x2::A {
-    struct S {
+    struct S has drop {
         f1: bool,
         f2: u64,
     }

--- a/language/move-vm/paranoid-tests/Cargo.toml
+++ b/language/move-vm/paranoid-tests/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "move-vm-paranoid-tests"
+version = "0.1.0"
+authors = ["Diem Association <opensource@diem.com>"]
+publish = false
+edition = "2021"
+license = "Apache-2.0"
+
+[dev-dependencies]
+fail = { version = "0.4.0", features = ['failpoints'] }
+datatest-stable = "0.1.1"
+move-transactional-test-runner = { path = "../../testing-infra/transactional-test-runner", features = ['failpoints'] }
+
+[[test]]
+name = "tests"
+harness = false

--- a/language/move-vm/paranoid-tests/src/lib.rs
+++ b/language/move-vm/paranoid-tests/src/lib.rs
@@ -1,0 +1,7 @@
+// Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#![forbid(unsafe_code)]
+
+// Empty src/lib.rs to get rusty-tags working.

--- a/language/move-vm/paranoid-tests/tests/ability/copy/copy_loc.exp
+++ b/language/move-vm/paranoid-tests/tests/ability/copy/copy_loc.exp
@@ -1,0 +1,10 @@
+processed 3 tasks
+
+task 2 'run'. lines 27-33:
+Error: Script execution failed with VMError: {
+    major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
+    sub_status: None,
+    location: 0x2::B,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 2)],
+}

--- a/language/move-vm/paranoid-tests/tests/ability/copy/copy_loc.mvir
+++ b/language/move-vm/paranoid-tests/tests/ability/copy/copy_loc.mvir
@@ -1,0 +1,33 @@
+//# publish
+module 0x2.A {
+  struct C has store { x: u64 }
+
+  public make(): Self.C {
+  label b0:
+    return C { x: 0};
+  }
+}
+
+//# publish
+module 0x2.B {
+    import 0x2.A;
+
+    public drop() {
+        let v: A.C;
+        let v2: A.C;
+
+    label b0:
+        v = A.make();
+        v2 = copy(v);
+
+        return;
+    }
+}
+
+//# run --signers 0x1 --check-runtime-types
+import 0x2.B;
+main(account: signer) {
+label b0:
+    B.drop();
+    return;
+}

--- a/language/move-vm/paranoid-tests/tests/ability/copy/copy_loc_2.exp
+++ b/language/move-vm/paranoid-tests/tests/ability/copy/copy_loc_2.exp
@@ -1,0 +1,1 @@
+processed 3 tasks

--- a/language/move-vm/paranoid-tests/tests/ability/copy/copy_loc_2.mvir
+++ b/language/move-vm/paranoid-tests/tests/ability/copy/copy_loc_2.mvir
@@ -1,0 +1,33 @@
+//# publish
+module 0x2.A {
+  struct C has copy, drop { x: u64 }
+
+  public make(): Self.C {
+  label b0:
+    return C { x: 0};
+  }
+}
+
+//# publish
+module 0x2.B {
+    import 0x2.A;
+
+    public drop() {
+        let v: A.C;
+        let v2: A.C;
+
+    label b0:
+        v = A.make();
+        v2 = copy(v);
+
+        return;
+    }
+}
+
+//# run --signers 0x1 --check-runtime-types
+import 0x2.B;
+main(account: signer) {
+label b0:
+    B.drop();
+    return;
+}

--- a/language/move-vm/paranoid-tests/tests/ability/copy/read_ref.exp
+++ b/language/move-vm/paranoid-tests/tests/ability/copy/read_ref.exp
@@ -1,0 +1,10 @@
+processed 3 tasks
+
+task 2 'run'. lines 29-35:
+Error: Script execution failed with VMError: {
+    major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
+    sub_status: None,
+    location: 0x2::B,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 5)],
+}

--- a/language/move-vm/paranoid-tests/tests/ability/copy/read_ref.mvir
+++ b/language/move-vm/paranoid-tests/tests/ability/copy/read_ref.mvir
@@ -1,0 +1,35 @@
+//# publish
+module 0x2.A {
+  struct C has store { x: u64 }
+
+  public make(): Self.C {
+  label b0:
+    return C { x: 0};
+  }
+}
+
+//# publish
+module 0x2.B {
+    import 0x2.A;
+
+    public test_copy() {
+        let v: A.C;
+        let v_ref: &A.C;
+        let v2: A.C;
+
+    label b0:
+        v = A.make();
+        v_ref = &v;
+        v2 = *move(v_ref);
+
+        return;
+    }
+}
+
+//# run --signers 0x1 --check-runtime-types
+import 0x2.B;
+main(account: signer) {
+label b0:
+    B.test_copy();
+    return;
+}

--- a/language/move-vm/paranoid-tests/tests/ability/copy/read_ref_2.exp
+++ b/language/move-vm/paranoid-tests/tests/ability/copy/read_ref_2.exp
@@ -1,0 +1,1 @@
+processed 3 tasks

--- a/language/move-vm/paranoid-tests/tests/ability/copy/read_ref_2.mvir
+++ b/language/move-vm/paranoid-tests/tests/ability/copy/read_ref_2.mvir
@@ -1,0 +1,35 @@
+//# publish
+module 0x2.A {
+  struct C has copy, drop { x: u64 }
+
+  public make(): Self.C {
+  label b0:
+    return C { x: 0};
+  }
+}
+
+//# publish
+module 0x2.B {
+    import 0x2.A;
+
+    public test_copy() {
+        let v: A.C;
+        let v_ref: &A.C;
+        let v2: A.C;
+
+    label b0:
+        v = A.make();
+        v_ref = &v;
+        v2 = *move(v_ref);
+
+        return;
+    }
+}
+
+//# run --signers 0x1 --check-runtime-types
+import 0x2.B;
+main(account: signer) {
+label b0:
+    B.test_copy();
+    return;
+}

--- a/language/move-vm/paranoid-tests/tests/ability/drop/eq.exp
+++ b/language/move-vm/paranoid-tests/tests/ability/drop/eq.exp
@@ -1,0 +1,10 @@
+processed 3 tasks
+
+task 2 'run'. lines 29-35:
+Error: Script execution failed with VMError: {
+    major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
+    sub_status: None,
+    location: 0x2::B,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 6)],
+}

--- a/language/move-vm/paranoid-tests/tests/ability/drop/eq.mvir
+++ b/language/move-vm/paranoid-tests/tests/ability/drop/eq.mvir
@@ -1,0 +1,35 @@
+//# publish
+module 0x2.A {
+  struct C { x: u64 }
+
+  public make(): Self.C {
+  label b0:
+    return C { x: 0};
+  }
+}
+
+//# publish
+module 0x2.B {
+    import 0x2.A;
+
+    public drop_eq() {
+        let v: A.C;
+        let v2: A.C;
+        let b: bool;
+
+    label b0:
+        v = A.make();
+        v2 = A.make();
+        b = move(v) == move(v2);
+
+        return;
+    }
+}
+
+//# run --signers 0x1 --check-runtime-types
+import 0x2.B;
+main(account: signer) {
+label b0:
+    B.drop_eq();
+    return;
+}

--- a/language/move-vm/paranoid-tests/tests/ability/drop/eq_2.exp
+++ b/language/move-vm/paranoid-tests/tests/ability/drop/eq_2.exp
@@ -1,0 +1,1 @@
+processed 3 tasks

--- a/language/move-vm/paranoid-tests/tests/ability/drop/eq_2.mvir
+++ b/language/move-vm/paranoid-tests/tests/ability/drop/eq_2.mvir
@@ -1,0 +1,35 @@
+//# publish
+module 0x2.A {
+  struct C has drop { x: u64 }
+
+  public make(): Self.C {
+  label b0:
+    return C { x: 0};
+  }
+}
+
+//# publish
+module 0x2.B {
+    import 0x2.A;
+
+    public drop_eq() {
+        let v: A.C;
+        let v2: A.C;
+        let b: bool;
+
+    label b0:
+        v = A.make();
+        v2 = A.make();
+        b = move(v) == move(v2);
+
+        return;
+    }
+}
+
+//# run --signers 0x1 --check-runtime-types
+import 0x2.B;
+main(account: signer) {
+label b0:
+    B.drop_eq();
+    return;
+}

--- a/language/move-vm/paranoid-tests/tests/ability/drop/hot_potato.exp
+++ b/language/move-vm/paranoid-tests/tests/ability/drop/hot_potato.exp
@@ -1,0 +1,10 @@
+processed 3 tasks
+
+task 2 'run'. lines 24-30:
+Error: Script execution failed with VMError: {
+    major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
+    sub_status: None,
+    location: 0x2::B,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 2)],
+}

--- a/language/move-vm/paranoid-tests/tests/ability/drop/hot_potato.mvir
+++ b/language/move-vm/paranoid-tests/tests/ability/drop/hot_potato.mvir
@@ -1,0 +1,30 @@
+//# publish
+module 0x2.A {
+  struct C { x: u64 }
+
+  public make(): Self.C {
+  label b0:
+    return C { x: 0};
+  }
+}
+
+//# publish
+module 0x2.B {
+    import 0x2.A;
+
+    public drop() {
+        let v: A.C;
+
+    label b0:
+        v = A.make();
+        return;
+    }
+}
+
+//# run --signers 0x1 --check-runtime-types
+import 0x2.B;
+main(account: signer) {
+label b0:
+    B.drop();
+    return;
+}

--- a/language/move-vm/paranoid-tests/tests/ability/drop/hot_potato_2.exp
+++ b/language/move-vm/paranoid-tests/tests/ability/drop/hot_potato_2.exp
@@ -1,0 +1,1 @@
+processed 3 tasks

--- a/language/move-vm/paranoid-tests/tests/ability/drop/hot_potato_2.mvir
+++ b/language/move-vm/paranoid-tests/tests/ability/drop/hot_potato_2.mvir
@@ -1,0 +1,30 @@
+//# publish
+module 0x2.A {
+  struct C has drop { x: u64 }
+
+  public make(): Self.C {
+  label b0:
+    return C { x: 0};
+  }
+}
+
+//# publish
+module 0x2.B {
+    import 0x2.A;
+
+    public drop() {
+        let v: A.C;
+
+    label b0:
+        v = A.make();
+        return;
+    }
+}
+
+//# run --signers 0x1 --check-runtime-types
+import 0x2.B;
+main(account: signer) {
+label b0:
+    B.drop();
+    return;
+}

--- a/language/move-vm/paranoid-tests/tests/ability/drop/neq.exp
+++ b/language/move-vm/paranoid-tests/tests/ability/drop/neq.exp
@@ -1,0 +1,10 @@
+processed 3 tasks
+
+task 2 'run'. lines 29-35:
+Error: Script execution failed with VMError: {
+    major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
+    sub_status: None,
+    location: 0x2::B,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 6)],
+}

--- a/language/move-vm/paranoid-tests/tests/ability/drop/neq.mvir
+++ b/language/move-vm/paranoid-tests/tests/ability/drop/neq.mvir
@@ -1,0 +1,35 @@
+//# publish
+module 0x2.A {
+  struct C { x: u64 }
+
+  public make(): Self.C {
+  label b0:
+    return C { x: 0};
+  }
+}
+
+//# publish
+module 0x2.B {
+    import 0x2.A;
+
+    public drop_eq() {
+        let v: A.C;
+        let v2: A.C;
+        let b: bool;
+
+    label b0:
+        v = A.make();
+        v2 = A.make();
+        b = move(v) != move(v2);
+
+        return;
+    }
+}
+
+//# run --signers 0x1 --check-runtime-types
+import 0x2.B;
+main(account: signer) {
+label b0:
+    B.drop_eq();
+    return;
+}

--- a/language/move-vm/paranoid-tests/tests/ability/drop/neq_2.exp
+++ b/language/move-vm/paranoid-tests/tests/ability/drop/neq_2.exp
@@ -1,0 +1,1 @@
+processed 3 tasks

--- a/language/move-vm/paranoid-tests/tests/ability/drop/neq_2.mvir
+++ b/language/move-vm/paranoid-tests/tests/ability/drop/neq_2.mvir
@@ -1,0 +1,35 @@
+//# publish
+module 0x2.A {
+  struct C has drop { x: u64 }
+
+  public make(): Self.C {
+  label b0:
+    return C { x: 0};
+  }
+}
+
+//# publish
+module 0x2.B {
+    import 0x2.A;
+
+    public drop_eq() {
+        let v: A.C;
+        let v2: A.C;
+        let b: bool;
+
+    label b0:
+        v = A.make();
+        v2 = A.make();
+        b = move(v) != move(v2);
+
+        return;
+    }
+}
+
+//# run --signers 0x1 --check-runtime-types
+import 0x2.B;
+main(account: signer) {
+label b0:
+    B.drop_eq();
+    return;
+}

--- a/language/move-vm/paranoid-tests/tests/ability/drop/pop.exp
+++ b/language/move-vm/paranoid-tests/tests/ability/drop/pop.exp
@@ -1,0 +1,10 @@
+processed 3 tasks
+
+task 2 'run'. lines 23-29:
+Error: Script execution failed with VMError: {
+    major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
+    sub_status: None,
+    location: 0x2::B,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 1)],
+}

--- a/language/move-vm/paranoid-tests/tests/ability/drop/pop.mvir
+++ b/language/move-vm/paranoid-tests/tests/ability/drop/pop.mvir
@@ -1,0 +1,29 @@
+//# publish
+module 0x2.A {
+  struct C { x: u64 }
+
+  public make(): Self.C {
+  label b0:
+    return C { x: 0};
+  }
+}
+
+//# publish
+module 0x2.B {
+    import 0x2.A;
+
+    public drop() {
+    label b0:
+        _ = A.make();
+
+        return;
+    }
+}
+
+//# run --signers 0x1 --check-runtime-types
+import 0x2.B;
+main(account: signer) {
+label b0:
+    B.drop();
+    return;
+}

--- a/language/move-vm/paranoid-tests/tests/ability/drop/pop_2.exp
+++ b/language/move-vm/paranoid-tests/tests/ability/drop/pop_2.exp
@@ -1,0 +1,1 @@
+processed 3 tasks

--- a/language/move-vm/paranoid-tests/tests/ability/drop/pop_2.mvir
+++ b/language/move-vm/paranoid-tests/tests/ability/drop/pop_2.mvir
@@ -1,0 +1,29 @@
+//# publish
+module 0x2.A {
+  struct C has drop { x: u64 }
+
+  public make(): Self.C {
+  label b0:
+    return C { x: 0};
+  }
+}
+
+//# publish
+module 0x2.B {
+    import 0x2.A;
+
+    public drop() {
+    label b0:
+        _ = A.make();
+
+        return;
+    }
+}
+
+//# run --signers 0x1 --check-runtime-types
+import 0x2.B;
+main(account: signer) {
+label b0:
+    B.drop();
+    return;
+}

--- a/language/move-vm/paranoid-tests/tests/ability/drop/ret_vector.exp
+++ b/language/move-vm/paranoid-tests/tests/ability/drop/ret_vector.exp
@@ -1,0 +1,10 @@
+processed 3 tasks
+
+task 2 'run'. lines 29-39:
+Error: Script execution failed with VMError: {
+    major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
+    sub_status: None,
+    location: script,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 3)],
+}

--- a/language/move-vm/paranoid-tests/tests/ability/drop/ret_vector.mvir
+++ b/language/move-vm/paranoid-tests/tests/ability/drop/ret_vector.mvir
@@ -1,0 +1,39 @@
+//# publish
+module 0x2.A {
+  struct C has drop { x: u64 }
+  struct D { x: u64 }
+
+  public make(): Self.C {
+  label b0:
+    return C { x: 0};
+  }
+
+  public make_d(): Self.D {
+  label b0:
+    return D { x: 0};
+  }
+}
+
+//# run --signers 0x1 --check-runtime-types
+import 0x2.A;
+main(account: signer) {
+    let v: vector<A.C>;
+    let a: A.C;
+
+label b0:
+    a = A.make();
+    v = vec_pack_1<A.C>(move(a));
+    return;
+}
+
+//# run --signers 0x1 --check-runtime-types
+import 0x2.A;
+main(account: signer) {
+    let v: vector<A.D>;
+    let a: A.D;
+
+label b0:
+    a = A.make();
+    v = vec_pack_1<A.D>(move(a));
+    return;
+}

--- a/language/move-vm/paranoid-tests/tests/ability/drop/store.exp
+++ b/language/move-vm/paranoid-tests/tests/ability/drop/store.exp
@@ -1,0 +1,10 @@
+processed 3 tasks
+
+task 2 'run'. lines 26-32:
+Error: Script execution failed with VMError: {
+    major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
+    sub_status: None,
+    location: 0x2::B,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 3)],
+}

--- a/language/move-vm/paranoid-tests/tests/ability/drop/store.mvir
+++ b/language/move-vm/paranoid-tests/tests/ability/drop/store.mvir
@@ -1,0 +1,32 @@
+//# publish
+module 0x2.A {
+  struct C { x: u64 }
+
+  public make(): Self.C {
+  label b0:
+    return C { x: 0};
+  }
+}
+
+//# publish
+module 0x2.B {
+    import 0x2.A;
+
+    public drop() {
+        let v: A.C;
+
+    label b0:
+        v = A.make();
+        v = A.make();
+
+        return;
+    }
+}
+
+//# run --signers 0x1 --check-runtime-types
+import 0x2.B;
+main(account: signer) {
+label b0:
+    B.drop();
+    return;
+}

--- a/language/move-vm/paranoid-tests/tests/ability/drop/store_2.exp
+++ b/language/move-vm/paranoid-tests/tests/ability/drop/store_2.exp
@@ -1,0 +1,1 @@
+processed 3 tasks

--- a/language/move-vm/paranoid-tests/tests/ability/drop/store_2.mvir
+++ b/language/move-vm/paranoid-tests/tests/ability/drop/store_2.mvir
@@ -1,0 +1,32 @@
+//# publish
+module 0x2.A {
+  struct C has drop { x: u64 }
+
+  public make(): Self.C {
+  label b0:
+    return C { x: 0};
+  }
+}
+
+//# publish
+module 0x2.B {
+    import 0x2.A;
+
+    public drop() {
+        let v: A.C;
+
+    label b0:
+        v = A.make();
+        v = A.make();
+
+        return;
+    }
+}
+
+//# run --signers 0x1 --check-runtime-types
+import 0x2.B;
+main(account: signer) {
+label b0:
+    B.drop();
+    return;
+}

--- a/language/move-vm/paranoid-tests/tests/ability/drop/write_ref.exp
+++ b/language/move-vm/paranoid-tests/tests/ability/drop/write_ref.exp
@@ -1,0 +1,10 @@
+processed 3 tasks
+
+task 2 'run'. lines 30-36:
+Error: Script execution failed with VMError: {
+    major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
+    sub_status: None,
+    location: 0x2::B,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 8)],
+}

--- a/language/move-vm/paranoid-tests/tests/ability/drop/write_ref.mvir
+++ b/language/move-vm/paranoid-tests/tests/ability/drop/write_ref.mvir
@@ -1,0 +1,36 @@
+//# publish
+module 0x2.A {
+  struct C { x: u64 }
+
+  public make(): Self.C {
+  label b0:
+    return C { x: 0};
+  }
+}
+
+//# publish
+module 0x2.B {
+    import 0x2.A;
+
+    public drop() {
+        let v: A.C;
+        let v2: A.C;
+        let v_ref: &mut A.C;
+
+    label b0:
+        v = A.make();
+        v2 = A.make();
+        v_ref = &mut v;
+        *move(v_ref) = move(v2);
+
+        return;
+    }
+}
+
+//# run --signers 0x1 --check-runtime-types
+import 0x2.B;
+main(account: signer) {
+label b0:
+    B.drop();
+    return;
+}

--- a/language/move-vm/paranoid-tests/tests/ability/drop/write_ref_2.exp
+++ b/language/move-vm/paranoid-tests/tests/ability/drop/write_ref_2.exp
@@ -1,0 +1,1 @@
+processed 3 tasks

--- a/language/move-vm/paranoid-tests/tests/ability/drop/write_ref_2.mvir
+++ b/language/move-vm/paranoid-tests/tests/ability/drop/write_ref_2.mvir
@@ -1,0 +1,36 @@
+//# publish
+module 0x2.A {
+  struct C has drop { x: u64 }
+
+  public make(): Self.C {
+  label b0:
+    return C { x: 0};
+  }
+}
+
+//# publish
+module 0x2.B {
+    import 0x2.A;
+
+    public drop() {
+        let v: A.C;
+        let v2: A.C;
+        let v_ref: &mut A.C;
+
+    label b0:
+        v = A.make();
+        v2 = A.make();
+        v_ref = &mut v;
+        *move(v_ref) = move(v2);
+
+        return;
+    }
+}
+
+//# run --signers 0x1 --check-runtime-types
+import 0x2.B;
+main(account: signer) {
+label b0:
+    B.drop();
+    return;
+}

--- a/language/move-vm/paranoid-tests/tests/ability/store/hot_potato_store.exp
+++ b/language/move-vm/paranoid-tests/tests/ability/store/hot_potato_store.exp
@@ -1,0 +1,1 @@
+processed 2 tasks

--- a/language/move-vm/paranoid-tests/tests/ability/store/hot_potato_store.mvir
+++ b/language/move-vm/paranoid-tests/tests/ability/store/hot_potato_store.mvir
@@ -1,0 +1,27 @@
+//# publish
+module 0x2.A {
+    struct HotPotato has store {}
+    struct X has store { h: Self.HotPotato }
+    struct G has key { x: Self.X }
+
+    public make_g(): Self.G {
+    label b0:
+        return G { x: X { h: HotPotato {} }};
+    }
+
+    public store(account: &signer, g: Self.G) {
+    label b0:
+        move_to<G>(move(account), move(g));
+        return;
+    }
+}
+
+//# run --signers 0x1  --check-runtime-types
+import 0x2.A;
+main(account: signer) {
+    let a: A.G;
+label b0:
+    a = A.make_g();
+    A.store(&account, move(a));
+    return;
+}

--- a/language/move-vm/paranoid-tests/tests/ability/store/invalid_store.exp
+++ b/language/move-vm/paranoid-tests/tests/ability/store/invalid_store.exp
@@ -1,0 +1,10 @@
+processed 3 tasks
+
+task 2 'run'. lines 28-34:
+Error: Script execution failed with VMError: {
+    major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
+    sub_status: None,
+    location: 0x2::B,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 4)],
+}

--- a/language/move-vm/paranoid-tests/tests/ability/store/invalid_store.mvir
+++ b/language/move-vm/paranoid-tests/tests/ability/store/invalid_store.mvir
@@ -1,0 +1,34 @@
+//# publish
+module 0x2.A {
+  struct C { x: u64 }
+
+  public make(): Self.C {
+  label b0:
+    return C { x: 0};
+  }
+}
+
+//# publish
+module 0x2.B {
+    import 0x2.A;
+
+    struct C has key { x: A.C }
+
+    public store(s: &signer) {
+        let v: A.C;
+
+    label b0:
+        v = A.make();
+        move_to<C>(move(s), C { x: move(v) });
+
+        return;
+    }
+}
+
+//# run --signers 0x1 --check-runtime-types
+import 0x2.B;
+main(account: signer) {
+label b0:
+    B.store(&account);
+    return;
+}

--- a/language/move-vm/paranoid-tests/tests/ability/store/invalid_store_2.exp
+++ b/language/move-vm/paranoid-tests/tests/ability/store/invalid_store_2.exp
@@ -1,0 +1,1 @@
+processed 3 tasks

--- a/language/move-vm/paranoid-tests/tests/ability/store/invalid_store_2.mvir
+++ b/language/move-vm/paranoid-tests/tests/ability/store/invalid_store_2.mvir
@@ -1,0 +1,34 @@
+//# publish
+module 0x2.A {
+  struct C has store { x: u64 }
+
+  public make(): Self.C {
+  label b0:
+    return C { x: 0};
+  }
+}
+
+//# publish
+module 0x2.B {
+    import 0x2.A;
+
+    struct C has key { x: A.C }
+
+    public store(s: &signer) {
+        let v: A.C;
+
+    label b0:
+        v = A.make();
+        move_to<C>(move(s), C { x: move(v) });
+
+        return;
+    }
+}
+
+//# run --signers 0x1 --check-runtime-types
+import 0x2.B;
+main(account: signer) {
+label b0:
+    B.store(&account);
+    return;
+}

--- a/language/move-vm/paranoid-tests/tests/encapsulation_safety/borrow_field.exp
+++ b/language/move-vm/paranoid-tests/tests/encapsulation_safety/borrow_field.exp
@@ -1,0 +1,10 @@
+processed 3 tasks
+
+task 2 'run'. lines 31-37:
+Error: Script execution failed with VMError: {
+    major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
+    sub_status: None,
+    location: 0x2::B,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 5)],
+}

--- a/language/move-vm/paranoid-tests/tests/encapsulation_safety/borrow_field.mvir
+++ b/language/move-vm/paranoid-tests/tests/encapsulation_safety/borrow_field.mvir
@@ -1,0 +1,37 @@
+//# publish
+module 0x2.A {
+  struct C { x: u64 }
+
+  public make(): Self.C {
+  label b0:
+    return C { x: 0};
+  }
+}
+
+//# publish
+module 0x2.B {
+    import 0x2.A;
+    struct C { x: u64 }
+
+    public mut_field() {
+        let v: A.C;
+        let v_ref: &A.C;
+        let x: &mut u64;
+
+    label b0:
+        v = A.make();
+        v_ref = &v;
+        x = &mut move(v_ref).C::x;
+        *move(x) = 10;
+
+        return;
+    }
+}
+
+//# run --signers 0x1 --check-runtime-types
+import 0x2.B;
+main(account: signer) {
+label b0:
+    B.mut_field();
+    return;
+}

--- a/language/move-vm/paranoid-tests/tests/encapsulation_safety/borrow_field_2.exp
+++ b/language/move-vm/paranoid-tests/tests/encapsulation_safety/borrow_field_2.exp
@@ -1,0 +1,1 @@
+processed 2 tasks

--- a/language/move-vm/paranoid-tests/tests/encapsulation_safety/borrow_field_2.mvir
+++ b/language/move-vm/paranoid-tests/tests/encapsulation_safety/borrow_field_2.mvir
@@ -1,0 +1,43 @@
+//# publish
+module 0x2.A {
+  struct C has drop { x: u64 }
+
+  public make(): Self.C {
+  label b0:
+    return C { x: 0};
+  }
+
+  public mutate(c: &mut Self.C) {
+    let c_ref: &mut u64;
+  label b0:
+    c_ref = &mut move(c).C::x;
+    *move(c_ref) = 10;
+    return;
+  }
+
+  public value(c: &Self.C): u64 {
+    let c_ref: &u64;
+  label b0:
+    c_ref = &move(c).C::x;
+    return *move(c_ref);
+  }
+}
+
+//# run --signers 0x1 --check-runtime-types
+import 0x2.A;
+main(account: signer) {
+    let c: A.C;
+    let c_ref_mut: &mut A.C;
+    let c_ref: &A.C;
+    let v: u64;
+
+label b0:
+    c = A.make();
+    c_ref_mut = &mut c;
+    A.mutate(move(c_ref_mut));
+    c_ref = &c;
+    v = A.value(move(c_ref));
+    assert(move(v) == 10, 1);
+
+    return;
+}

--- a/language/move-vm/paranoid-tests/tests/encapsulation_safety/borrow_field_generic.exp
+++ b/language/move-vm/paranoid-tests/tests/encapsulation_safety/borrow_field_generic.exp
@@ -1,0 +1,10 @@
+processed 3 tasks
+
+task 2 'run'. lines 31-37:
+Error: Script execution failed with VMError: {
+    major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
+    sub_status: None,
+    location: 0x2::B,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 6)],
+}

--- a/language/move-vm/paranoid-tests/tests/encapsulation_safety/borrow_field_generic.mvir
+++ b/language/move-vm/paranoid-tests/tests/encapsulation_safety/borrow_field_generic.mvir
@@ -1,0 +1,37 @@
+//# publish
+module 0x2.A {
+  struct C<T> { x: T }
+
+  public make<T>(x: T): Self.C<T> {
+  label b0:
+    return C<T> { x: move(x) };
+  }
+}
+
+//# publish
+module 0x2.B {
+    import 0x2.A;
+    struct C { x: u64 }
+
+    public mut_field() {
+        let v: A.C<u64>;
+        let v_ref: &mut A.C<u64>;
+        let x: &mut u64;
+
+    label b0:
+        v = A.make<u64>(20u64);
+        v_ref = &mut v;
+        x = &mut move(v_ref).C::x;
+        *move(x) = 10;
+
+        return;
+    }
+}
+
+//# run --signers 0x1 --check-runtime-types
+import 0x2.B;
+main(account: signer) {
+label b0:
+    B.mut_field();
+    return;
+}

--- a/language/move-vm/paranoid-tests/tests/encapsulation_safety/unpack.exp
+++ b/language/move-vm/paranoid-tests/tests/encapsulation_safety/unpack.exp
@@ -1,0 +1,10 @@
+processed 3 tasks
+
+task 2 'run'. lines 29-35:
+Error: Script execution failed with VMError: {
+    major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
+    sub_status: None,
+    location: 0x2::B,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 3)],
+}

--- a/language/move-vm/paranoid-tests/tests/encapsulation_safety/unpack.mvir
+++ b/language/move-vm/paranoid-tests/tests/encapsulation_safety/unpack.mvir
@@ -1,0 +1,35 @@
+//# publish
+module 0x2.A {
+  struct C { x: u64 }
+
+  public make(): Self.C {
+  label b0:
+    return C { x: 0};
+  }
+}
+
+//# publish
+module 0x2.B {
+    import 0x2.A;
+
+    struct C { x: u64 }
+
+    public drop() {
+        let v: A.C;
+        let x: u64;
+
+    label b0:
+        v = A.make();
+        C { x } = move(v);
+
+        return;
+    }
+}
+
+//# run --signers 0x1 --check-runtime-types
+import 0x2.B;
+main(account: signer) {
+label b0:
+    B.drop();
+    return;
+}

--- a/language/move-vm/paranoid-tests/tests/encapsulation_safety/unpack_generic.exp
+++ b/language/move-vm/paranoid-tests/tests/encapsulation_safety/unpack_generic.exp
@@ -1,0 +1,10 @@
+processed 3 tasks
+
+task 2 'run'. lines 28-34:
+Error: Script execution failed with VMError: {
+    major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
+    sub_status: None,
+    location: 0x2::B,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 4)],
+}

--- a/language/move-vm/paranoid-tests/tests/encapsulation_safety/unpack_generic.mvir
+++ b/language/move-vm/paranoid-tests/tests/encapsulation_safety/unpack_generic.mvir
@@ -1,0 +1,34 @@
+//# publish
+module 0x2.A {
+  struct C<T> { x: T }
+
+  public make<T>(x: T): Self.C<T> {
+  label b0:
+    return C<T> { x: move(x) };
+  }
+}
+
+//# publish
+module 0x2.B {
+    import 0x2.A;
+    struct C { x: u64 }
+
+    public unpack() {
+        let v: A.C<u64>;
+        let x: u64;
+
+    label b0:
+        v = A.make<u64>(20u64);
+        C { x } = move(v);
+
+        return;
+    }
+}
+
+//# run --signers 0x1 --check-runtime-types
+import 0x2.B;
+main(account: signer) {
+label b0:
+    B.unpack();
+    return;
+}

--- a/language/move-vm/paranoid-tests/tests/tests.rs
+++ b/language/move-vm/paranoid-tests/tests/tests.rs
@@ -1,0 +1,20 @@
+// Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+pub const TEST_DIR: &str = "tests";
+use fail::FailScenario;
+use move_transactional_test_runner::vm_test_harness::run_test;
+use std::path::Path;
+
+fn run_test_(path: &Path) -> Result<(), Box<dyn std::error::Error>> {
+    let scenario = FailScenario::setup();
+    fail::cfg("verifier-failpoint-1", "100%return").unwrap();
+    fail::cfg("verifier-failpoint-2", "100%return").unwrap();
+    fail::cfg("verifier-failpoint-3", "100%return").unwrap();
+    run_test(path)?;
+    scenario.teardown();
+    Ok(())
+}
+
+datatest_stable::harness!(run_test_, TEST_DIR, r".*\.(mvir|move)$");

--- a/language/move-vm/paranoid-tests/tests/type_safety/bcs.exp
+++ b/language/move-vm/paranoid-tests/tests/type_safety/bcs.exp
@@ -1,0 +1,10 @@
+processed 3 tasks
+
+task 2 'run'. lines 30-41:
+Error: Script execution failed with VMError: {
+    major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
+    sub_status: None,
+    location: undefined,
+    indices: [],
+    offsets: [],
+}

--- a/language/move-vm/paranoid-tests/tests/type_safety/bcs.mvir
+++ b/language/move-vm/paranoid-tests/tests/type_safety/bcs.mvir
@@ -1,0 +1,42 @@
+//# publish
+module 0x2.A {
+  struct A has drop { x: u64 }
+  struct B has drop { x: u64 }
+
+  public make_a(): Self.A {
+  label b0:
+    return A { x : 0 };
+  }
+
+  public make_b(): Self.B {
+  label b0:
+    return B { x : 0 };
+  }
+}
+
+//# run --signers 0x1 --check-runtime-types
+import 0x1.bcs;
+import 0x2.A;
+main(account: signer) {
+    let a: A.A;
+
+label b0:
+    a = A.make_a();
+    _ = bcs.to_bytes<A.A>(&a);
+
+    return;
+}
+
+//# run --signers 0x1 --check-runtime-types
+import 0x1.bcs;
+import 0x2.A;
+main(account: signer) {
+    let a: A.B;
+
+label b0:
+    a = A.make_b();
+    _ = bcs.to_bytes<A.A>(&a);
+
+    return;
+}
+

--- a/language/move-vm/paranoid-tests/tests/type_safety/call_generic_mismatch.exp
+++ b/language/move-vm/paranoid-tests/tests/type_safety/call_generic_mismatch.exp
@@ -1,0 +1,10 @@
+processed 2 tasks
+
+task 1 'run'. lines 19-28:
+Error: Script execution failed with VMError: {
+    major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
+    sub_status: None,
+    location: undefined,
+    indices: [],
+    offsets: [],
+}

--- a/language/move-vm/paranoid-tests/tests/type_safety/call_generic_mismatch.mvir
+++ b/language/move-vm/paranoid-tests/tests/type_safety/call_generic_mismatch.mvir
@@ -1,0 +1,28 @@
+//# publish
+module 0x2.A {
+  struct C<T> has drop { x: T, y: u64 }
+
+  struct D has drop { x: u64 }
+
+  public make<T>(x: T): Self.C<T> {
+  label b0:
+    return C<T> { x: move(x), y: 0 };
+  }
+
+  public make_d(): Self.D {
+  label b0:
+    return D { x : 0 };
+  }
+}
+
+
+//# run --signers 0x1 --check-runtime-types
+import 0x2.A;
+main(account: signer) {
+    let c: A.C<A.D>;
+    let d: A.D;
+label b0:
+    d = A.make_d();
+    c = A.make<A.D>(10u64);
+    return;
+}

--- a/language/move-vm/paranoid-tests/tests/type_safety/call_mismatch.exp
+++ b/language/move-vm/paranoid-tests/tests/type_safety/call_mismatch.exp
@@ -1,0 +1,28 @@
+processed 5 tasks
+
+task 1 'run'. lines 19-28:
+Error: Script execution failed with VMError: {
+    major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
+    sub_status: None,
+    location: undefined,
+    indices: [],
+    offsets: [],
+}
+
+task 3 'run'. lines 41-50:
+Error: Script execution failed with VMError: {
+    major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
+    sub_status: None,
+    location: undefined,
+    indices: [],
+    offsets: [],
+}
+
+task 4 'run'. lines 52-61:
+Error: Script execution failed with VMError: {
+    major_status: INTERNAL_TYPE_ERROR,
+    sub_status: None,
+    location: undefined,
+    indices: [],
+    offsets: [],
+}

--- a/language/move-vm/paranoid-tests/tests/type_safety/call_mismatch.mvir
+++ b/language/move-vm/paranoid-tests/tests/type_safety/call_mismatch.mvir
@@ -1,0 +1,61 @@
+//# publish
+module 0x2.A {
+  struct A has key { b: Self.B }
+  struct B has store { x: u64 }
+  struct C has store { x: u64 }
+
+  public make(): Self.C {
+  label b0:
+    return C { x: 0};
+  }
+
+  public store(x: Self.B, s: &signer) {
+  label b0:
+    move_to<A>(move(s), A { b: move(x)});
+    return;
+  }
+}
+
+//# run --signers 0x1 --check-runtime-types
+import 0x2.A;
+main(account: signer) {
+    let v: A.C;
+
+label b0:
+    v = A.make();
+    A.store(move(v), &account);
+    return;
+}
+
+//# run --signers 0x1
+import 0x2.A;
+main(account: signer) {
+    let v: A.C;
+
+label b0:
+    v = A.make();
+    A.store(move(v), &account);
+    return;
+}
+
+//# run --signers 0x2 --check-runtime-types
+import 0x2.A;
+main(account: signer) {
+    let v: u64;
+
+label b0:
+    v = 0;
+    A.store(move(v), &account);
+    return;
+}
+
+//# run --signers 0x2
+import 0x2.A;
+main(account: signer) {
+    let v: u64;
+
+label b0:
+    v = 0;
+    A.store(move(v), &account);
+    return;
+}

--- a/language/move-vm/paranoid-tests/tests/type_safety/call_with_mutliple_args.exp
+++ b/language/move-vm/paranoid-tests/tests/type_safety/call_with_mutliple_args.exp
@@ -1,0 +1,28 @@
+processed 6 tasks
+
+task 2 'run'. lines 30-36:
+Error: Script execution failed with VMError: {
+    major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
+    sub_status: None,
+    location: undefined,
+    indices: [],
+    offsets: [],
+}
+
+task 3 'run'. lines 38-44:
+Error: Script execution failed with VMError: {
+    major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
+    sub_status: None,
+    location: undefined,
+    indices: [],
+    offsets: [],
+}
+
+task 5 'run'. lines 56-64:
+Error: Script execution failed with VMError: {
+    major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
+    sub_status: None,
+    location: undefined,
+    indices: [],
+    offsets: [],
+}

--- a/language/move-vm/paranoid-tests/tests/type_safety/call_with_mutliple_args.mvir
+++ b/language/move-vm/paranoid-tests/tests/type_safety/call_with_mutliple_args.mvir
@@ -1,0 +1,64 @@
+//# publish
+module 0x2.A {
+  struct A has drop { v: u64 }
+
+  public make_a(): Self.A {
+  label b0:
+    return A { v: 10 };
+  }
+
+  public call(a: u64, b: bool, c: u8) {
+  label b0:
+    return;
+  }
+
+  public call_a(a: Self.A, b: bool, c: u8) {
+  label b0:
+    return;
+  }
+}
+
+//# run --signers 0x1 --check-runtime-types
+import 0x2.A;
+main(account: signer) {
+label b0:
+    A.call(10, true, 8u8);
+    return;
+}
+
+
+//# run --signers 0x1 --check-runtime-types
+import 0x2.A;
+main(account: signer) {
+label b0:
+    A.call(true, true, 8u8);
+    return;
+}
+
+//# run --signers 0x1 --check-runtime-types
+import 0x2.A;
+main(account: signer) {
+label b0:
+    A.call(10, true, true);
+    return;
+}
+
+//# run --signers 0x1 --check-runtime-types
+import 0x2.A;
+main(account: signer) {
+    let a: A.A;
+label b0:
+    a = A.make_a();
+    A.call_a(move(a), true, 8u8);
+    return;
+}
+
+//# run --signers 0x1 --check-runtime-types
+import 0x2.A;
+main(account: signer) {
+    let a: A.A;
+label b0:
+    a = A.make_a();
+    A.call_a(8, true, move(a));
+    return;
+}

--- a/language/move-vm/paranoid-tests/tests/type_safety/call_with_reference.exp
+++ b/language/move-vm/paranoid-tests/tests/type_safety/call_with_reference.exp
@@ -1,0 +1,10 @@
+processed 3 tasks
+
+task 1 'run'. lines 19-28:
+Error: Script execution failed with VMError: {
+    major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
+    sub_status: None,
+    location: undefined,
+    indices: [],
+    offsets: [],
+}

--- a/language/move-vm/paranoid-tests/tests/type_safety/call_with_reference.mvir
+++ b/language/move-vm/paranoid-tests/tests/type_safety/call_with_reference.mvir
@@ -1,0 +1,39 @@
+//# publish
+module 0x2.A {
+  struct A has key { x: u64 }
+  struct B has store { x: u64 }
+  struct C has store { x: u64 }
+
+  public make(): Self.C {
+  label b0:
+    return C { x: 0};
+  }
+
+  public store(x: &Self.B, s: &signer) {
+  label b0:
+    move_to<A>(move(s), A { x: 0 });
+    return;
+  }
+}
+
+//# run --signers 0x1 --check-runtime-types
+import 0x2.A;
+main(account: signer) {
+    let v: A.C;
+
+label b0:
+    v = A.make();
+    A.store(&v, &account);
+    return;
+}
+
+//# run --signers 0x1
+import 0x2.A;
+main(account: signer) {
+    let v: A.C;
+
+label b0:
+    v = A.make();
+    A.store(&v, &account);
+    return;
+}

--- a/language/move-vm/paranoid-tests/tests/type_safety/call_with_vector.exp
+++ b/language/move-vm/paranoid-tests/tests/type_safety/call_with_vector.exp
@@ -1,0 +1,10 @@
+processed 3 tasks
+
+task 2 'run'. lines 36-48:
+Error: Script execution failed with VMError: {
+    major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
+    sub_status: None,
+    location: script,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 3)],
+}

--- a/language/move-vm/paranoid-tests/tests/type_safety/call_with_vector.mvir
+++ b/language/move-vm/paranoid-tests/tests/type_safety/call_with_vector.mvir
@@ -1,0 +1,48 @@
+//# publish
+module 0x2.A {
+  struct B has drop { x: u64 }
+  struct C has drop { x: u64 }
+
+  public make(): Self.C {
+  label b0:
+    return C { x: 0};
+  }
+
+  public make_b(): Self.B {
+  label b0:
+    return B { x: 0};
+  }
+
+  public run(x: &vector<Self.C>) {
+  label b0:
+    return;
+  }
+}
+
+//# run --signers 0x1 --check-runtime-types
+import 0x2.A;
+main(account: signer) {
+    let v: vector<A.C>;
+    let a: A.C;
+
+label b0:
+    a = A.make();
+    v = vec_pack_1<A.C>(move(a));
+
+    A.run(&v);
+    return;
+}
+
+//# run --signers 0x1 --check-runtime-types
+import 0x2.A;
+main(account: signer) {
+    let v: vector<A.C>;
+    let a: A.B;
+
+label b0:
+    a = A.make_b();
+    v = vec_pack_1<A.C>(move(a));
+
+    A.run(&v);
+    return;
+}

--- a/language/move-vm/paranoid-tests/tests/type_safety/pack_and_move.exp
+++ b/language/move-vm/paranoid-tests/tests/type_safety/pack_and_move.exp
@@ -1,0 +1,10 @@
+processed 3 tasks
+
+task 2 'run'. lines 34-40:
+Error: Script execution failed with VMError: {
+    major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
+    sub_status: None,
+    location: 0x2::B,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 4)],
+}

--- a/language/move-vm/paranoid-tests/tests/type_safety/pack_and_move.mvir
+++ b/language/move-vm/paranoid-tests/tests/type_safety/pack_and_move.mvir
@@ -1,0 +1,40 @@
+//# publish
+module 0x2.A {
+  struct C { x: u64 }
+  struct D { x: u64 }
+
+  public make_c(): Self.C {
+  label b0:
+    return C { x: 0};
+  }
+
+  public make_d(): Self.D {
+  label b0:
+    return D { x: 0};
+  }
+}
+
+//# publish
+module 0x2.B {
+    import 0x2.A;
+
+    struct C { x: A.C }
+
+    public store(s: &signer) {
+        let v: A.D;
+
+    label b0:
+        v = A.make_d();
+        move_to<C>(move(s), C { x: move(v) });
+
+        return;
+    }
+}
+
+//# run --signers 0x1 --check-runtime-types
+import 0x2.B;
+main(account: signer) {
+label b0:
+    B.store(&account);
+    return;
+}

--- a/language/move-vm/paranoid-tests/tests/type_safety/pack_and_unpack.exp
+++ b/language/move-vm/paranoid-tests/tests/type_safety/pack_and_unpack.exp
@@ -1,0 +1,10 @@
+processed 3 tasks
+
+task 2 'run'. lines 45-51:
+Error: Script execution failed with VMError: {
+    major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
+    sub_status: None,
+    location: 0x2::B,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 3)],
+}

--- a/language/move-vm/paranoid-tests/tests/type_safety/pack_and_unpack.mvir
+++ b/language/move-vm/paranoid-tests/tests/type_safety/pack_and_unpack.mvir
@@ -1,0 +1,51 @@
+//# publish
+module 0x2.A {
+  struct C { x: u64 }
+  struct D { x: u64 }
+
+  public make_c(): Self.C {
+  label b0:
+    return C { x: 0};
+  }
+
+  public make_d(): Self.D {
+  label b0:
+    return D { x: 0};
+  }
+
+  public take_c(c: Self.C) {
+    let x: u64;
+  label b0:
+    C { x } = move(c);
+  }
+}
+
+//# publish
+module 0x2.B {
+    import 0x2.A;
+
+    struct C { x: A.C }
+
+    public store(s: &signer) {
+        let v: A.D;
+        let c: Self.C;
+        let x: A.C;
+
+    label b0:
+        v = A.make_d();
+        c = C { x: move(v) };
+
+        C { x } = move(c);
+        A.take_c(move(x));
+
+        return;
+    }
+}
+
+//# run --signers 0x1 --check-runtime-types
+import 0x2.B;
+main(account: signer) {
+label b0:
+    B.store(&account);
+    return;
+}

--- a/language/move-vm/paranoid-tests/tests/type_safety/pack_generic.exp
+++ b/language/move-vm/paranoid-tests/tests/type_safety/pack_generic.exp
@@ -1,0 +1,1 @@
+processed 2 tasks

--- a/language/move-vm/paranoid-tests/tests/type_safety/pack_generic.mvir
+++ b/language/move-vm/paranoid-tests/tests/type_safety/pack_generic.mvir
@@ -1,0 +1,28 @@
+//# publish
+module 0x2.A {
+  struct C<T> has drop { x: T, y: u64 }
+
+  struct D has drop { x: u64 }
+
+  public make<T>(x: T): Self.C<T> {
+  label b0:
+    return C<T> { x: move(x), y: 0 };
+  }
+
+  public make_d(): Self.D {
+  label b0:
+    return D { x : 0 };
+  }
+}
+
+
+//# run --signers 0x1 --check-runtime-types
+import 0x2.A;
+main(account: signer) {
+    let c: A.C<A.D>;
+    let d: A.D;
+label b0:
+    d = A.make_d();
+    c = A.make<A.D>(move(d));
+    return;
+}

--- a/language/move-vm/paranoid-tests/tests/type_safety/pack_generic_mismatch.exp
+++ b/language/move-vm/paranoid-tests/tests/type_safety/pack_generic_mismatch.exp
@@ -1,0 +1,10 @@
+processed 3 tasks
+
+task 2 'run'. lines 27-36:
+Error: Script execution failed with VMError: {
+    major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
+    sub_status: None,
+    location: 0x2::A,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 2)],
+}

--- a/language/move-vm/paranoid-tests/tests/type_safety/pack_generic_mismatch.mvir
+++ b/language/move-vm/paranoid-tests/tests/type_safety/pack_generic_mismatch.mvir
@@ -1,0 +1,36 @@
+//# publish
+module 0x2.A {
+  struct C<T> has drop { x: T, y: u64 }
+
+  struct D has drop { x: u64 }
+
+  public make<T>(x: T): Self.C<T> {
+  label b0:
+    return C<T> { x: 0, y: move(x) };
+  }
+
+  public make_d(): Self.D {
+  label b0:
+    return D { x : 0 };
+  }
+}
+
+//# run --signers 0x1 --check-runtime-types
+import 0x2.A;
+main(account: signer) {
+    let c: A.C<u64>;
+label b0:
+    c = A.make<u64>(10u64);
+    return;
+}
+
+//# run --signers 0x1 --check-runtime-types
+import 0x2.A;
+main(account: signer) {
+    let c: A.C<A.D>;
+    let d: A.D;
+label b0:
+    d = A.make_d();
+    c = A.make<A.D>(move(d));
+    return;
+}

--- a/language/move-vm/paranoid-tests/tests/type_safety/primitives/address.exp
+++ b/language/move-vm/paranoid-tests/tests/type_safety/primitives/address.exp
@@ -1,0 +1,37 @@
+processed 7 tasks
+
+task 2 'run'. lines 33-41:
+Error: Script execution failed with VMError: {
+    major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
+    sub_status: None,
+    location: 0x2::A,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(2), 3)],
+}
+
+task 3 'run'. lines 43-53:
+Error: Script execution failed with VMError: {
+    major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
+    sub_status: None,
+    location: script,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 4)],
+}
+
+task 4 'run'. lines 55-65:
+Error: Script execution failed with VMError: {
+    major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
+    sub_status: None,
+    location: script,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 4)],
+}
+
+task 6 'run'. lines 78-87:
+Error: Script execution failed with VMError: {
+    major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
+    sub_status: None,
+    location: script,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 6)],
+}

--- a/language/move-vm/paranoid-tests/tests/type_safety/primitives/address.mvir
+++ b/language/move-vm/paranoid-tests/tests/type_safety/primitives/address.mvir
@@ -1,0 +1,87 @@
+//# publish
+module 0x2.A {
+  struct A has drop { x: address }
+
+  public make_a(): Self.A {
+  label b0:
+    return A { x: 0x1 };
+  }
+
+  public test(a: &mut Self.A) {
+  label b0:
+    *&(move(a)).A::x = 0x1;
+    return;
+  }
+
+  public test_invalid(a: &mut Self.A) {
+  label b0:
+    *&(move(a)).A::x = 10u64;
+    return;
+  }
+}
+
+//# run --signers 0x1 --check-runtime-types
+import 0x2.A;
+main(account: signer) {
+    let a: A.A;
+label b0:
+    a = A.make_a();
+    A.test(&mut a);
+    return;
+}
+
+//# run --signers 0x1 --check-runtime-types
+import 0x2.A;
+main(account: signer) {
+    let a: A.A;
+label b0:
+    a = A.make_a();
+    A.test_invalid(&mut a);
+    return;
+}
+
+//# run --signers 0x1 --check-runtime-types
+main(account: signer) {
+    let a: vector<address>;
+    let b: &mut address;
+label b0:
+    a = vec_pack_0<address>();
+    vec_push_back<address>(&mut a, true);
+    b = vec_mut_borrow<address>(&mut a, 0);
+    *move(b) = 0x1;
+    return;
+}
+
+//# run --signers 0x1 --check-runtime-types
+main(account: signer) {
+    let a: vector<address>;
+    let b: &mut address;
+label b0:
+    a = vec_pack_0<address>();
+    vec_push_back<address>(&mut a, true);
+    b = vec_mut_borrow<address>(&mut a, 0);
+    *move(b) = 5u64;
+    return;
+}
+
+//# run --signers 0x1 --check-runtime-types
+main(account: signer) {
+    let a: address;
+    let b: &mut address;
+label b0:
+    a = 0x2;
+    b = &mut a;
+    *move(b) = 0x1;
+    return;
+}
+
+//# run --signers 0x1 --check-runtime-types
+main(account: signer) {
+    let a: address;
+    let b: &mut address;
+label b0:
+    a = 0x2;
+    b = &mut a;
+    *move(b) = 10u64;
+    return;
+}

--- a/language/move-vm/paranoid-tests/tests/type_safety/primitives/bool.exp
+++ b/language/move-vm/paranoid-tests/tests/type_safety/primitives/bool.exp
@@ -1,0 +1,28 @@
+processed 7 tasks
+
+task 2 'run'. lines 33-41:
+Error: Script execution failed with VMError: {
+    major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
+    sub_status: None,
+    location: 0x2::A,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(2), 3)],
+}
+
+task 4 'run'. lines 55-65:
+Error: Script execution failed with VMError: {
+    major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
+    sub_status: None,
+    location: script,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 11)],
+}
+
+task 6 'run'. lines 78-87:
+Error: Script execution failed with VMError: {
+    major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
+    sub_status: None,
+    location: script,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 6)],
+}

--- a/language/move-vm/paranoid-tests/tests/type_safety/primitives/bool.mvir
+++ b/language/move-vm/paranoid-tests/tests/type_safety/primitives/bool.mvir
@@ -1,0 +1,87 @@
+//# publish
+module 0x2.A {
+  struct A has drop { x: bool }
+
+  public make_a(): Self.A {
+  label b0:
+    return A { x: true };
+  }
+
+  public test(a: &mut Self.A) {
+  label b0:
+    *&(move(a)).A::x = true;
+    return;
+  }
+
+  public test_invalid(a: &mut Self.A) {
+  label b0:
+    *&(move(a)).A::x = 10u64;
+    return;
+  }
+}
+
+//# run --signers 0x1 --check-runtime-types
+import 0x2.A;
+main(account: signer) {
+    let a: A.A;
+label b0:
+    a = A.make_a();
+    A.test(&mut a);
+    return;
+}
+
+//# run --signers 0x1 --check-runtime-types
+import 0x2.A;
+main(account: signer) {
+    let a: A.A;
+label b0:
+    a = A.make_a();
+    A.test_invalid(&mut a);
+    return;
+}
+
+//# run --signers 0x1 --check-runtime-types
+main(account: signer) {
+    let a: vector<bool>;
+    let b: &mut bool;
+label b0:
+    a = vec_pack_0<bool>();
+    vec_push_back<bool>(&mut a, true);
+    b = vec_mut_borrow<bool>(&mut a, 0);
+    *move(b) = false;
+    return;
+}
+
+//# run --signers 0x1 --check-runtime-types
+main(account: signer) {
+    let a: vector<bool>;
+    let b: &mut bool;
+label b0:
+    a = vec_pack_0<bool>();
+    vec_push_back<bool>(&mut a, true);
+    b = vec_mut_borrow<bool>(&mut a, 0);
+    *move(b) = 5u64;
+    return;
+}
+
+//# run --signers 0x1 --check-runtime-types
+main(account: signer) {
+    let a: bool;
+    let b: &mut bool;
+label b0:
+    a = false;
+    b = &mut a;
+    *move(b) = true;
+    return;
+}
+
+//# run --signers 0x1 --check-runtime-types
+main(account: signer) {
+    let a: bool;
+    let b: &mut bool;
+label b0:
+    a = false;
+    b = &mut a;
+    *move(b) = 10u64;
+    return;
+}

--- a/language/move-vm/paranoid-tests/tests/type_safety/primitives/u128.exp
+++ b/language/move-vm/paranoid-tests/tests/type_safety/primitives/u128.exp
@@ -1,0 +1,28 @@
+processed 7 tasks
+
+task 2 'run'. lines 33-41:
+Error: Script execution failed with VMError: {
+    major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
+    sub_status: None,
+    location: 0x2::A,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(2), 3)],
+}
+
+task 4 'run'. lines 55-65:
+Error: Script execution failed with VMError: {
+    major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
+    sub_status: None,
+    location: script,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 11)],
+}
+
+task 6 'run'. lines 78-87:
+Error: Script execution failed with VMError: {
+    major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
+    sub_status: None,
+    location: script,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 6)],
+}

--- a/language/move-vm/paranoid-tests/tests/type_safety/primitives/u128.mvir
+++ b/language/move-vm/paranoid-tests/tests/type_safety/primitives/u128.mvir
@@ -1,0 +1,87 @@
+//# publish
+module 0x2.A {
+  struct A has drop { x: u128 }
+
+  public make_a(): Self.A {
+  label b0:
+    return A { x: 0u128 };
+  }
+
+  public test(a: &mut Self.A) {
+  label b0:
+    *&(move(a)).A::x = 10u128;
+    return;
+  }
+
+  public test_invalid(a: &mut Self.A) {
+  label b0:
+    *&(move(a)).A::x = 10u8;
+    return;
+  }
+}
+
+//# run --signers 0x1 --check-runtime-types
+import 0x2.A;
+main(account: signer) {
+    let a: A.A;
+label b0:
+    a = A.make_a();
+    A.test(&mut a);
+    return;
+}
+
+//# run --signers 0x1 --check-runtime-types
+import 0x2.A;
+main(account: signer) {
+    let a: A.A;
+label b0:
+    a = A.make_a();
+    A.test_invalid(&mut a);
+    return;
+}
+
+//# run --signers 0x1 --check-runtime-types
+main(account: signer) {
+    let a: vector<u128>;
+    let b: &mut u128;
+label b0:
+    a = vec_pack_0<u128>();
+    vec_push_back<u128>(&mut a, 1u128);
+    b = vec_mut_borrow<u128>(&mut a, 0);
+    *move(b) = 5u128;
+    return;
+}
+
+//# run --signers 0x1 --check-runtime-types
+main(account: signer) {
+    let a: vector<u128>;
+    let b: &mut u128;
+label b0:
+    a = vec_pack_0<u128>();
+    vec_push_back<u128>(&mut a, 1u128);
+    b = vec_mut_borrow<u128>(&mut a, 0);
+    *move(b) = 5u8;
+    return;
+}
+
+//# run --signers 0x1 --check-runtime-types
+main(account: signer) {
+    let a: u128;
+    let b: &mut u128;
+label b0:
+    a = 0u128;
+    b = &mut a;
+    *move(b) = 10u128;
+    return;
+}
+
+//# run --signers 0x1 --check-runtime-types
+main(account: signer) {
+    let a: u128;
+    let b: &mut u128;
+label b0:
+    a = 0u128;
+    b = &mut a;
+    *move(b) = 10u64;
+    return;
+}

--- a/language/move-vm/paranoid-tests/tests/type_safety/primitives/u16.exp
+++ b/language/move-vm/paranoid-tests/tests/type_safety/primitives/u16.exp
@@ -1,0 +1,28 @@
+processed 7 tasks
+
+task 2 'run'. lines 33-41:
+Error: Script execution failed with VMError: {
+    major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
+    sub_status: None,
+    location: 0x2::A,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(2), 3)],
+}
+
+task 4 'run'. lines 55-65:
+Error: Script execution failed with VMError: {
+    major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
+    sub_status: None,
+    location: script,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 11)],
+}
+
+task 6 'run'. lines 78-87:
+Error: Script execution failed with VMError: {
+    major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
+    sub_status: None,
+    location: script,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 6)],
+}

--- a/language/move-vm/paranoid-tests/tests/type_safety/primitives/u16.mvir
+++ b/language/move-vm/paranoid-tests/tests/type_safety/primitives/u16.mvir
@@ -1,0 +1,87 @@
+//# publish
+module 0x2.A {
+  struct A has drop { x: u16 }
+
+  public make_a(): Self.A {
+  label b0:
+    return A { x: 0u16 };
+  }
+
+  public test(a: &mut Self.A) {
+  label b0:
+    *&(move(a)).A::x = 10u16;
+    return;
+  }
+
+  public test_invalid(a: &mut Self.A) {
+  label b0:
+    *&(move(a)).A::x = 10u64;
+    return;
+  }
+}
+
+//# run --signers 0x1 --check-runtime-types
+import 0x2.A;
+main(account: signer) {
+    let a: A.A;
+label b0:
+    a = A.make_a();
+    A.test(&mut a);
+    return;
+}
+
+//# run --signers 0x1 --check-runtime-types
+import 0x2.A;
+main(account: signer) {
+    let a: A.A;
+label b0:
+    a = A.make_a();
+    A.test_invalid(&mut a);
+    return;
+}
+
+//# run --signers 0x1 --check-runtime-types
+main(account: signer) {
+    let a: vector<u16>;
+    let b: &mut u16;
+label b0:
+    a = vec_pack_0<u16>();
+    vec_push_back<u16>(&mut a, 1u16);
+    b = vec_mut_borrow<u16>(&mut a, 0);
+    *move(b) = 5u16;
+    return;
+}
+
+//# run --signers 0x1 --check-runtime-types
+main(account: signer) {
+    let a: vector<u16>;
+    let b: &mut u16;
+label b0:
+    a = vec_pack_0<u16>();
+    vec_push_back<u16>(&mut a, 1u16);
+    b = vec_mut_borrow<u16>(&mut a, 0);
+    *move(b) = 5u64;
+    return;
+}
+
+//# run --signers 0x1 --check-runtime-types
+main(account: signer) {
+    let a: u16;
+    let b: &mut u16;
+label b0:
+    a = 0u16;
+    b = &mut a;
+    *move(b) = 10u16;
+    return;
+}
+
+//# run --signers 0x1 --check-runtime-types
+main(account: signer) {
+    let a: u16;
+    let b: &mut u16;
+label b0:
+    a = 0u16;
+    b = &mut a;
+    *move(b) = 10u64;
+    return;
+}

--- a/language/move-vm/paranoid-tests/tests/type_safety/primitives/u256.exp
+++ b/language/move-vm/paranoid-tests/tests/type_safety/primitives/u256.exp
@@ -1,0 +1,28 @@
+processed 7 tasks
+
+task 2 'run'. lines 33-41:
+Error: Script execution failed with VMError: {
+    major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
+    sub_status: None,
+    location: 0x2::A,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(2), 3)],
+}
+
+task 4 'run'. lines 55-65:
+Error: Script execution failed with VMError: {
+    major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
+    sub_status: None,
+    location: script,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 11)],
+}
+
+task 6 'run'. lines 78-87:
+Error: Script execution failed with VMError: {
+    major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
+    sub_status: None,
+    location: script,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 6)],
+}

--- a/language/move-vm/paranoid-tests/tests/type_safety/primitives/u256.mvir
+++ b/language/move-vm/paranoid-tests/tests/type_safety/primitives/u256.mvir
@@ -1,0 +1,87 @@
+//# publish
+module 0x2.A {
+  struct A has drop { x: u256 }
+
+  public make_a(): Self.A {
+  label b0:
+    return A { x: 0u256 };
+  }
+
+  public test(a: &mut Self.A) {
+  label b0:
+    *&(move(a)).A::x = 10u256;
+    return;
+  }
+
+  public test_invalid(a: &mut Self.A) {
+  label b0:
+    *&(move(a)).A::x = 10u8;
+    return;
+  }
+}
+
+//# run --signers 0x1 --check-runtime-types
+import 0x2.A;
+main(account: signer) {
+    let a: A.A;
+label b0:
+    a = A.make_a();
+    A.test(&mut a);
+    return;
+}
+
+//# run --signers 0x1 --check-runtime-types
+import 0x2.A;
+main(account: signer) {
+    let a: A.A;
+label b0:
+    a = A.make_a();
+    A.test_invalid(&mut a);
+    return;
+}
+
+//# run --signers 0x1 --check-runtime-types
+main(account: signer) {
+    let a: vector<u256>;
+    let b: &mut u256;
+label b0:
+    a = vec_pack_0<u256>();
+    vec_push_back<u256>(&mut a, 1u256);
+    b = vec_mut_borrow<u256>(&mut a, 0);
+    *move(b) = 5u256;
+    return;
+}
+
+//# run --signers 0x1 --check-runtime-types
+main(account: signer) {
+    let a: vector<u256>;
+    let b: &mut u256;
+label b0:
+    a = vec_pack_0<u256>();
+    vec_push_back<u256>(&mut a, 1u256);
+    b = vec_mut_borrow<u256>(&mut a, 0);
+    *move(b) = 5u8;
+    return;
+}
+
+//# run --signers 0x1 --check-runtime-types
+main(account: signer) {
+    let a: u256;
+    let b: &mut u256;
+label b0:
+    a = 0u256;
+    b = &mut a;
+    *move(b) = 10u256;
+    return;
+}
+
+//# run --signers 0x1 --check-runtime-types
+main(account: signer) {
+    let a: u256;
+    let b: &mut u256;
+label b0:
+    a = 0u256;
+    b = &mut a;
+    *move(b) = 10u64;
+    return;
+}

--- a/language/move-vm/paranoid-tests/tests/type_safety/primitives/u32.exp
+++ b/language/move-vm/paranoid-tests/tests/type_safety/primitives/u32.exp
@@ -1,0 +1,28 @@
+processed 7 tasks
+
+task 2 'run'. lines 33-41:
+Error: Script execution failed with VMError: {
+    major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
+    sub_status: None,
+    location: 0x2::A,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(2), 3)],
+}
+
+task 4 'run'. lines 55-65:
+Error: Script execution failed with VMError: {
+    major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
+    sub_status: None,
+    location: script,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 11)],
+}
+
+task 6 'run'. lines 78-87:
+Error: Script execution failed with VMError: {
+    major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
+    sub_status: None,
+    location: script,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 6)],
+}

--- a/language/move-vm/paranoid-tests/tests/type_safety/primitives/u32.mvir
+++ b/language/move-vm/paranoid-tests/tests/type_safety/primitives/u32.mvir
@@ -1,0 +1,87 @@
+//# publish
+module 0x2.A {
+  struct A has drop { x: u32 }
+
+  public make_a(): Self.A {
+  label b0:
+    return A { x: 0u32 };
+  }
+
+  public test(a: &mut Self.A) {
+  label b0:
+    *&(move(a)).A::x = 10u32;
+    return;
+  }
+
+  public test_invalid(a: &mut Self.A) {
+  label b0:
+    *&(move(a)).A::x = 10u64;
+    return;
+  }
+}
+
+//# run --signers 0x1 --check-runtime-types
+import 0x2.A;
+main(account: signer) {
+    let a: A.A;
+label b0:
+    a = A.make_a();
+    A.test(&mut a);
+    return;
+}
+
+//# run --signers 0x1 --check-runtime-types
+import 0x2.A;
+main(account: signer) {
+    let a: A.A;
+label b0:
+    a = A.make_a();
+    A.test_invalid(&mut a);
+    return;
+}
+
+//# run --signers 0x1 --check-runtime-types
+main(account: signer) {
+    let a: vector<u32>;
+    let b: &mut u32;
+label b0:
+    a = vec_pack_0<u32>();
+    vec_push_back<u32>(&mut a, 1u32);
+    b = vec_mut_borrow<u32>(&mut a, 0);
+    *move(b) = 5u32;
+    return;
+}
+
+//# run --signers 0x1 --check-runtime-types
+main(account: signer) {
+    let a: vector<u32>;
+    let b: &mut u32;
+label b0:
+    a = vec_pack_0<u32>();
+    vec_push_back<u32>(&mut a, 1u32);
+    b = vec_mut_borrow<u32>(&mut a, 0);
+    *move(b) = 5u64;
+    return;
+}
+
+//# run --signers 0x1 --check-runtime-types
+main(account: signer) {
+    let a: u32;
+    let b: &mut u32;
+label b0:
+    a = 0u32;
+    b = &mut a;
+    *move(b) = 10u32;
+    return;
+}
+
+//# run --signers 0x1 --check-runtime-types
+main(account: signer) {
+    let a: u32;
+    let b: &mut u32;
+label b0:
+    a = 0u32;
+    b = &mut a;
+    *move(b) = 10u64;
+    return;
+}

--- a/language/move-vm/paranoid-tests/tests/type_safety/primitives/u64.exp
+++ b/language/move-vm/paranoid-tests/tests/type_safety/primitives/u64.exp
@@ -1,0 +1,28 @@
+processed 7 tasks
+
+task 2 'run'. lines 33-41:
+Error: Script execution failed with VMError: {
+    major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
+    sub_status: None,
+    location: 0x2::A,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(2), 3)],
+}
+
+task 4 'run'. lines 55-65:
+Error: Script execution failed with VMError: {
+    major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
+    sub_status: None,
+    location: script,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 11)],
+}
+
+task 6 'run'. lines 78-87:
+Error: Script execution failed with VMError: {
+    major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
+    sub_status: None,
+    location: script,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 6)],
+}

--- a/language/move-vm/paranoid-tests/tests/type_safety/primitives/u64.mvir
+++ b/language/move-vm/paranoid-tests/tests/type_safety/primitives/u64.mvir
@@ -1,0 +1,87 @@
+//# publish
+module 0x2.A {
+  struct A has drop { x: u64 }
+
+  public make_a(): Self.A {
+  label b0:
+    return A { x: 0u64 };
+  }
+
+  public test(a: &mut Self.A) {
+  label b0:
+    *&(move(a)).A::x = 10u64;
+    return;
+  }
+
+  public test_invalid(a: &mut Self.A) {
+  label b0:
+    *&(move(a)).A::x = 10u8;
+    return;
+  }
+}
+
+//# run --signers 0x1 --check-runtime-types
+import 0x2.A;
+main(account: signer) {
+    let a: A.A;
+label b0:
+    a = A.make_a();
+    A.test(&mut a);
+    return;
+}
+
+//# run --signers 0x1 --check-runtime-types
+import 0x2.A;
+main(account: signer) {
+    let a: A.A;
+label b0:
+    a = A.make_a();
+    A.test_invalid(&mut a);
+    return;
+}
+
+//# run --signers 0x1 --check-runtime-types
+main(account: signer) {
+    let a: vector<u64>;
+    let b: &mut u64;
+label b0:
+    a = vec_pack_0<u64>();
+    vec_push_back<u64>(&mut a, 1u64);
+    b = vec_mut_borrow<u64>(&mut a, 0);
+    *move(b) = 5u64;
+    return;
+}
+
+//# run --signers 0x1 --check-runtime-types
+main(account: signer) {
+    let a: vector<u64>;
+    let b: &mut u64;
+label b0:
+    a = vec_pack_0<u64>();
+    vec_push_back<u64>(&mut a, 1u64);
+    b = vec_mut_borrow<u64>(&mut a, 0);
+    *move(b) = 5u8;
+    return;
+}
+
+//# run --signers 0x1 --check-runtime-types
+main(account: signer) {
+    let a: u64;
+    let b: &mut u64;
+label b0:
+    a = 0u64;
+    b = &mut a;
+    *move(b) = 10u64;
+    return;
+}
+
+//# run --signers 0x1 --check-runtime-types
+main(account: signer) {
+    let a: u64;
+    let b: &mut u64;
+label b0:
+    a = 0u64;
+    b = &mut a;
+    *move(b) = 10u8;
+    return;
+}

--- a/language/move-vm/paranoid-tests/tests/type_safety/primitives/u8.exp
+++ b/language/move-vm/paranoid-tests/tests/type_safety/primitives/u8.exp
@@ -1,0 +1,28 @@
+processed 7 tasks
+
+task 2 'run'. lines 33-41:
+Error: Script execution failed with VMError: {
+    major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
+    sub_status: None,
+    location: 0x2::A,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(2), 3)],
+}
+
+task 4 'run'. lines 55-65:
+Error: Script execution failed with VMError: {
+    major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
+    sub_status: None,
+    location: script,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 11)],
+}
+
+task 6 'run'. lines 78-87:
+Error: Script execution failed with VMError: {
+    major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
+    sub_status: None,
+    location: script,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 6)],
+}

--- a/language/move-vm/paranoid-tests/tests/type_safety/primitives/u8.mvir
+++ b/language/move-vm/paranoid-tests/tests/type_safety/primitives/u8.mvir
@@ -1,0 +1,87 @@
+//# publish
+module 0x2.A {
+  struct A has drop { x: u8 }
+
+  public make_a(): Self.A {
+  label b0:
+    return A { x: 0u8 };
+  }
+
+  public test(a: &mut Self.A) {
+  label b0:
+    *&(move(a)).A::x = 10u8;
+    return;
+  }
+
+  public test_invalid(a: &mut Self.A) {
+  label b0:
+    *&(move(a)).A::x = 10u64;
+    return;
+  }
+}
+
+//# run --signers 0x1 --check-runtime-types
+import 0x2.A;
+main(account: signer) {
+    let a: A.A;
+label b0:
+    a = A.make_a();
+    A.test(&mut a);
+    return;
+}
+
+//# run --signers 0x1 --check-runtime-types
+import 0x2.A;
+main(account: signer) {
+    let a: A.A;
+label b0:
+    a = A.make_a();
+    A.test_invalid(&mut a);
+    return;
+}
+
+//# run --signers 0x1 --check-runtime-types
+main(account: signer) {
+    let a: vector<u8>;
+    let b: &mut u8;
+label b0:
+    a = vec_pack_0<u8>();
+    vec_push_back<u8>(&mut a, 1u8);
+    b = vec_mut_borrow<u8>(&mut a, 0);
+    *move(b) = 5u8;
+    return;
+}
+
+//# run --signers 0x1 --check-runtime-types
+main(account: signer) {
+    let a: vector<u8>;
+    let b: &mut u8;
+label b0:
+    a = vec_pack_0<u8>();
+    vec_push_back<u8>(&mut a, 1u8);
+    b = vec_mut_borrow<u8>(&mut a, 0);
+    *move(b) = 5u64;
+    return;
+}
+
+//# run --signers 0x1 --check-runtime-types
+main(account: signer) {
+    let a: u8;
+    let b: &mut u8;
+label b0:
+    a = 0u8;
+    b = &mut a;
+    *move(b) = 10u8;
+    return;
+}
+
+//# run --signers 0x1 --check-runtime-types
+main(account: signer) {
+    let a: u8;
+    let b: &mut u8;
+label b0:
+    a = 0u8;
+    b = &mut a;
+    *move(b) = 10u64;
+    return;
+}

--- a/language/move-vm/paranoid-tests/tests/type_safety/type_info.exp
+++ b/language/move-vm/paranoid-tests/tests/type_safety/type_info.exp
@@ -1,0 +1,1 @@
+processed 2 tasks

--- a/language/move-vm/paranoid-tests/tests/type_safety/type_info.mvir
+++ b/language/move-vm/paranoid-tests/tests/type_safety/type_info.mvir
@@ -1,0 +1,19 @@
+//# publish
+module 0x2.A {
+  struct A has drop { x: u64 }
+}
+
+//# run --signers 0x1 --check-runtime-types
+import 0x1.type_name;
+import 0x1.ascii;
+import 0x2.A;
+main(account: signer) {
+    let v: type_name.TypeName;
+    let s: ascii.String;
+
+label b0:
+    v = type_name.get<A.A>();
+    s = type_name.into_string(move(v));
+
+    return;
+}

--- a/language/move-vm/paranoid-tests/tests/type_safety/vec_pack_mismatch.exp
+++ b/language/move-vm/paranoid-tests/tests/type_safety/vec_pack_mismatch.exp
@@ -1,0 +1,10 @@
+processed 4 tasks
+
+task 2 'run'. lines 27-37:
+Error: Script execution failed with VMError: {
+    major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
+    sub_status: None,
+    location: 0x2::Math,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 2)],
+}

--- a/language/move-vm/paranoid-tests/tests/type_safety/vec_pack_mismatch.mvir
+++ b/language/move-vm/paranoid-tests/tests/type_safety/vec_pack_mismatch.mvir
@@ -1,0 +1,49 @@
+//# publish
+module 0x2.A {
+  struct Password has key { x: u64 }
+
+  public store(x: Self.Password, s: &signer) {
+  label b0:
+    move_to<Password>(move(s), move(x));
+    return;
+  }
+}
+
+//# publish
+module 0x2.Math {
+  import 0x2.A;
+
+  struct R { v: u64 }
+
+  public test(): A.Password {
+      let v1: vector<A.Password>;
+
+  label b0:
+      v1 = vec_pack_1<A.Password>(R { v: 0 });
+      return vec_unpack_1<A.Password>(move(v1));
+  }
+}
+
+//# run --signers 0x1 --check-runtime-types
+import 0x2.Math;
+import 0x2.A;
+main(account: signer) {
+    let v: A.Password;
+
+label b0:
+    v = Math.test();
+    A.store(move(v), &account);
+    return;
+}
+
+//# run --signers 0x1
+import 0x2.Math;
+import 0x2.A;
+main(account: signer) {
+    let v: A.Password;
+
+label b0:
+    v = Math.test();
+    A.store(move(v), &account);
+    return;
+}

--- a/language/move-vm/paranoid-tests/tests/type_safety/vec_push_back.exp
+++ b/language/move-vm/paranoid-tests/tests/type_safety/vec_push_back.exp
@@ -1,0 +1,10 @@
+processed 3 tasks
+
+task 2 'run'. lines 32-48:
+Error: Script execution failed with VMError: {
+    major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
+    sub_status: None,
+    location: script,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 11)],
+}

--- a/language/move-vm/paranoid-tests/tests/type_safety/vec_push_back.mvir
+++ b/language/move-vm/paranoid-tests/tests/type_safety/vec_push_back.mvir
@@ -1,0 +1,48 @@
+//# publish
+module 0x2.A {
+  struct C has drop { x: u64 }
+  struct D has drop { x: u64 }
+
+  public make(): Self.C {
+  label b0:
+    return C { x: 0};
+  }
+
+  public make_d(): Self.D {
+  label b0:
+    return D { x: 0};
+  }
+}
+
+//# run --signers 0x1 --check-runtime-types
+import 0x2.A;
+main(account: signer) {
+    let v: vector<A.C>;
+    let a: A.C;
+
+label b0:
+    v = vec_pack_0<A.C>();
+    a = A.make();
+
+    vec_push_back<A.C>(&mut v, move(a));
+
+    return;
+}
+
+//# run --signers 0x1 --check-runtime-types
+import 0x2.A;
+main(account: signer) {
+    let v: vector<A.C>;
+    let a: A.C;
+    let b: A.D;
+
+label b0:
+    v = vec_pack_0<A.C>();
+    a = A.make();
+    b = A.make_d();
+
+    vec_push_back<A.C>(&mut v, move(a));
+    vec_push_back<A.C>(&mut v, move(b));
+
+    return;
+}

--- a/language/move-vm/paranoid-tests/tests/type_safety/write_ref_with_struct.exp
+++ b/language/move-vm/paranoid-tests/tests/type_safety/write_ref_with_struct.exp
@@ -1,0 +1,10 @@
+processed 3 tasks
+
+task 2 'run'. lines 47-53:
+Error: Script execution failed with VMError: {
+    major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
+    sub_status: None,
+    location: 0x2::A,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(3), 10)],
+}

--- a/language/move-vm/paranoid-tests/tests/type_safety/write_ref_with_struct.mvir
+++ b/language/move-vm/paranoid-tests/tests/type_safety/write_ref_with_struct.mvir
@@ -1,0 +1,53 @@
+//# publish
+module 0x2.A {
+  struct C has drop { x: u64 }
+  struct D has drop { x: u64 }
+  struct A has drop { c: Self.C }
+
+  public make_c(): Self.C {
+  label b0:
+    return C { x: 0};
+  }
+
+  public make_d(): Self.D {
+  label b0:
+    return D { x: 0 };
+  }
+
+  public test_mutate() {
+    let a: Self.A;
+    let c_ref: &mut Self.C;
+    let c: Self.C;
+  label b0:
+    a = A { c: C { x: 0 }};
+    c_ref =  &mut (&mut a).A::c;
+    *copy(c_ref) = C { x: 20u64 };
+    return;
+  }
+
+  public test_invalid_mutate() {
+    let a: Self.A;
+    let c_ref: &mut Self.C;
+  label b0:
+    a = A { c: C { x: 0 }};
+    c_ref =  &mut (&mut a).A::c;
+    *move(c_ref) = D { x: 20 };
+    return;
+  }
+}
+
+//# run --signers 0x1 --check-runtime-types
+import 0x2.A;
+main(account: signer) {
+label b0:
+    A.test_mutate();
+    return;
+}
+
+//# run --signers 0x1 --check-runtime-types
+import 0x2.A;
+main(account: signer) {
+label b0:
+    A.test_invalid_mutate();
+    return;
+}

--- a/language/move-vm/paranoid-tests/tests/type_safety/write_ref_with_vector.exp
+++ b/language/move-vm/paranoid-tests/tests/type_safety/write_ref_with_vector.exp
@@ -1,0 +1,10 @@
+processed 3 tasks
+
+task 2 'run'. lines 35-50:
+Error: Script execution failed with VMError: {
+    major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
+    sub_status: None,
+    location: script,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 13)],
+}

--- a/language/move-vm/paranoid-tests/tests/type_safety/write_ref_with_vector.mvir
+++ b/language/move-vm/paranoid-tests/tests/type_safety/write_ref_with_vector.mvir
@@ -1,0 +1,50 @@
+//# publish
+module 0x2.A {
+  struct C has drop { x: u64 }
+  struct D has drop { x: u64 }
+  struct A has drop { c: Self.C }
+
+  public make_c(): Self.C {
+  label b0:
+    return C { x: 0};
+  }
+
+  public make_d(): Self.D {
+  label b0:
+    return D { x: 0 };
+  }
+}
+
+//# run --signers 0x1 --check-runtime-types
+import 0x2.A;
+main(account: signer) {
+    let c: A.C;
+    let v: vector<A.C>;
+    let c_ref: &mut A.C;
+label b0:
+    c = A.make_c();
+    v = vec_pack_1<A.C>(move(c));
+    c_ref = vec_mut_borrow<A.C>(&mut v, 0);
+
+    c = A.make_c();
+    *move(c_ref) = move(c);
+    return;
+}
+
+
+//# run --signers 0x1 --check-runtime-types
+import 0x2.A;
+main(account: signer) {
+    let c: A.C;
+    let d: A.D;
+    let v: vector<A.C>;
+    let c_ref: &mut A.C;
+label b0:
+    c = A.make_c();
+    v = vec_pack_1<A.C>(move(c));
+    c_ref = vec_mut_borrow<A.C>(&mut v, 0);
+
+    d = A.make_d();
+    *move(c_ref) = move(d);
+    return;
+}

--- a/language/move-vm/runtime/src/loader.rs
+++ b/language/move-vm/runtime/src/loader.rs
@@ -4,6 +4,7 @@
 
 use crate::{
     logging::expect_no_verification_errors,
+    move_vm::RuntimeConfig,
     native_functions::{NativeFunction, NativeFunctions, UnboxedNativeFunction},
     session::LoadedFunctionInstantiation,
 };
@@ -16,7 +17,7 @@ use move_binary_format::{
         FieldHandleIndex, FieldInstantiationIndex, FunctionDefinition, FunctionDefinitionIndex,
         FunctionHandleIndex, FunctionInstantiationIndex, Signature, SignatureIndex, SignatureToken,
         StructDefInstantiationIndex, StructDefinition, StructDefinitionIndex,
-        StructFieldInformation, TableIndex,
+        StructFieldInformation, StructHandleIndex, TableIndex, Visibility,
     },
     IndexKind,
 };
@@ -487,10 +488,16 @@ pub(crate) struct Loader {
     module_cache_hits: RwLock<BTreeSet<ModuleId>>,
 
     verifier_config: VerifierConfig,
+
+    runtime_config: RuntimeConfig,
 }
 
 impl Loader {
-    pub(crate) fn new(natives: NativeFunctions, verifier_config: VerifierConfig) -> Self {
+    pub(crate) fn new(
+        natives: NativeFunctions,
+        verifier_config: VerifierConfig,
+        runtime_config: RuntimeConfig,
+    ) -> Self {
         Self {
             scripts: RwLock::new(ScriptCache::new()),
             module_cache: RwLock::new(ModuleCache::new()),
@@ -499,6 +506,7 @@ impl Loader {
             invalidated: RwLock::new(false),
             module_cache_hits: RwLock::new(BTreeSet::new()),
             verifier_config,
+            runtime_config,
         }
     }
 
@@ -654,6 +662,8 @@ impl Loader {
     // Script verification steps.
     // See `verify_module()` for module verification steps.
     fn verify_script(&self, script: &CompiledScript) -> VMResult<()> {
+        fail::fail_point!("verifier-failpoint-3", |_| { Ok(()) });
+
         move_bytecode_verifier::verify_script_with_config(&self.verifier_config, script)
     }
 
@@ -775,6 +785,8 @@ impl Loader {
         bundle_unverified: &BTreeSet<ModuleId>,
         data_store: &impl DataStore,
     ) -> VMResult<()> {
+        fail::fail_point!("verifier-failpoint-1", |_| { Ok(()) });
+
         // Performs all verification steps to load the module without loading it, i.e., the new
         // module will NOT show up in `module_cache`. In the module republishing case, it means
         // that the old module is still in the `module_cache`, unless a new Loader is created,
@@ -1009,6 +1021,18 @@ impl Loader {
                     .finish(Location::Module(id.clone()))
             })
             .map_err(expect_no_verification_errors)?;
+
+        fail::fail_point!("verifier-failpoint-2", |_| { Ok(module.clone()) });
+
+        if self.runtime_config.paranoid_type_checks {
+            if &module.self_id() != id {
+                return Err(
+                    PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
+                        .with_message(format!("Module self id mismatch with storage"))
+                        .finish(Location::Module(id.clone())),
+                );
+            }
+        }
 
         // bytecode verifier checks that can be performed with the module itself
         move_bytecode_verifier::verify_module_with_config(&self.verifier_config, &module)
@@ -1393,6 +1417,49 @@ impl<'a> Resolver<'a> {
         Type::Struct(struct_def)
     }
 
+    pub(crate) fn get_struct_fields(
+        &self,
+        idx: StructDefinitionIndex,
+    ) -> PartialVMResult<Arc<StructType>> {
+        let idx = match &self.binary {
+            BinaryType::Module(module) => module.struct_at(idx),
+            BinaryType::Script(_) => unreachable!("Scripts cannot have type instructions"),
+        };
+        self.loader.get_struct_type(idx).ok_or_else(|| {
+            PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
+                .with_message("Struct Definition not resolved".to_string())
+        })
+    }
+
+    pub(crate) fn instantiate_generic_fields(
+        &self,
+        idx: StructDefInstantiationIndex,
+        ty_args: &[Type],
+    ) -> PartialVMResult<Vec<Type>> {
+        let struct_inst = match &self.binary {
+            BinaryType::Module(module) => module.struct_instantiation_at(idx.0),
+            BinaryType::Script(_) => unreachable!("Scripts cannot have type instructions"),
+        };
+        let struct_type = self
+            .loader
+            .get_struct_type(struct_inst.def)
+            .ok_or_else(|| {
+                PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
+                    .with_message("Struct Definition not resolved".to_string())
+            })?;
+
+        let instantiation_types = struct_inst
+            .instantiation
+            .iter()
+            .map(|inst_ty| inst_ty.subst(ty_args))
+            .collect::<PartialVMResult<Vec<_>>>()?;
+        struct_type
+            .fields
+            .iter()
+            .map(|ty| ty.subst(&instantiation_types))
+            .collect::<PartialVMResult<Vec<_>>>()
+    }
+
     pub(crate) fn instantiate_generic_type(
         &self,
         idx: StructDefInstantiationIndex,
@@ -1412,6 +1479,42 @@ impl<'a> Resolver<'a> {
         ))
     }
 
+    pub(crate) fn resolve_signature_token(&self, tok: &SignatureToken) -> PartialVMResult<Type> {
+        Ok(match tok {
+            SignatureToken::Address => Type::Address,
+            SignatureToken::Bool => Type::Bool,
+            SignatureToken::Signer => Type::Signer,
+            SignatureToken::U8 => Type::U8,
+            SignatureToken::U16 => Type::U16,
+            SignatureToken::U32 => Type::U32,
+            SignatureToken::U64 => Type::U64,
+            SignatureToken::U128 => Type::U128,
+            SignatureToken::U256 => Type::U256,
+            SignatureToken::Reference(r) => {
+                Type::Reference(Box::new(self.resolve_signature_token(r)?))
+            }
+            SignatureToken::MutableReference(r) => {
+                Type::MutableReference(Box::new(self.resolve_signature_token(r)?))
+            }
+            SignatureToken::Struct(idx) => Type::Struct(self.get_struct_handle_idx(*idx)),
+            SignatureToken::Vector(ty) => Type::Vector(Box::new(self.resolve_signature_token(ty)?)),
+            SignatureToken::StructInstantiation(idx, tys) => Type::StructInstantiation(
+                self.get_struct_handle_idx(*idx),
+                tys.iter()
+                    .map(|tok| self.resolve_signature_token(tok))
+                    .collect::<PartialVMResult<Vec<_>>>()?,
+            ),
+            SignatureToken::TypeParameter(idx) => Type::TyParam(*idx as usize),
+        })
+    }
+
+    fn get_struct_handle_idx(&self, idx: StructHandleIndex) -> CachedStructIndex {
+        match &self.binary {
+            BinaryType::Module(module) => module.struct_handle_at(idx),
+            BinaryType::Script(script) => script.struct_handle_at(idx),
+        }
+    }
+
     fn single_type_at(&self, idx: SignatureIndex) -> &Type {
         match &self.binary {
             BinaryType::Module(module) => module.single_type_at(idx),
@@ -1426,6 +1529,10 @@ impl<'a> Resolver<'a> {
     ) -> PartialVMResult<Type> {
         let ty = self.single_type_at(idx);
         ty.subst(ty_args)
+    }
+
+    pub(crate) fn abilities(&self, ty: &Type) -> PartialVMResult<AbilitySet> {
+        self.loader.abilities(ty)
     }
 
     //
@@ -1457,6 +1564,31 @@ impl<'a> Resolver<'a> {
         match &self.binary {
             BinaryType::Module(module) => module.field_instantiation_count(idx.0),
             BinaryType::Script(_) => unreachable!("Scripts cannot have type instructions"),
+        }
+    }
+
+    pub(crate) fn field_handle_to_struct(&self, idx: FieldHandleIndex) -> Type {
+        match &self.binary {
+            BinaryType::Module(module) => Type::Struct(module.field_handles[idx.0 as usize].owner),
+            BinaryType::Script(_) => unreachable!("Scripts cannot have field instructions"),
+        }
+    }
+
+    pub(crate) fn field_instantiation_to_struct(
+        &self,
+        idx: FieldInstantiationIndex,
+        args: &[Type],
+    ) -> PartialVMResult<Type> {
+        match &self.binary {
+            BinaryType::Module(module) => Ok(Type::StructInstantiation(
+                module.field_instantiations[idx.0 as usize].owner,
+                module.field_instantiations[idx.0 as usize]
+                    .instantiation
+                    .iter()
+                    .map(|ty| ty.subst(args))
+                    .collect::<PartialVMResult<Vec<_>>>()?,
+            )),
+            BinaryType::Script(_) => unreachable!("Scripts cannot have field instructions"),
         }
     }
 
@@ -1690,7 +1822,15 @@ impl Module {
                 let fh_idx = f_inst.handle;
                 let owner = field_handles[fh_idx.0 as usize].owner;
                 let offset = field_handles[fh_idx.0 as usize].offset;
-                field_instantiations.push(FieldInstantiation { offset, owner });
+                let mut instantiation = vec![];
+                for ty in &module.signature_at(f_inst.type_parameters).0 {
+                    instantiation.push(cache.make_type_while_loading(&module, ty)?);
+                }
+                field_instantiations.push(FieldInstantiation {
+                    offset,
+                    owner,
+                    instantiation,
+                });
             }
 
             Ok(())
@@ -1717,6 +1857,10 @@ impl Module {
 
     fn struct_at(&self, idx: StructDefinitionIndex) -> CachedStructIndex {
         self.structs[idx.0 as usize].idx
+    }
+
+    fn struct_handle_at(&self, idx: StructHandleIndex) -> CachedStructIndex {
+        self.struct_refs[idx.0 as usize]
     }
 
     fn struct_instantiation_at(&self, idx: u16) -> &StructInstantiation {
@@ -1885,6 +2029,7 @@ impl Script {
             type_parameters,
             native,
             def_is_native,
+            def_is_friend_or_private: false,
             scope,
             name,
         });
@@ -1947,6 +2092,10 @@ impl Script {
         self.function_refs[idx as usize]
     }
 
+    fn struct_handle_at(&self, idx: StructHandleIndex) -> CachedStructIndex {
+        self.struct_refs[idx.0 as usize]
+    }
+
     fn function_instantiation_at(&self, idx: u16) -> &FunctionInstantiation {
         &self.function_instantiations[idx as usize]
     }
@@ -1977,6 +2126,7 @@ pub(crate) struct Function {
     type_parameters: Vec<AbilitySet>,
     native: Option<NativeFunction>,
     def_is_native: bool,
+    def_is_friend_or_private: bool,
     scope: Scope,
     name: Identifier,
 }
@@ -1991,6 +2141,12 @@ impl Function {
         let handle = module.function_handle_at(def.function);
         let name = module.identifier_at(handle.name).to_owned();
         let module_id = module.self_id();
+
+        let def_is_friend_or_private = match def.visibility {
+            Visibility::Friend | Visibility::Private => true,
+            Visibility::Public => false,
+        };
+
         let (native, def_is_native) = if def.is_native() {
             (
                 natives.resolve(
@@ -2032,6 +2188,7 @@ impl Function {
             type_parameters,
             native,
             def_is_native,
+            def_is_friend_or_private,
             scope,
             name,
         }
@@ -2068,6 +2225,14 @@ impl Function {
 
     pub(crate) fn local_count(&self) -> usize {
         self.locals.len()
+    }
+
+    pub(crate) fn local_types(&self) -> &[SignatureToken] {
+        &self.locals.0
+    }
+
+    pub(crate) fn return_types(&self) -> &[SignatureToken] {
+        &self.return_.0
     }
 
     pub(crate) fn arg_count(&self) -> usize {
@@ -2109,6 +2274,10 @@ impl Function {
 
     pub(crate) fn is_native(&self) -> bool {
         self.def_is_native
+    }
+
+    pub(crate) fn is_friend_or_private(&self) -> bool {
+        self.def_is_friend_or_private
     }
 
     pub(crate) fn get_native(&self) -> PartialVMResult<&UnboxedNativeFunction> {
@@ -2177,6 +2346,7 @@ struct FieldInstantiation {
     // `ModuelCache::structs` global table index. It is the generic type.
     #[allow(unused)]
     owner: CachedStructIndex,
+    instantiation: Vec<Type>,
 }
 
 //
@@ -2300,7 +2470,21 @@ impl Loader {
             .iter()
             .map(|ty| self.type_to_type_layout_impl(ty, depth + 1))
             .collect::<PartialVMResult<Vec<_>>>()?;
-        let struct_layout = MoveStructLayout::new(field_layouts);
+
+        let struct_layout = if self.runtime_config.paranoid_type_checks {
+            MoveStructLayout::CheckedRuntime {
+                fields: field_layouts,
+                tag: if ty_args.is_empty() {
+                    Type::Struct(gidx)
+                } else {
+                    Type::StructInstantiation(gidx, ty_args.to_vec())
+                }
+                .get_hash(),
+                ability: struct_type.abilities.into_u8(),
+            }
+        } else {
+            MoveStructLayout::Runtime(field_layouts)
+        };
 
         self.type_cache
             .write()
@@ -2443,6 +2627,10 @@ impl Loader {
         ty: &Type,
     ) -> PartialVMResult<MoveTypeLayout> {
         self.type_to_fully_annotated_layout_impl(ty, 1)
+    }
+
+    pub(crate) fn runtime_config(&self) -> RuntimeConfig {
+        self.runtime_config
     }
 }
 

--- a/language/move-vm/runtime/src/move_vm.rs
+++ b/language/move-vm/runtime/src/move_vm.rs
@@ -18,6 +18,11 @@ use move_core_types::{
     metadata::Metadata, resolver::MoveResolver,
 };
 
+#[derive(Debug, Clone, Default, Copy)]
+pub struct RuntimeConfig {
+    pub paranoid_type_checks: bool,
+}
+
 pub struct MoveVM {
     runtime: VMRuntime,
 }
@@ -26,19 +31,26 @@ impl MoveVM {
     pub fn new(
         natives: impl IntoIterator<Item = (AccountAddress, Identifier, Identifier, NativeFunction)>,
     ) -> VMResult<Self> {
-        Self::new_with_verifier_config(natives, VerifierConfig::default())
+        Self::new_with_configs(natives, VerifierConfig::default(), RuntimeConfig::default())
     }
 
     pub fn new_with_verifier_config(
         natives: impl IntoIterator<Item = (AccountAddress, Identifier, Identifier, NativeFunction)>,
         verifier_config: VerifierConfig,
     ) -> VMResult<Self> {
+        Self::new_with_configs(natives, verifier_config, RuntimeConfig::default())
+    }
+
+    pub fn new_with_configs(
+        natives: impl IntoIterator<Item = (AccountAddress, Identifier, Identifier, NativeFunction)>,
+        verifier_config: VerifierConfig,
+        runtime_config: RuntimeConfig,
+    ) -> VMResult<Self> {
         Ok(Self {
-            runtime: VMRuntime::new(natives, verifier_config)
+            runtime: VMRuntime::new(natives, verifier_config, runtime_config)
                 .map_err(|err| err.finish(Location::Undefined))?,
         })
     }
-
     /// Create a new Session backed by the given storage.
     ///
     /// Right now it is the caller's responsibility to ensure cache coherence of the Move VM Loader

--- a/language/move-vm/runtime/src/runtime.rs
+++ b/language/move-vm/runtime/src/runtime.rs
@@ -6,6 +6,7 @@ use crate::{
     data_cache::TransactionDataCache,
     interpreter::Interpreter,
     loader::{Function, Loader},
+    move_vm::RuntimeConfig,
     native_extensions::NativeContextExtensions,
     native_functions::{NativeFunction, NativeFunctions},
     session::{LoadedFunctionInstantiation, SerializedReturnValues, Session},
@@ -44,9 +45,14 @@ impl VMRuntime {
     pub(crate) fn new(
         natives: impl IntoIterator<Item = (AccountAddress, Identifier, Identifier, NativeFunction)>,
         verifier_config: VerifierConfig,
+        runtime_config: RuntimeConfig,
     ) -> PartialVMResult<Self> {
         Ok(VMRuntime {
-            loader: Loader::new(NativeFunctions::new(natives)?, verifier_config),
+            loader: Loader::new(
+                NativeFunctions::new(natives)?,
+                verifier_config,
+                runtime_config,
+            ),
         })
     }
 

--- a/language/move-vm/transactional-tests/tests/entry_points/generic_return_values.move
+++ b/language/move-vm/transactional-tests/tests/entry_points/generic_return_values.move
@@ -2,7 +2,7 @@
 
 module 0x42::Test {
 
-    struct Cup<T> { value: T }
+    struct Cup<T> has drop { value: T }
 
     public fun t1<T>(x: T): T {
         x

--- a/language/move-vm/types/src/loaded_data/runtime_types.rs
+++ b/language/move-vm/types/src/loaded_data/runtime_types.rs
@@ -10,6 +10,10 @@ use move_core_types::{
     gas_algebra::AbstractMemorySize, identifier::Identifier, language_storage::ModuleId,
     vm_status::StatusCode,
 };
+use std::{
+    collections::hash_map::DefaultHasher,
+    hash::{Hash, Hasher},
+};
 
 pub const TYPE_DEPTH_MAX: usize = 256;
 
@@ -131,5 +135,15 @@ impl Type {
                 .iter()
                 .fold(Self::LEGACY_BASE_MEMORY_SIZE, |acc, ty| acc + ty.size()),
         }
+    }
+
+    /// Get a u64 hash for the type.
+    ///
+    /// This is just used for generating unique identifier for types at runtime checks.
+    /// We may want to revisit if hash collision is really a concern here.
+    pub fn get_hash(&self) -> u64 {
+        let mut s = DefaultHasher::new();
+        self.hash(&mut s);
+        s.finish()
     }
 }

--- a/language/testing-infra/transactional-test-runner/Cargo.toml
+++ b/language/testing-infra/transactional-test-runner/Cargo.toml
@@ -20,6 +20,7 @@ tempfile = "3.2.0"
 
 
 move-stackless-bytecode-interpreter = { path = "../../move-prover/interpreter" }
+move-bytecode-verifier = { path = "../../move-bytecode-verifier" }
 move-bytecode-source-map = { path = "../../move-ir-compiler/move-bytecode-source-map" }
 move-disassembler = { path = "../../tools/move-disassembler" }
 move-binary-format = { path = "../../move-binary-format" }
@@ -44,3 +45,6 @@ difference = "2.0.0"
 [[test]]
 name = "tests"
 harness = false
+
+[features]
+failpoints = ['move-vm-runtime/failpoints']

--- a/language/testing-infra/transactional-test-runner/src/vm_test_harness.rs
+++ b/language/testing-infra/transactional-test-runner/src/vm_test_harness.rs
@@ -16,6 +16,7 @@ use move_binary_format::{
     file_format::CompiledScript,
     CompiledModule,
 };
+use move_bytecode_verifier::VerifierConfig;
 use move_command_line_common::{
     address::ParsedAddress, files::verify_and_create_named_address_mapping,
 };
@@ -33,7 +34,7 @@ use move_resource_viewer::MoveValueAnnotator;
 use move_stdlib::move_stdlib_named_addresses;
 use move_symbol_pool::Symbol;
 use move_vm_runtime::{
-    move_vm::MoveVM,
+    move_vm::{MoveVM, RuntimeConfig},
     session::{SerializedReturnValues, Session},
 };
 use move_vm_test_utils::{gas_schedule::GasStatus, InMemoryStorage};
@@ -82,11 +83,17 @@ pub struct AdapterPublishArgs {
     pub skip_check_friend_linking: bool,
 }
 
+#[derive(Debug, Parser)]
+pub struct AdapterExecuteArgs {
+    #[clap(long)]
+    pub check_runtime_types: bool,
+}
+
 impl<'a> MoveTestAdapter<'a> for SimpleVMTestAdapter<'a> {
     type ExtraInitArgs = EmptyCommand;
     type ExtraPublishArgs = AdapterPublishArgs;
     type ExtraValueArgs = ();
-    type ExtraRunArgs = EmptyCommand;
+    type ExtraRunArgs = AdapterExecuteArgs;
     type Subcommand = EmptyCommand;
 
     fn compiled_state(&mut self) -> &mut CompiledState<'a> {
@@ -126,19 +133,23 @@ impl<'a> MoveTestAdapter<'a> for SimpleVMTestAdapter<'a> {
         };
 
         adapter
-            .perform_session_action(None, |session, gas_status| {
-                for module in &*MOVE_STDLIB_COMPILED {
-                    let mut module_bytes = vec![];
-                    module.serialize(&mut module_bytes).unwrap();
+            .perform_session_action(
+                None,
+                |session, gas_status| {
+                    for module in &*MOVE_STDLIB_COMPILED {
+                        let mut module_bytes = vec![];
+                        module.serialize(&mut module_bytes).unwrap();
 
-                    let id = module.self_id();
-                    let sender = *id.address();
-                    session
-                        .publish_module(module_bytes, sender, gas_status)
-                        .unwrap();
-                }
-                Ok(())
-            })
+                        let id = module.self_id();
+                        let sender = *id.address();
+                        session
+                            .publish_module(module_bytes, sender, gas_status)
+                            .unwrap();
+                    }
+                    Ok(())
+                },
+                RuntimeConfig::default(),
+            )
             .unwrap();
         let mut addr_to_name_mapping = BTreeMap::new();
         for (name, addr) in move_stdlib_named_addresses() {
@@ -169,20 +180,24 @@ impl<'a> MoveTestAdapter<'a> for SimpleVMTestAdapter<'a> {
 
         let id = module.self_id();
         let sender = *id.address();
-        match self.perform_session_action(gas_budget, |session, gas_status| {
-            let compat = Compatibility::new(
-                !extra_args.skip_check_struct_and_pub_function_linking,
-                !extra_args.skip_check_struct_layout,
-                !extra_args.skip_check_friend_linking,
-            );
+        match self.perform_session_action(
+            gas_budget,
+            |session, gas_status| {
+                let compat = Compatibility::new(
+                    !extra_args.skip_check_struct_and_pub_function_linking,
+                    !extra_args.skip_check_struct_layout,
+                    !extra_args.skip_check_friend_linking,
+                );
 
-            session.publish_module_bundle_with_compat_config(
-                vec![module_bytes],
-                sender,
-                gas_status,
-                compat,
-            )
-        }) {
+                session.publish_module_bundle_with_compat_config(
+                    vec![module_bytes],
+                    sender,
+                    gas_status,
+                    compat,
+                )
+            },
+            RuntimeConfig::default(),
+        ) {
             Ok(()) => Ok((None, module)),
             Err(e) => Err(anyhow!(
                 "Unable to publish module '{}'. Got VMError: {}",
@@ -199,7 +214,7 @@ impl<'a> MoveTestAdapter<'a> for SimpleVMTestAdapter<'a> {
         signers: Vec<ParsedAddress>,
         txn_args: Vec<MoveValue>,
         gas_budget: Option<u64>,
-        _extra_args: Self::ExtraRunArgs,
+        extra_args: Self::ExtraRunArgs,
     ) -> Result<(Option<String>, SerializedReturnValues)> {
         let signers: Vec<_> = signers
             .into_iter()
@@ -220,9 +235,13 @@ impl<'a> MoveTestAdapter<'a> for SimpleVMTestAdapter<'a> {
             .chain(args)
             .collect();
         let serialized_return_values = self
-            .perform_session_action(gas_budget, |session, gas_status| {
-                session.execute_script(script_bytes, type_args, args, gas_status)
-            })
+            .perform_session_action(
+                gas_budget,
+                |session, gas_status| {
+                    session.execute_script(script_bytes, type_args, args, gas_status)
+                },
+                RuntimeConfig::from(extra_args),
+            )
             .map_err(|e| {
                 anyhow!(
                     "Script execution failed with VMError: {}",
@@ -240,7 +259,7 @@ impl<'a> MoveTestAdapter<'a> for SimpleVMTestAdapter<'a> {
         signers: Vec<ParsedAddress>,
         txn_args: Vec<MoveValue>,
         gas_budget: Option<u64>,
-        _extra_args: Self::ExtraRunArgs,
+        extra_args: Self::ExtraRunArgs,
     ) -> Result<(Option<String>, SerializedReturnValues)> {
         let signers: Vec<_> = signers
             .into_iter()
@@ -258,11 +277,15 @@ impl<'a> MoveTestAdapter<'a> for SimpleVMTestAdapter<'a> {
             .chain(args)
             .collect();
         let serialized_return_values = self
-            .perform_session_action(gas_budget, |session, gas_status| {
-                session.execute_function_bypass_visibility(
-                    module, function, type_args, args, gas_status,
-                )
-            })
+            .perform_session_action(
+                gas_budget,
+                |session, gas_status| {
+                    session.execute_function_bypass_visibility(
+                        module, function, type_args, args, gas_status,
+                    )
+                },
+                RuntimeConfig::from(extra_args),
+            )
             .map_err(|e| {
                 anyhow!(
                     "Function execution failed with VMError: {}",
@@ -315,13 +338,18 @@ impl<'a> SimpleVMTestAdapter<'a> {
         &mut self,
         gas_budget: Option<u64>,
         f: impl FnOnce(&mut Session<InMemoryStorage>, &mut GasStatus) -> VMResult<Ret>,
+        runtime_config: RuntimeConfig,
     ) -> VMResult<Ret> {
         // start session
-        let vm = MoveVM::new(move_stdlib::natives::all_natives(
-            STD_ADDR,
-            // TODO: come up with a suitable gas schedule
-            move_stdlib::natives::GasParameters::zeros(),
-        ))
+        let vm = MoveVM::new_with_configs(
+            move_stdlib::natives::all_natives(
+                STD_ADDR,
+                // TODO: come up with a suitable gas schedule
+                move_stdlib::natives::GasParameters::zeros(),
+            ),
+            VerifierConfig::default(),
+            runtime_config,
+        )
         .unwrap();
         let (mut session, mut gas_status) = {
             let gas_status = move_cli::sandbox::utils::get_gas_status(
@@ -395,4 +423,12 @@ static MOVE_STDLIB_COMPILED: Lazy<Vec<CompiledModule>> = Lazy::new(|| {
 
 pub fn run_test(path: &Path) -> Result<(), Box<dyn std::error::Error>> {
     run_test_impl::<SimpleVMTestAdapter>(path, Some(&*PRECOMPILED_MOVE_STDLIB))
+}
+
+impl From<AdapterExecuteArgs> for RuntimeConfig {
+    fn from(arg: AdapterExecuteArgs) -> RuntimeConfig {
+        RuntimeConfig {
+            paranoid_type_checks: arg.check_runtime_types,
+        }
+    }
 }

--- a/x.toml
+++ b/x.toml
@@ -130,6 +130,7 @@ members = [
     "move-compiler-transactional-tests",
     "move-explain",
     "move-ir-compiler-transactional-tests",
+    "move-vm-paranoid-tests",
     "move-prover-test-utils",
     "move-transactional-test-runner",
     "move-vm-integration-tests",


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Move Language.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

This is the refined version of #493 and #509 and hopefully we can embrace the idea of runtime checks and merge it into main.

The main idea is the following: provide a runtime-configurable mode in MoveVM that checks the resource safety properties of Move. Specifically we are trying to prove that with this paranoid mode on, each `move_vm_types::Value` will have the following properties guaranteed:
1. Type Safety:
    - All primitive values are well typed. e.g: u8, u64, u128, bool
    - Structs are well typed iff all its field elements are well typed and matches the field declaration of the struct
    - Vectors are well typed iff all elements in the vector have the same type that matches with the vector declaration.

2. Ability Safety: Consumption of all `Value` needs to abide to the ability declaration of the value.
3. Encapsulation Safety: 
    - `Struct` can only be created, destructed by the module that defines the struct. Same constraint applies for global operations and borrow_field.
    - Modules can only be invoked by other modules via its public interfaces. Moreover, arguments of the public function invocation needs to match with the type declaration of arguments.

The paranoid checks aims to achieve the three properties by tagging struct with its type and ability information at runtime. We still need to verify if all the checks here is a complete in order to prove whether the claim here is correct or not.

To review this PR, it might makes sense to get started by looking under the changes in the `move-vm-types`, particularly the additional runtime checker functions in `value.rs`. Then look for changes in `move-vm-runtime` where those checks are actually invoked. Once you have a better understanding of what we are checking, look for test cases under `paranoid-test` crate to see the behaviors there.


### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes

## Test Plan

Added a full testsuite called `paranoid-test`. In this test, I used `failpoint` injection to bypass the bytecode verifier pass in the VM and published modules that intensionally violates the three properties mentioned above and make sure the newly introduced paranoid mode can indeed capture those issues.
