### PR TITLE
[docgen] Fix `{{move-index}}` placeholder

### DIFF
--- a/language/move-prover/move-docgen/src/docgen.rs
+++ b/language/move-prover/move-docgen/src/docgen.rs
@@ -882,6 +882,11 @@ impl<'env> Docgen<'env> {
         self.begin_items();
         for (id, _) in sorted_infos {
             let module_env = self.env.get_module(*id);
+            if !module_env.is_target() {
+                // Do not include modules which are not target (outside of the package)
+                // into the index.
+                continue;
+            }
             self.item_text(&format!(
                 "[`{}`]({})",
                 module_env.get_name().display_full(module_env.symbol_pool()),


### PR DESCRIPTION
The placeholder produced all modules in the transitive closure of dependencies. We only want to see the target modules here. For example, if this is used to document a package, the index should only contain the modules declared in that package.
