### PR TITLE
Modify GasMeter functions to take in stack information about where the function is being called

### DIFF
--- a/language/move-vm/types/src/gas.rs
+++ b/language/move-vm/types/src/gas.rs
@@ -5,8 +5,11 @@ use crate::views::{TypeView, ValueView};
 use move_binary_format::errors::PartialVMResult;
 use move_core_types::{
     gas_algebra::{InternalGas, NumArgs, NumBytes},
+    identifier::Identifier,
     language_storage::ModuleId,
 };
+
+pub type FuncCallStack = Vec<Identifier>;
 
 /// Enum of instructions that do not need extra information for gas metering.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -65,10 +68,15 @@ pub enum SimpleInstruction {
 /// their own metering scheme.
 pub trait GasMeter {
     /// Charge an instruction and fail if not enough gas units are left.
-    fn charge_simple_instr(&mut self, instr: SimpleInstruction) -> PartialVMResult<()>;
+    fn charge_simple_instr(
+        &mut self,
+        stack: &FuncCallStack,
+        instr: SimpleInstruction,
+    ) -> PartialVMResult<()>;
 
     fn charge_call(
         &mut self,
+        stack: &FuncCallStack,
         module_id: &ModuleId,
         func_name: &str,
         args: impl ExactSizeIterator<Item = impl ValueView>,
@@ -76,42 +84,76 @@ pub trait GasMeter {
 
     fn charge_call_generic(
         &mut self,
+        stack: &FuncCallStack,
         module_id: &ModuleId,
         func_name: &str,
         ty_args: impl ExactSizeIterator<Item = impl TypeView>,
         args: impl ExactSizeIterator<Item = impl ValueView>,
     ) -> PartialVMResult<()>;
 
-    fn charge_ld_const(&mut self, size: NumBytes) -> PartialVMResult<()>;
+    fn charge_ld_const(&mut self, stack: &FuncCallStack, size: NumBytes) -> PartialVMResult<()>;
 
-    fn charge_copy_loc(&mut self, val: impl ValueView) -> PartialVMResult<()>;
+    fn charge_copy_loc(
+        &mut self,
+        stack: &FuncCallStack,
+        val: impl ValueView,
+    ) -> PartialVMResult<()>;
 
-    fn charge_move_loc(&mut self, val: impl ValueView) -> PartialVMResult<()>;
+    fn charge_move_loc(
+        &mut self,
+        stack: &FuncCallStack,
+        val: impl ValueView,
+    ) -> PartialVMResult<()>;
 
-    fn charge_store_loc(&mut self, val: impl ValueView) -> PartialVMResult<()>;
+    fn charge_store_loc(
+        &mut self,
+        stack: &FuncCallStack,
+        val: impl ValueView,
+    ) -> PartialVMResult<()>;
 
     fn charge_pack(
         &mut self,
+        stack: &FuncCallStack,
         is_generic: bool,
         args: impl ExactSizeIterator<Item = impl ValueView>,
     ) -> PartialVMResult<()>;
 
     fn charge_unpack(
         &mut self,
+        stack: &FuncCallStack,
         is_generic: bool,
         args: impl ExactSizeIterator<Item = impl ValueView>,
     ) -> PartialVMResult<()>;
 
-    fn charge_read_ref(&mut self, val: impl ValueView) -> PartialVMResult<()>;
+    fn charge_read_ref(
+        &mut self,
+        stack: &FuncCallStack,
+        val: impl ValueView,
+    ) -> PartialVMResult<()>;
 
-    fn charge_write_ref(&mut self, val: impl ValueView) -> PartialVMResult<()>;
+    fn charge_write_ref(
+        &mut self,
+        stack: &FuncCallStack,
+        val: impl ValueView,
+    ) -> PartialVMResult<()>;
 
-    fn charge_eq(&mut self, lhs: impl ValueView, rhs: impl ValueView) -> PartialVMResult<()>;
+    fn charge_eq(
+        &mut self,
+        stack: &FuncCallStack,
+        lhs: impl ValueView,
+        rhs: impl ValueView,
+    ) -> PartialVMResult<()>;
 
-    fn charge_neq(&mut self, lhs: impl ValueView, rhs: impl ValueView) -> PartialVMResult<()>;
+    fn charge_neq(
+        &mut self,
+        stack: &FuncCallStack,
+        lhs: impl ValueView,
+        rhs: impl ValueView,
+    ) -> PartialVMResult<()>;
 
     fn charge_borrow_global(
         &mut self,
+        stack: &FuncCallStack,
         is_mut: bool,
         is_generic: bool,
         ty: impl TypeView,
@@ -120,6 +162,7 @@ pub trait GasMeter {
 
     fn charge_exists(
         &mut self,
+        stack: &FuncCallStack,
         is_generic: bool,
         ty: impl TypeView,
         // TODO(Gas): see if we can get rid of this param
@@ -128,6 +171,7 @@ pub trait GasMeter {
 
     fn charge_move_from(
         &mut self,
+        stack: &FuncCallStack,
         is_generic: bool,
         ty: impl TypeView,
         val: Option<impl ValueView>,
@@ -135,6 +179,7 @@ pub trait GasMeter {
 
     fn charge_move_to(
         &mut self,
+        stack: &FuncCallStack,
         is_generic: bool,
         ty: impl TypeView,
         val: impl ValueView,
@@ -143,14 +188,16 @@ pub trait GasMeter {
 
     fn charge_vec_pack<'a>(
         &mut self,
+        stack: &FuncCallStack,
         ty: impl TypeView + 'a,
         args: impl ExactSizeIterator<Item = impl ValueView>,
     ) -> PartialVMResult<()>;
 
-    fn charge_vec_len(&mut self, ty: impl TypeView) -> PartialVMResult<()>;
+    fn charge_vec_len(&mut self, stack: &FuncCallStack, ty: impl TypeView) -> PartialVMResult<()>;
 
     fn charge_vec_borrow(
         &mut self,
+        stack: &FuncCallStack,
         is_mut: bool,
         ty: impl TypeView,
         is_success: bool,
@@ -158,12 +205,14 @@ pub trait GasMeter {
 
     fn charge_vec_push_back(
         &mut self,
+        stack: &FuncCallStack,
         ty: impl TypeView,
         val: impl ValueView,
     ) -> PartialVMResult<()>;
 
     fn charge_vec_pop_back(
         &mut self,
+        stack: &FuncCallStack,
         ty: impl TypeView,
         val: Option<impl ValueView>,
     ) -> PartialVMResult<()>;
@@ -171,12 +220,13 @@ pub trait GasMeter {
     // TODO(Gas): Expose the elements
     fn charge_vec_unpack(
         &mut self,
+        stack: &FuncCallStack,
         ty: impl TypeView,
         expect_num_elements: NumArgs,
     ) -> PartialVMResult<()>;
 
     // TODO(Gas): Expose the two elements
-    fn charge_vec_swap(&mut self, ty: impl TypeView) -> PartialVMResult<()>;
+    fn charge_vec_swap(&mut self, stack: &FuncCallStack, ty: impl TypeView) -> PartialVMResult<()>;
 
     /// Charges for loading a resource from storage. This is only called when the resource is not
     /// cached.
@@ -185,7 +235,11 @@ pub trait GasMeter {
     ///
     /// WARNING: This can be dangerous if you execute multiple user transactions in the same
     /// session -- identical transactions can have different gas costs. Use at your own risk.
-    fn charge_load_resource(&mut self, loaded: Option<NumBytes>) -> PartialVMResult<()>;
+    fn charge_load_resource(
+        &mut self,
+        stack: &FuncCallStack,
+        loaded: Option<NumBytes>,
+    ) -> PartialVMResult<()>;
 
     /// Charge for executing a native function.
     /// The cost is calculated returned by the native function implementation.
@@ -193,7 +247,11 @@ pub trait GasMeter {
     ///
     /// In the future, we may want to remove this and directly pass a reference to the GasMeter
     /// instance to the native functions to allow gas to be deducted during computation.
-    fn charge_native_function(&mut self, amount: InternalGas) -> PartialVMResult<()>;
+    fn charge_native_function(
+        &mut self,
+        stack: &FuncCallStack,
+        amount: InternalGas,
+    ) -> PartialVMResult<()>;
 }
 
 /// A dummy gas meter that does not meter anything.
@@ -201,12 +259,17 @@ pub trait GasMeter {
 pub struct UnmeteredGasMeter;
 
 impl GasMeter for UnmeteredGasMeter {
-    fn charge_simple_instr(&mut self, _instr: SimpleInstruction) -> PartialVMResult<()> {
+    fn charge_simple_instr(
+        &mut self,
+        _stack: &FuncCallStack,
+        _instr: SimpleInstruction,
+    ) -> PartialVMResult<()> {
         Ok(())
     }
 
     fn charge_call(
         &mut self,
+        _stack: &FuncCallStack,
         _module_id: &ModuleId,
         _func_name: &str,
         _args: impl IntoIterator<Item = impl ValueView>,
@@ -216,6 +279,7 @@ impl GasMeter for UnmeteredGasMeter {
 
     fn charge_call_generic(
         &mut self,
+        _stack: &FuncCallStack,
         _module_id: &ModuleId,
         _func_name: &str,
         _ty_args: impl ExactSizeIterator<Item = impl TypeView>,
@@ -224,24 +288,37 @@ impl GasMeter for UnmeteredGasMeter {
         Ok(())
     }
 
-    fn charge_ld_const(&mut self, _size: NumBytes) -> PartialVMResult<()> {
+    fn charge_ld_const(&mut self, _stack: &FuncCallStack, _size: NumBytes) -> PartialVMResult<()> {
         Ok(())
     }
 
-    fn charge_copy_loc(&mut self, _val: impl ValueView) -> PartialVMResult<()> {
+    fn charge_copy_loc(
+        &mut self,
+        _stack: &FuncCallStack,
+        _val: impl ValueView,
+    ) -> PartialVMResult<()> {
         Ok(())
     }
 
-    fn charge_move_loc(&mut self, _val: impl ValueView) -> PartialVMResult<()> {
+    fn charge_move_loc(
+        &mut self,
+        _stack: &FuncCallStack,
+        _val: impl ValueView,
+    ) -> PartialVMResult<()> {
         Ok(())
     }
 
-    fn charge_store_loc(&mut self, _val: impl ValueView) -> PartialVMResult<()> {
+    fn charge_store_loc(
+        &mut self,
+        _stack: &FuncCallStack,
+        _val: impl ValueView,
+    ) -> PartialVMResult<()> {
         Ok(())
     }
 
     fn charge_pack(
         &mut self,
+        _stack: &FuncCallStack,
         _is_generic: bool,
         _args: impl ExactSizeIterator<Item = impl ValueView>,
     ) -> PartialVMResult<()> {
@@ -250,30 +327,50 @@ impl GasMeter for UnmeteredGasMeter {
 
     fn charge_unpack(
         &mut self,
+        _stack: &FuncCallStack,
         _is_generic: bool,
         _args: impl ExactSizeIterator<Item = impl ValueView>,
     ) -> PartialVMResult<()> {
         Ok(())
     }
 
-    fn charge_read_ref(&mut self, _val: impl ValueView) -> PartialVMResult<()> {
+    fn charge_read_ref(
+        &mut self,
+        _stack: &FuncCallStack,
+        _val: impl ValueView,
+    ) -> PartialVMResult<()> {
         Ok(())
     }
 
-    fn charge_write_ref(&mut self, _val: impl ValueView) -> PartialVMResult<()> {
+    fn charge_write_ref(
+        &mut self,
+        _stack: &FuncCallStack,
+        _val: impl ValueView,
+    ) -> PartialVMResult<()> {
         Ok(())
     }
 
-    fn charge_eq(&mut self, _lhs: impl ValueView, _rhs: impl ValueView) -> PartialVMResult<()> {
+    fn charge_eq(
+        &mut self,
+        _stack: &FuncCallStack,
+        _lhs: impl ValueView,
+        _rhs: impl ValueView,
+    ) -> PartialVMResult<()> {
         Ok(())
     }
 
-    fn charge_neq(&mut self, _lhs: impl ValueView, _rhs: impl ValueView) -> PartialVMResult<()> {
+    fn charge_neq(
+        &mut self,
+        _stack: &FuncCallStack,
+        _lhs: impl ValueView,
+        _rhs: impl ValueView,
+    ) -> PartialVMResult<()> {
         Ok(())
     }
 
     fn charge_borrow_global(
         &mut self,
+        _stack: &FuncCallStack,
         _is_mut: bool,
         _is_generic: bool,
         _ty: impl TypeView,
@@ -284,6 +381,7 @@ impl GasMeter for UnmeteredGasMeter {
 
     fn charge_exists(
         &mut self,
+        _stack: &FuncCallStack,
         _is_generic: bool,
         _ty: impl TypeView,
         _exists: bool,
@@ -293,6 +391,7 @@ impl GasMeter for UnmeteredGasMeter {
 
     fn charge_move_from(
         &mut self,
+        _stack: &FuncCallStack,
         _is_generic: bool,
         _ty: impl TypeView,
         _val: Option<impl ValueView>,
@@ -302,6 +401,7 @@ impl GasMeter for UnmeteredGasMeter {
 
     fn charge_move_to(
         &mut self,
+        _stack: &FuncCallStack,
         _is_generic: bool,
         _ty: impl TypeView,
         _val: impl ValueView,
@@ -312,18 +412,24 @@ impl GasMeter for UnmeteredGasMeter {
 
     fn charge_vec_pack<'a>(
         &mut self,
+        _stack: &FuncCallStack,
         _ty: impl TypeView + 'a,
         _args: impl ExactSizeIterator<Item = impl ValueView>,
     ) -> PartialVMResult<()> {
         Ok(())
     }
 
-    fn charge_vec_len(&mut self, _ty: impl TypeView) -> PartialVMResult<()> {
+    fn charge_vec_len(
+        &mut self,
+        _stack: &FuncCallStack,
+        _ty: impl TypeView,
+    ) -> PartialVMResult<()> {
         Ok(())
     }
 
     fn charge_vec_borrow(
         &mut self,
+        _stack: &FuncCallStack,
         _is_mut: bool,
         _ty: impl TypeView,
         _is_success: bool,
@@ -333,6 +439,7 @@ impl GasMeter for UnmeteredGasMeter {
 
     fn charge_vec_push_back(
         &mut self,
+        _stack: &FuncCallStack,
         _ty: impl TypeView,
         _val: impl ValueView,
     ) -> PartialVMResult<()> {
@@ -341,6 +448,7 @@ impl GasMeter for UnmeteredGasMeter {
 
     fn charge_vec_pop_back(
         &mut self,
+        _stack: &FuncCallStack,
         _ty: impl TypeView,
         _val: Option<impl ValueView>,
     ) -> PartialVMResult<()> {
@@ -349,21 +457,34 @@ impl GasMeter for UnmeteredGasMeter {
 
     fn charge_vec_unpack(
         &mut self,
+        _stack: &FuncCallStack,
         _ty: impl TypeView,
         _expect_num_elements: NumArgs,
     ) -> PartialVMResult<()> {
         Ok(())
     }
 
-    fn charge_vec_swap(&mut self, _ty: impl TypeView) -> PartialVMResult<()> {
+    fn charge_vec_swap(
+        &mut self,
+        _stack: &FuncCallStack,
+        _ty: impl TypeView,
+    ) -> PartialVMResult<()> {
         Ok(())
     }
 
-    fn charge_load_resource(&mut self, _loaded: Option<NumBytes>) -> PartialVMResult<()> {
+    fn charge_load_resource(
+        &mut self,
+        _stack: &FuncCallStack,
+        _loaded: Option<NumBytes>,
+    ) -> PartialVMResult<()> {
         Ok(())
     }
 
-    fn charge_native_function(&mut self, _amount: InternalGas) -> PartialVMResult<()> {
+    fn charge_native_function(
+        &mut self,
+        _stack: &FuncCallStack,
+        _amount: InternalGas,
+    ) -> PartialVMResult<()> {
         Ok(())
     }
 }


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Move Language.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

We've been using a modified version of the aptos node locally which spits out profiles of how much gas is used by each method during a transaction. Figured it would be useful for the rest of the community so wanted to publish it.

We first need to make the GasMeter trait accept more information about where the charge call is being made. This diff creates a `FuncCallStack` type (just a vector of function names) and passes that into the gas meter methods.

The idea is that the GasMeter implementation can use the passed in information to develop a profile of how gas is used.

Would love suggestions on other context that could be useful to pass to the gas meter. 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes

## Test Plan

Changes add a function parameter to each method of a trait. Made sure the changes compiled and existing tests passed.
