### PR TITLE
[resolution][EASY] Fix missing space in error message

### DIFF
--- a/language/tools/move-package/src/resolution/resolution_graph.rs
+++ b/language/tools/move-package/src/resolution/resolution_graph.rs
@@ -307,7 +307,7 @@ impl ResolvingGraph {
                     other.unify(addr_opt).with_context(|| {
                         format!(
                             "Unable to resolve named address '{}' in \
-                                package '{}' when resolving dependencies",
+                             package '{}' when resolving dependencies",
                             name, package_name
                         )
                     })?;

--- a/language/tools/move-package/src/resolution/resolution_graph.rs
+++ b/language/tools/move-package/src/resolution/resolution_graph.rs
@@ -306,7 +306,7 @@ impl ResolvingGraph {
                 Some(other) => {
                     other.unify(addr_opt).with_context(|| {
                         format!(
-                            "Unable to resolve named address '{}' in\
+                            "Unable to resolve named address '{}' in \
                                 package '{}' when resolving dependencies",
                             name, package_name
                         )

--- a/language/tools/move-package/tests/test_sources/resolution/one_dep_unification_across_local_renamings_with_resolution/Move.exp
+++ b/language/tools/move-package/tests/test_sources/resolution/one_dep_unification_across_local_renamings_with_resolution/Move.exp
@@ -1,1 +1,1 @@
-Unable to resolve packages for package 'Root': Unable to resolve named address 'A' inpackage 'Root' when resolving dependencies: Attempted to assign a different value '0x1' to an a already-assigned named address '0x2'
+Unable to resolve packages for package 'Root': Unable to resolve named address 'A' in package 'Root' when resolving dependencies: Attempted to assign a different value '0x1' to an a already-assigned named address '0x2'


### PR DESCRIPTION
## Motivation

Spotted that there was no space between "in" and "package" in this error message, because of the newline escape.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes.

## Test Plan

:eyes: