### PR TITLE
[unit tests] Improve DevX of unit tests diagnosis

### DIFF
--- a/language/tools/move-unit-test/src/test_runner.rs
+++ b/language/tools/move-unit-test/src/test_runner.rs
@@ -554,9 +554,16 @@ impl SharedTestingConfig {
                     // Unexpected return status from the VM, signal that we hit an unknown error.
                     (_, None) => {
                         output.fail(function_name);
+                        let failure_reason = if err.major_status() as usize >= 4000
+                            && err.major_status() as usize <= 4999
+                        {
+                            FailureReason::execution_failure(err.major_status())
+                        } else {
+                            FailureReason::unknown()
+                        };
                         stats.test_failure(
                             TestFailure::new(
-                                FailureReason::unknown(),
+                                failure_reason,
                                 test_run_info,
                                 Some(err),
                                 save_session_state(),

--- a/language/tools/move-unit-test/tests/move_unit_test_testsuite.rs
+++ b/language/tools/move-unit-test/tests/move_unit_test_testsuite.rs
@@ -89,6 +89,7 @@ fn run_test_impl(path: &Path) -> anyhow::Result<()> {
             .into_iter()
             .collect(),
         report_writeset: true,
+        report_stacktrace_on_abort: true,
 
         ..UnitTestingConfig::default_with_bound(None)
     };

--- a/language/tools/move-unit-test/tests/test_sources/cross_module_aborts.exp
+++ b/language/tools/move-unit-test/tests/test_sources/cross_module_aborts.exp
@@ -20,6 +20,9 @@ Failures in 0x1::B:
 │   │         ^^^^^^^ Test was not expected to abort but it aborted with 0 here
 │ 
 │ 
+│ stack trace
+│ 	B::failing_test(tests/test_sources/cross_module_aborts.move:19)
+│ 
 └──────────────────
 
 Test result: FAILED. Total tests: 2; passed: 1; failed: 1

--- a/language/tools/move-unit-test/tests/test_sources/missing_data.evm.exp
+++ b/language/tools/move-unit-test/tests/test_sources/missing_data.evm.exp
@@ -1,5 +1,6 @@
 Running Move unit tests
 [ FAIL    ] 0x1::MissingData::missing_data
+[ FAIL    ] 0x1::MissingData::missing_data_from_other_function
 
 Test failures:
 
@@ -10,4 +11,10 @@ Failures in 0x1::MissingData:
 │ VMError (if there is one): 
 └──────────────────
 
-Test result: FAILED. Total tests: 1; passed: 0; failed: 1
+
+┌── missing_data_from_other_function ──────
+│ ITE: An unknown error was reported. Location: 
+│ VMError (if there is one): 
+└──────────────────
+
+Test result: FAILED. Total tests: 2; passed: 0; failed: 2

--- a/language/tools/move-unit-test/tests/test_sources/missing_data.exp
+++ b/language/tools/move-unit-test/tests/test_sources/missing_data.exp
@@ -1,6 +1,9 @@
 Running Move unit tests
 [ FAIL    ] 0x1::MissingData::missing_data
+[ FAIL    ] 0x1::MissingData::missing_data_from_other_function
 0x1::MissingData::missing_data
+Output: Ok(ChangeSet { accounts: {} })
+0x1::MissingData::missing_data_from_other_function
 Output: Ok(ChangeSet { accounts: {} })
 
 Test failures:
@@ -8,36 +11,31 @@ Test failures:
 Failures in 0x1::MissingData:
 
 ┌── missing_data ──────
-│ ITE: An unknown error was reported. Location: error[E11001]: test failure
+│ error[E11001]: test failure
 │   ┌─ missing_data.move:6:9
 │   │
 │ 5 │     fun missing_data() acquires Missing {
 │   │         ------------ In this function in 0x1::MissingData
 │ 6 │         borrow_global<Missing>(@0x0);
-│   │         ^^^^^^^^^^^^^
+│   │         ^^^^^^^^^^^^^ Execution failure MISSING_DATA
 │ 
 │ 
-│ VMError (if there is one): VMError {
-│     major_status: MISSING_DATA,
-│     sub_status: None,
-│     message: None,
-│     exec_state: None,
-│     location: Module(
-│         ModuleId {
-│             address: 00000000000000000000000000000001,
-│             name: Identifier(
-│                 "MissingData",
-│             ),
-│         },
-│     ),
-│     indices: [],
-│     offsets: [
-│         (
-│             FunctionDefinitionIndex(0),
-│             1,
-│         ),
-│     ],
-│ }
 └──────────────────
 
-Test result: FAILED. Total tests: 1; passed: 0; failed: 1
+
+┌── missing_data_from_other_function ──────
+│ error[E11001]: test failure
+│   ┌─ missing_data.move:6:9
+│   │
+│ 5 │     fun missing_data() acquires Missing {
+│   │         ------------ In this function in 0x1::MissingData
+│ 6 │         borrow_global<Missing>(@0x0);
+│   │         ^^^^^^^^^^^^^ Execution failure MISSING_DATA
+│ 
+│ 
+│ stack trace
+│ 	MissingData::missing_data_from_other_function(tests/test_sources/missing_data.move:12)
+│ 
+└──────────────────
+
+Test result: FAILED. Total tests: 2; passed: 0; failed: 2

--- a/language/tools/move-unit-test/tests/test_sources/missing_data.move
+++ b/language/tools/move-unit-test/tests/test_sources/missing_data.move
@@ -5,4 +5,10 @@ module 0x1::MissingData {
     fun missing_data() acquires Missing {
         borrow_global<Missing>(@0x0);
     }
+
+    #[test]
+    fun missing_data_from_other_function() acquires Missing {
+        // This call should create a stack trace entry
+        missing_data()
+    }
 }

--- a/language/tools/move-unit-test/tests/test_sources/unexpected_abort.exp
+++ b/language/tools/move-unit-test/tests/test_sources/unexpected_abort.exp
@@ -42,6 +42,9 @@ Failures in 0x1::M:
 │    │         ^^^^^^^ Test was not expected to abort but it aborted with 1 here
 │ 
 │ 
+│ stack trace
+│ 	M::unexpected_abort_in_other_function(tests/test_sources/unexpected_abort.move:33)
+│ 
 └──────────────────
 
 


### PR DESCRIPTION
This does two improvements for UT diagnosis:

- We now capture the stack trace (if according feature flags are enabled) for every interpreter error, not just aborts. The restriction to just aborts seem to be unnecessary.
- We now treat execution failures (arithmetic errors, borrow errors, index out of bounds) as regular errors, not longer as internal VM errors.

Effectively, were we had an output like this before:

```
│ ITE: An unknown error was reported. Location: error[E11001]: test failure
│   ┌─ missing_data.move:6:9
│   │
│ 5 │     fun missing_data() acquires Missing {
│   │         ------------ In this function in 0x1::MissingData
│ 6 │         borrow_global<Missing>(@0x0);
│   │         ^^^^^^^^^^^^^
│
│
│ VMError (if there is one): VMError {
│     major_status: MISSING_DATA,
│     sub_status: None,
│     message: None,
│     exec_state: None,
│     location: Module(
│         ModuleId {
│             address: 00000000000000000000000000000001,
│             name: Identifier(
│                 "MissingData",
│             ),
│         },
│     ),
│     indices: [],
│     offsets: [
│         (
│             FunctionDefinitionIndex(0),
│             1,
│         ),
│     ],
│ }
```

... we now have:

```
│ error[E11001]: test failure
│   ┌─ missing_data.move:6:9
│   │
│ 5 │     fun missing_data() acquires Missing {
│   │         ------------ In this function in 0x1::MissingData
│ 6 │         borrow_global<Missing>(@0x0);
│   │         ^^^^^^^^^^^^^ Execution failure MISSING_DATA
│
│
│ stack trace
│ 	MissingData::missing_data_from_other_function(tests/test_sources/missing_data.move:12)
│
```

