### PR TITLE
[Prover]  Extends the intrinsic table implementation by adding more pragmas

### DIFF
--- a/language/extensions/move-table-extension/sources/Table.spec.move
+++ b/language/extensions/move-table-extension/sources/Table.spec.move
@@ -15,7 +15,7 @@ spec extensions::table {
             map_borrow = borrow,
             map_borrow_mut = borrow_mut,
             map_spec_get = spec_get,
-            map_spec_set = spec_add,
+            map_spec_set = spec_set,
             map_spec_del = spec_remove,
             map_spec_len = spec_len,
             map_spec_has_key = spec_contains;
@@ -61,7 +61,7 @@ spec extensions::table {
 
     spec native fun spec_len<K, V>(t: Table<K, V>): num;
     spec native fun spec_contains<K, V>(t: Table<K, V>, k: K): bool;
-    spec native fun spec_add<K, V>(t: Table<K, V>, k: K, v: V): Table<K, V>;
+    spec native fun spec_set<K, V>(t: Table<K, V>, k: K, v: V): Table<K, V>;
     spec native fun spec_remove<K, V>(t: Table<K, V>, k: K): Table<K, V>;
     spec native fun spec_get<K, V>(t: Table<K, V>, k: K): V;
 }

--- a/language/move-model/src/pragmas.rs
+++ b/language/move-model/src/pragmas.rs
@@ -133,9 +133,17 @@ pub const INTRINSIC_FUN_MAP_DESTROY_EMPTY: &str = "map_destroy_empty";
 /// `[move] fun map_add_no_override<K, V>(m: &mut Map<K, V>, k: K, v: V)`
 pub const INTRINSIC_FUN_MAP_ADD_NO_OVERRIDE: &str = "map_add_no_override";
 
-/// Remove an entry from the map, aborts if the key already exists
+/// Add a new entry to the map, override if the key already exists
+/// `[move] fun map_add_override_if_exists<K, V>(m: &mut Map<K, V>, k: K, v: V)`
+pub const INTRINSIC_FUN_MAP_ADD_OVERRIDE_IF_EXISTS: &str = "map_add_override_if_exists";
+
+/// Remove an entry from the map, aborts if the key does not exists
 /// `[move] fun map_del_must_exist<K, V>(m: &mut Map<K, V>, k: K): V`
 pub const INTRINSIC_FUN_MAP_DEL_MUST_EXIST: &str = "map_del_must_exist";
+
+/// Remove an entry from the map, aborts if the key does not exists
+/// `[move] fun map_del_return_key<K, V>(m: &mut Map<K, V>, k: K): (K, V)`
+pub const INTRINSIC_FUN_MAP_DEL_RETURN_KEY: &str = "map_del_return_key";
 
 /// Immutable borrow of a value from the map, aborts if the key does not exist
 /// `[move] fun map_borrow<K, V>(m: &Map<K, V>, k: K): &V`
@@ -161,7 +169,9 @@ pub static INTRINSIC_TYPE_MAP_ASSOC_FUNCTIONS: Lazy<BTreeMap<&'static str, bool>
             (INTRINSIC_FUN_MAP_HAS_KEY, true),
             (INTRINSIC_FUN_MAP_DESTROY_EMPTY, true),
             (INTRINSIC_FUN_MAP_ADD_NO_OVERRIDE, true),
+            (INTRINSIC_FUN_MAP_ADD_OVERRIDE_IF_EXISTS, true),
             (INTRINSIC_FUN_MAP_DEL_MUST_EXIST, true),
+            (INTRINSIC_FUN_MAP_DEL_RETURN_KEY, true),
             (INTRINSIC_FUN_MAP_BORROW, true),
             (INTRINSIC_FUN_MAP_BORROW_MUT, true),
         ])

--- a/language/move-prover/boogie-backend/src/lib.rs
+++ b/language/move-prover/boogie-backend/src/lib.rs
@@ -18,8 +18,9 @@ use move_model::{
     emit, emitln,
     model::{GlobalEnv, QualifiedId, StructId},
     pragmas::{
-        INTRINSIC_FUN_MAP_ADD_NO_OVERRIDE, INTRINSIC_FUN_MAP_BORROW, INTRINSIC_FUN_MAP_BORROW_MUT,
-        INTRINSIC_FUN_MAP_DEL_MUST_EXIST, INTRINSIC_FUN_MAP_DESTROY_EMPTY,
+        INTRINSIC_FUN_MAP_ADD_NO_OVERRIDE, INTRINSIC_FUN_MAP_ADD_OVERRIDE_IF_EXISTS,
+        INTRINSIC_FUN_MAP_BORROW, INTRINSIC_FUN_MAP_BORROW_MUT, INTRINSIC_FUN_MAP_DEL_MUST_EXIST,
+        INTRINSIC_FUN_MAP_DEL_RETURN_KEY, INTRINSIC_FUN_MAP_DESTROY_EMPTY,
         INTRINSIC_FUN_MAP_HAS_KEY, INTRINSIC_FUN_MAP_IS_EMPTY, INTRINSIC_FUN_MAP_LEN,
         INTRINSIC_FUN_MAP_NEW, INTRINSIC_FUN_MAP_SPEC_DEL, INTRINSIC_FUN_MAP_SPEC_GET,
         INTRINSIC_FUN_MAP_SPEC_HAS_KEY, INTRINSIC_FUN_MAP_SPEC_IS_EMPTY,
@@ -75,7 +76,9 @@ struct MapImpl {
     fun_is_empty: String,
     fun_has_key: String,
     fun_add_no_override: String,
+    fun_add_override_if_exists: String,
     fun_del_must_exist: String,
+    fun_del_return_key: String,
     fun_borrow: String,
     fun_borrow_mut: String,
     // spec functions
@@ -251,8 +254,14 @@ impl MapImpl {
             fun_add_no_override: Self::triple_opt_to_name(
                 decl.get_fun_triple(env, INTRINSIC_FUN_MAP_ADD_NO_OVERRIDE),
             ),
+            fun_add_override_if_exists: Self::triple_opt_to_name(
+                decl.get_fun_triple(env, INTRINSIC_FUN_MAP_ADD_OVERRIDE_IF_EXISTS),
+            ),
             fun_del_must_exist: Self::triple_opt_to_name(
                 decl.get_fun_triple(env, INTRINSIC_FUN_MAP_DEL_MUST_EXIST),
+            ),
+            fun_del_return_key: Self::triple_opt_to_name(
+                decl.get_fun_triple(env, INTRINSIC_FUN_MAP_DEL_RETURN_KEY),
             ),
             fun_borrow: Self::triple_opt_to_name(
                 decl.get_fun_triple(env, INTRINSIC_FUN_MAP_BORROW),

--- a/language/move-prover/tests/sources/functional/verify_custom_table.exp
+++ b/language/move-prover/tests/sources/functional/verify_custom_table.exp
@@ -1,43 +1,43 @@
 Move prover returns: exiting with verification errors
 error: post-condition does not hold
-    ┌─ tests/sources/functional/verify_custom_table.move:170:9
+    ┌─ tests/sources/functional/verify_custom_table.move:202:9
     │
-170 │         ensures spec_get(result.t, k1) == 23;
+202 │         ensures spec_get(result.t, k1) == 23;
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/verify_custom_table.move:166: add_R_fail (spec)
-    =     at tests/sources/functional/verify_custom_table.move:167: add_R_fail (spec)
-    =     at tests/sources/functional/verify_custom_table.move:163: add_R_fail
-    =     at tests/sources/functional/verify_custom_table.move:144: make_R
+    =     at tests/sources/functional/verify_custom_table.move:198: add_R_fail (spec)
+    =     at tests/sources/functional/verify_custom_table.move:199: add_R_fail (spec)
+    =     at tests/sources/functional/verify_custom_table.move:195: add_R_fail
+    =     at tests/sources/functional/verify_custom_table.move:176: make_R
     =         t = <redacted>
-    =     at tests/sources/functional/verify_custom_table.move:145: make_R
+    =     at tests/sources/functional/verify_custom_table.move:177: make_R
     =         t = <redacted>
-    =     at tests/sources/functional/verify_custom_table.move:146: make_R
+    =     at tests/sources/functional/verify_custom_table.move:178: make_R
     =         t = <redacted>
-    =     at tests/sources/functional/verify_custom_table.move:147: make_R
+    =     at tests/sources/functional/verify_custom_table.move:179: make_R
     =         result = <redacted>
-    =     at tests/sources/functional/verify_custom_table.move:148: make_R
+    =     at tests/sources/functional/verify_custom_table.move:180: make_R
     =         result = <redacted>
-    =     at tests/sources/functional/verify_custom_table.move:164: add_R_fail
-    =     at tests/sources/functional/verify_custom_table.move:168: add_R_fail (spec)
-    =     at tests/sources/functional/verify_custom_table.move:169: add_R_fail (spec)
-    =     at tests/sources/functional/verify_custom_table.move:170: add_R_fail (spec)
+    =     at tests/sources/functional/verify_custom_table.move:196: add_R_fail
+    =     at tests/sources/functional/verify_custom_table.move:200: add_R_fail (spec)
+    =     at tests/sources/functional/verify_custom_table.move:201: add_R_fail (spec)
+    =     at tests/sources/functional/verify_custom_table.move:202: add_R_fail (spec)
 
 error: post-condition does not hold
-   ┌─ tests/sources/functional/verify_custom_table.move:68:9
+   ┌─ tests/sources/functional/verify_custom_table.move:72:9
    │
-68 │         ensures spec_get(result, 1) == 1;
+72 │         ensures spec_get(result, 1) == 1;
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    │
-   =     at tests/sources/functional/verify_custom_table.move:61: add_fail
-   =         t = <redacted>
-   =     at tests/sources/functional/verify_custom_table.move:62: add_fail
-   =         t = <redacted>
-   =     at tests/sources/functional/verify_custom_table.move:63: add_fail
-   =         t = <redacted>
-   =     at tests/sources/functional/verify_custom_table.move:64: add_fail
-   =         t = <redacted>
    =     at tests/sources/functional/verify_custom_table.move:65: add_fail
-   =         result = <redacted>
+   =         t = <redacted>
    =     at tests/sources/functional/verify_custom_table.move:66: add_fail
-   =     at tests/sources/functional/verify_custom_table.move:68: add_fail (spec)
+   =         t = <redacted>
+   =     at tests/sources/functional/verify_custom_table.move:67: add_fail
+   =         t = <redacted>
+   =     at tests/sources/functional/verify_custom_table.move:68: add_fail
+   =         t = <redacted>
+   =     at tests/sources/functional/verify_custom_table.move:69: add_fail
+   =         result = <redacted>
+   =     at tests/sources/functional/verify_custom_table.move:70: add_fail
+   =     at tests/sources/functional/verify_custom_table.move:72: add_fail (spec)


### PR DESCRIPTION
- Added two pragmas for the intrinsic table implementation
  - map_del_return_key: a delete function that returns not only the value but also the key. `simple_map` needs this because keys are not drop-able there.
  - map_add_override_if_exists: an add function that override the value rather than abort when the key already exists. This models the `upsert` functions in the table modules

- Modified the meaning of `map_spec_set` so that the length only increases when a new entry is added.


## Motivation

To add necessary pragmas for table

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

yes

## Test Plan

cargo test
