### PR TITLE
[docgen] displays "entry" in the function headers of entry functions

### DIFF
--- a/language/move-prover/move-docgen/src/docgen.rs
+++ b/language/move-prover/move-docgen/src/docgen.rs
@@ -1077,9 +1077,15 @@ impl<'env> Docgen<'env> {
                 return_types.iter().map(|ty| ty.display(tctx)).join(", ")
             ),
         };
+        let entry_str = if func_env.is_entry() && !func_env.module_env.is_script_module() {
+            "entry ".to_owned()
+        } else {
+            "".to_owned()
+        };
         format!(
-            "{}fun {}{}({}){}",
+            "{}{}fun {}{}({}){}",
             func_env.visibility_str(),
+            entry_str,
             name,
             self.type_parameter_list_display(&func_env.get_named_type_parameters()),
             params,

--- a/language/move-prover/move-docgen/tests/sources/different_visbilities.spec_inline.md
+++ b/language/move-prover/move-docgen/tests/sources/different_visbilities.spec_inline.md
@@ -44,7 +44,7 @@ This is a public function
 This is a public entry function
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="different_visbilities.md#0x2_TestViz_this_is_a_public_script_fun">this_is_a_public_script_fun</a>()
+<pre><code><b>public</b> entry <b>fun</b> <a href="different_visbilities.md#0x2_TestViz_this_is_a_public_script_fun">this_is_a_public_script_fun</a>()
 </code></pre>
 
 

--- a/language/move-prover/move-docgen/tests/sources/different_visbilities.spec_inline_no_fold.md
+++ b/language/move-prover/move-docgen/tests/sources/different_visbilities.spec_inline_no_fold.md
@@ -41,7 +41,7 @@ This is a public function
 This is a public entry function
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="different_visbilities.md#0x2_TestViz_this_is_a_public_script_fun">this_is_a_public_script_fun</a>()
+<pre><code><b>public</b> entry <b>fun</b> <a href="different_visbilities.md#0x2_TestViz_this_is_a_public_script_fun">this_is_a_public_script_fun</a>()
 </code></pre>
 
 

--- a/language/move-prover/move-docgen/tests/sources/different_visbilities.spec_separate.md
+++ b/language/move-prover/move-docgen/tests/sources/different_visbilities.spec_separate.md
@@ -44,7 +44,7 @@ This is a public function
 This is a public entry function
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="different_visbilities.md#0x2_TestViz_this_is_a_public_script_fun">this_is_a_public_script_fun</a>()
+<pre><code><b>public</b> entry <b>fun</b> <a href="different_visbilities.md#0x2_TestViz_this_is_a_public_script_fun">this_is_a_public_script_fun</a>()
 </code></pre>
 
 

--- a/language/move-prover/move-docgen/tests/sources/root_template.spec_inline.md
+++ b/language/move-prover/move-docgen/tests/sources/root_template.spec_inline.md
@@ -147,7 +147,7 @@ This script does also abort.
 This is a script
 
 
-<pre><code><b>fun</b> <a href="root.md#0x1_OneTypeOfScript_script1">script1</a>()
+<pre><code>entry <b>fun</b> <a href="root.md#0x1_OneTypeOfScript_script1">script1</a>()
 </code></pre>
 
 
@@ -170,7 +170,7 @@ This is a script
 This is another script
 
 
-<pre><code><b>fun</b> <a href="root.md#0x1_OneTypeOfScript_script2">script2</a>()
+<pre><code>entry <b>fun</b> <a href="root.md#0x1_OneTypeOfScript_script2">script2</a>()
 </code></pre>
 
 
@@ -207,7 +207,7 @@ This is another module full of script funs too:
 This is a script
 
 
-<pre><code><b>fun</b> <a href="root.md#0x1_AnotherTypeOfScript_script3">script3</a>()
+<pre><code>entry <b>fun</b> <a href="root.md#0x1_AnotherTypeOfScript_script3">script3</a>()
 </code></pre>
 
 
@@ -230,7 +230,7 @@ This is a script
 This is another script
 
 
-<pre><code><b>fun</b> <a href="root.md#0x1_AnotherTypeOfScript_script4">script4</a>()
+<pre><code>entry <b>fun</b> <a href="root.md#0x1_AnotherTypeOfScript_script4">script4</a>()
 </code></pre>
 
 

--- a/language/move-prover/move-docgen/tests/sources/root_template.spec_inline_no_fold.md
+++ b/language/move-prover/move-docgen/tests/sources/root_template.spec_inline_no_fold.md
@@ -135,7 +135,7 @@ This script does also abort.
 This is a script
 
 
-<pre><code><b>fun</b> <a href="root.md#0x1_OneTypeOfScript_script1">script1</a>()
+<pre><code>entry <b>fun</b> <a href="root.md#0x1_OneTypeOfScript_script1">script1</a>()
 </code></pre>
 
 
@@ -155,7 +155,7 @@ This is a script
 This is another script
 
 
-<pre><code><b>fun</b> <a href="root.md#0x1_OneTypeOfScript_script2">script2</a>()
+<pre><code>entry <b>fun</b> <a href="root.md#0x1_OneTypeOfScript_script2">script2</a>()
 </code></pre>
 
 
@@ -189,7 +189,7 @@ This is another module full of script funs too:
 This is a script
 
 
-<pre><code><b>fun</b> <a href="root.md#0x1_AnotherTypeOfScript_script3">script3</a>()
+<pre><code>entry <b>fun</b> <a href="root.md#0x1_AnotherTypeOfScript_script3">script3</a>()
 </code></pre>
 
 
@@ -209,7 +209,7 @@ This is a script
 This is another script
 
 
-<pre><code><b>fun</b> <a href="root.md#0x1_AnotherTypeOfScript_script4">script4</a>()
+<pre><code>entry <b>fun</b> <a href="root.md#0x1_AnotherTypeOfScript_script4">script4</a>()
 </code></pre>
 
 

--- a/language/move-prover/move-docgen/tests/sources/root_template.spec_separate.md
+++ b/language/move-prover/move-docgen/tests/sources/root_template.spec_separate.md
@@ -167,7 +167,7 @@ This script does also abort.
 This is a script
 
 
-<pre><code><b>fun</b> <a href="root.md#0x1_OneTypeOfScript_script1">script1</a>()
+<pre><code>entry <b>fun</b> <a href="root.md#0x1_OneTypeOfScript_script1">script1</a>()
 </code></pre>
 
 
@@ -190,7 +190,7 @@ This is a script
 This is another script
 
 
-<pre><code><b>fun</b> <a href="root.md#0x1_OneTypeOfScript_script2">script2</a>()
+<pre><code>entry <b>fun</b> <a href="root.md#0x1_OneTypeOfScript_script2">script2</a>()
 </code></pre>
 
 
@@ -227,7 +227,7 @@ This is another module full of script funs too:
 This is a script
 
 
-<pre><code><b>fun</b> <a href="root.md#0x1_AnotherTypeOfScript_script3">script3</a>()
+<pre><code>entry <b>fun</b> <a href="root.md#0x1_AnotherTypeOfScript_script3">script3</a>()
 </code></pre>
 
 
@@ -250,7 +250,7 @@ This is a script
 This is another script
 
 
-<pre><code><b>fun</b> <a href="root.md#0x1_AnotherTypeOfScript_script4">script4</a>()
+<pre><code>entry <b>fun</b> <a href="root.md#0x1_AnotherTypeOfScript_script4">script4</a>()
 </code></pre>
 
 


### PR DESCRIPTION
- "entry" keyword was missing in the function headers
- this PR displays the keyword "entry" properly

This PR resolves https://github.com/move-language/move/issues/631

## Motivation

To properly display the "entry" keyword in the function headers

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

yes

## Test Plan

cargo test