### PR TITLE
[gas] share more info with the gas meter

### DIFF
--- a/language/move-stdlib/src/natives/debug.rs
+++ b/language/move-stdlib/src/natives/debug.rs
@@ -45,6 +45,7 @@ fn is_string_type(context: &NativeContext, ty: &Type, move_std_addr: AccountAddr
     }
 }
 
+#[allow(unused_mut)]
 #[inline]
 fn native_print(
     gas_params: &PrintGasParameters,
@@ -109,6 +110,7 @@ pub struct PrintStackTraceGasParameters {
     pub base_cost: InternalGas,
 }
 
+#[allow(unused_variables)]
 #[inline]
 fn native_print_stack_trace(
     gas_params: &PrintStackTraceGasParameters,

--- a/language/move-vm/runtime/src/interpreter.rs
+++ b/language/move-vm/runtime/src/interpreter.rs
@@ -160,6 +160,7 @@ impl Interpreter {
                             self.operand_stack
                                 .last_n(func.arg_count())
                                 .map_err(|e| set_err_info!(current_frame, e))?,
+                            (func.local_count() as u64).into(),
                         )
                         .map_err(|e| set_err_info!(current_frame, e))?;
 
@@ -209,6 +210,7 @@ impl Interpreter {
                             self.operand_stack
                                 .last_n(func.arg_count())
                                 .map_err(|e| set_err_info!(current_frame, e))?,
+                            (func.local_count() as u64).into(),
                         )
                         .map_err(|e| set_err_info!(current_frame, e))?;
 
@@ -302,11 +304,23 @@ impl Interpreter {
         let native_function = function.get_native()?;
 
         let result = native_function(&mut native_context, ty_args, args)?;
-        gas_meter.charge_native_function(result.cost)?;
 
-        let return_values = result
-            .result
-            .map_err(|code| PartialVMError::new(StatusCode::ABORTED).with_sub_status(code))?;
+        // Note(Gas): The order by which gas is charged / error gets returned MUST NOT be modified
+        //            here or otherwise it becomes an incompatible change!!!
+        let return_values = match result.result {
+            Ok(vals) => {
+                gas_meter.charge_native_function(result.cost, Some(vals.iter()))?;
+                vals
+            }
+            Err(code) => {
+                gas_meter.charge_native_function(
+                    result.cost,
+                    Option::<std::iter::Empty<&Value>>::None,
+                )?;
+                return Err(PartialVMError::new(StatusCode::ABORTED).with_sub_status(code));
+            }
+        };
+
         // Paranoid check to protect us against incorrect native function implementations. A native function that
         // returns a different number of values than its declared types will trigger this check
         if return_values.len() != return_type_count {

--- a/language/move-vm/runtime/src/interpreter.rs
+++ b/language/move-vm/runtime/src/interpreter.rs
@@ -133,6 +133,17 @@ impl Interpreter {
                     .map_err(|err| self.maybe_core_dump(err, &current_frame))?;
             match exit_code {
                 ExitCode::Return => {
+                    // TODO: Check if the error location is set correctly.
+                    gas_meter
+                        .charge_drop_frame(
+                            current_frame
+                                .locals
+                                .into_values()
+                                .map_err(|e| self.set_location(e))?
+                                .map(|(_idx, val)| val),
+                        )
+                        .map_err(|e| self.set_location(e))?;
+
                     if let Some(frame) = self.call_stack.pop() {
                         // Note: the caller will find the callee's return values at the top of the shared operand stack
                         current_frame = frame;
@@ -303,6 +314,14 @@ impl Interpreter {
         let mut native_context = NativeContext::new(self, data_store, resolver, extensions);
         let native_function = function.get_native()?;
 
+        gas_meter.charge_native_function_before_execution(
+            ty_args.iter().map(|ty| TypeWithLoader {
+                ty,
+                loader: resolver.loader(),
+            }),
+            args.iter(),
+        )?;
+
         let result = native_function(&mut native_context, ty_args, args)?;
 
         // Note(Gas): The order by which gas is charged / error gets returned MUST NOT be modified
@@ -385,7 +404,20 @@ impl Interpreter {
         match data_store.load_resource(addr, ty) {
             Ok((gv, load_res)) => {
                 if let Some(loaded) = load_res {
-                    gas_meter.charge_load_resource(loaded)?;
+                    let opt = match loaded {
+                        Some(num_bytes) => {
+                            let view = gv.view().ok_or_else(|| {
+                                PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
+                                    .with_message(
+                                        "Failed to create view for global value".to_owned(),
+                                    )
+                            })?;
+
+                            Some((num_bytes, view))
+                        }
+                        None => None,
+                    };
+                    gas_meter.charge_load_resource(opt)?;
                 }
                 Ok(gv)
             }
@@ -869,8 +901,8 @@ impl Frame {
 
                 match instruction {
                     Bytecode::Pop => {
-                        gas_meter.charge_simple_instr(S::Pop)?;
-                        interpreter.operand_stack.pop()?;
+                        let popped_val = interpreter.operand_stack.pop()?;
+                        gas_meter.charge_pop(popped_val)?;
                     }
                     Bytecode::Ret => {
                         gas_meter.charge_simple_instr(S::Ret)?;
@@ -910,15 +942,18 @@ impl Frame {
                     Bytecode::LdConst(idx) => {
                         let constant = resolver.constant_at(*idx);
                         gas_meter.charge_ld_const(NumBytes::new(constant.data.len() as u64))?;
-                        interpreter.operand_stack.push(
-                            Value::deserialize_constant(constant).ok_or_else(|| {
-                                PartialVMError::new(StatusCode::VERIFIER_INVARIANT_VIOLATION)
-                                    .with_message(
+
+                        let val = Value::deserialize_constant(constant).ok_or_else(|| {
+                            PartialVMError::new(StatusCode::VERIFIER_INVARIANT_VIOLATION)
+                                .with_message(
                                     "Verifier failed to verify the deserialization of constants"
                                         .to_owned(),
                                 )
-                            })?,
-                        )?
+                        })?;
+
+                        gas_meter.charge_ld_const_after_deserialization(&val)?;
+
+                        interpreter.operand_stack.push(val)?
                     }
                     Bytecode::LdTrue => {
                         gas_meter.charge_simple_instr(S::LdTrue)?;
@@ -1038,7 +1073,7 @@ impl Frame {
                     Bytecode::WriteRef => {
                         let reference = interpreter.operand_stack.pop_as::<Reference>()?;
                         let value = interpreter.operand_stack.pop()?;
-                        gas_meter.charge_write_ref(&value)?;
+                        gas_meter.charge_write_ref(&value, reference.value_view())?;
                         reference.write_ref(value)?;
                     }
                     Bytecode::CastU8 => {
@@ -1349,7 +1384,11 @@ impl Frame {
                     Bytecode::VecUnpack(si, num) => {
                         let vec_val = interpreter.operand_stack.pop_as::<Vector>()?;
                         let ty = &resolver.instantiate_single_type(*si, self.ty_args())?;
-                        gas_meter.charge_vec_unpack(make_ty!(ty), NumArgs::new(*num))?;
+                        gas_meter.charge_vec_unpack(
+                            make_ty!(ty),
+                            NumArgs::new(*num),
+                            vec_val.elem_views(),
+                        )?;
                         let elements = vec_val.unpack(ty, *num)?;
                         for value in elements {
                             interpreter.operand_stack.push(value)?;

--- a/language/move-vm/test-utils/src/gas_schedule.rs
+++ b/language/move-vm/test-utils/src/gas_schedule.rs
@@ -260,7 +260,11 @@ impl<'b> GasMeter for GasStatus<'b> {
         self.charge_instr(get_simple_instruction_opcode(instr))
     }
 
-    fn charge_native_function(&mut self, amount: InternalGas) -> PartialVMResult<()> {
+    fn charge_native_function(
+        &mut self,
+        amount: InternalGas,
+        _ret_vals: Option<impl ExactSizeIterator<Item = impl ValueView>>,
+    ) -> PartialVMResult<()> {
         self.deduct_gas(amount)
     }
 
@@ -269,6 +273,7 @@ impl<'b> GasMeter for GasStatus<'b> {
         _module_id: &ModuleId,
         _func_name: &str,
         args: impl ExactSizeIterator<Item = impl ValueView>,
+        _num_locals: NumArgs,
     ) -> PartialVMResult<()> {
         self.charge_instr_with_size(Opcodes::CALL, (args.len() as u64 + 1).into())
     }
@@ -279,6 +284,7 @@ impl<'b> GasMeter for GasStatus<'b> {
         _func_name: &str,
         ty_args: impl ExactSizeIterator<Item = impl TypeView>,
         args: impl ExactSizeIterator<Item = impl ValueView>,
+        _num_locals: NumArgs,
     ) -> PartialVMResult<()> {
         self.charge_instr_with_size(
             Opcodes::CALL_GENERIC,

--- a/language/move-vm/types/src/gas.rs
+++ b/language/move-vm/types/src/gas.rs
@@ -72,6 +72,7 @@ pub trait GasMeter {
         module_id: &ModuleId,
         func_name: &str,
         args: impl ExactSizeIterator<Item = impl ValueView>,
+        num_locals: NumArgs,
     ) -> PartialVMResult<()>;
 
     fn charge_call_generic(
@@ -80,6 +81,7 @@ pub trait GasMeter {
         func_name: &str,
         ty_args: impl ExactSizeIterator<Item = impl TypeView>,
         args: impl ExactSizeIterator<Item = impl ValueView>,
+        num_locals: NumArgs,
     ) -> PartialVMResult<()>;
 
     fn charge_ld_const(&mut self, size: NumBytes) -> PartialVMResult<()>;
@@ -193,7 +195,11 @@ pub trait GasMeter {
     ///
     /// In the future, we may want to remove this and directly pass a reference to the GasMeter
     /// instance to the native functions to allow gas to be deducted during computation.
-    fn charge_native_function(&mut self, amount: InternalGas) -> PartialVMResult<()>;
+    fn charge_native_function(
+        &mut self,
+        amount: InternalGas,
+        ret_vals: Option<impl ExactSizeIterator<Item = impl ValueView>>,
+    ) -> PartialVMResult<()>;
 }
 
 /// A dummy gas meter that does not meter anything.
@@ -210,6 +216,7 @@ impl GasMeter for UnmeteredGasMeter {
         _module_id: &ModuleId,
         _func_name: &str,
         _args: impl IntoIterator<Item = impl ValueView>,
+        _num_locals: NumArgs,
     ) -> PartialVMResult<()> {
         Ok(())
     }
@@ -220,6 +227,7 @@ impl GasMeter for UnmeteredGasMeter {
         _func_name: &str,
         _ty_args: impl ExactSizeIterator<Item = impl TypeView>,
         _args: impl ExactSizeIterator<Item = impl ValueView>,
+        _num_locals: NumArgs,
     ) -> PartialVMResult<()> {
         Ok(())
     }
@@ -363,7 +371,11 @@ impl GasMeter for UnmeteredGasMeter {
         Ok(())
     }
 
-    fn charge_native_function(&mut self, _amount: InternalGas) -> PartialVMResult<()> {
+    fn charge_native_function(
+        &mut self,
+        _amount: InternalGas,
+        _ret_vals: Option<impl ExactSizeIterator<Item = impl ValueView>>,
+    ) -> PartialVMResult<()> {
         Ok(())
     }
 }

--- a/language/move-vm/types/src/values/values_impl.rs
+++ b/language/move-vm/types/src/values/values_impl.rs
@@ -939,6 +939,16 @@ impl Locals {
         self.swap_loc(idx, x)?;
         Ok(())
     }
+
+    pub fn into_values(self) -> PartialVMResult<impl Iterator<Item = (usize, Value)>> {
+        Ok(take_unique_ownership(self.0)?
+            .into_iter()
+            .enumerate()
+            .flat_map(|(idx, val)| match &val {
+                ValueImpl::Invalid => None,
+                _ => Some((idx, Value(val))),
+            }))
+    }
 }
 
 /***************************************************************************************
@@ -2844,6 +2854,29 @@ impl Struct {
     #[allow(clippy::needless_lifetimes)]
     pub fn field_views<'a>(&'a self) -> impl ExactSizeIterator<Item = impl ValueView + 'a> {
         self.fields.iter()
+    }
+}
+
+impl Vector {
+    #[allow(clippy::needless_lifetimes)]
+    pub fn elem_views<'a>(&'a self) -> impl ExactSizeIterator<Item = impl ValueView + 'a> {
+        struct ElemView<'b> {
+            container: &'b Container,
+            idx: usize,
+        }
+
+        impl<'b> ValueView for ElemView<'b> {
+            fn visit(&self, visitor: &mut impl ValueVisitor) {
+                self.container.visit_indexed(visitor, 0, self.idx)
+            }
+        }
+
+        let len = self.0.len();
+
+        (0..len).map(|idx| ElemView {
+            container: &self.0,
+            idx,
+        })
     }
 }
 


### PR DESCRIPTION
This modifies a few callbacks of the `GasMeter` trait and adds a few more, allowing the client to implement more functionalities (e.g. a memory usage tracker)

(Cherry-picking https://github.com/move-language/move/pull/531 and https://github.com/move-language/move/pull/536.)