### PR TITLE
[vm][binary-format] implements proper versioning for the code deserializer inside the VM

### DIFF
--- a/language/move-binary-format/src/file_format_common.rs
+++ b/language/move-binary-format/src/file_format_common.rs
@@ -24,10 +24,10 @@ use std::{
 pub enum BinaryConstants {}
 impl BinaryConstants {
     /// The blob that must start a binary.
-    pub const DIEM_MAGIC_SIZE: usize = 4;
-    pub const DIEM_MAGIC: [u8; BinaryConstants::DIEM_MAGIC_SIZE] = [0xA1, 0x1C, 0xEB, 0x0B];
+    pub const MOVE_MAGIC_SIZE: usize = 4;
+    pub const MOVE_MAGIC: [u8; BinaryConstants::MOVE_MAGIC_SIZE] = [0xA1, 0x1C, 0xEB, 0x0B];
     /// The `DIEM_MAGIC` size, 4 byte for major version and 1 byte for table count.
-    pub const HEADER_SIZE: usize = BinaryConstants::DIEM_MAGIC_SIZE + 5;
+    pub const HEADER_SIZE: usize = BinaryConstants::MOVE_MAGIC_SIZE + 5;
     /// A (Table Type, Start Offset, Byte Count) size, which is 1 byte for the type and
     /// 4 bytes for the offset/count.
     pub const TABLE_HEADER_SIZE: u8 = size_of::<u32>() as u8 * 2 + 1;
@@ -429,9 +429,9 @@ pub(crate) mod versioned_data {
     impl<'a> VersionedBinary<'a> {
         fn new(binary: &'a [u8]) -> BinaryLoaderResult<(Self, Cursor<&'a [u8]>)> {
             let mut cursor = Cursor::<&'a [u8]>::new(binary);
-            let mut magic = [0u8; BinaryConstants::DIEM_MAGIC_SIZE];
+            let mut magic = [0u8; BinaryConstants::MOVE_MAGIC_SIZE];
             if let Ok(count) = cursor.read(&mut magic) {
-                if count != BinaryConstants::DIEM_MAGIC_SIZE || magic != BinaryConstants::DIEM_MAGIC
+                if count != BinaryConstants::MOVE_MAGIC_SIZE || magic != BinaryConstants::MOVE_MAGIC
                 {
                     return Err(PartialVMError::new(StatusCode::BAD_MAGIC));
                 }

--- a/language/move-binary-format/src/serializer.rs
+++ b/language/move-binary-format/src/serializer.rs
@@ -320,7 +320,7 @@ fn serialize_table_index(
 }
 
 fn serialize_magic(binary: &mut BinaryData) -> Result<()> {
-    for byte in &BinaryConstants::DIEM_MAGIC {
+    for byte in &BinaryConstants::MOVE_MAGIC {
         binary.push(*byte)?;
     }
     Ok(())

--- a/language/move-binary-format/src/unit_tests/deserializer_tests.rs
+++ b/language/move-binary-format/src/unit_tests/deserializer_tests.rs
@@ -10,7 +10,7 @@ use move_core_types::vm_status::StatusCode;
 
 fn malformed_simple_versioned_test(version: u32) {
     // bad uleb (more than allowed for table count)
-    let mut binary = BinaryConstants::DIEM_MAGIC.to_vec();
+    let mut binary = BinaryConstants::MOVE_MAGIC.to_vec();
     binary.extend(version.to_le_bytes()); // version
     binary.push(150); // table count (high bit 1)
     binary.push(150); // table count (high bit 1)
@@ -22,7 +22,7 @@ fn malformed_simple_versioned_test(version: u32) {
     );
 
     // bad uleb (too big)
-    let mut binary = BinaryConstants::DIEM_MAGIC.to_vec();
+    let mut binary = BinaryConstants::MOVE_MAGIC.to_vec();
     binary.extend(version.to_le_bytes()); // version
     binary.push(150); // table count (high bit 1)
     binary.push(150); // table count again (high bit 1)
@@ -43,7 +43,7 @@ fn malformed_simple_versioned_test(version: u32) {
     );
 
     // no tables
-    let mut binary = BinaryConstants::DIEM_MAGIC.to_vec();
+    let mut binary = BinaryConstants::MOVE_MAGIC.to_vec();
     binary.extend(version.to_le_bytes()); // version
     binary.push(0); // table count
     let res = CompiledModule::deserialize(&binary);
@@ -53,7 +53,7 @@ fn malformed_simple_versioned_test(version: u32) {
     );
 
     // missing tables
-    let mut binary = BinaryConstants::DIEM_MAGIC.to_vec();
+    let mut binary = BinaryConstants::MOVE_MAGIC.to_vec();
     binary.extend(version.to_le_bytes()); // version
     binary.push(10); // table count
     let res = CompiledModule::deserialize(&binary);
@@ -63,7 +63,7 @@ fn malformed_simple_versioned_test(version: u32) {
     );
 
     // missing table content
-    let mut binary = BinaryConstants::DIEM_MAGIC.to_vec();
+    let mut binary = BinaryConstants::MOVE_MAGIC.to_vec();
     binary.extend(version.to_le_bytes()); // version
     binary.push(1); // table count
     binary.push(1); // table type
@@ -76,7 +76,7 @@ fn malformed_simple_versioned_test(version: u32) {
     );
 
     // bad table header (bad offset)
-    let mut binary = BinaryConstants::DIEM_MAGIC.to_vec();
+    let mut binary = BinaryConstants::MOVE_MAGIC.to_vec();
     binary.extend(version.to_le_bytes()); // version
     binary.push(1); // table count
     binary.push(1); // table type
@@ -89,7 +89,7 @@ fn malformed_simple_versioned_test(version: u32) {
     );
 
     // bad table header (bad offset)
-    let mut binary = BinaryConstants::DIEM_MAGIC.to_vec();
+    let mut binary = BinaryConstants::MOVE_MAGIC.to_vec();
     binary.extend(version.to_le_bytes()); // version
     binary.push(2); // table count
     binary.push(1); // table type
@@ -106,7 +106,7 @@ fn malformed_simple_versioned_test(version: u32) {
     );
 
     // incomplete table
-    let mut binary = BinaryConstants::DIEM_MAGIC.to_vec();
+    let mut binary = BinaryConstants::MOVE_MAGIC.to_vec();
     binary.extend(version.to_le_bytes()); // version
     binary.push(1); // table count
     binary.push(1); // table type
@@ -120,7 +120,7 @@ fn malformed_simple_versioned_test(version: u32) {
     );
 
     // unknown table
-    let mut binary = BinaryConstants::DIEM_MAGIC.to_vec();
+    let mut binary = BinaryConstants::MOVE_MAGIC.to_vec();
     binary.extend(version.to_le_bytes()); // version
     binary.push(1); // table count
     binary.push(100); // table type
@@ -134,7 +134,7 @@ fn malformed_simple_versioned_test(version: u32) {
     );
 
     // duplicate table
-    let mut binary = BinaryConstants::DIEM_MAGIC.to_vec();
+    let mut binary = BinaryConstants::MOVE_MAGIC.to_vec();
     binary.extend(version.to_le_bytes()); // version
     binary.push(3); // table count
     binary.push(1); // table type
@@ -155,7 +155,7 @@ fn malformed_simple_versioned_test(version: u32) {
     );
 
     // bad table in script
-    let mut binary = BinaryConstants::DIEM_MAGIC.to_vec();
+    let mut binary = BinaryConstants::MOVE_MAGIC.to_vec();
     binary.extend(version.to_le_bytes()); // version
     binary.push(1); // table count
     binary.push(0xD); // table type - FieldHandle not good for script
@@ -198,7 +198,7 @@ fn malformed_simple() {
     );
 
     // only magic
-    let binary = BinaryConstants::DIEM_MAGIC.to_vec();
+    let binary = BinaryConstants::MOVE_MAGIC.to_vec();
     let res = CompiledScript::deserialize(&binary);
     assert_eq!(
         res.expect_err("Expected malformed binary").major_status(),
@@ -206,7 +206,7 @@ fn malformed_simple() {
     );
 
     // bad version
-    let mut binary = BinaryConstants::DIEM_MAGIC.to_vec();
+    let mut binary = BinaryConstants::MOVE_MAGIC.to_vec();
     binary.extend((VERSION_MAX.checked_add(1).unwrap()).to_le_bytes()); // version
     binary.push(10); // table count
     binary.push(0); // rest of binary

--- a/language/move-binary-format/src/unit_tests/deserializer_tests.rs
+++ b/language/move-binary-format/src/unit_tests/deserializer_tests.rs
@@ -222,6 +222,21 @@ fn malformed_simple() {
     }
 }
 
+#[test]
+fn max_version_lower_than_hardcoded() {
+    let mut binary = BinaryConstants::MOVE_MAGIC.to_vec();
+    binary.extend((VERSION_MAX).to_le_bytes()); // version
+    binary.push(10); // table count
+    binary.push(0); // rest of binary
+
+    let res =
+        CompiledScript::deserialize_with_max_version(&binary, VERSION_MAX.checked_sub(1).unwrap());
+    assert_eq!(
+        res.expect_err("Expected unknown version").major_status(),
+        StatusCode::UNKNOWN_VERSION
+    );
+}
+
 // Ensure that we can deserialize a script from disk
 static EMPTY_SCRIPT: &[u8] = include_bytes!("empty_script.mv");
 

--- a/language/move-compiler/src/command_line/compiler.rs
+++ b/language/move-compiler/src/command_line/compiler.rs
@@ -707,12 +707,12 @@ fn has_compiled_module_magic_number(path: &str) -> bool {
         Err(_) => return false,
         Ok(f) => f,
     };
-    let mut magic = [0u8; BinaryConstants::DIEM_MAGIC_SIZE];
+    let mut magic = [0u8; BinaryConstants::MOVE_MAGIC_SIZE];
     let num_bytes_read = match file.read(&mut magic) {
         Err(_) => return false,
         Ok(n) => n,
     };
-    num_bytes_read == BinaryConstants::DIEM_MAGIC_SIZE && magic == BinaryConstants::DIEM_MAGIC
+    num_bytes_read == BinaryConstants::MOVE_MAGIC_SIZE && magic == BinaryConstants::MOVE_MAGIC
 }
 
 //**************************************************************************************************

--- a/language/move-vm/integration-tests/src/tests/binary_format_version.rs
+++ b/language/move-vm/integration-tests/src/tests/binary_format_version.rs
@@ -1,0 +1,139 @@
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use move_binary_format::{
+    file_format::{basic_test_module, basic_test_script},
+    file_format_common::VERSION_MAX,
+};
+use move_core_types::{account_address::AccountAddress, vm_status::StatusCode};
+use move_vm_runtime::{config::VMConfig, move_vm::MoveVM};
+use move_vm_test_utils::InMemoryStorage;
+use move_vm_types::gas::UnmeteredGasMeter;
+
+#[test]
+fn test_publish_module_with_custom_max_binary_format_version() {
+    let m = basic_test_module();
+    let mut b_new = vec![];
+    let mut b_old = vec![];
+    m.serialize_for_version(Some(VERSION_MAX), &mut b_new)
+        .unwrap();
+    m.serialize_for_version(Some(VERSION_MAX.checked_sub(1).unwrap()), &mut b_old)
+        .unwrap();
+
+    // Should accept both modules with the default settings
+    {
+        let storage = InMemoryStorage::new();
+        let vm = MoveVM::new(move_stdlib::natives::all_natives(
+            AccountAddress::from_hex_literal("0x1").unwrap(),
+            move_stdlib::natives::GasParameters::zeros(),
+        ))
+        .unwrap();
+        let mut sess = vm.new_session(&storage);
+
+        sess.publish_module(
+            b_new.clone(),
+            *m.self_id().address(),
+            &mut UnmeteredGasMeter,
+        )
+        .unwrap();
+
+        sess.publish_module(
+            b_old.clone(),
+            *m.self_id().address(),
+            &mut UnmeteredGasMeter,
+        )
+        .unwrap();
+    }
+
+    // Should reject the module with newer version with max binary format version being set to VERSION_MAX - 1
+    {
+        let storage = InMemoryStorage::new();
+        let vm = MoveVM::new_with_config(
+            move_stdlib::natives::all_natives(
+                AccountAddress::from_hex_literal("0x1").unwrap(),
+                move_stdlib::natives::GasParameters::zeros(),
+            ),
+            VMConfig {
+                max_binary_format_version: VERSION_MAX.checked_sub(1).unwrap(),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let mut sess = vm.new_session(&storage);
+
+        assert_eq!(
+            sess.publish_module(
+                b_new.clone(),
+                *m.self_id().address(),
+                &mut UnmeteredGasMeter,
+            )
+            .unwrap_err()
+            .major_status(),
+            StatusCode::UNKNOWN_VERSION
+        );
+
+        sess.publish_module(
+            b_old.clone(),
+            *m.self_id().address(),
+            &mut UnmeteredGasMeter,
+        )
+        .unwrap();
+    }
+}
+
+#[test]
+fn test_run_script_with_custom_max_binary_format_version() {
+    let s = basic_test_script();
+    let mut b_new = vec![];
+    let mut b_old = vec![];
+    s.serialize_for_version(Some(VERSION_MAX), &mut b_new)
+        .unwrap();
+    s.serialize_for_version(Some(VERSION_MAX.checked_sub(1).unwrap()), &mut b_old)
+        .unwrap();
+
+    // Should accept both modules with the default settings
+    {
+        let storage = InMemoryStorage::new();
+        let vm = MoveVM::new(move_stdlib::natives::all_natives(
+            AccountAddress::from_hex_literal("0x1").unwrap(),
+            move_stdlib::natives::GasParameters::zeros(),
+        ))
+        .unwrap();
+        let mut sess = vm.new_session(&storage);
+
+        let args: Vec<Vec<u8>> = vec![];
+        sess.execute_script(b_new.clone(), vec![], args.clone(), &mut UnmeteredGasMeter)
+            .unwrap();
+
+        sess.execute_script(b_old.clone(), vec![], args, &mut UnmeteredGasMeter)
+            .unwrap();
+    }
+
+    // Should reject the module with newer version with max binary format version being set to VERSION_MAX - 1
+    {
+        let storage = InMemoryStorage::new();
+        let vm = MoveVM::new_with_config(
+            move_stdlib::natives::all_natives(
+                AccountAddress::from_hex_literal("0x1").unwrap(),
+                move_stdlib::natives::GasParameters::zeros(),
+            ),
+            VMConfig {
+                max_binary_format_version: VERSION_MAX.checked_sub(1).unwrap(),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let mut sess = vm.new_session(&storage);
+
+        let args: Vec<Vec<u8>> = vec![];
+        assert_eq!(
+            sess.execute_script(b_new.clone(), vec![], args.clone(), &mut UnmeteredGasMeter)
+                .unwrap_err()
+                .major_status(),
+            StatusCode::CODE_DESERIALIZATION_ERROR
+        );
+
+        sess.execute_script(b_old.clone(), vec![], args, &mut UnmeteredGasMeter)
+            .unwrap();
+    }
+}

--- a/language/move-vm/integration-tests/src/tests/mod.rs
+++ b/language/move-vm/integration-tests/src/tests/mod.rs
@@ -4,6 +4,7 @@
 
 mod bad_entry_point_tests;
 mod bad_storage_tests;
+mod binary_format_version;
 mod exec_func_effects_tests;
 mod function_arg_tests;
 mod loader_tests;

--- a/language/move-vm/integration-tests/src/tests/nested_loop_tests.rs
+++ b/language/move-vm/integration-tests/src/tests/nested_loop_tests.rs
@@ -4,7 +4,7 @@
 use crate::compiler::{as_module, as_script, compile_units};
 use move_bytecode_verifier::VerifierConfig;
 use move_core_types::account_address::AccountAddress;
-use move_vm_runtime::move_vm::MoveVM;
+use move_vm_runtime::{config::VMConfig, move_vm::MoveVM};
 use move_vm_test_utils::InMemoryStorage;
 use move_vm_types::gas::UnmeteredGasMeter;
 
@@ -38,14 +38,17 @@ fn test_publish_module_with_nested_loops() {
     // Should succeed with max_loop_depth = 2
     {
         let storage = InMemoryStorage::new();
-        let vm = MoveVM::new_with_verifier_config(
+        let vm = MoveVM::new_with_config(
             move_stdlib::natives::all_natives(
                 AccountAddress::from_hex_literal("0x1").unwrap(),
                 move_stdlib::natives::GasParameters::zeros(),
             ),
-            VerifierConfig {
-                max_loop_depth: Some(2),
-                ..VerifierConfig::default()
+            VMConfig {
+                verifier: VerifierConfig {
+                    max_loop_depth: Some(2),
+                    ..Default::default()
+                },
+                ..Default::default()
             },
         )
         .unwrap();
@@ -58,14 +61,17 @@ fn test_publish_module_with_nested_loops() {
     // Should fail with max_loop_depth = 1
     {
         let storage = InMemoryStorage::new();
-        let vm = MoveVM::new_with_verifier_config(
+        let vm = MoveVM::new_with_config(
             move_stdlib::natives::all_natives(
                 AccountAddress::from_hex_literal("0x1").unwrap(),
                 move_stdlib::natives::GasParameters::zeros(),
             ),
-            VerifierConfig {
-                max_loop_depth: Some(1),
-                ..VerifierConfig::default()
+            VMConfig {
+                verifier: VerifierConfig {
+                    max_loop_depth: Some(1),
+                    ..Default::default()
+                },
+                ..Default::default()
             },
         )
         .unwrap();
@@ -104,14 +110,17 @@ fn test_run_script_with_nested_loops() {
     // Should succeed with max_loop_depth = 2
     {
         let storage = InMemoryStorage::new();
-        let vm = MoveVM::new_with_verifier_config(
+        let vm = MoveVM::new_with_config(
             move_stdlib::natives::all_natives(
                 AccountAddress::from_hex_literal("0x1").unwrap(),
                 move_stdlib::natives::GasParameters::zeros(),
             ),
-            VerifierConfig {
-                max_loop_depth: Some(2),
-                ..VerifierConfig::default()
+            VMConfig {
+                verifier: VerifierConfig {
+                    max_loop_depth: Some(2),
+                    ..Default::default()
+                },
+                ..Default::default()
             },
         )
         .unwrap();
@@ -125,14 +134,17 @@ fn test_run_script_with_nested_loops() {
     // Should fail with max_loop_depth = 1
     {
         let storage = InMemoryStorage::new();
-        let vm = MoveVM::new_with_verifier_config(
+        let vm = MoveVM::new_with_config(
             move_stdlib::natives::all_natives(
                 AccountAddress::from_hex_literal("0x1").unwrap(),
                 move_stdlib::natives::GasParameters::zeros(),
             ),
-            VerifierConfig {
-                max_loop_depth: Some(1),
-                ..VerifierConfig::default()
+            VMConfig {
+                verifier: VerifierConfig {
+                    max_loop_depth: Some(1),
+                    ..Default::default()
+                },
+                ..Default::default()
             },
         )
         .unwrap();

--- a/language/move-vm/runtime/src/config.rs
+++ b/language/move-vm/runtime/src/config.rs
@@ -1,0 +1,14 @@
+use move_bytecode_verifier::VerifierConfig;
+
+/// Dynamic config options for the Move VM.
+pub struct VMConfig {
+    pub verifier: VerifierConfig,
+}
+
+impl Default for VMConfig {
+    fn default() -> Self {
+        Self {
+            verifier: VerifierConfig::default(),
+        }
+    }
+}

--- a/language/move-vm/runtime/src/config.rs
+++ b/language/move-vm/runtime/src/config.rs
@@ -1,14 +1,20 @@
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use move_binary_format::file_format_common::VERSION_MAX;
 use move_bytecode_verifier::VerifierConfig;
 
 /// Dynamic config options for the Move VM.
 pub struct VMConfig {
     pub verifier: VerifierConfig,
+    pub max_binary_format_version: u32,
 }
 
 impl Default for VMConfig {
     fn default() -> Self {
         Self {
             verifier: VerifierConfig::default(),
+            max_binary_format_version: VERSION_MAX,
         }
     }
 }

--- a/language/move-vm/runtime/src/lib.rs
+++ b/language/move-vm/runtime/src/lib.rs
@@ -21,6 +21,7 @@ mod runtime;
 pub mod session;
 #[macro_use]
 mod tracing;
+pub mod config;
 
 // Only include debugging functionality in debug builds
 #[cfg(any(debug_assertions, feature = "debugging"))]

--- a/language/move-vm/runtime/src/move_vm.rs
+++ b/language/move-vm/runtime/src/move_vm.rs
@@ -5,14 +5,13 @@
 use std::{collections::BTreeSet, sync::Arc};
 
 use crate::{
-    data_cache::TransactionDataCache, native_extensions::NativeContextExtensions,
+    config::VMConfig, data_cache::TransactionDataCache, native_extensions::NativeContextExtensions,
     native_functions::NativeFunction, runtime::VMRuntime, session::Session,
 };
 use move_binary_format::{
     errors::{Location, VMResult},
     CompiledModule,
 };
-use move_bytecode_verifier::VerifierConfig;
 use move_core_types::{
     account_address::AccountAddress, identifier::Identifier, language_storage::ModuleId,
     metadata::Metadata, resolver::MoveResolver,
@@ -26,15 +25,15 @@ impl MoveVM {
     pub fn new(
         natives: impl IntoIterator<Item = (AccountAddress, Identifier, Identifier, NativeFunction)>,
     ) -> VMResult<Self> {
-        Self::new_with_verifier_config(natives, VerifierConfig::default())
+        Self::new_with_config(natives, VMConfig::default())
     }
 
-    pub fn new_with_verifier_config(
+    pub fn new_with_config(
         natives: impl IntoIterator<Item = (AccountAddress, Identifier, Identifier, NativeFunction)>,
-        verifier_config: VerifierConfig,
+        vm_config: VMConfig,
     ) -> VMResult<Self> {
         Ok(Self {
-            runtime: VMRuntime::new(natives, verifier_config)
+            runtime: VMRuntime::new(natives, vm_config)
                 .map_err(|err| err.finish(Location::Undefined))?,
         })
     }

--- a/language/move-vm/runtime/src/runtime.rs
+++ b/language/move-vm/runtime/src/runtime.rs
@@ -79,7 +79,12 @@ impl VMRuntime {
         // used with the `[]` operator
         let compiled_modules = match modules
             .iter()
-            .map(|blob| CompiledModule::deserialize(blob))
+            .map(|blob| {
+                CompiledModule::deserialize_with_max_version(
+                    blob,
+                    self.loader.vm_config().max_binary_format_version,
+                )
+            })
             .collect::<PartialVMResult<Vec<_>>>()
         {
             Ok(modules) => modules,

--- a/language/move-vm/runtime/src/runtime.rs
+++ b/language/move-vm/runtime/src/runtime.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
+    config::VMConfig,
     data_cache::TransactionDataCache,
     interpreter::Interpreter,
     loader::{Function, Loader},
@@ -17,7 +18,7 @@ use move_binary_format::{
     file_format::LocalIndex,
     normalized, CompiledModule, IndexKind,
 };
-use move_bytecode_verifier::{script_signature, VerifierConfig};
+use move_bytecode_verifier::script_signature;
 use move_core_types::{
     account_address::AccountAddress,
     identifier::{IdentStr, Identifier},
@@ -43,10 +44,10 @@ pub(crate) struct VMRuntime {
 impl VMRuntime {
     pub(crate) fn new(
         natives: impl IntoIterator<Item = (AccountAddress, Identifier, Identifier, NativeFunction)>,
-        verifier_config: VerifierConfig,
+        vm_config: VMConfig,
     ) -> PartialVMResult<Self> {
         Ok(VMRuntime {
-            loader: Loader::new(NativeFunctions::new(natives)?, verifier_config),
+            loader: Loader::new(NativeFunctions::new(natives)?, vm_config),
         })
     }
 


### PR DESCRIPTION
This adds a new VM config option that would allow one to specify the maximum binary format version acceptable dynamically, making it possible for downstream clients to roll out binary format changes (e.g. https://github.com/move-language/move/pull/547) in a backward compatible way.

**Note: this PR contains multiple small commits and it might be easier to review them one at a time.**