### PR TITLE
[move-compiler][crash fix] Removed unnecessary assert

### DIFF
--- a/language/move-compiler/src/cfgir/borrows/mod.rs
+++ b/language/move-compiler/src/cfgir/borrows/mod.rs
@@ -140,7 +140,6 @@ fn command(context: &mut Context, sp!(loc, cmd_): &Command) {
 }
 
 fn lvalues(context: &mut Context, ls: &[LValue], values: Values) {
-    assert!(ls.len() == values.len());
     ls.iter()
         .zip(values)
         .for_each(|(l, value)| lvalue(context, l, value))

--- a/language/move-compiler/tests/move_check/borrows/unused_ref.exp
+++ b/language/move-compiler/tests/move_check/borrows/unused_ref.exp
@@ -1,0 +1,9 @@
+error[E04017]: too many arguments
+   ┌─ tests/move_check/borrows/unused_ref.move:28:5
+   │
+28 │     borrow<u64, u64>(&mut x, 0, 0);
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │     │               │
+   │     │               Found 3 argument(s) here
+   │     Invalid call of '0x42::m::borrow'. The call expected 2 argument(s) but got 3
+

--- a/language/move-compiler/tests/move_check/borrows/unused_ref.move
+++ b/language/move-compiler/tests/move_check/borrows/unused_ref.move
@@ -1,0 +1,32 @@
+module 0x42::m {
+
+struct Txn { sender: address }
+struct X {}
+
+fun begin(sender: address): Txn {
+    Txn { sender }
+}
+
+fun new(_: &mut Txn): X {
+    X {}
+}
+
+fun add<K: copy + drop + store, V: store>(_x: &mut X, _k: K, _v: V) {
+    abort 0
+}
+
+
+fun borrow<K: copy + drop + store, V: store>(_x: &X, _k: K): &V {
+    abort 0
+}
+
+fun borrow_wrong_type() {
+    let sender = @0x0;
+    let scenario = begin(sender);
+    let x = new(&mut scenario);
+    add(&mut x, 0, 0);
+    borrow<u64, u64>(&mut x, 0, 0);
+    abort 42
+}
+
+}


### PR DESCRIPTION
- Assert is left over from before the error/warning refactor. It shouldn't be necessary


## Motivation

- Fix a compiler crash

## Test Plan

- New test
