### PR TITLE
[move-cli] update description for 'move test --coverage' command

### DIFF
--- a/language/tools/move-cli/src/base/test.rs
+++ b/language/tools/move-cli/src/base/test.rs
@@ -72,7 +72,7 @@ pub struct Test {
     /// Verbose mode
     #[clap(long = "verbose")]
     pub verbose_mode: bool,
-    /// Collect coverage information for later use with the various `package coverage` subcommands
+    /// Collect coverage information for later use with the various `move coverage` subcommands
     #[clap(long = "coverage")]
     pub compute_coverage: bool,
 


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Move Language.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

The usage description for `--coverage` flag in `move test --help` was
```
 --coverage
        Collect coverage information for later use with the various `package coverage`
        subcommands
```

I updated the `package coverage` part to `move coverage`

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

yes

## Test Plan

It's a minor doc change. No extra test case needed.
