### PR TITLE
add support for loading resources via NativeContext

### DIFF
--- a/language/move-vm/runtime/src/loader.rs
+++ b/language/move-vm/runtime/src/loader.rs
@@ -893,7 +893,7 @@ impl Loader {
     pub(crate) fn load_type(
         &self,
         type_tag: &TypeTag,
-        data_store: &impl DataStore,
+        data_store: &dyn DataStore,
     ) -> VMResult<Type> {
         Ok(match type_tag {
             TypeTag::Bool => Type::Bool,
@@ -932,7 +932,7 @@ impl Loader {
     pub(crate) fn load_module(
         &self,
         id: &ModuleId,
-        data_store: &impl DataStore,
+        data_store: &dyn DataStore,
     ) -> VMResult<Arc<Module>> {
         self.load_module_internal(id, &BTreeMap::new(), &BTreeSet::new(), data_store)
     }
@@ -944,7 +944,7 @@ impl Loader {
         id: &ModuleId,
         bundle_verified: &BTreeMap<ModuleId, CompiledModule>,
         bundle_unverified: &BTreeSet<ModuleId>,
-        data_store: &impl DataStore,
+        data_store: &dyn DataStore,
     ) -> VMResult<Arc<Module>> {
         // if the module is already in the code cache, load the cached version
         if let Some(cached) = self.module_cache.read().module_at(id) {
@@ -975,7 +975,7 @@ impl Loader {
     fn load_and_verify_module(
         &self,
         id: &ModuleId,
-        data_store: &impl DataStore,
+        data_store: &dyn DataStore,
         allow_loading_failure: bool,
     ) -> VMResult<CompiledModule> {
         // bytes fetching, allow loading to fail if the flag is set
@@ -1013,7 +1013,7 @@ impl Loader {
         &self,
         id: &ModuleId,
         bundle_verified: &BTreeMap<ModuleId, CompiledModule>,
-        data_store: &impl DataStore,
+        data_store: &dyn DataStore,
         visited: &mut BTreeSet<ModuleId>,
         friends_discovered: &mut BTreeSet<ModuleId>,
         allow_module_loading_failure: bool,
@@ -1053,7 +1053,7 @@ impl Loader {
         &self,
         module: &CompiledModule,
         bundle_verified: &BTreeMap<ModuleId, CompiledModule>,
-        data_store: &impl DataStore,
+        data_store: &dyn DataStore,
         visited: &mut BTreeSet<ModuleId>,
         friends_discovered: &mut BTreeSet<ModuleId>,
         allow_dependency_loading_failure: bool,
@@ -1109,7 +1109,7 @@ impl Loader {
         id: &ModuleId,
         bundle_verified: &BTreeMap<ModuleId, CompiledModule>,
         bundle_unverified: &BTreeSet<ModuleId>,
-        data_store: &impl DataStore,
+        data_store: &dyn DataStore,
         allow_module_loading_failure: bool,
     ) -> VMResult<Arc<Module>> {
         // load the closure of the module in terms of dependency relation
@@ -1143,7 +1143,7 @@ impl Loader {
         friends_discovered: BTreeSet<ModuleId>,
         bundle_verified: &BTreeMap<ModuleId, CompiledModule>,
         bundle_unverified: &BTreeSet<ModuleId>,
-        data_store: &impl DataStore,
+        data_store: &dyn DataStore,
         allow_friend_loading_failure: bool,
     ) -> VMResult<()> {
         // for each new module discovered in the frontier, load them fully and expand the frontier.

--- a/language/move-vm/runtime/src/native_functions.rs
+++ b/language/move-vm/runtime/src/native_functions.rs
@@ -5,17 +5,20 @@
 use crate::{
     interpreter::Interpreter, loader::Resolver, native_extensions::NativeContextExtensions,
 };
-use move_binary_format::errors::{ExecutionState, PartialVMError, PartialVMResult};
+use move_binary_format::errors::{ExecutionState, PartialVMError, PartialVMResult, VMResult};
 use move_core_types::{
     account_address::AccountAddress,
+    gas_algebra::NumBytes,
     identifier::Identifier,
     language_storage::TypeTag,
     value::MoveTypeLayout,
     vm_status::{StatusCode, StatusType},
 };
 use move_vm_types::{
-    data_store::DataStore, loaded_data::runtime_types::Type, natives::function::NativeResult,
-    values::Value,
+    data_store::DataStore,
+    loaded_data::runtime_types::Type,
+    natives::function::NativeResult,
+    values::{GlobalValue, Value},
 };
 use std::{
     collections::{HashMap, VecDeque},
@@ -165,6 +168,18 @@ impl<'a, 'b> NativeContext<'a, 'b> {
 
     pub fn extensions_mut(&mut self) -> &mut NativeContextExtensions<'b> {
         self.extensions
+    }
+
+    pub fn load_type(&self, type_tag: &TypeTag) -> VMResult<Type> {
+        self.resolver.loader().load_type(type_tag, self.data_store)
+    }
+
+    pub fn load_resource(
+        &mut self,
+        addr: AccountAddress,
+        ty: &Type,
+    ) -> PartialVMResult<(&mut GlobalValue, Option<Option<NumBytes>>)> {
+        self.data_store.load_resource(addr, ty)
     }
 
     /// Get count stack frames, including the one of the called native function. This


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Move Language.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

It is often necessary for Move native functions implemented in Rust to read resources. Currently, there is no easy way to do this in a native function because the `load_resource` method inside the `DataStore` in a `NativeContext` is not accessible.

This PR makes it accessible, together with a `load_type` method for converting a `TypeTag` to a `Type`, which is needed as an argument of `load_resource`.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes!

## Test Plan

Just exporting some existing APIs. No testing.