### PR TITLE
[build] switch to lld on linux and optimize ci build

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -11,3 +11,6 @@ nextest = "run --package x --bin x -- nextest"
 
 [target.x86_64-pc-windows-msvc]
 rustflags = ["-C", "link-arg=/STACK:8000000"]
+
+[target.x86_64-unknown-linux-gnu]
+rustflags = ["-C", "link-arg=-fuse-ld=lld"]

--- a/.github/workflows/ci-pre-land.yml
+++ b/.github/workflows/ci-pre-land.yml
@@ -216,8 +216,12 @@ jobs:
       - prepare
     steps:
       - uses: actions/checkout@v2.4.0
-      - name: install rust toolchain
+      - name: Install rust toolchain
         uses: actions-rs/toolchain@v1
+      - name: Install lld
+        uses: knicknic/os-specific-run@v1.0.3
+        with:
+          linux: sudo apt-get -y install lld
       - name: Use Node.js 14
         uses: actions/setup-node@v2.4.0
         with:
@@ -246,8 +250,10 @@ jobs:
       - prepare
     steps:
       - uses: actions/checkout@v2.4.0
-      - name: install rust toolchain
+      - name: Install rust toolchain
         uses: actions-rs/toolchain@v1
+      - name: Install lld
+        run: sudo apt-get -y install lld
       - name: Use Node.js 14
         uses: actions/setup-node@v2.4.0
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,7 +109,6 @@ debug = true
 # use release settings to reduce memory pressure in the linking step in CI
 [profile.ci]
 inherits = "test"
-opt-level = 3
 debug = 0 # for saving disk space during linking
 incremental = false
 codegen-units = 16

--- a/scripts/dev_setup.sh
+++ b/scripts/dev_setup.sh
@@ -218,6 +218,13 @@ function install_gcc_powerpc_linux_gnu {
   #fi
 }
 
+function install_lld {
+  # Right now, only install lld for linux
+  if [[ "$(uname)" == "Linux" ]]; then
+    install_pkg lld "$PACKAGE_MANAGER"
+  fi
+}
+
 function install_toolchain {
   version=$1
   FOUND=$(rustup show | grep -c "$version" || true)
@@ -594,6 +601,8 @@ if [[ "$INSTALL_BUILD_TOOLS" == "true" ]]; then
   install_pkg cmake "$PACKAGE_MANAGER"
   install_pkg clang "$PACKAGE_MANAGER"
   install_pkg llvm "$PACKAGE_MANAGER"
+
+  install_lld
 
   install_gcc_powerpc_linux_gnu "$PACKAGE_MANAGER"
   install_openssl_dev "$PACKAGE_MANAGER"


### PR DESCRIPTION
`ld`, the default linker on linux, consumes a lot of memory and does not run in parallel. This PR switches us over to `lld`, which should greatly reduce memory consumption and improve linking speed on machines with many cores. Here's a comparison on a 64-core VM:
- `ld`: 17GB Ram, 48.21s
- `lld`: 4.5GB Ram, 34.40s

The reduction in memory consumption also allows us to switch back to debug build in CI, **cutting the running time from 33m down to 15m (with cache)**.

Note: this does require `lld` to be installed on linux platforms, which is now included in the dev setup script. However existing developers may need to re-run the script or install `lld` manually.