### PR TITLE
[byecode utils] make struct layout generation work with serdegen

### DIFF
--- a/language/tools/move-cli/src/sandbox/cli.rs
+++ b/language/tools/move-cli/src/sandbox/cli.rs
@@ -173,6 +173,21 @@ pub struct StructLayoutOptions {
         multiple_occurrences(true)
     )]
     type_args: Option<Vec<TypeTag>>,
+    /// If set, replace all Move source syntax separators ("::" for address/struct/module name
+    /// separation, "<", ">", and "," for generics separation) with this string.
+    /// If unset, use the same syntax as Move source
+    #[clap(long = "separator")]
+    separator: Option<String>,
+    /// If true, do not include addresses in fully qualified type names.
+    /// If there is a name conflict (e.g., the registry we're building has both
+    /// 0x1::M::T and 0x2::M::T), layout generation will fail when this option is true.
+    #[clap(long = "omit-addresses")]
+    omit_addresses: bool,
+    /// If true, do not include phantom types in fully qualified type names, since they do not contribute to the layout
+    /// E.g., if we have `struct S<phantom T> { u: 64 }` and try to generate bindings for this struct with `T = u8`,
+    /// the name for `S` in the registry will be `S<u64>` when this option is false, and `S` when this option is true
+    #[clap(long = "ignore-phantom-types")]
+    ignore_phantom_types: bool,
     /// If set, generate bindings only for the struct passed in.
     /// When unset, generates bindings for the struct and all of its transitive dependencies.
     #[clap(long = "shallow")]
@@ -299,6 +314,9 @@ fn handle_generate_commands(cmd: &GenerateCommand, state: &OnDiskStateView) -> R
                 module,
                 &options.struct_,
                 &options.type_args,
+                options.separator.clone(),
+                options.omit_addresses,
+                options.ignore_phantom_types,
                 options.shallow,
                 state,
             )

--- a/language/tools/move-cli/tests/sandbox_tests/generate_struct_layout/args.exp
+++ b/language/tools/move-cli/tests/sandbox_tests/generate_struct_layout/args.exp
@@ -77,13 +77,16 @@ Signer:
 
 Command `sandbox generate struct-layouts --module storage/0x00000000000000000000000000000001/modules/M1.mv --struct B --type-args bool --shallow`:
 ---
-"00000000000000000000000000000001::M1::B<bool>":
-  STRUCT:
-    - a:
-        TYPENAME: AccountAddress
-    - c:
-        TYPENAME: "00000000000000000000000000000001::M2::C<bool>"
-    - t: BOOL
+AccountAddress:
+  NEWTYPESTRUCT:
+    TUPLEARRAY:
+      CONTENT: U8
+      SIZE: 16
+Signer:
+  NEWTYPESTRUCT:
+    TUPLEARRAY:
+      CONTENT: U8
+      SIZE: 16
 
 Command `sandbox generate struct-layouts --module storage/0x00000000000000000000000000000001/modules/M1.mv --struct A --type-args 0x1::M1::S<u64>`:
 ---
@@ -159,21 +162,29 @@ Signer:
 
 Command `sandbox generate struct-layouts --module storage/0x00000000000000000000000000000001/modules/M1.mv --struct A --type-args 0x1::M1::S<u64> --shallow`:
 ---
-"00000000000000000000000000000001::M1::A<00000000000000000000000000000001::M1::S<u64>>":
-  STRUCT:
-    - f: U64
-    - v: BYTES
-    - b:
-        TYPENAME: "00000000000000000000000000000001::M1::B<00000000000000000000000000000001::M1::S<u64>>"
+AccountAddress:
+  NEWTYPESTRUCT:
+    TUPLEARRAY:
+      CONTENT: U8
+      SIZE: 16
+Signer:
+  NEWTYPESTRUCT:
+    TUPLEARRAY:
+      CONTENT: U8
+      SIZE: 16
 
 Command `sandbox generate struct-layouts --module storage/0x00000000000000000000000000000001/modules/M1.mv --struct A --type-args vector<0x1::M1::S<u64>> --shallow`:
 ---
-"00000000000000000000000000000001::M1::A<vector<00000000000000000000000000000001::M1::S<u64>>>":
-  STRUCT:
-    - f: U64
-    - v: BYTES
-    - b:
-        TYPENAME: "00000000000000000000000000000001::M1::B<vector<00000000000000000000000000000001::M1::S<u64>>>"
+AccountAddress:
+  NEWTYPESTRUCT:
+    TUPLEARRAY:
+      CONTENT: U8
+      SIZE: 16
+Signer:
+  NEWTYPESTRUCT:
+    TUPLEARRAY:
+      CONTENT: U8
+      SIZE: 16
 
 Command `sandbox generate struct-layouts --module storage/0x00000000000000000000000000000001/modules/M2.mv --struct C --type-args 0x1::M2::C<u64>`:
 ---
@@ -217,4 +228,170 @@ Signer:
     TUPLEARRAY:
       CONTENT: U8
       SIZE: 16
+
+Command `sandbox generate struct-layouts --module storage/0x00000000000000000000000000000001/modules/phantoms.mv --struct A --type-args bool --ignore-phantom-types`:
+---
+"00000000000000000000000000000001::phantoms::A":
+  STRUCT:
+    - dummy_field: BOOL
+AccountAddress:
+  NEWTYPESTRUCT:
+    TUPLEARRAY:
+      CONTENT: U8
+      SIZE: 16
+Signer:
+  NEWTYPESTRUCT:
+    TUPLEARRAY:
+      CONTENT: U8
+      SIZE: 16
+
+Command `sandbox generate struct-layouts --module storage/0x00000000000000000000000000000001/modules/phantoms.mv --struct A --type-args u64 --ignore-phantom-types`:
+---
+"00000000000000000000000000000001::phantoms::A":
+  STRUCT:
+    - dummy_field: BOOL
+AccountAddress:
+  NEWTYPESTRUCT:
+    TUPLEARRAY:
+      CONTENT: U8
+      SIZE: 16
+Signer:
+  NEWTYPESTRUCT:
+    TUPLEARRAY:
+      CONTENT: U8
+      SIZE: 16
+
+Command `sandbox generate struct-layouts --module storage/0x00000000000000000000000000000001/modules/phantoms.mv --struct B --type-args bool u8 --ignore-phantom-types`:
+---
+"00000000000000000000000000000001::phantoms::B":
+  STRUCT:
+    - dummy_field: BOOL
+AccountAddress:
+  NEWTYPESTRUCT:
+    TUPLEARRAY:
+      CONTENT: U8
+      SIZE: 16
+Signer:
+  NEWTYPESTRUCT:
+    TUPLEARRAY:
+      CONTENT: U8
+      SIZE: 16
+
+Command `sandbox generate struct-layouts --module storage/0x00000000000000000000000000000001/modules/phantoms.mv --struct C --type-args u8 u64 u128 --ignore-phantom-types`:
+---
+"00000000000000000000000000000001::phantoms::A":
+  STRUCT:
+    - dummy_field: BOOL
+"00000000000000000000000000000001::phantoms::B":
+  STRUCT:
+    - dummy_field: BOOL
+"00000000000000000000000000000001::phantoms::C":
+  STRUCT:
+    - a:
+        TYPENAME: "00000000000000000000000000000001::phantoms::A"
+    - b:
+        TYPENAME: "00000000000000000000000000000001::phantoms::B"
+AccountAddress:
+  NEWTYPESTRUCT:
+    TUPLEARRAY:
+      CONTENT: U8
+      SIZE: 16
+Signer:
+  NEWTYPESTRUCT:
+    TUPLEARRAY:
+      CONTENT: U8
+      SIZE: 16
+
+Command `sandbox generate struct-layouts --module storage/0x00000000000000000000000000000001/modules/phantoms.mv --struct D --type-args bool u64 --ignore-phantom-types`:
+---
+"00000000000000000000000000000001::phantoms::D<u64>":
+  STRUCT:
+    - v:
+        SEQ: U64
+AccountAddress:
+  NEWTYPESTRUCT:
+    TUPLEARRAY:
+      CONTENT: U8
+      SIZE: 16
+Signer:
+  NEWTYPESTRUCT:
+    TUPLEARRAY:
+      CONTENT: U8
+      SIZE: 16
+
+Command `sandbox generate struct-layouts --module storage/0x00000000000000000000000000000001/modules/phantoms.mv --struct E --type-args bool u64 u128 --ignore-phantom-types`:
+---
+"00000000000000000000000000000001::phantoms::E<bool,u128>":
+  STRUCT:
+    - v1:
+        SEQ: BOOL
+    - v2:
+        SEQ: U128
+AccountAddress:
+  NEWTYPESTRUCT:
+    TUPLEARRAY:
+      CONTENT: U8
+      SIZE: 16
+Signer:
+  NEWTYPESTRUCT:
+    TUPLEARRAY:
+      CONTENT: U8
+      SIZE: 16
+
+Command `sandbox generate struct-layouts --module storage/0x00000000000000000000000000000001/modules/phantoms.mv --struct E --type-args bool u64 u128 --omit-addresses`:
+---
+AccountAddress:
+  NEWTYPESTRUCT:
+    TUPLEARRAY:
+      CONTENT: U8
+      SIZE: 16
+Signer:
+  NEWTYPESTRUCT:
+    TUPLEARRAY:
+      CONTENT: U8
+      SIZE: 16
+"phantoms::E<bool,u64,u128>":
+  STRUCT:
+    - v1:
+        SEQ: BOOL
+    - v2:
+        SEQ: U128
+
+Command `sandbox generate struct-layouts --module storage/0x00000000000000000000000000000001/modules/phantoms.mv --struct E --type-args bool u64 u128 --separator __`:
+---
+00000000000000000000000000000001__phantoms__E__bool__u64__u128__:
+  STRUCT:
+    - v1:
+        SEQ: BOOL
+    - v2:
+        SEQ: U128
+AccountAddress:
+  NEWTYPESTRUCT:
+    TUPLEARRAY:
+      CONTENT: U8
+      SIZE: 16
+Signer:
+  NEWTYPESTRUCT:
+    TUPLEARRAY:
+      CONTENT: U8
+      SIZE: 16
+
+Command `sandbox generate struct-layouts --module storage/0x00000000000000000000000000000001/modules/phantoms.mv --struct E --type-args bool u64 u128 --omit-addresses --separator __`:
+---
+AccountAddress:
+  NEWTYPESTRUCT:
+    TUPLEARRAY:
+      CONTENT: U8
+      SIZE: 16
+Signer:
+  NEWTYPESTRUCT:
+    TUPLEARRAY:
+      CONTENT: U8
+      SIZE: 16
+phantoms__E__bool__u64__u128__:
+  STRUCT:
+    - v1:
+        SEQ: BOOL
+    - v2:
+        SEQ: U128
 

--- a/language/tools/move-cli/tests/sandbox_tests/generate_struct_layout/args.txt
+++ b/language/tools/move-cli/tests/sandbox_tests/generate_struct_layout/args.txt
@@ -22,3 +22,18 @@ sandbox generate struct-layouts --module storage/0x00000000000000000000000000000
 
 # without --type-args
 sandbox generate struct-layouts --module storage/0x00000000000000000000000000000001/modules/M1.mv --struct G
+
+# phantom type arguments should not appear in struct keys when --ignore-phantom-types is set
+sandbox generate struct-layouts --module storage/0x00000000000000000000000000000001/modules/phantoms.mv --struct A --type-args bool --ignore-phantom-types
+sandbox generate struct-layouts --module storage/0x00000000000000000000000000000001/modules/phantoms.mv --struct A --type-args u64 --ignore-phantom-types
+sandbox generate struct-layouts --module storage/0x00000000000000000000000000000001/modules/phantoms.mv --struct B --type-args bool u8 --ignore-phantom-types
+sandbox generate struct-layouts --module storage/0x00000000000000000000000000000001/modules/phantoms.mv --struct C --type-args u8 u64 u128 --ignore-phantom-types
+sandbox generate struct-layouts --module storage/0x00000000000000000000000000000001/modules/phantoms.mv --struct D --type-args bool u64 --ignore-phantom-types
+sandbox generate struct-layouts --module storage/0x00000000000000000000000000000001/modules/phantoms.mv --struct E --type-args bool u64 u128 --ignore-phantom-types
+
+# test config options: address omission + separators
+sandbox generate struct-layouts --module storage/0x00000000000000000000000000000001/modules/phantoms.mv --struct E --type-args bool u64 u128 --omit-addresses
+
+sandbox generate struct-layouts --module storage/0x00000000000000000000000000000001/modules/phantoms.mv --struct E --type-args bool u64 u128 --separator __
+
+sandbox generate struct-layouts --module storage/0x00000000000000000000000000000001/modules/phantoms.mv --struct E --type-args bool u64 u128 --omit-addresses --separator __

--- a/language/tools/move-cli/tests/sandbox_tests/generate_struct_layout/sources/phantoms.move
+++ b/language/tools/move-cli/tests/sandbox_tests/generate_struct_layout/sources/phantoms.move
@@ -1,0 +1,19 @@
+module 0x1::phantoms {
+    struct A<phantom T> {}
+
+    struct B<phantom T1, phantom T2> {}
+
+    struct C<phantom T1, phantom T2, phantom T3> {
+        a: A<T1>,
+        b: B<T2, T3>
+    }
+
+    struct D<phantom T1, T2: store> {
+        v: vector<T2>
+    }
+
+    struct E<T1, phantom T2: store, T3> {
+        v1: vector<T1>,
+        v2: vector<T3>
+    }
+}


### PR DESCRIPTION
One of the promises of generating layout YAML's for Move structs is that we can leverage `serdegen` to autogenerate wrapper types for Move structs in all the languages `serdegen` handles. This PR moves us closer to that.
    
- Add `separator` option that allows replacing the Move source syntax separators ("::", "<", ">", ",") in type names with a user
-defined string. This is helpful because a name like `0x1::M::T<u64>` is very unlikely to be a valid identifier in any of the langua
ges `serdegen` handles. Setting (e.g.) `separator = __` allows a fully qualified Move type name to be a valid identifier.
- Add an `omit_addresses` option that omits the addresses from a fully qualified Move type name. This is useful in the (common) 
case where you are generating bindings for a package that does not have any name conflicts and don't want to bother with the addresses. The generator looks for name conflicts and panics if it finds one.
- Add an `ignore_phantom_types` option that does not include phantom type parameters in struct names, since they do not influence layout.
    
After these changes, the following PoC for serdegen works:    
    ```
    move sandbox generate struct-layouts --module storage/0x00000000000000000000000000000001/modules/M1.mv --struct G --omit-addresses --separator "__" > test.yaml
    serdegen --language python3 test.yaml > test.py
    python test.py
    ```
    
, where `test.py` is
    
```python
from dataclasses import dataclass
import typing
import serde_types as st
    
@dataclass(frozen=True)
class M1__G:
    x: st.uint64
    s: "M1__S__bool__"
    
@dataclass(frozen=True)
class M1__S__bool__:
    t: bool
```