### PR TITLE
[Tutorial] fix a minor inconsistency with code in step_4

### DIFF
--- a/language/documentation/tutorial/README.md
+++ b/language/documentation/tutorial/README.md
@@ -405,7 +405,7 @@ move_to(account, Balance { coin:  empty_coin });
 `mint` method mints coins to a given account. Here we require that `mint` must be approved
 by the module owner. We enforce this using the assert statement:
 ```
-assert!(signer::address_of(&module_owner) == MODULE_OWNER, errors::requires_address(ENOT_MODULE_OWNER));
+assert!(signer::address_of(&module_owner) == MODULE_OWNER, ENOT_MODULE_OWNER);
 ```
 Assert statements in Move can be used in this way: `assert!(<predicate>, <abort_code>);`. This means that if the `<predicate>`
 is false, then abort the transaction with `<abort_code>`. Here `MODULE_OWNER` and `ENOT_MODULE_OWNER` are both constants


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Move Language.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

`errors` lib was removed in `tutorials/step_4/BasicCoin/sources/BasicCoin.move`  in PR #248 [commit 5f673876](https://github.com/move-language/move/pull/248/commits/5f673876b8bb3966da22bae40e869b52d21eced8), but the related doc in tutorial hasn't. So a modification was made to make the doc and the code consistent.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

yes

## Test Plan

Only document change. No test plan.