### PR TITLE
[Move Prover] Prevent generating track_exp_sub for exps with free variables

### DIFF
--- a/language/move-prover/bytecode/src/spec_instrumentation.rs
+++ b/language/move-prover/bytecode/src/spec_instrumentation.rs
@@ -806,7 +806,11 @@ impl<'a> Instrumenter<'a> {
             .iter()
             .filter(|(_, _, exp)| node_ids.contains(&exp.node_id()));
         for (node_id, kind, exp) in traces {
-            let loc = self.builder.global_env().get_node_loc(*node_id);
+            let env = self.builder.global_env();
+            let loc = env.get_node_loc(*node_id);
+            if !exp.free_vars(env).is_empty() {
+                continue;
+            }
             self.builder.set_loc(loc);
             let temp = if let ExpData::Temporary(_, temp) = exp.as_ref() {
                 *temp


### PR DESCRIPTION
## Motivation

When a quantified expression contains a sub expression with a bound variable, the prover will generate a track_exp_sub for this sub expression where the bound variable becomes free. This PR adds logic to filter out these expressions when generating traces for verification failure. 

close #600 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes

