### PR TITLE
[Prover] Disable the nonlinear test cases that cause timeouts in CI

### DIFF
--- a/language/move-prover/tests/sources/functional/nonlinear_arithm.exp
+++ b/language/move-prover/tests/sources/functional/nonlinear_arithm.exp
@@ -1,40 +1,40 @@
 Move prover returns: exiting with verification errors
 error: post-condition does not hold
-    ┌─ tests/sources/functional/nonlinear_arithm.move:226:9
+    ┌─ tests/sources/functional/nonlinear_arithm.move:228:9
     │
-226 │         ensures result == a*b*c + a*b*d + a*b;
+228 │         ensures result == a*b*c + a*b*d + a*b;
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/nonlinear_arithm.move:222: distribution_law_incorrect
+    =     at tests/sources/functional/nonlinear_arithm.move:224: distribution_law_incorrect
     =         a = <redacted>
     =         b = <redacted>
     =         c = <redacted>
     =         d = <redacted>
-    =     at tests/sources/functional/nonlinear_arithm.move:223: distribution_law_incorrect
+    =     at tests/sources/functional/nonlinear_arithm.move:225: distribution_law_incorrect
     =         result = <redacted>
-    =     at tests/sources/functional/nonlinear_arithm.move:224: distribution_law_incorrect
-    =     at tests/sources/functional/nonlinear_arithm.move:226: distribution_law_incorrect (spec)
+    =     at tests/sources/functional/nonlinear_arithm.move:226: distribution_law_incorrect
+    =     at tests/sources/functional/nonlinear_arithm.move:228: distribution_law_incorrect (spec)
 
 error: post-condition does not hold
-    ┌─ tests/sources/functional/nonlinear_arithm.move:212:9
+    ┌─ tests/sources/functional/nonlinear_arithm.move:214:9
     │
-212 │         ensures result != 720;
+214 │         ensures result != 720;
     │         ^^^^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/nonlinear_arithm.move:201: mul5_incorrect
+    =     at tests/sources/functional/nonlinear_arithm.move:203: mul5_incorrect
     =         a = <redacted>
     =         b = <redacted>
     =         c = <redacted>
     =         d = <redacted>
     =         e = <redacted>
-    =     at tests/sources/functional/nonlinear_arithm.move:203: mul5_incorrect
-    =     at tests/sources/functional/nonlinear_arithm.move:204: mul5_incorrect
     =     at tests/sources/functional/nonlinear_arithm.move:205: mul5_incorrect
     =     at tests/sources/functional/nonlinear_arithm.move:206: mul5_incorrect
+    =     at tests/sources/functional/nonlinear_arithm.move:207: mul5_incorrect
     =     at tests/sources/functional/nonlinear_arithm.move:208: mul5_incorrect
+    =     at tests/sources/functional/nonlinear_arithm.move:210: mul5_incorrect
     =         result = <redacted>
-    =     at tests/sources/functional/nonlinear_arithm.move:209: mul5_incorrect
-    =     at tests/sources/functional/nonlinear_arithm.move:212: mul5_incorrect (spec)
+    =     at tests/sources/functional/nonlinear_arithm.move:211: mul5_incorrect
+    =     at tests/sources/functional/nonlinear_arithm.move:214: mul5_incorrect (spec)
 
 error: abort not covered by any of the `aborts_if` clauses
    ┌─ tests/sources/functional/nonlinear_arithm.move:51:5
@@ -53,25 +53,6 @@ error: abort not covered by any of the `aborts_if` clauses
    =         c = <redacted>
    =     at tests/sources/functional/nonlinear_arithm.move:49: overflow_u128_mul_3_incorrect
    =         ABORTED
-
-error: abort not covered by any of the `aborts_if` clauses
-    ┌─ tests/sources/functional/nonlinear_arithm.move:107:5
-    │
-105 │           a * b * c * d
-    │             - abort happened here with execution failure
-106 │       }
-107 │ ╭     spec overflow_u128_mul_4_incorrect {
-108 │ │         aborts_if false;
-109 │ │     }
-    │ ╰─────^
-    │
-    =     at tests/sources/functional/nonlinear_arithm.move:104: overflow_u128_mul_4_incorrect
-    =         a = <redacted>
-    =         b = <redacted>
-    =         c = <redacted>
-    =         d = <redacted>
-    =     at tests/sources/functional/nonlinear_arithm.move:105: overflow_u128_mul_4_incorrect
-    =         ABORTED
 
 error: abort not covered by any of the `aborts_if` clauses
    ┌─ tests/sources/functional/nonlinear_arithm.move:35:5
@@ -111,23 +92,23 @@ error: abort not covered by any of the `aborts_if` clauses
    =         ABORTED
 
 error: abort not covered by any of the `aborts_if` clauses
-    ┌─ tests/sources/functional/nonlinear_arithm.move:148:5
+    ┌─ tests/sources/functional/nonlinear_arithm.move:150:5
     │
-146 │           a * b * c * d * e
+148 │           a * b * c * d * e
     │             - abort happened here with execution failure
-147 │       }
-148 │ ╭     spec overflow_u64_mul_5_incorrect {
-149 │ │         aborts_if false;
-150 │ │     }
+149 │       }
+150 │ ╭     spec overflow_u64_mul_5_incorrect {
+151 │ │         aborts_if false;
+152 │ │     }
     │ ╰─────^
     │
-    =     at tests/sources/functional/nonlinear_arithm.move:145: overflow_u64_mul_5_incorrect
+    =     at tests/sources/functional/nonlinear_arithm.move:147: overflow_u64_mul_5_incorrect
     =         a = <redacted>
     =         b = <redacted>
     =         c = <redacted>
     =         d = <redacted>
     =         e = <redacted>
-    =     at tests/sources/functional/nonlinear_arithm.move:146: overflow_u64_mul_5_incorrect
+    =     at tests/sources/functional/nonlinear_arithm.move:148: overflow_u64_mul_5_incorrect
     =         ABORTED
 
 error: abort not covered by any of the `aborts_if` clauses
@@ -168,21 +149,21 @@ error: abort not covered by any of the `aborts_if` clauses
    =         ABORTED
 
 error: abort not covered by any of the `aborts_if` clauses
-    ┌─ tests/sources/functional/nonlinear_arithm.move:129:5
+    ┌─ tests/sources/functional/nonlinear_arithm.move:131:5
     │
-127 │           a * b * c * d * e
+129 │           a * b * c * d * e
     │             - abort happened here with execution failure
-128 │       }
-129 │ ╭     spec overflow_u8_mul_5_incorrect {
-130 │ │         aborts_if false;
-131 │ │     }
+130 │       }
+131 │ ╭     spec overflow_u8_mul_5_incorrect {
+132 │ │         aborts_if false;
+133 │ │     }
     │ ╰─────^
     │
-    =     at tests/sources/functional/nonlinear_arithm.move:126: overflow_u8_mul_5_incorrect
+    =     at tests/sources/functional/nonlinear_arithm.move:128: overflow_u8_mul_5_incorrect
     =         a = <redacted>
     =         b = <redacted>
     =         c = <redacted>
     =         d = <redacted>
     =         e = <redacted>
-    =     at tests/sources/functional/nonlinear_arithm.move:127: overflow_u8_mul_5_incorrect
+    =     at tests/sources/functional/nonlinear_arithm.move:129: overflow_u8_mul_5_incorrect
     =         ABORTED

--- a/language/move-prover/tests/sources/functional/nonlinear_arithm.move
+++ b/language/move-prover/tests/sources/functional/nonlinear_arithm.move
@@ -105,6 +105,7 @@ module 0x42::TestNonlinearArithmetic {
         a * b * c * d
     }
     spec overflow_u128_mul_4_incorrect {
+        pragma verify = false; // times out on smaller machines
         aborts_if false;
     }
 
@@ -112,6 +113,7 @@ module 0x42::TestNonlinearArithmetic {
         a * b * c * d
     }
     spec overflow_u128_mul_4 {
+        pragma verify = false; // times out on smaller machines
         aborts_if a * b > max_u128();
         aborts_if a * b * c > max_u128();
         aborts_if a * b * c * d > max_u128();


### PR DESCRIPTION
- Disabled the test cases `overflow_u128_mul_4` and `overflow_u128_mul_4_incorrect` in `nonlinear_arithm.move` because they cause timeouts in CI

## Motivation

To fix the timeouts in CI test for Prover

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

yes

## Test Plan

cargo test
