### PR TITLE
[bytecode utils] fix a few issues with struct layout generation

### DIFF
--- a/language/tools/move-cli/src/sandbox/commands/generate.rs
+++ b/language/tools/move-cli/src/sandbox/commands/generate.rs
@@ -30,9 +30,9 @@ pub fn generate_struct_layouts(
                 type_params,
             };
             let mut layout_builder = if shallow {
-                SerdeLayoutBuilder::new_shallow(state)
+                SerdeLayoutBuilder::new_shallow(&state)
             } else {
-                SerdeLayoutBuilder::new(state)
+                SerdeLayoutBuilder::new(&state)
             };
             layout_builder.build_struct_layout(&struct_tag)?;
             let layout = serde_yaml::to_string(layout_builder.registry())?;

--- a/language/tools/move-cli/tests/sandbox_tests/generate_struct_layout/args.exp
+++ b/language/tools/move-cli/tests/sandbox_tests/generate_struct_layout/args.exp
@@ -199,7 +199,7 @@ Signer:
 
 Command `sandbox generate struct-layouts --module storage/0x00000000000000000000000000000001/modules/M1.mv --struct G`:
 ---
-"00000000000000000000000000000001::M1::G<>":
+"00000000000000000000000000000001::M1::G":
   STRUCT:
     - x: U64
     - s:


### PR DESCRIPTION
- Remove printing of angle brackets for typenames without generics
- Take a reference to the ModuleResolver instead of requiring ownership