### PR TITLE
[native functions] adds pretty-printing to `std::debug::print`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3541,6 +3541,7 @@ dependencies = [
  "anyhow",
  "dir-diff",
  "file_diff",
+ "hex",
  "log",
  "move-binary-format",
  "move-cli",

--- a/language/move-core/types/src/language_storage.rs
+++ b/language/move-core/types/src/language_storage.rs
@@ -104,6 +104,14 @@ impl StructTag {
         key
     }
 
+    /// Returns true if this is a `StructTag` for an `std::string::String` struct defined in the
+    /// standard library at address `move_std_addr`.
+    pub fn is_std_string(&self, move_std_addr: &AccountAddress) -> bool {
+        self.address == *move_std_addr
+            && self.module.as_str().eq("string")
+            && self.name.as_str().eq("String")
+    }
+
     pub fn module_id(&self) -> ModuleId {
         ModuleId::new(self.address, self.module.to_owned())
     }

--- a/language/move-core/types/src/value.rs
+++ b/language/move-core/types/src/value.rs
@@ -8,7 +8,7 @@ use crate::{
     language_storage::{StructTag, TypeTag},
     u256,
 };
-use anyhow::{bail, Result as AResult};
+use anyhow::{anyhow, bail, Result as AResult};
 use serde::{
     de::Error as DeError,
     ser::{SerializeMap, SerializeSeq, SerializeStruct, SerializeTuple},
@@ -122,6 +122,27 @@ impl MoveValue {
 
     pub fn vector_u8(v: Vec<u8>) -> Self {
         MoveValue::Vector(v.into_iter().map(MoveValue::U8).collect())
+    }
+
+    /// Converts the `Vec<MoveValue>` to a `Vec<u8>` if the inner `MoveValue` is a `MoveValue::U8`,
+    /// or returns an error otherwise.
+    pub fn vec_to_vec_u8(vec: Vec<MoveValue>) -> AResult<Vec<u8>> {
+        let mut vec_u8 = Vec::with_capacity(vec.len());
+
+        for byte in vec {
+            match byte {
+                MoveValue::U8(u8) => {
+                    vec_u8.push(u8);
+                }
+                _ => {
+                    return Err(anyhow!(
+                        "Expected inner MoveValue in Vec<MoveValue> to be a MoveValue::U8"
+                            .to_string(),
+                    ));
+                }
+            }
+        }
+        Ok(vec_u8)
     }
 
     pub fn vector_address(v: Vec<AccountAddress>) -> Self {

--- a/language/move-stdlib/Cargo.toml
+++ b/language/move-stdlib/Cargo.toml
@@ -26,6 +26,7 @@ smallvec = "1.6.1"
 sha2 = "0.9.3"
 sha3 = "0.9.1"
 anyhow = "1.0.52"
+hex = "0.4.3"
 
 [dev-dependencies]
 move-unit-test = { path = "../tools/move-unit-test" }

--- a/language/move-stdlib/nursery/sources/debug.move
+++ b/language/move-stdlib/nursery/sources/debug.move
@@ -1,19 +1,18 @@
 /// Module providing debug functionality.
 module std::debug {
+
+    /// Pretty-prints any Move value. For a Move struct, includes its field names, their types and their values.
     native public fun print<T>(x: &T);
 
+    /// Prints the calling function's stack trace.
     native public fun print_stack_trace();
 
     #[test_only]
     use std::string;
 
-    #[test]
-    fun test_print_string() {
-        let str_bytes = b"Hello, sane Move debugging!";
-
-        print(&str_bytes);
-
-        let str = string::utf8(str_bytes);
-        print<string::String>(&str);
+    #[test_only]
+    /// Utility function for printing a sequence of UTF8 bytes as a string (e.g., `b"Hello"`).
+    public fun print_string(utf8_bytes: vector<u8>) {
+        print<string::String>(&string::utf8(utf8_bytes));
     }
 }

--- a/language/move-stdlib/src/natives/debug.rs
+++ b/language/move-stdlib/src/natives/debug.rs
@@ -3,20 +3,537 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::natives::helpers::make_module_natives;
+#[cfg(feature = "testing")]
+use move_binary_format::errors::PartialVMError;
 use move_binary_format::errors::PartialVMResult;
+use move_core_types::{account_address::AccountAddress, gas_algebra::InternalGas};
+#[cfg(feature = "testing")]
 use move_core_types::{
-    account_address::AccountAddress, gas_algebra::InternalGas, language_storage::TypeTag,
+    language_storage::{StructTag, TypeTag},
+    value::{MoveStruct, MoveStructLayout, MoveTypeLayout, MoveValue},
+    vm_status::StatusCode,
 };
 use move_vm_runtime::native_functions::{NativeContext, NativeFunction};
-use move_vm_types::values::VectorRef;
-#[allow(unused_imports)]
-use move_vm_types::values::{values_impl::debug::print_reference, Reference, StructRef};
+#[cfg(feature = "testing")]
+use move_vm_types::values::Reference;
 #[allow(unused_imports)]
 use move_vm_types::{
     loaded_data::runtime_types::Type, natives::function::NativeResult, pop_arg, values::Value,
 };
 use smallvec::smallvec;
 use std::{collections::VecDeque, sync::Arc};
+#[cfg(feature = "testing")]
+use std::{
+    fmt,
+    fmt::{Error, Write},
+};
+
+#[cfg(feature = "testing")]
+fn is_string_struct_tag(struct_tag: &StructTag, move_std_addr: &AccountAddress) -> bool {
+    struct_tag.address == *move_std_addr
+        && struct_tag.module.as_str().eq("string")
+        && struct_tag.name.as_str().eq("String")
+}
+
+#[cfg(feature = "testing")]
+const HANDLE_FMT_WRITE_ERROR: fn(Error) -> PartialVMError = |e: fmt::Error| {
+    let vmerr = PartialVMError::new(StatusCode::UNKNOWN_STATUS);
+    vmerr.with_message("write! macro failed with: ".to_string() + e.to_string().as_str())
+};
+
+#[cfg(feature = "testing")]
+fn get_annotated_struct_layout(
+    context: &NativeContext,
+    ty: &Type,
+) -> PartialVMResult<MoveStructLayout> {
+    let annotated_type_layout = context.type_to_fully_annotated_layout(ty)?.unwrap();
+    match annotated_type_layout {
+        MoveTypeLayout::Struct(annotated_struct_layout) => Ok(annotated_struct_layout),
+        _ => Err(
+            PartialVMError::new(StatusCode::INTERNAL_TYPE_ERROR).with_message(
+                "Could not convert Type to fully-annotated MoveTypeLayout via NativeContext"
+                    .to_string(),
+            ),
+        ),
+    }
+}
+#[cfg(feature = "testing")]
+fn get_vector_inner_type(ty: &Type) -> PartialVMResult<&Type> {
+    match ty {
+        Type::Vector(ty) => Ok(ty),
+        _ => Err(PartialVMError::new(StatusCode::INTERNAL_TYPE_ERROR)
+            .with_message("Could not get the inner Type of a vector's Type".to_string())),
+    }
+}
+
+#[cfg(feature = "testing")]
+fn vector_move_value_to_vec_u8(bytes: Vec<MoveValue>) -> PartialVMResult<Vec<u8>> {
+    let mut buf = vec![];
+    for byte in bytes {
+        match byte {
+            MoveValue::U8(u8) => {
+                buf.push(u8);
+            }
+            _ => {
+                return Err(
+                    PartialVMError::new(StatusCode::INTERNAL_TYPE_ERROR).with_message(
+                        "Got not u8 inside bytes field of std::string::String bytes".to_string(),
+                    ),
+                );
+            }
+        }
+    }
+    Ok(buf)
+}
+
+#[cfg(feature = "testing")]
+/// Prints an std::string::String by wrapping it in double quotes and escaping double quotes inside it.
+///
+/// Examples:
+///  - 'Hello' prints as "Hello"
+///  - '"Hello?" What are you saying?' prints as "\"Hello?\" What are you saying?"
+fn print_move_value_as_string(out: &mut String, val: MoveValue) -> PartialVMResult<()> {
+    match val {
+        MoveValue::Vector(bytes) => {
+            let buf = vector_move_value_to_vec_u8(bytes)?;
+
+            let str = String::from_utf8(buf).map_err(|e| {
+                PartialVMError::new(StatusCode::INTERNAL_TYPE_ERROR).with_message(
+                    "Could not parse UTF8 bytes: ".to_string() + e.to_string().as_str(),
+                )
+            })?;
+
+            // We need to escape displayed double quotes " as \" and, as a result, also escape
+            // displayed \ as \\.
+            let str = str.replace('\\', "\\\\").replace('"', "\\\"");
+
+            write!(out, "\"{}\"", str).map_err(HANDLE_FMT_WRITE_ERROR)?;
+        }
+        _ => {
+            return Err(
+                PartialVMError::new(StatusCode::INTERNAL_TYPE_ERROR).with_message(
+                    "Expected std::string::String to have vector<u8> bytes field".to_string(),
+                ),
+            )
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(feature = "testing")]
+fn print_padding_at_depth(out: &mut String, depth: usize) -> PartialVMResult<()> {
+    for _ in 0..depth {
+        // add 2 spaces
+        write!(out, "  ").map_err(HANDLE_FMT_WRITE_ERROR)?;
+    }
+
+    Ok(())
+}
+
+#[cfg(feature = "testing")]
+fn is_vector_u8(vec: &Vec<MoveValue>) -> bool {
+    if vec.is_empty() {
+        false
+    } else {
+        matches!(vec.last().unwrap(), MoveValue::U8(_))
+    }
+}
+
+#[cfg(feature = "testing")]
+fn is_vector_or_struct_move_value(mv: &MoveValue) -> bool {
+    matches!(mv, MoveValue::Vector(_) | MoveValue::Struct(_))
+}
+
+#[cfg(feature = "testing")]
+macro_rules! ref_to_val {
+    ($val:ident) => {{
+        let arg_ref = $val.value_as::<Reference>()?;
+        arg_ref.read_ref()?
+    }};
+}
+
+#[cfg(feature = "testing")]
+const VECTOR_BEGIN: &str = "[";
+
+#[cfg(feature = "testing")]
+const VECTOR_OR_STRUCT_SEP: &str = ",";
+
+#[cfg(feature = "testing")]
+const VECTOR_END: &str = "]";
+
+#[cfg(feature = "testing")]
+const STRUCT_BEGIN: &str = "{";
+
+#[cfg(feature = "testing")]
+const STRUCT_END: &str = "}";
+
+#[cfg(feature = "testing")]
+fn print_value(
+    context: &NativeContext,
+    out: &mut String,
+    val: Value,
+    ty: Type,
+    move_std_addr: &AccountAddress,
+    depth: usize,
+    canonicalize: bool,
+    single_line: bool,
+    include_int_types: bool,
+) -> PartialVMResult<()> {
+    // get type layout in VM format
+    let ty_layout = context.type_to_type_layout(&ty)?.unwrap();
+
+    match &ty_layout {
+        MoveTypeLayout::Vector(_) => {
+            // get the inner type T of a vector<T>
+            let inner_ty = get_vector_inner_type(&ty)?;
+            let inner_tyl = context.type_to_type_layout(inner_ty)?.unwrap();
+
+            match inner_tyl {
+                // We cannot simply convert this vector `Value` to a `MoveValue` because there might
+                // be a struct in the vector that needs to be "decorated" using the logic in this
+                // function. Instead, we recursively "unpack" the vector until we get down to either
+                // a primitive type or a struct, which this function can then forward to
+                // `print_move_value`.
+                MoveTypeLayout::Vector(_) | MoveTypeLayout::Struct(_) => {
+                    // `val` is either a `Vec<Vec<Value>>`, a `Vec<Struct>`,  or a `Vec<signer>`, so we cast `val` as a `Vec<Value>` and call ourselves recursively
+                    let vec = val.value_as::<Vec<Value>>()?;
+
+                    let print_inner_value =
+                        |out: &mut String,
+                         val: Value,
+                         move_std_addr: &AccountAddress,
+                         depth: usize,
+                         canonicalize: bool,
+                         single_line: bool,
+                         include_int_types: bool| {
+                            print_value(
+                                context,
+                                out,
+                                val,
+                                inner_ty.clone(),
+                                move_std_addr,
+                                depth,
+                                canonicalize,
+                                single_line,
+                                include_int_types,
+                            )
+                        };
+
+                    print_non_u8_vector(
+                        out,
+                        move_std_addr,
+                        depth,
+                        canonicalize,
+                        single_line,
+                        include_int_types,
+                        vec,
+                        print_inner_value,
+                        true,
+                    )?;
+                }
+                // If the inner type T of this vector<T> is a primitive bool/unsigned integer/address type, we convert the
+                // vector<T> to a MoveValue and print it.
+                _ => {
+                    let mv = val.as_move_value(&ty_layout);
+                    print_move_value(
+                        out,
+                        mv,
+                        move_std_addr,
+                        depth,
+                        canonicalize,
+                        single_line,
+                        include_int_types,
+                    )?;
+                }
+            };
+        }
+        // For a struct, we convert it to a MoveValue annotated with its field names and types and print it
+        MoveTypeLayout::Struct(_) => {
+            let move_struct = match val.as_move_value(&ty_layout) {
+                MoveValue::Struct(s) => s,
+                _ => {
+                    return Err(PartialVMError::new(StatusCode::INTERNAL_TYPE_ERROR)
+                        .with_message("Expected MoveValue::MoveStruct".to_string()))
+                }
+            };
+
+            let annotated_struct_layout = get_annotated_struct_layout(context, &ty)?;
+            let decorated_struct = move_struct.decorate(&annotated_struct_layout);
+
+            print_move_value(
+                out,
+                MoveValue::Struct(decorated_struct),
+                move_std_addr,
+                depth,
+                canonicalize,
+                single_line,
+                include_int_types,
+            )?;
+        }
+        // For non-structs and non-vectors, convert them to a MoveValue and print them
+        _ => {
+            print_move_value(
+                out,
+                val.as_move_value(&ty_layout),
+                move_std_addr,
+                depth,
+                canonicalize,
+                single_line,
+                include_int_types,
+            )?;
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(feature = "testing")]
+/// Prints the MoveValue, optionally-including its type if `print_type` is true.
+fn print_move_value(
+    out: &mut String,
+    mv: MoveValue,
+    move_std_addr: &AccountAddress,
+    depth: usize,
+    canonicalize: bool,
+    single_line: bool,
+    include_int_types: bool,
+) -> PartialVMResult<()> {
+    match mv {
+        MoveValue::U8(u8) => {
+            write!(out, "{}", u8).map_err(HANDLE_FMT_WRITE_ERROR)?;
+            if include_int_types {
+                write!(out, "u8").map_err(HANDLE_FMT_WRITE_ERROR)?;
+            }
+        }
+        MoveValue::U16(u16) => {
+            write!(out, "{}", u16).map_err(HANDLE_FMT_WRITE_ERROR)?;
+            if include_int_types {
+                write!(out, "u16").map_err(HANDLE_FMT_WRITE_ERROR)?;
+            }
+        }
+        MoveValue::U32(u32) => {
+            write!(out, "{}", u32).map_err(HANDLE_FMT_WRITE_ERROR)?;
+            if include_int_types {
+                write!(out, "u32").map_err(HANDLE_FMT_WRITE_ERROR)?;
+            }
+        }
+        MoveValue::U64(u64) => {
+            write!(out, "{}", u64).map_err(HANDLE_FMT_WRITE_ERROR)?;
+            if include_int_types {
+                write!(out, "u64").map_err(HANDLE_FMT_WRITE_ERROR)?;
+            }
+        }
+        MoveValue::U128(u128) => {
+            write!(out, "{}", u128).map_err(HANDLE_FMT_WRITE_ERROR)?;
+            if include_int_types {
+                write!(out, "u128").map_err(HANDLE_FMT_WRITE_ERROR)?;
+            }
+        }
+        MoveValue::U256(u256) => {
+            write!(out, "{}", u256).map_err(HANDLE_FMT_WRITE_ERROR)?;
+            if include_int_types {
+                write!(out, "u256").map_err(HANDLE_FMT_WRITE_ERROR)?;
+            }
+        }
+        MoveValue::Bool(b) => {
+            // The type here can be inferred just from the true/false value, when `include_int_types` is enabled.
+            write!(out, "{}", if b { "true" } else { "false" }).map_err(HANDLE_FMT_WRITE_ERROR)?;
+        }
+        MoveValue::Address(a) => {
+            let str = if canonicalize {
+                a.to_canonical_string()
+            } else {
+                a.to_hex_literal()
+            };
+            write!(out, "@{}", str).map_err(HANDLE_FMT_WRITE_ERROR)?;
+        }
+        MoveValue::Signer(s) => {
+            let str = if canonicalize {
+                s.to_canonical_string()
+            } else {
+                s.to_hex_literal()
+            };
+            write!(out, "signer({})", str).map_err(HANDLE_FMT_WRITE_ERROR)?;
+        }
+        MoveValue::Vector(vec) => {
+            // If this is a vector<u8> we print it in hex (as most users would expect us to)
+            if is_vector_u8(&vec) {
+                let bytes = vector_move_value_to_vec_u8(vec)?;
+                write!(out, "0x{}", hex::encode(&bytes)).map_err(HANDLE_FMT_WRITE_ERROR)?;
+            } else {
+                let is_complex_inner_type =
+                    vec.last().map_or(false, is_vector_or_struct_move_value);
+                print_non_u8_vector(
+                    out,
+                    move_std_addr,
+                    depth,
+                    canonicalize,
+                    single_line,
+                    include_int_types,
+                    vec,
+                    print_move_value,
+                    is_complex_inner_type,
+                )?;
+            }
+        }
+        MoveValue::Struct(move_struct) => match move_struct {
+            MoveStruct::WithTypes { type_, mut fields } => {
+                let type_tag = TypeTag::from(type_.clone());
+
+                // Check if struct is an std::string::String
+                if !canonicalize && is_string_struct_tag(&type_, move_std_addr) {
+                    assert_eq!(fields.len(), 1);
+
+                    let (id, val) = fields.pop().unwrap();
+                    assert_eq!(id.into_string(), "bytes");
+
+                    print_move_value_as_string(out, val)?;
+                } else {
+                    write!(out, "{} ", type_tag).map_err(HANDLE_FMT_WRITE_ERROR)?;
+                    write!(out, "{}", STRUCT_BEGIN).map_err(HANDLE_FMT_WRITE_ERROR)?;
+
+                    // For each field, print its name and value (and type)
+                    let mut iter = fields.into_iter();
+                    if let Some((field_name, field_value)) = iter.next() {
+                        // Start an indented new line
+                        if !single_line {
+                            writeln!(out).map_err(HANDLE_FMT_WRITE_ERROR)?;
+                            print_padding_at_depth(out, depth + 1)?;
+                        }
+
+                        write!(out, "{}: ", field_name.into_string())
+                            .map_err(HANDLE_FMT_WRITE_ERROR)?;
+                        print_move_value(
+                            out,
+                            field_value,
+                            move_std_addr,
+                            depth + 1,
+                            canonicalize,
+                            single_line,
+                            include_int_types,
+                        )?;
+
+                        for (field_name, field_value) in iter {
+                            write!(out, "{}", VECTOR_OR_STRUCT_SEP)
+                                .map_err(HANDLE_FMT_WRITE_ERROR)?;
+
+                            if !single_line {
+                                writeln!(out).map_err(HANDLE_FMT_WRITE_ERROR)?;
+                                print_padding_at_depth(out, depth + 1)?;
+                            } else {
+                                write!(out, " ").map_err(HANDLE_FMT_WRITE_ERROR)?;
+                            }
+                            write!(out, "{}: ", field_name.into_string())
+                                .map_err(HANDLE_FMT_WRITE_ERROR)?;
+                            print_move_value(
+                                out,
+                                field_value,
+                                move_std_addr,
+                                depth + 1,
+                                canonicalize,
+                                single_line,
+                                include_int_types,
+                            )?;
+                        }
+                    }
+
+                    // Ends printing the struct with "}", which could be on its own line
+                    if !single_line {
+                        writeln!(out).map_err(HANDLE_FMT_WRITE_ERROR)?;
+                        print_padding_at_depth(out, depth)?;
+                    }
+                    write!(out, "{}", STRUCT_END).map_err(HANDLE_FMT_WRITE_ERROR)?;
+                }
+            }
+            _ => {
+                return Err(PartialVMError::new(StatusCode::INTERNAL_TYPE_ERROR)
+                    .with_message("Expected MoveStruct::WithTypes".to_string()))
+            }
+        },
+    }
+
+    Ok(())
+}
+
+#[cfg(feature = "testing")]
+fn print_non_u8_vector<ValType>(
+    out: &mut String,
+    move_std_addr: &AccountAddress,
+    depth: usize,
+    canonicalize: bool,
+    single_line: bool,
+    include_int_types: bool,
+    vec: Vec<ValType>,
+    print_inner_value: impl Fn(
+        &mut String,
+        ValType,
+        &AccountAddress,
+        usize,
+        bool,
+        bool,
+        bool,
+    ) -> PartialVMResult<()>,
+    is_complex_inner_type: bool,
+) -> PartialVMResult<()> {
+    write!(out, "{}", VECTOR_BEGIN).map_err(HANDLE_FMT_WRITE_ERROR)?;
+    let mut iter = vec.into_iter();
+    let mut empty_vec = true;
+
+    if let Some(first_elem) = iter.next() {
+        empty_vec = false;
+
+        // For vectors-of-vectors, and for vectors-of-structs, we start a newline for each element
+        if !single_line && is_complex_inner_type {
+            writeln!(out).map_err(HANDLE_FMT_WRITE_ERROR)?;
+            print_padding_at_depth(out, depth + 1)?;
+        } else {
+            write!(out, " ").map_err(HANDLE_FMT_WRITE_ERROR)?;
+        }
+
+        print_inner_value(
+            out,
+            first_elem,
+            move_std_addr,
+            depth + 1,
+            canonicalize,
+            single_line,
+            include_int_types,
+        )?;
+
+        for elem in iter {
+            write!(out, "{}", VECTOR_OR_STRUCT_SEP).map_err(HANDLE_FMT_WRITE_ERROR)?;
+
+            // For vectors of vectors or vectors of structs, we start a newline for each element
+            if !single_line && is_complex_inner_type {
+                writeln!(out).map_err(HANDLE_FMT_WRITE_ERROR)?;
+                print_padding_at_depth(out, depth + 1)?;
+            } else {
+                write!(out, " ").map_err(HANDLE_FMT_WRITE_ERROR)?;
+            }
+            print_inner_value(
+                out,
+                elem,
+                move_std_addr,
+                depth + 1,
+                canonicalize,
+                single_line,
+                include_int_types,
+            )?;
+        }
+    }
+
+    // For vectors of vectors or vectors of structs, we display the closing ] on a newline
+    if !single_line && is_complex_inner_type {
+        writeln!(out).map_err(HANDLE_FMT_WRITE_ERROR)?;
+        print_padding_at_depth(out, depth)?;
+    } else if !empty_vec {
+        write!(out, " ").map_err(HANDLE_FMT_WRITE_ERROR)?;
+    }
+    write!(out, "{}", VECTOR_END).map_err(HANDLE_FMT_WRITE_ERROR)?;
+
+    Ok(())
+}
 
 /***************************************************************************************************
  * native fun print
@@ -28,62 +545,41 @@ pub struct PrintGasParameters {
     pub base_cost: InternalGas,
 }
 
-#[cfg(feature = "testing")]
-fn is_string_type(context: &NativeContext, ty: &Type, move_std_addr: AccountAddress) -> bool {
-    let ty_tag = match context.type_to_type_tag(ty) {
-        Ok(ty_tag) => ty_tag,
-        Err(_) => return false,
-    };
-
-    match ty_tag {
-        TypeTag::Struct(struct_tag) => {
-            struct_tag.address == move_std_addr
-                && struct_tag.module.as_str().eq("string")
-                && struct_tag.name.as_str().eq("String")
-        }
-        _ => false,
-    }
-}
-
-#[allow(unused_mut)]
 #[inline]
 fn native_print(
     gas_params: &PrintGasParameters,
     _context: &mut NativeContext,
     mut ty_args: Vec<Type>,
     mut args: VecDeque<Value>,
-    move_std_addr: AccountAddress,
+    _move_std_addr: AccountAddress,
 ) -> PartialVMResult<NativeResult> {
     debug_assert!(ty_args.len() == 1);
     debug_assert!(args.len() == 1);
 
+    let _val = args.pop_back().unwrap();
+    let _ty = ty_args.pop().unwrap();
+
     // No-op if the feature flag is not present.
     #[cfg(feature = "testing")]
     {
-        let ty = ty_args.pop().unwrap();
+        let include_int_types = false;
+        let canonical = false;
 
-        match is_string_type(_context, &ty, move_std_addr) {
-            true => {
-                let r = pop_arg!(args, StructRef);
-
-                let field_ref = r
-                    .borrow_field(0)? // borrows the 'bytes' field of the std::string::String struct
-                    .value_as::<VectorRef>()?;
-
-                let bytes = field_ref.as_bytes_ref();
-
-                // This is safe because we guarantee the bytes to be utf8.
-                let str = unsafe { std::str::from_utf8_unchecked(bytes.as_slice()) };
-
-                println!("[debug] {}", str);
-            }
-            false => {
-                let r = pop_arg!(args, Reference);
-                let mut buf = String::new();
-                print_reference(&mut buf, &r)?;
-                println!("[debug] {}", buf);
-            }
-        }
+        let mut dest = "[debug] ".to_string();
+        let val = ref_to_val!(_val);
+        let single_line = false;
+        print_value(
+            _context,
+            &mut dest,
+            val,
+            _ty,
+            &_move_std_addr,
+            0,
+            canonical,
+            single_line,
+            include_int_types,
+        )?;
+        println!("{}", dest);
     }
 
     Ok(NativeResult::ok(gas_params.base_cost, smallvec![]))

--- a/language/move-stdlib/src/natives/debug.rs
+++ b/language/move-stdlib/src/natives/debug.rs
@@ -3,537 +3,18 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::natives::helpers::make_module_natives;
-#[cfg(feature = "testing")]
-use move_binary_format::errors::PartialVMError;
 use move_binary_format::errors::PartialVMResult;
 use move_core_types::{account_address::AccountAddress, gas_algebra::InternalGas};
-#[cfg(feature = "testing")]
-use move_core_types::{
-    language_storage::{StructTag, TypeTag},
-    value::{MoveStruct, MoveStructLayout, MoveTypeLayout, MoveValue},
-    vm_status::StatusCode,
-};
 use move_vm_runtime::native_functions::{NativeContext, NativeFunction};
-#[cfg(feature = "testing")]
-use move_vm_types::values::Reference;
 #[allow(unused_imports)]
 use move_vm_types::{
-    loaded_data::runtime_types::Type, natives::function::NativeResult, pop_arg, values::Value,
+    loaded_data::runtime_types::Type,
+    natives::function::NativeResult,
+    pop_arg,
+    values::{Reference, Value},
 };
 use smallvec::smallvec;
 use std::{collections::VecDeque, sync::Arc};
-#[cfg(feature = "testing")]
-use std::{
-    fmt,
-    fmt::{Error, Write},
-};
-
-#[cfg(feature = "testing")]
-fn is_string_struct_tag(struct_tag: &StructTag, move_std_addr: &AccountAddress) -> bool {
-    struct_tag.address == *move_std_addr
-        && struct_tag.module.as_str().eq("string")
-        && struct_tag.name.as_str().eq("String")
-}
-
-#[cfg(feature = "testing")]
-const HANDLE_FMT_WRITE_ERROR: fn(Error) -> PartialVMError = |e: fmt::Error| {
-    let vmerr = PartialVMError::new(StatusCode::UNKNOWN_STATUS);
-    vmerr.with_message("write! macro failed with: ".to_string() + e.to_string().as_str())
-};
-
-#[cfg(feature = "testing")]
-fn get_annotated_struct_layout(
-    context: &NativeContext,
-    ty: &Type,
-) -> PartialVMResult<MoveStructLayout> {
-    let annotated_type_layout = context.type_to_fully_annotated_layout(ty)?.unwrap();
-    match annotated_type_layout {
-        MoveTypeLayout::Struct(annotated_struct_layout) => Ok(annotated_struct_layout),
-        _ => Err(
-            PartialVMError::new(StatusCode::INTERNAL_TYPE_ERROR).with_message(
-                "Could not convert Type to fully-annotated MoveTypeLayout via NativeContext"
-                    .to_string(),
-            ),
-        ),
-    }
-}
-#[cfg(feature = "testing")]
-fn get_vector_inner_type(ty: &Type) -> PartialVMResult<&Type> {
-    match ty {
-        Type::Vector(ty) => Ok(ty),
-        _ => Err(PartialVMError::new(StatusCode::INTERNAL_TYPE_ERROR)
-            .with_message("Could not get the inner Type of a vector's Type".to_string())),
-    }
-}
-
-#[cfg(feature = "testing")]
-fn vector_move_value_to_vec_u8(bytes: Vec<MoveValue>) -> PartialVMResult<Vec<u8>> {
-    let mut buf = vec![];
-    for byte in bytes {
-        match byte {
-            MoveValue::U8(u8) => {
-                buf.push(u8);
-            }
-            _ => {
-                return Err(
-                    PartialVMError::new(StatusCode::INTERNAL_TYPE_ERROR).with_message(
-                        "Got not u8 inside bytes field of std::string::String bytes".to_string(),
-                    ),
-                );
-            }
-        }
-    }
-    Ok(buf)
-}
-
-#[cfg(feature = "testing")]
-/// Prints an std::string::String by wrapping it in double quotes and escaping double quotes inside it.
-///
-/// Examples:
-///  - 'Hello' prints as "Hello"
-///  - '"Hello?" What are you saying?' prints as "\"Hello?\" What are you saying?"
-fn print_move_value_as_string(out: &mut String, val: MoveValue) -> PartialVMResult<()> {
-    match val {
-        MoveValue::Vector(bytes) => {
-            let buf = vector_move_value_to_vec_u8(bytes)?;
-
-            let str = String::from_utf8(buf).map_err(|e| {
-                PartialVMError::new(StatusCode::INTERNAL_TYPE_ERROR).with_message(
-                    "Could not parse UTF8 bytes: ".to_string() + e.to_string().as_str(),
-                )
-            })?;
-
-            // We need to escape displayed double quotes " as \" and, as a result, also escape
-            // displayed \ as \\.
-            let str = str.replace('\\', "\\\\").replace('"', "\\\"");
-
-            write!(out, "\"{}\"", str).map_err(HANDLE_FMT_WRITE_ERROR)?;
-        }
-        _ => {
-            return Err(
-                PartialVMError::new(StatusCode::INTERNAL_TYPE_ERROR).with_message(
-                    "Expected std::string::String to have vector<u8> bytes field".to_string(),
-                ),
-            )
-        }
-    }
-
-    Ok(())
-}
-
-#[cfg(feature = "testing")]
-fn print_padding_at_depth(out: &mut String, depth: usize) -> PartialVMResult<()> {
-    for _ in 0..depth {
-        // add 2 spaces
-        write!(out, "  ").map_err(HANDLE_FMT_WRITE_ERROR)?;
-    }
-
-    Ok(())
-}
-
-#[cfg(feature = "testing")]
-fn is_vector_u8(vec: &Vec<MoveValue>) -> bool {
-    if vec.is_empty() {
-        false
-    } else {
-        matches!(vec.last().unwrap(), MoveValue::U8(_))
-    }
-}
-
-#[cfg(feature = "testing")]
-fn is_vector_or_struct_move_value(mv: &MoveValue) -> bool {
-    matches!(mv, MoveValue::Vector(_) | MoveValue::Struct(_))
-}
-
-#[cfg(feature = "testing")]
-macro_rules! ref_to_val {
-    ($val:ident) => {{
-        let arg_ref = $val.value_as::<Reference>()?;
-        arg_ref.read_ref()?
-    }};
-}
-
-#[cfg(feature = "testing")]
-const VECTOR_BEGIN: &str = "[";
-
-#[cfg(feature = "testing")]
-const VECTOR_OR_STRUCT_SEP: &str = ",";
-
-#[cfg(feature = "testing")]
-const VECTOR_END: &str = "]";
-
-#[cfg(feature = "testing")]
-const STRUCT_BEGIN: &str = "{";
-
-#[cfg(feature = "testing")]
-const STRUCT_END: &str = "}";
-
-#[cfg(feature = "testing")]
-fn print_value(
-    context: &NativeContext,
-    out: &mut String,
-    val: Value,
-    ty: Type,
-    move_std_addr: &AccountAddress,
-    depth: usize,
-    canonicalize: bool,
-    single_line: bool,
-    include_int_types: bool,
-) -> PartialVMResult<()> {
-    // get type layout in VM format
-    let ty_layout = context.type_to_type_layout(&ty)?.unwrap();
-
-    match &ty_layout {
-        MoveTypeLayout::Vector(_) => {
-            // get the inner type T of a vector<T>
-            let inner_ty = get_vector_inner_type(&ty)?;
-            let inner_tyl = context.type_to_type_layout(inner_ty)?.unwrap();
-
-            match inner_tyl {
-                // We cannot simply convert this vector `Value` to a `MoveValue` because there might
-                // be a struct in the vector that needs to be "decorated" using the logic in this
-                // function. Instead, we recursively "unpack" the vector until we get down to either
-                // a primitive type or a struct, which this function can then forward to
-                // `print_move_value`.
-                MoveTypeLayout::Vector(_) | MoveTypeLayout::Struct(_) => {
-                    // `val` is either a `Vec<Vec<Value>>`, a `Vec<Struct>`,  or a `Vec<signer>`, so we cast `val` as a `Vec<Value>` and call ourselves recursively
-                    let vec = val.value_as::<Vec<Value>>()?;
-
-                    let print_inner_value =
-                        |out: &mut String,
-                         val: Value,
-                         move_std_addr: &AccountAddress,
-                         depth: usize,
-                         canonicalize: bool,
-                         single_line: bool,
-                         include_int_types: bool| {
-                            print_value(
-                                context,
-                                out,
-                                val,
-                                inner_ty.clone(),
-                                move_std_addr,
-                                depth,
-                                canonicalize,
-                                single_line,
-                                include_int_types,
-                            )
-                        };
-
-                    print_non_u8_vector(
-                        out,
-                        move_std_addr,
-                        depth,
-                        canonicalize,
-                        single_line,
-                        include_int_types,
-                        vec,
-                        print_inner_value,
-                        true,
-                    )?;
-                }
-                // If the inner type T of this vector<T> is a primitive bool/unsigned integer/address type, we convert the
-                // vector<T> to a MoveValue and print it.
-                _ => {
-                    let mv = val.as_move_value(&ty_layout);
-                    print_move_value(
-                        out,
-                        mv,
-                        move_std_addr,
-                        depth,
-                        canonicalize,
-                        single_line,
-                        include_int_types,
-                    )?;
-                }
-            };
-        }
-        // For a struct, we convert it to a MoveValue annotated with its field names and types and print it
-        MoveTypeLayout::Struct(_) => {
-            let move_struct = match val.as_move_value(&ty_layout) {
-                MoveValue::Struct(s) => s,
-                _ => {
-                    return Err(PartialVMError::new(StatusCode::INTERNAL_TYPE_ERROR)
-                        .with_message("Expected MoveValue::MoveStruct".to_string()))
-                }
-            };
-
-            let annotated_struct_layout = get_annotated_struct_layout(context, &ty)?;
-            let decorated_struct = move_struct.decorate(&annotated_struct_layout);
-
-            print_move_value(
-                out,
-                MoveValue::Struct(decorated_struct),
-                move_std_addr,
-                depth,
-                canonicalize,
-                single_line,
-                include_int_types,
-            )?;
-        }
-        // For non-structs and non-vectors, convert them to a MoveValue and print them
-        _ => {
-            print_move_value(
-                out,
-                val.as_move_value(&ty_layout),
-                move_std_addr,
-                depth,
-                canonicalize,
-                single_line,
-                include_int_types,
-            )?;
-        }
-    }
-
-    Ok(())
-}
-
-#[cfg(feature = "testing")]
-/// Prints the MoveValue, optionally-including its type if `print_type` is true.
-fn print_move_value(
-    out: &mut String,
-    mv: MoveValue,
-    move_std_addr: &AccountAddress,
-    depth: usize,
-    canonicalize: bool,
-    single_line: bool,
-    include_int_types: bool,
-) -> PartialVMResult<()> {
-    match mv {
-        MoveValue::U8(u8) => {
-            write!(out, "{}", u8).map_err(HANDLE_FMT_WRITE_ERROR)?;
-            if include_int_types {
-                write!(out, "u8").map_err(HANDLE_FMT_WRITE_ERROR)?;
-            }
-        }
-        MoveValue::U16(u16) => {
-            write!(out, "{}", u16).map_err(HANDLE_FMT_WRITE_ERROR)?;
-            if include_int_types {
-                write!(out, "u16").map_err(HANDLE_FMT_WRITE_ERROR)?;
-            }
-        }
-        MoveValue::U32(u32) => {
-            write!(out, "{}", u32).map_err(HANDLE_FMT_WRITE_ERROR)?;
-            if include_int_types {
-                write!(out, "u32").map_err(HANDLE_FMT_WRITE_ERROR)?;
-            }
-        }
-        MoveValue::U64(u64) => {
-            write!(out, "{}", u64).map_err(HANDLE_FMT_WRITE_ERROR)?;
-            if include_int_types {
-                write!(out, "u64").map_err(HANDLE_FMT_WRITE_ERROR)?;
-            }
-        }
-        MoveValue::U128(u128) => {
-            write!(out, "{}", u128).map_err(HANDLE_FMT_WRITE_ERROR)?;
-            if include_int_types {
-                write!(out, "u128").map_err(HANDLE_FMT_WRITE_ERROR)?;
-            }
-        }
-        MoveValue::U256(u256) => {
-            write!(out, "{}", u256).map_err(HANDLE_FMT_WRITE_ERROR)?;
-            if include_int_types {
-                write!(out, "u256").map_err(HANDLE_FMT_WRITE_ERROR)?;
-            }
-        }
-        MoveValue::Bool(b) => {
-            // The type here can be inferred just from the true/false value, when `include_int_types` is enabled.
-            write!(out, "{}", if b { "true" } else { "false" }).map_err(HANDLE_FMT_WRITE_ERROR)?;
-        }
-        MoveValue::Address(a) => {
-            let str = if canonicalize {
-                a.to_canonical_string()
-            } else {
-                a.to_hex_literal()
-            };
-            write!(out, "@{}", str).map_err(HANDLE_FMT_WRITE_ERROR)?;
-        }
-        MoveValue::Signer(s) => {
-            let str = if canonicalize {
-                s.to_canonical_string()
-            } else {
-                s.to_hex_literal()
-            };
-            write!(out, "signer({})", str).map_err(HANDLE_FMT_WRITE_ERROR)?;
-        }
-        MoveValue::Vector(vec) => {
-            // If this is a vector<u8> we print it in hex (as most users would expect us to)
-            if is_vector_u8(&vec) {
-                let bytes = vector_move_value_to_vec_u8(vec)?;
-                write!(out, "0x{}", hex::encode(&bytes)).map_err(HANDLE_FMT_WRITE_ERROR)?;
-            } else {
-                let is_complex_inner_type =
-                    vec.last().map_or(false, is_vector_or_struct_move_value);
-                print_non_u8_vector(
-                    out,
-                    move_std_addr,
-                    depth,
-                    canonicalize,
-                    single_line,
-                    include_int_types,
-                    vec,
-                    print_move_value,
-                    is_complex_inner_type,
-                )?;
-            }
-        }
-        MoveValue::Struct(move_struct) => match move_struct {
-            MoveStruct::WithTypes { type_, mut fields } => {
-                let type_tag = TypeTag::from(type_.clone());
-
-                // Check if struct is an std::string::String
-                if !canonicalize && is_string_struct_tag(&type_, move_std_addr) {
-                    assert_eq!(fields.len(), 1);
-
-                    let (id, val) = fields.pop().unwrap();
-                    assert_eq!(id.into_string(), "bytes");
-
-                    print_move_value_as_string(out, val)?;
-                } else {
-                    write!(out, "{} ", type_tag).map_err(HANDLE_FMT_WRITE_ERROR)?;
-                    write!(out, "{}", STRUCT_BEGIN).map_err(HANDLE_FMT_WRITE_ERROR)?;
-
-                    // For each field, print its name and value (and type)
-                    let mut iter = fields.into_iter();
-                    if let Some((field_name, field_value)) = iter.next() {
-                        // Start an indented new line
-                        if !single_line {
-                            writeln!(out).map_err(HANDLE_FMT_WRITE_ERROR)?;
-                            print_padding_at_depth(out, depth + 1)?;
-                        }
-
-                        write!(out, "{}: ", field_name.into_string())
-                            .map_err(HANDLE_FMT_WRITE_ERROR)?;
-                        print_move_value(
-                            out,
-                            field_value,
-                            move_std_addr,
-                            depth + 1,
-                            canonicalize,
-                            single_line,
-                            include_int_types,
-                        )?;
-
-                        for (field_name, field_value) in iter {
-                            write!(out, "{}", VECTOR_OR_STRUCT_SEP)
-                                .map_err(HANDLE_FMT_WRITE_ERROR)?;
-
-                            if !single_line {
-                                writeln!(out).map_err(HANDLE_FMT_WRITE_ERROR)?;
-                                print_padding_at_depth(out, depth + 1)?;
-                            } else {
-                                write!(out, " ").map_err(HANDLE_FMT_WRITE_ERROR)?;
-                            }
-                            write!(out, "{}: ", field_name.into_string())
-                                .map_err(HANDLE_FMT_WRITE_ERROR)?;
-                            print_move_value(
-                                out,
-                                field_value,
-                                move_std_addr,
-                                depth + 1,
-                                canonicalize,
-                                single_line,
-                                include_int_types,
-                            )?;
-                        }
-                    }
-
-                    // Ends printing the struct with "}", which could be on its own line
-                    if !single_line {
-                        writeln!(out).map_err(HANDLE_FMT_WRITE_ERROR)?;
-                        print_padding_at_depth(out, depth)?;
-                    }
-                    write!(out, "{}", STRUCT_END).map_err(HANDLE_FMT_WRITE_ERROR)?;
-                }
-            }
-            _ => {
-                return Err(PartialVMError::new(StatusCode::INTERNAL_TYPE_ERROR)
-                    .with_message("Expected MoveStruct::WithTypes".to_string()))
-            }
-        },
-    }
-
-    Ok(())
-}
-
-#[cfg(feature = "testing")]
-fn print_non_u8_vector<ValType>(
-    out: &mut String,
-    move_std_addr: &AccountAddress,
-    depth: usize,
-    canonicalize: bool,
-    single_line: bool,
-    include_int_types: bool,
-    vec: Vec<ValType>,
-    print_inner_value: impl Fn(
-        &mut String,
-        ValType,
-        &AccountAddress,
-        usize,
-        bool,
-        bool,
-        bool,
-    ) -> PartialVMResult<()>,
-    is_complex_inner_type: bool,
-) -> PartialVMResult<()> {
-    write!(out, "{}", VECTOR_BEGIN).map_err(HANDLE_FMT_WRITE_ERROR)?;
-    let mut iter = vec.into_iter();
-    let mut empty_vec = true;
-
-    if let Some(first_elem) = iter.next() {
-        empty_vec = false;
-
-        // For vectors-of-vectors, and for vectors-of-structs, we start a newline for each element
-        if !single_line && is_complex_inner_type {
-            writeln!(out).map_err(HANDLE_FMT_WRITE_ERROR)?;
-            print_padding_at_depth(out, depth + 1)?;
-        } else {
-            write!(out, " ").map_err(HANDLE_FMT_WRITE_ERROR)?;
-        }
-
-        print_inner_value(
-            out,
-            first_elem,
-            move_std_addr,
-            depth + 1,
-            canonicalize,
-            single_line,
-            include_int_types,
-        )?;
-
-        for elem in iter {
-            write!(out, "{}", VECTOR_OR_STRUCT_SEP).map_err(HANDLE_FMT_WRITE_ERROR)?;
-
-            // For vectors of vectors or vectors of structs, we start a newline for each element
-            if !single_line && is_complex_inner_type {
-                writeln!(out).map_err(HANDLE_FMT_WRITE_ERROR)?;
-                print_padding_at_depth(out, depth + 1)?;
-            } else {
-                write!(out, " ").map_err(HANDLE_FMT_WRITE_ERROR)?;
-            }
-            print_inner_value(
-                out,
-                elem,
-                move_std_addr,
-                depth + 1,
-                canonicalize,
-                single_line,
-                include_int_types,
-            )?;
-        }
-    }
-
-    // For vectors of vectors or vectors of structs, we display the closing ] on a newline
-    if !single_line && is_complex_inner_type {
-        writeln!(out).map_err(HANDLE_FMT_WRITE_ERROR)?;
-        print_padding_at_depth(out, depth)?;
-    } else if !empty_vec {
-        write!(out, " ").map_err(HANDLE_FMT_WRITE_ERROR)?;
-    }
-    write!(out, "{}", VECTOR_END).map_err(HANDLE_FMT_WRITE_ERROR)?;
-
-    Ok(())
-}
 
 /***************************************************************************************************
  * native fun print
@@ -562,15 +43,16 @@ fn native_print(
     // No-op if the feature flag is not present.
     #[cfg(feature = "testing")]
     {
-        let include_int_types = false;
         let canonical = false;
-
-        let mut dest = "[debug] ".to_string();
-        let val = ref_to_val!(_val);
         let single_line = false;
-        print_value(
+        let include_int_types = false;
+
+        let mut out = "[debug] ".to_string();
+        let val = _val.value_as::<Reference>()?.read_ref()?;
+
+        testing::print_value(
             _context,
-            &mut dest,
+            &mut out,
             val,
             _ty,
             &_move_std_addr,
@@ -579,7 +61,7 @@ fn native_print(
             single_line,
             include_int_types,
         )?;
-        println!("{}", dest);
+        println!("{}", out);
     }
 
     Ok(NativeResult::ok(gas_params.base_cost, smallvec![]))
@@ -657,4 +139,483 @@ pub fn make_all(
     ];
 
     make_module_natives(natives)
+}
+
+#[cfg(feature = "testing")]
+mod testing {
+    use move_binary_format::errors::{PartialVMError, PartialVMResult};
+    use move_core_types::{
+        account_address::AccountAddress,
+        language_storage::TypeTag,
+        value::{MoveStruct, MoveStructLayout, MoveTypeLayout, MoveValue},
+        vm_status::StatusCode,
+    };
+    use move_vm_runtime::native_functions::NativeContext;
+    use move_vm_types::{loaded_data::runtime_types::Type, values::Value};
+    use std::{fmt, fmt::Write};
+
+    const VECTOR_BEGIN: &str = "[";
+
+    const VECTOR_OR_STRUCT_SEP: &str = ",";
+
+    const VECTOR_END: &str = "]";
+
+    const STRUCT_BEGIN: &str = "{";
+
+    const STRUCT_END: &str = "}";
+
+    fn fmt_error_to_partial_vm_error(e: fmt::Error) -> PartialVMError {
+        let vmerr = PartialVMError::new(StatusCode::UNKNOWN_STATUS);
+        vmerr.with_message("write! macro failed with: ".to_string() + e.to_string().as_str())
+    }
+
+    fn to_vec_u8_type_err<E>(_e: E) -> PartialVMError {
+        PartialVMError::new(StatusCode::INTERNAL_TYPE_ERROR)
+            .with_message("Could not convert Vec<MoveValue> to Vec<u8>: ".to_string())
+    }
+
+    fn get_annotated_struct_layout(
+        context: &NativeContext,
+        ty: &Type,
+    ) -> PartialVMResult<MoveStructLayout> {
+        let annotated_type_layout = context.type_to_fully_annotated_layout(ty)?.unwrap();
+        match annotated_type_layout {
+            MoveTypeLayout::Struct(annotated_struct_layout) => Ok(annotated_struct_layout),
+            _ => Err(
+                PartialVMError::new(StatusCode::INTERNAL_TYPE_ERROR).with_message(
+                    "Could not convert Type to fully-annotated MoveTypeLayout via NativeContext"
+                        .to_string(),
+                ),
+            ),
+        }
+    }
+
+    fn get_vector_inner_type(ty: &Type) -> PartialVMResult<&Type> {
+        match ty {
+            Type::Vector(ty) => Ok(ty),
+            _ => Err(PartialVMError::new(StatusCode::INTERNAL_TYPE_ERROR)
+                .with_message("Could not get the inner Type of a vector's Type".to_string())),
+        }
+    }
+
+    /// Prints an std::string::String by wrapping it in double quotes and escaping double quotes inside it.
+    ///
+    /// Examples:
+    ///  - 'Hello' prints as "Hello"
+    ///  - '"Hello?" What are you saying?' prints as "\"Hello?\" What are you saying?"
+    fn print_move_value_as_string(out: &mut String, val: MoveValue) -> PartialVMResult<()> {
+        match val {
+            MoveValue::Vector(bytes) => {
+                let buf = MoveValue::vec_to_vec_u8(bytes).map_err(to_vec_u8_type_err)?;
+
+                let str = String::from_utf8(buf).map_err(|e| {
+                    PartialVMError::new(StatusCode::INTERNAL_TYPE_ERROR).with_message(
+                        "Could not parse UTF8 bytes: ".to_string() + e.to_string().as_str(),
+                    )
+                })?;
+
+                // We need to escape displayed double quotes " as \" and, as a result, also escape
+                // displayed \ as \\.
+                let str = str.replace('\\', "\\\\").replace('"', "\\\"");
+
+                write!(out, "\"{}\"", str).map_err(fmt_error_to_partial_vm_error)?;
+            }
+            _ => {
+                return Err(
+                    PartialVMError::new(StatusCode::INTERNAL_TYPE_ERROR).with_message(
+                        "Expected std::string::String to have vector<u8> bytes field".to_string(),
+                    ),
+                )
+            }
+        }
+
+        Ok(())
+    }
+
+    fn print_padding_at_depth(out: &mut String, depth: usize) -> PartialVMResult<()> {
+        for _ in 0..depth {
+            // add 2 spaces
+            write!(out, "  ").map_err(fmt_error_to_partial_vm_error)?;
+        }
+
+        Ok(())
+    }
+
+    fn is_non_empty_vector_u8(vec: &Vec<MoveValue>) -> bool {
+        if vec.is_empty() {
+            false
+        } else {
+            matches!(vec.last().unwrap(), MoveValue::U8(_))
+        }
+    }
+
+    fn is_vector_or_struct_move_value(mv: &MoveValue) -> bool {
+        matches!(mv, MoveValue::Vector(_) | MoveValue::Struct(_))
+    }
+
+    pub(crate) fn print_value(
+        context: &NativeContext,
+        out: &mut String,
+        val: Value,
+        ty: Type,
+        move_std_addr: &AccountAddress,
+        depth: usize,
+        canonicalize: bool,
+        single_line: bool,
+        include_int_types: bool,
+    ) -> PartialVMResult<()> {
+        // get type layout in VM format
+        let ty_layout = context.type_to_type_layout(&ty)?.unwrap();
+
+        match &ty_layout {
+            MoveTypeLayout::Vector(_) => {
+                // get the inner type T of a vector<T>
+                let inner_ty = get_vector_inner_type(&ty)?;
+                let inner_tyl = context.type_to_type_layout(inner_ty)?.unwrap();
+
+                match inner_tyl {
+                    // We cannot simply convert this vector `Value` to a `MoveValue` because there might
+                    // be a struct in the vector that needs to be "decorated" using the logic in this
+                    // function. Instead, we recursively "unpack" the vector until we get down to either
+                    // a primitive type or a struct, which this function can then forward to
+                    // `print_move_value`.
+                    MoveTypeLayout::Vector(_) | MoveTypeLayout::Struct(_) => {
+                        // `val` is either a `Vec<Vec<Value>>`, a `Vec<Struct>`,  or a `Vec<signer>`, so we cast `val` as a `Vec<Value>` and call ourselves recursively
+                        let vec = val.value_as::<Vec<Value>>()?;
+
+                        let print_inner_value =
+                            |out: &mut String,
+                             val: Value,
+                             move_std_addr: &AccountAddress,
+                             depth: usize,
+                             canonicalize: bool,
+                             single_line: bool,
+                             include_int_types: bool| {
+                                print_value(
+                                    context,
+                                    out,
+                                    val,
+                                    inner_ty.clone(),
+                                    move_std_addr,
+                                    depth,
+                                    canonicalize,
+                                    single_line,
+                                    include_int_types,
+                                )
+                            };
+
+                        print_non_u8_vector(
+                            out,
+                            move_std_addr,
+                            depth,
+                            canonicalize,
+                            single_line,
+                            include_int_types,
+                            vec,
+                            print_inner_value,
+                            true,
+                        )?;
+                    }
+                    // If the inner type T of this vector<T> is a primitive bool/unsigned integer/address type, we convert the
+                    // vector<T> to a MoveValue and print it.
+                    _ => {
+                        let mv = val.as_move_value(&ty_layout);
+                        print_move_value(
+                            out,
+                            mv,
+                            move_std_addr,
+                            depth,
+                            canonicalize,
+                            single_line,
+                            include_int_types,
+                        )?;
+                    }
+                };
+            }
+            // For a struct, we convert it to a MoveValue annotated with its field names and types and print it
+            MoveTypeLayout::Struct(_) => {
+                let move_struct = match val.as_move_value(&ty_layout) {
+                    MoveValue::Struct(s) => s,
+                    _ => {
+                        return Err(PartialVMError::new(StatusCode::INTERNAL_TYPE_ERROR)
+                            .with_message("Expected MoveValue::MoveStruct".to_string()))
+                    }
+                };
+
+                let annotated_struct_layout = get_annotated_struct_layout(context, &ty)?;
+                let decorated_struct = move_struct.decorate(&annotated_struct_layout);
+
+                print_move_value(
+                    out,
+                    MoveValue::Struct(decorated_struct),
+                    move_std_addr,
+                    depth,
+                    canonicalize,
+                    single_line,
+                    include_int_types,
+                )?;
+            }
+            // For non-structs and non-vectors, convert them to a MoveValue and print them
+            _ => {
+                print_move_value(
+                    out,
+                    val.as_move_value(&ty_layout),
+                    move_std_addr,
+                    depth,
+                    canonicalize,
+                    single_line,
+                    include_int_types,
+                )?;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Prints the MoveValue, optionally-including its type if `print_type` is true.
+    fn print_move_value(
+        out: &mut String,
+        mv: MoveValue,
+        move_std_addr: &AccountAddress,
+        depth: usize,
+        canonicalize: bool,
+        single_line: bool,
+        include_int_types: bool,
+    ) -> PartialVMResult<()> {
+        match mv {
+            MoveValue::U8(u8) => {
+                write!(out, "{}", u8).map_err(fmt_error_to_partial_vm_error)?;
+                if include_int_types {
+                    write!(out, "u8").map_err(fmt_error_to_partial_vm_error)?;
+                }
+            }
+            MoveValue::U16(u16) => {
+                write!(out, "{}", u16).map_err(fmt_error_to_partial_vm_error)?;
+                if include_int_types {
+                    write!(out, "u16").map_err(fmt_error_to_partial_vm_error)?;
+                }
+            }
+            MoveValue::U32(u32) => {
+                write!(out, "{}", u32).map_err(fmt_error_to_partial_vm_error)?;
+                if include_int_types {
+                    write!(out, "u32").map_err(fmt_error_to_partial_vm_error)?;
+                }
+            }
+            MoveValue::U64(u64) => {
+                write!(out, "{}", u64).map_err(fmt_error_to_partial_vm_error)?;
+                if include_int_types {
+                    write!(out, "u64").map_err(fmt_error_to_partial_vm_error)?;
+                }
+            }
+            MoveValue::U128(u128) => {
+                write!(out, "{}", u128).map_err(fmt_error_to_partial_vm_error)?;
+                if include_int_types {
+                    write!(out, "u128").map_err(fmt_error_to_partial_vm_error)?;
+                }
+            }
+            MoveValue::U256(u256) => {
+                write!(out, "{}", u256).map_err(fmt_error_to_partial_vm_error)?;
+                if include_int_types {
+                    write!(out, "u256").map_err(fmt_error_to_partial_vm_error)?;
+                }
+            }
+            MoveValue::Bool(b) => {
+                // The type here can be inferred just from the true/false value, when `include_int_types` is enabled.
+                write!(out, "{}", if b { "true" } else { "false" })
+                    .map_err(fmt_error_to_partial_vm_error)?;
+            }
+            MoveValue::Address(a) => {
+                let str = if canonicalize {
+                    a.to_canonical_string()
+                } else {
+                    a.to_hex_literal()
+                };
+                write!(out, "@{}", str).map_err(fmt_error_to_partial_vm_error)?;
+            }
+            MoveValue::Signer(s) => {
+                let str = if canonicalize {
+                    s.to_canonical_string()
+                } else {
+                    s.to_hex_literal()
+                };
+                write!(out, "signer({})", str).map_err(fmt_error_to_partial_vm_error)?;
+            }
+            MoveValue::Vector(vec) => {
+                // If this is a vector<u8> we print it in hex (as most users would expect us to)
+                if is_non_empty_vector_u8(&vec) {
+                    let bytes = MoveValue::vec_to_vec_u8(vec).map_err(to_vec_u8_type_err)?;
+                    write!(out, "0x{}", hex::encode(&bytes))
+                        .map_err(fmt_error_to_partial_vm_error)?;
+                } else {
+                    let is_complex_inner_type =
+                        vec.last().map_or(false, is_vector_or_struct_move_value);
+                    print_non_u8_vector(
+                        out,
+                        move_std_addr,
+                        depth,
+                        canonicalize,
+                        single_line,
+                        include_int_types,
+                        vec,
+                        print_move_value,
+                        is_complex_inner_type,
+                    )?;
+                }
+            }
+            MoveValue::Struct(move_struct) => match move_struct {
+                MoveStruct::WithTypes { type_, mut fields } => {
+                    let type_tag = TypeTag::from(type_.clone());
+
+                    // Check if struct is an std::string::String
+                    if !canonicalize && type_.is_std_string(move_std_addr) {
+                        assert_eq!(fields.len(), 1);
+
+                        let (id, val) = fields.pop().unwrap();
+                        assert_eq!(id.into_string(), "bytes");
+
+                        print_move_value_as_string(out, val)?;
+                    } else {
+                        write!(out, "{} ", type_tag).map_err(fmt_error_to_partial_vm_error)?;
+                        write!(out, "{}", STRUCT_BEGIN).map_err(fmt_error_to_partial_vm_error)?;
+
+                        // For each field, print its name and value (and type)
+                        let mut iter = fields.into_iter();
+                        if let Some((field_name, field_value)) = iter.next() {
+                            // Start an indented new line
+                            if !single_line {
+                                writeln!(out).map_err(fmt_error_to_partial_vm_error)?;
+                                print_padding_at_depth(out, depth + 1)?;
+                            }
+
+                            write!(out, "{}: ", field_name.into_string())
+                                .map_err(fmt_error_to_partial_vm_error)?;
+                            print_move_value(
+                                out,
+                                field_value,
+                                move_std_addr,
+                                depth + 1,
+                                canonicalize,
+                                single_line,
+                                include_int_types,
+                            )?;
+
+                            for (field_name, field_value) in iter {
+                                write!(out, "{}", VECTOR_OR_STRUCT_SEP)
+                                    .map_err(fmt_error_to_partial_vm_error)?;
+
+                                if !single_line {
+                                    writeln!(out).map_err(fmt_error_to_partial_vm_error)?;
+                                    print_padding_at_depth(out, depth + 1)?;
+                                } else {
+                                    write!(out, " ").map_err(fmt_error_to_partial_vm_error)?;
+                                }
+                                write!(out, "{}: ", field_name.into_string())
+                                    .map_err(fmt_error_to_partial_vm_error)?;
+                                print_move_value(
+                                    out,
+                                    field_value,
+                                    move_std_addr,
+                                    depth + 1,
+                                    canonicalize,
+                                    single_line,
+                                    include_int_types,
+                                )?;
+                            }
+                        }
+
+                        // Ends printing the struct with "}", which could be on its own line
+                        if !single_line {
+                            writeln!(out).map_err(fmt_error_to_partial_vm_error)?;
+                            print_padding_at_depth(out, depth)?;
+                        }
+                        write!(out, "{}", STRUCT_END).map_err(fmt_error_to_partial_vm_error)?;
+                    }
+                }
+                _ => {
+                    return Err(PartialVMError::new(StatusCode::INTERNAL_TYPE_ERROR)
+                        .with_message("Expected MoveStruct::WithTypes".to_string()))
+                }
+            },
+        }
+
+        Ok(())
+    }
+
+    fn print_non_u8_vector<ValType>(
+        out: &mut String,
+        move_std_addr: &AccountAddress,
+        depth: usize,
+        canonicalize: bool,
+        single_line: bool,
+        include_int_types: bool,
+        vec: Vec<ValType>,
+        print_inner_value: impl Fn(
+            &mut String,
+            ValType,
+            &AccountAddress,
+            usize,
+            bool,
+            bool,
+            bool,
+        ) -> PartialVMResult<()>,
+        is_complex_inner_type: bool,
+    ) -> PartialVMResult<()> {
+        write!(out, "{}", VECTOR_BEGIN).map_err(fmt_error_to_partial_vm_error)?;
+        let mut iter = vec.into_iter();
+        let mut empty_vec = true;
+
+        if let Some(first_elem) = iter.next() {
+            empty_vec = false;
+
+            // For vectors-of-vectors, and for vectors-of-structs, we start a newline for each element
+            if !single_line && is_complex_inner_type {
+                writeln!(out).map_err(fmt_error_to_partial_vm_error)?;
+                print_padding_at_depth(out, depth + 1)?;
+            } else {
+                write!(out, " ").map_err(fmt_error_to_partial_vm_error)?;
+            }
+
+            print_inner_value(
+                out,
+                first_elem,
+                move_std_addr,
+                depth + 1,
+                canonicalize,
+                single_line,
+                include_int_types,
+            )?;
+
+            for elem in iter {
+                write!(out, "{}", VECTOR_OR_STRUCT_SEP).map_err(fmt_error_to_partial_vm_error)?;
+
+                // For vectors of vectors or vectors of structs, we start a newline for each element
+                if !single_line && is_complex_inner_type {
+                    writeln!(out).map_err(fmt_error_to_partial_vm_error)?;
+                    print_padding_at_depth(out, depth + 1)?;
+                } else {
+                    write!(out, " ").map_err(fmt_error_to_partial_vm_error)?;
+                }
+                print_inner_value(
+                    out,
+                    elem,
+                    move_std_addr,
+                    depth + 1,
+                    canonicalize,
+                    single_line,
+                    include_int_types,
+                )?;
+            }
+        }
+
+        // For vectors of vectors or vectors of structs, we display the closing ] on a newline
+        if !single_line && is_complex_inner_type {
+            writeln!(out).map_err(fmt_error_to_partial_vm_error)?;
+            print_padding_at_depth(out, depth)?;
+        } else if !empty_vec {
+            write!(out, " ").map_err(fmt_error_to_partial_vm_error)?;
+        }
+        write!(out, "{}", VECTOR_END).map_err(fmt_error_to_partial_vm_error)?;
+
+        Ok(())
+    }
 }

--- a/language/move-vm/types/src/values/values_impl.rs
+++ b/language/move-vm/types/src/values/values_impl.rs
@@ -2790,6 +2790,7 @@ pub mod debug {
         }
     }
 
+    // TODO: This function was used in an old implementation of std::debug::print, and can probably be removed.
     pub fn print_reference<B: Write>(buf: &mut B, r: &Reference) -> PartialVMResult<()> {
         match &r.0 {
             ReferenceImpl::ContainerRef(r) => print_container_ref(buf, r),
@@ -3531,76 +3532,72 @@ pub mod prop {
             (Just(layout), value_strategy)
         })
     }
+}
 
-    impl ValueImpl {
-        pub fn as_move_value(&self, layout: &MoveTypeLayout) -> MoveValue {
-            use MoveTypeLayout as L;
+use move_core_types::value::{MoveStruct, MoveValue};
 
-            match (layout, &self) {
-                (L::U8, ValueImpl::U8(x)) => MoveValue::U8(*x),
-                (L::U16, ValueImpl::U16(x)) => MoveValue::U16(*x),
-                (L::U32, ValueImpl::U32(x)) => MoveValue::U32(*x),
-                (L::U64, ValueImpl::U64(x)) => MoveValue::U64(*x),
-                (L::U128, ValueImpl::U128(x)) => MoveValue::U128(*x),
-                (L::U256, ValueImpl::U256(x)) => MoveValue::U256(*x),
-                (L::Bool, ValueImpl::Bool(x)) => MoveValue::Bool(*x),
-                (L::Address, ValueImpl::Address(x)) => MoveValue::Address(*x),
+impl ValueImpl {
+    pub fn as_move_value(&self, layout: &MoveTypeLayout) -> MoveValue {
+        use MoveTypeLayout as L;
 
-                (L::Struct(struct_layout), ValueImpl::Container(Container::Struct(r))) => {
-                    let mut fields = vec![];
-                    for (v, field_layout) in r.borrow().iter().zip(struct_layout.fields().iter()) {
-                        fields.push(v.as_move_value(field_layout));
-                    }
-                    MoveValue::Struct(MoveStruct::new(fields))
+        match (layout, &self) {
+            (L::U8, ValueImpl::U8(x)) => MoveValue::U8(*x),
+            (L::U16, ValueImpl::U16(x)) => MoveValue::U16(*x),
+            (L::U32, ValueImpl::U32(x)) => MoveValue::U32(*x),
+            (L::U64, ValueImpl::U64(x)) => MoveValue::U64(*x),
+            (L::U128, ValueImpl::U128(x)) => MoveValue::U128(*x),
+            (L::U256, ValueImpl::U256(x)) => MoveValue::U256(*x),
+            (L::Bool, ValueImpl::Bool(x)) => MoveValue::Bool(*x),
+            (L::Address, ValueImpl::Address(x)) => MoveValue::Address(*x),
+
+            (L::Struct(struct_layout), ValueImpl::Container(Container::Struct(r))) => {
+                let mut fields = vec![];
+                for (v, field_layout) in r.borrow().iter().zip(struct_layout.fields().iter()) {
+                    fields.push(v.as_move_value(field_layout));
                 }
-
-                (L::Vector(inner_layout), ValueImpl::Container(c)) => MoveValue::Vector(match c {
-                    Container::VecU8(r) => r.borrow().iter().map(|u| MoveValue::U8(*u)).collect(),
-                    Container::VecU16(r) => r.borrow().iter().map(|u| MoveValue::U16(*u)).collect(),
-                    Container::VecU32(r) => r.borrow().iter().map(|u| MoveValue::U32(*u)).collect(),
-                    Container::VecU64(r) => r.borrow().iter().map(|u| MoveValue::U64(*u)).collect(),
-                    Container::VecU128(r) => {
-                        r.borrow().iter().map(|u| MoveValue::U128(*u)).collect()
-                    }
-                    Container::VecU256(r) => {
-                        r.borrow().iter().map(|u| MoveValue::U256(*u)).collect()
-                    }
-                    Container::VecBool(r) => {
-                        r.borrow().iter().map(|u| MoveValue::Bool(*u)).collect()
-                    }
-                    Container::VecAddress(r) => {
-                        r.borrow().iter().map(|u| MoveValue::Address(*u)).collect()
-                    }
-                    Container::Vec(r) => r
-                        .borrow()
-                        .iter()
-                        .map(|v| v.as_move_value(inner_layout.as_ref()))
-                        .collect(),
-                    Container::Struct(_) => {
-                        panic!("got struct container when converting vec")
-                    }
-                    Container::Locals(_) => panic!("got locals container when converting vec"),
-                }),
-
-                (L::Signer, ValueImpl::Container(Container::Struct(r))) => {
-                    let v = r.borrow();
-                    if v.len() != 1 {
-                        panic!("Unexpected signer layout: {:?}", v);
-                    }
-                    match &v[0] {
-                        ValueImpl::Address(a) => MoveValue::Signer(*a),
-                        v => panic!("Unexpected non-address while converting signer: {:?}", v),
-                    }
-                }
-
-                (layout, val) => panic!("Cannot convert value {:?} as {:?}", val, layout),
+                MoveValue::Struct(MoveStruct::new(fields))
             }
+
+            (L::Vector(inner_layout), ValueImpl::Container(c)) => MoveValue::Vector(match c {
+                Container::VecU8(r) => r.borrow().iter().map(|u| MoveValue::U8(*u)).collect(),
+                Container::VecU16(r) => r.borrow().iter().map(|u| MoveValue::U16(*u)).collect(),
+                Container::VecU32(r) => r.borrow().iter().map(|u| MoveValue::U32(*u)).collect(),
+                Container::VecU64(r) => r.borrow().iter().map(|u| MoveValue::U64(*u)).collect(),
+                Container::VecU128(r) => r.borrow().iter().map(|u| MoveValue::U128(*u)).collect(),
+                Container::VecU256(r) => r.borrow().iter().map(|u| MoveValue::U256(*u)).collect(),
+                Container::VecBool(r) => r.borrow().iter().map(|u| MoveValue::Bool(*u)).collect(),
+                Container::VecAddress(r) => {
+                    r.borrow().iter().map(|u| MoveValue::Address(*u)).collect()
+                }
+                Container::Vec(r) => r
+                    .borrow()
+                    .iter()
+                    .map(|v| v.as_move_value(inner_layout.as_ref()))
+                    .collect(),
+                Container::Struct(_) => {
+                    panic!("got struct container when converting vec")
+                }
+                Container::Locals(_) => panic!("got locals container when converting vec"),
+            }),
+
+            (L::Signer, ValueImpl::Container(Container::Struct(r))) => {
+                let v = r.borrow();
+                if v.len() != 1 {
+                    panic!("Unexpected signer layout: {:?}", v);
+                }
+                match &v[0] {
+                    ValueImpl::Address(a) => MoveValue::Signer(*a),
+                    v => panic!("Unexpected non-address while converting signer: {:?}", v),
+                }
+            }
+
+            (layout, val) => panic!("Cannot convert value {:?} as {:?}", val, layout),
         }
     }
+}
 
-    impl Value {
-        pub fn as_move_value(&self, layout: &MoveTypeLayout) -> MoveValue {
-            self.0.as_move_value(layout)
-        }
+impl Value {
+    pub fn as_move_value(&self, layout: &MoveTypeLayout) -> MoveValue {
+        self.0.as_move_value(layout)
     }
 }

--- a/language/tools/move-cli/tests/sandbox_tests/print_values/args.exp
+++ b/language/tools/move-cli/tests/sandbox_tests/print_values/args.exp
@@ -1,7 +1,168 @@
 Command `sandbox publish`:
-Command `sandbox run scripts/print_values.move --dry-run`:
+Command `test`:
+INCLUDING DEPENDENCY MoveNursery
+INCLUDING DEPENDENCY MoveStdlib
+BUILDING print_values
+Running Move unit tests
 [debug] 42
-[debug] (&) [100, 200, 300]
-[debug] (&) { false }
-[debug] (&) { 404, { false }, true }
-[debug] (&) { { false } }
+[debug] [ 100, 200, 300 ]
+[debug] 0x2::M::Foo {
+  dummy_field: false
+}
+[debug] 0x2::M::Bar {
+  x: 404,
+  y: 0x2::M::Foo {
+    dummy_field: false
+  },
+  z: true
+}
+[debug] 0x2::M::Box<0x2::M::Foo> {
+  x: 0x2::M::Foo {
+    dummy_field: false
+  }
+}
+[debug] "test_print_quoted_string"
+[debug] "Can you say \"Hel\\lo\"?"
+[debug] "test_print_string"
+[debug] 0x48656c6c6f2c2073616e65204d6f766520646562756767696e6721
+[debug] "Hello, sane Move debugging!"
+[debug] "test_print_primitive_types"
+[debug] 255
+[debug] 65535
+[debug] 4294967295
+[debug] 18446744073709551615
+[debug] 340282366920938463463374607431768211455
+[debug] 115792089237316195423570985008687907853269984665640564039457584007913129639935
+[debug] false
+[debug] true
+[debug] @0x1234c0ffee
+[debug] signer(0x0)
+[debug] "test_print_struct"
+[debug] 0x2::M::TestInner {
+  val: 100,
+  vec: [ 200, 400 ],
+  msgs: [
+    0x616263646566,
+    0x313233343536
+  ]
+}
+[debug] 0x2::M::TestInner {
+  val: 10,
+  vec: [],
+  msgs: []
+}
+[debug] "test_print_vectors"
+[debug] 0xffabcdef
+[debug] [ 16, 17, 18, 19 ]
+[debug] [ 32, 33, 34, 35 ]
+[debug] [ 64, 65, 66, 67 ]
+[debug] [ 128, 129, 130, 131 ]
+[debug] [ 256, 257, 258, 259 ]
+[debug] [ true, false ]
+[debug] [ @0x1234, @0x5678, @0xabcdef ]
+[debug] [ signer(0x0), signer(0x1000000000000000000000000000000), signer(0x2000000000000000000000000000000), signer(0x3000000000000000000000000000000) ]
+[debug] [
+  0x2::M::TestInner {
+    val: 4,
+    vec: [ 127, 128 ],
+    msgs: [
+      0x00ff,
+      0xabcd
+    ]
+  },
+  0x2::M::TestInner {
+    val: 8,
+    vec: [ 128, 129 ],
+    msgs: [
+      0x0000
+    ]
+  }
+]
+[debug] "test_print_vector_of_vectors"
+[debug] [
+  0xffab,
+  0xcdef
+]
+[debug] [
+  [ 16, 17 ],
+  [ 18, 19 ]
+]
+[debug] [
+  [ 32, 33 ],
+  [ 34, 35 ]
+]
+[debug] [
+  [ 64, 65 ],
+  [ 66, 67 ]
+]
+[debug] [
+  [ 128, 129 ],
+  [ 130, 131 ]
+]
+[debug] [
+  [ 256, 257 ],
+  [ 258, 259 ]
+]
+[debug] [
+  [ true, false ],
+  [ false, true ]
+]
+[debug] [
+  [ @0x1234, @0x5678 ],
+  [ @0xabcdef, @0x9999 ]
+]
+[debug] [
+  [ signer(0x0), signer(0x1000000000000000000000000000000) ],
+  [ signer(0x0), signer(0x1000000000000000000000000000000) ]
+]
+[debug] [
+  [
+    0x2::M::TestInner {
+      val: 4,
+      vec: [ 127, 128 ],
+      msgs: []
+    },
+    0x2::M::TestInner {
+      val: 8,
+      vec: [ 128, 129 ],
+      msgs: []
+    }
+  ],
+  [
+    0x2::M::TestInner {
+      val: 4,
+      vec: [ 127, 128 ],
+      msgs: []
+    },
+    0x2::M::TestInner {
+      val: 8,
+      vec: [ 128, 129 ],
+      msgs: []
+    }
+  ]
+]
+[debug] "test_print_nested_struct"
+[debug] 0x2::M::TestStruct {
+  addr: @0x1,
+  number: 255,
+  bytes: 0xc0ffee,
+  name: "He\"llo",
+  vec: [
+    0x2::M::TestInner {
+      val: 1,
+      vec: [ 130, 131 ],
+      msgs: []
+    },
+    0x2::M::TestInner {
+      val: 2,
+      vec: [ 132, 133 ],
+      msgs: []
+    }
+  ]
+}
+[debug] "test_print_generic_struct"
+[debug] 0x2::M::GenericStruct<0x2::M::Foo> {
+  val: 60
+}
+[ PASS    ] 0x2::M::test
+Test result: OK. Total tests: 1; passed: 1; failed: 0

--- a/language/tools/move-cli/tests/sandbox_tests/print_values/args.txt
+++ b/language/tools/move-cli/tests/sandbox_tests/print_values/args.txt
@@ -1,2 +1,2 @@
 sandbox publish
-sandbox run scripts/print_values.move --dry-run
+test

--- a/language/tools/move-cli/tests/sandbox_tests/print_values/scripts/print_values.move
+++ b/language/tools/move-cli/tests/sandbox_tests/print_values/scripts/print_values.move
@@ -1,7 +1,0 @@
-script {
-use 0x2::M;
-
-fun print_values() {
-    M::test();
-}
-}

--- a/language/tools/move-cli/tests/sandbox_tests/print_values/sources/M.move
+++ b/language/tools/move-cli/tests/sandbox_tests/print_values/sources/M.move
@@ -1,30 +1,267 @@
 address 0x2 {
 module M {
-    use std::debug;
+    #[test_only]
+    use std::debug::print;
+    #[test_only]
+    use std::debug::print_string;
+    use std::string;
+    #[test_only]
+    use std::unit_test::create_signers_for_testing;
+    #[test_only]
     use std::vector;
 
     struct Foo has drop {}
     struct Bar has drop { x: u128, y: Foo, z: bool }
     struct Box<T> has drop { x: T }
 
+    struct GenericStruct<phantom T> has drop {
+        val: u64,
+    }
+
+    struct TestInner has drop {
+        val: u128,
+        vec: vector<u128>,
+        msgs: vector<vector<u8>>
+    }
+
+    struct TestStruct has drop {
+        addr: address,
+        number: u8,
+        bytes: vector<u8>,
+        name: string::String,
+        vec: vector<TestInner>,
+    }
+
+    #[test]
     public fun test()  {
         let x = 42;
-        debug::print(&x);
+        print(&x);
 
         let v = vector::empty();
         vector::push_back(&mut v, 100);
         vector::push_back(&mut v, 200);
         vector::push_back(&mut v, 300);
-        debug::print(&v);
+        print(&v);
 
         let foo = Foo {};
-        debug::print(&foo);
+        print(&foo);
 
         let bar = Bar { x: 404, y: Foo {}, z: true };
-        debug::print(&bar);
+        print(&bar);
 
         let box = Box { x: Foo {} };
-        debug::print(&box);
+        print(&box);
+
+        test_print_quoted_string();
+        test_print_string();
+        test_print_primitive_types();
+        test_print_struct();
+        test_print_vectors();
+        test_print_vector_of_vectors();
+        test_print_nested_struct();
+        test_print_generic_struct();
+    }
+
+    #[test_only]
+    fun test_print_string() {
+        print_string(b"test_print_string");
+
+        let str_bytes = b"Hello, sane Move debugging!";
+
+        print(&str_bytes);
+
+        let str = string::utf8(str_bytes);
+        print<string::String>(&str);
+    }
+
+    #[test_only]
+    fun test_print_quoted_string() {
+        print_string(b"test_print_quoted_string");
+
+        let str_bytes = b"Can you say \"Hel\\lo\"?";
+
+        let str = string::utf8(str_bytes);
+        print<string::String>(&str);
+    }
+
+    #[test_only]
+    fun test_print_primitive_types() {
+        print_string(b"test_print_primitive_types");
+
+        let u8 = 255u8;
+        print(&u8);
+
+        let u16 = 65535u16;
+        print(&u16);
+
+        let u32 = 4294967295u32;
+        print(&u32);
+
+        let u64 = 18446744073709551615u64;
+        print(&u64);
+
+        let u128 = 340282366920938463463374607431768211455u128;
+        print(&u128);
+
+        let u256 = 115792089237316195423570985008687907853269984665640564039457584007913129639935u256;
+        print(&u256);
+
+        let bool = false;
+        print(&bool);
+
+        let bool = true;
+        print(&bool);
+
+        let a = @0x1234c0ffee;
+        print(&a);
+
+        // print a signer
+        let senders = create_signers_for_testing(1);
+        let sender = vector::pop_back(&mut senders);
+        print(&sender);
+    }
+
+    const MSG_1 : vector<u8> = b"abcdef";
+    const MSG_2 : vector<u8> = b"123456";
+
+    #[test_only]
+    fun test_print_struct() {
+        print_string(b"test_print_struct");
+
+        let obj = TestInner {
+            val: 100,
+            vec: vector[200u128, 400u128],
+            msgs: vector[MSG_1, MSG_2],
+        };
+
+        print(&obj);
+
+        let obj = TestInner {
+            val: 10,
+            vec: vector[],
+            msgs: vector[],
+        };
+
+        print(&obj);
+    }
+
+    #[test_only]
+    fun test_print_vectors() {
+        print_string(b"test_print_vectors");
+
+        let v_u8 = x"ffabcdef";
+        print(&v_u8);
+
+        let v_u16 = vector[16u16, 17u16, 18u16, 19u16];
+        print(&v_u16);
+
+        let v_u32 = vector[32u32, 33u32, 34u32, 35u32];
+        print(&v_u32);
+
+        let v_u64 = vector[64u64, 65u64, 66u64, 67u64];
+        print(&v_u64);
+
+        let v_u128 = vector[128u128, 129u128, 130u128, 131u128];
+        print(&v_u128);
+
+        let v_u256 = vector[256u256, 257u256, 258u256, 259u256];
+        print(&v_u256);
+
+        let v_bool = vector[true, false];
+        print(&v_bool);
+
+        let v_addr = vector[@0x1234, @0x5678, @0xabcdef];
+        print(&v_addr);
+
+        let v_signer = create_signers_for_testing(4);
+        print(&v_signer);
+
+        let v = vector[
+            TestInner {
+                val: 4u128,
+                vec: vector[127u128, 128u128],
+                msgs: vector[x"00ff", x"abcd"],
+            },
+            TestInner {
+                val: 8u128 ,
+                vec: vector[128u128, 129u128],
+                msgs: vector[x"0000"],
+            }
+        ];
+        print(&v);
+    }
+
+    #[test_only]
+    fun test_print_vector_of_vectors() {
+        print_string(b"test_print_vector_of_vectors");
+
+        let v_u8 = vector[x"ffab", x"cdef"];
+        print(&v_u8);
+
+        let v_u16 = vector[vector[16u16, 17u16], vector[18u16, 19u16]];
+        print(&v_u16);
+
+        let v_u32 = vector[vector[32u32, 33u32], vector[34u32, 35u32]];
+        print(&v_u32);
+
+        let v_u64 = vector[vector[64u64, 65u64], vector[66u64, 67u64]];
+        print(&v_u64);
+
+        let v_u128 = vector[vector[128u128, 129u128], vector[130u128, 131u128]];
+        print(&v_u128);
+
+        let v_u256 = vector[vector[256u256, 257u256], vector[258u256, 259u256]];
+        print(&v_u256);
+
+        let v_bool = vector[vector[true, false], vector[false, true]];
+        print(&v_bool);
+
+        let v_addr = vector[vector[@0x1234, @0x5678], vector[@0xabcdef, @0x9999]];
+        print(&v_addr);
+
+        let v_signer = vector[create_signers_for_testing(2), create_signers_for_testing(2)];
+        print(&v_signer);
+
+        let v = vector[
+            vector[
+                TestInner { val: 4u128, vec: vector[127u128, 128u128], msgs: vector[] },
+                TestInner { val: 8u128 , vec: vector[128u128, 129u128], msgs: vector[] }
+            ],
+            vector[
+                TestInner { val: 4u128, vec: vector[127u128, 128u128], msgs: vector[] },
+                TestInner { val: 8u128 , vec: vector[128u128, 129u128], msgs: vector[] }
+            ]
+        ];
+        print(&v);
+    }
+
+    #[test_only]
+    fun test_print_nested_struct() {
+        print_string(b"test_print_nested_struct");
+
+        let obj = TestStruct {
+            addr: @0x1,
+            number: 255u8,
+            bytes: x"c0ffee",
+            name: string::utf8(b"He\"llo"),
+            vec: vector[
+                TestInner { val: 1, vec: vector[130u128, 131u128], msgs: vector[] },
+                TestInner { val: 2, vec: vector[132u128, 133u128], msgs: vector[] }
+            ],
+        };
+
+        print(&obj);
+    }
+
+    #[test_only]
+    fun test_print_generic_struct() {
+        print_string(b"test_print_generic_struct");
+
+        let obj = GenericStruct<Foo> {
+        val: 60u64,
+        };
+
+        print(&obj);
     }
 }
 }


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Move Language

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

This **draft** PR implements pretty-printing of Move values via `std::debug::print`, building upon #603 which added support for printing `std::string::String`.

An example of the new `std::debug::print` output:

```
[debug] 0x1::debug::TestStruct {
  addr: @0x1,
  number: 255,
  bytes: 0xc0ffee,
  name: "He\"llo",
  vec: [
    0x1::debug::TestInner {
      val: 1,
      vec: [ 130, 131 ]
    },
    0x1::debug::TestInner {
      val: 2,
      vec: [ 132, 133 ]
    }
  ]
}
```

Note that we print `vector<u8>`'s as hexadecimal strings, since this is likely to be a more useful format for developers to inspect.

Also note that when a `vector<T>` has a complex type, such as `T = vector<S>` or a `T = struct`, we display the vector entries on separate lines, instead of the same line.

**TODOs:**

 - <strike>fix `cargo build` warnings due to missing "testing" feature flag</strike>
 - <strike>print `vector<u8>` as hex-encoded strings</strike>
 - <strike>optionally-include u8/16/.../256 types</strike>
 - <strike>update & fix tests in `language/tools/move-cli/tests/sandbox_tests` via `cargo test -- print_`</strike>
 - <strike>update pretty-print example above</strike>

## Motivation

It is very difficult for Move developers to debug their code without the ability to print a `struct`'s fields names and values.

## If you are reviewing this PR

 - Tell me if I am returning the wrong `StatusCode` in the `PartialVMError` objects
 - Tell me if I am escaping strings correctly via `let str = str.replace('\\', "\\\\").replace('"', "\\\"");`

## Approach

Our approach is to first convert the `Value` passed to `std::debug::print` to a `MoveValue`, carefully handling the `vector` and `struct` cases (Specifically, structs need to be annotated with field names and types while vectors need to be unpacked into their inner elements recursively). 

Then, we reimplement the `std::fmt::Display` logic for `MoveValue`'s to pretty-print them. 

This reimplementation effort is necessary for us to:

 - manually inspect if a struct is an `std::string::String` and pretty-print it
   + Might want to do something similar for `std::option::Option`
 - manually select whether we display canonical addresses (useful for signatures) or compressed addresses (useful for pretty-printing)
 - add indentation based on current depth inside a struct

### Alternative approach: Avoid exposing `Value::as_move_value()` as public

**Reason 1:** Without a public `Value::as_move_value()` we would have to serialize & deserialize a struct `Value` into a `MoveValue::MoveStruct`, which is less efficient than calling `Value::as_move_value()`. Although performance is not a constraint for pretty-printing, it **is** a constraint for verifying signatures on canonical serialization of structs.

**Reason 2:** Furthermore, converting every `Value` to a `MoveValue` allows us to implement (almost) all printing logic inside a single `print_move_value` function that operates on `MoveValue`'s.

First, recall that we "decorate" struct `Value`'s  with their fields' type information and obtain a `MoveValue::MoveStruct`.  So if we want to quickly print such a `MoveValue::MoveStruct`, we need to implement recursively-printing any `MoveValue`, which we do in `print_move_value`.

Our next goal then becomes not to reimplement any more printing logic, which is why it is convenient to turn any `Value` into a `MoveValue` and pass it in to `print_move_value`.

<!--
## Initial hurdles

Tried to print a struct with its field names and values (and maybe types).

Inside the `native_print` Rust native, when doing...

```
let old_type_layout = context.type_to_type_layout(&ty)?.unwrap();

println!("Type: {:?}", &ty);
println!("Value: {:?}", &args[0]);
println!("MoveTypeLayout: {:?}", old_type_layout);

let blob = &args[0].simple_serialize(&old_type_layout).unwrap();
```

...we fail with:
```
Type: Struct(CachedStructIndex(2))
Value: Value(ContainerRef(Local(Struct(RefCell { value: [U8(255), Container(VecU8(RefCell { value: [192, 255, 238] })), Container(Struct(RefCell { value: [Container(VecU8(RefCell { value: [72, 101, 108, 108, 111, 44, 32, 115, 97, 110, 101, 32, 77, 111, 118, 101, 32, 100, 101, 98, 117, 103, 103, 105, 110, 103, 33] }))] }))] }))))
MoveTypeLayout: Struct(Runtime([U8, Vector(U8), Struct(Runtime([Vector(U8)]))]))
thread '<unnamed>' panicked at 'called `Option::unwrap()` on a `None` value', language/move-stdlib/src/natives/debug.rs:74:64
```
-->

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes.

## Test Plan

 - Test pretty-printing of basic types (see all `MoveValue` types)
 - Test pretty-printing of a simple struct
 - Test pretty-printing of nested structs
 - Test pretty-printing of generic structs
 - Test pretty-printing of vectors, and vectors of vectors