### PR TITLE
[Prover] Added support for new primitive types to arithmetic ops

### DIFF
--- a/language/move-prover/boogie-backend/src/bytecode_translator.rs
+++ b/language/move-prover/boogie-backend/src/bytecode_translator.rs
@@ -1335,8 +1335,11 @@ impl<'env> FunctionTranslator<'env> {
                         };
                         let add_type = match &self.get_local_type(dest) {
                             Type::Primitive(PrimitiveType::U8) => "U8".to_string(),
+                            Type::Primitive(PrimitiveType::U16) => format!("U16{}", unchecked),
+                            Type::Primitive(PrimitiveType::U32) => format!("U32{}", unchecked),
                             Type::Primitive(PrimitiveType::U64) => format!("U64{}", unchecked),
                             Type::Primitive(PrimitiveType::U128) => format!("U128{}", unchecked),
+                            Type::Primitive(PrimitiveType::U256) => format!("U256{}", unchecked),
                             _ => unreachable!(),
                         };
                         emitln!(
@@ -1366,8 +1369,11 @@ impl<'env> FunctionTranslator<'env> {
                         let op2 = srcs[1];
                         let mul_type = match &self.get_local_type(dest) {
                             Type::Primitive(PrimitiveType::U8) => "U8",
+                            Type::Primitive(PrimitiveType::U16) => "U16",
+                            Type::Primitive(PrimitiveType::U32) => "U32",
                             Type::Primitive(PrimitiveType::U64) => "U64",
                             Type::Primitive(PrimitiveType::U128) => "U128",
+                            Type::Primitive(PrimitiveType::U256) => "U256",
                             _ => unreachable!(),
                         };
                         emitln!(

--- a/language/move-prover/boogie-backend/src/prelude/prelude.bpl
+++ b/language/move-prover/boogie-backend/src/prelude/prelude.bpl
@@ -314,6 +314,24 @@ procedure {:inline 1} $CastU8(src: int) returns (dst: int)
     dst := src;
 }
 
+procedure {:inline 1} $CastU16(src: int) returns (dst: int)
+{
+    if (src > $MAX_U16) {
+        call $ExecFailureAbort();
+        return;
+    }
+    dst := src;
+}
+
+procedure {:inline 1} $CastU32(src: int) returns (dst: int)
+{
+    if (src > $MAX_U32) {
+        call $ExecFailureAbort();
+        return;
+    }
+    dst := src;
+}
+
 procedure {:inline 1} $CastU64(src: int) returns (dst: int)
 {
     if (src > $MAX_U64) {
@@ -332,12 +350,49 @@ procedure {:inline 1} $CastU128(src: int) returns (dst: int)
     dst := src;
 }
 
+procedure {:inline 1} $CastU256(src: int) returns (dst: int)
+{
+    if (src > $MAX_U256) {
+        call $ExecFailureAbort();
+        return;
+    }
+    dst := src;
+}
+
 procedure {:inline 1} $AddU8(src1: int, src2: int) returns (dst: int)
 {
     if (src1 + src2 > $MAX_U8) {
         call $ExecFailureAbort();
         return;
     }
+    dst := src1 + src2;
+}
+
+procedure {:inline 1} $AddU16(src1: int, src2: int) returns (dst: int)
+{
+    if (src1 + src2 > $MAX_U16) {
+        call $ExecFailureAbort();
+        return;
+    }
+    dst := src1 + src2;
+}
+
+procedure {:inline 1} $AddU16_unchecked(src1: int, src2: int) returns (dst: int)
+{
+    dst := src1 + src2;
+}
+
+procedure {:inline 1} $AddU32(src1: int, src2: int) returns (dst: int)
+{
+    if (src1 + src2 > $MAX_U32) {
+        call $ExecFailureAbort();
+        return;
+    }
+    dst := src1 + src2;
+}
+
+procedure {:inline 1} $AddU32_unchecked(src1: int, src2: int) returns (dst: int)
+{
     dst := src1 + src2;
 }
 
@@ -365,6 +420,20 @@ procedure {:inline 1} $AddU128(src1: int, src2: int) returns (dst: int)
 }
 
 procedure {:inline 1} $AddU128_unchecked(src1: int, src2: int) returns (dst: int)
+{
+    dst := src1 + src2;
+}
+
+procedure {:inline 1} $AddU256(src1: int, src2: int) returns (dst: int)
+{
+    if (src1 + src2 > $MAX_U256) {
+        call $ExecFailureAbort();
+        return;
+    }
+    dst := src1 + src2;
+}
+
+procedure {:inline 1} $AddU256_unchecked(src1: int, src2: int) returns (dst: int)
 {
     dst := src1 + src2;
 }
@@ -552,6 +621,24 @@ procedure {:inline 1} $MulU8(src1: int, src2: int) returns (dst: int)
     dst := src1 * src2;
 }
 
+procedure {:inline 1} $MulU16(src1: int, src2: int) returns (dst: int)
+{
+    if (src1 * src2 > $MAX_U16) {
+        call $ExecFailureAbort();
+        return;
+    }
+    dst := src1 * src2;
+}
+
+procedure {:inline 1} $MulU32(src1: int, src2: int) returns (dst: int)
+{
+    if (src1 * src2 > $MAX_U32) {
+        call $ExecFailureAbort();
+        return;
+    }
+    dst := src1 * src2;
+}
+
 procedure {:inline 1} $MulU64(src1: int, src2: int) returns (dst: int)
 {
     if (src1 * src2 > $MAX_U64) {
@@ -564,6 +651,15 @@ procedure {:inline 1} $MulU64(src1: int, src2: int) returns (dst: int)
 procedure {:inline 1} $MulU128(src1: int, src2: int) returns (dst: int)
 {
     if (src1 * src2 > $MAX_U128) {
+        call $ExecFailureAbort();
+        return;
+    }
+    dst := src1 * src2;
+}
+
+procedure {:inline 1} $MulU256(src1: int, src2: int) returns (dst: int)
+{
+    if (src1 * src2 > $MAX_U256) {
         call $ExecFailureAbort();
         return;
     }

--- a/language/move-prover/tests/sources/functional/arithm.exp
+++ b/language/move-prover/tests/sources/functional/arithm.exp
@@ -17,37 +17,37 @@ error: abort not covered by any of the `aborts_if` clauses
     =         ABORTED
 
 error: abort not covered by any of the `aborts_if` clauses
-    ┌─ tests/sources/functional/arithm.move:180:5
+    ┌─ tests/sources/functional/arithm.move:212:5
     │
-178 │           x + y
+210 │           x + y
     │             - abort happened here with execution failure
-179 │       }
-180 │ ╭     spec overflow_u128_add_incorrect {
-181 │ │         aborts_if false;
-182 │ │     }
+211 │       }
+212 │ ╭     spec overflow_u128_add_incorrect {
+213 │ │         aborts_if false;
+214 │ │     }
     │ ╰─────^
     │
-    =     at tests/sources/functional/arithm.move:177: overflow_u128_add_incorrect
+    =     at tests/sources/functional/arithm.move:209: overflow_u128_add_incorrect
     =         x = <redacted>
     =         y = <redacted>
-    =     at tests/sources/functional/arithm.move:178: overflow_u128_add_incorrect
+    =     at tests/sources/functional/arithm.move:210: overflow_u128_add_incorrect
     =         ABORTED
 
 error: abort not covered by any of the `aborts_if` clauses
-    ┌─ tests/sources/functional/arithm.move:232:5
+    ┌─ tests/sources/functional/arithm.move:312:5
     │
-230 │           x * y
+310 │           x * y
     │             - abort happened here with execution failure
-231 │       }
-232 │ ╭     spec overflow_u128_mul_incorrect {
-233 │ │         aborts_if false;
-234 │ │     }
+311 │       }
+312 │ ╭     spec overflow_u128_mul_incorrect {
+313 │ │         aborts_if false;
+314 │ │     }
     │ ╰─────^
     │
-    =     at tests/sources/functional/arithm.move:229: overflow_u128_mul_incorrect
+    =     at tests/sources/functional/arithm.move:309: overflow_u128_mul_incorrect
     =         x = <redacted>
     =         y = <redacted>
-    =     at tests/sources/functional/arithm.move:230: overflow_u128_mul_incorrect
+    =     at tests/sources/functional/arithm.move:310: overflow_u128_mul_incorrect
     =         ABORTED
 
 error: abort not covered by any of the `aborts_if` clauses
@@ -56,32 +56,134 @@ error: abort not covered by any of the `aborts_if` clauses
 162 │           x + y
     │             - abort happened here with execution failure
 163 │       }
-164 │ ╭     spec overflow_u64_add_incorrect {
+164 │ ╭     spec overflow_u16_add_incorrect {
 165 │ │         aborts_if false;
 166 │ │     }
     │ ╰─────^
     │
-    =     at tests/sources/functional/arithm.move:161: overflow_u64_add_incorrect
+    =     at tests/sources/functional/arithm.move:161: overflow_u16_add_incorrect
     =         x = <redacted>
     =         y = <redacted>
-    =     at tests/sources/functional/arithm.move:162: overflow_u64_add_incorrect
+    =     at tests/sources/functional/arithm.move:162: overflow_u16_add_incorrect
     =         ABORTED
 
 error: abort not covered by any of the `aborts_if` clauses
-    ┌─ tests/sources/functional/arithm.move:217:5
+    ┌─ tests/sources/functional/arithm.move:265:5
     │
-215 │           x * y
+263 │           x * y
     │             - abort happened here with execution failure
-216 │       }
-217 │ ╭     spec overflow_u64_mul_incorrect {
-218 │ │         aborts_if false;
-219 │ │     }
+264 │       }
+265 │ ╭     spec overflow_u16_mul_incorrect {
+266 │ │         aborts_if false;
+267 │ │     }
     │ ╰─────^
     │
-    =     at tests/sources/functional/arithm.move:214: overflow_u64_mul_incorrect
+    =     at tests/sources/functional/arithm.move:262: overflow_u16_mul_incorrect
     =         x = <redacted>
     =         y = <redacted>
-    =     at tests/sources/functional/arithm.move:215: overflow_u64_mul_incorrect
+    =     at tests/sources/functional/arithm.move:263: overflow_u16_mul_incorrect
+    =         ABORTED
+
+error: abort not covered by any of the `aborts_if` clauses
+    ┌─ tests/sources/functional/arithm.move:228:5
+    │
+226 │           x + y
+    │             - abort happened here with execution failure
+227 │       }
+228 │ ╭     spec overflow_u256_add_incorrect {
+229 │ │         aborts_if false;
+230 │ │     }
+    │ ╰─────^
+    │
+    =     at tests/sources/functional/arithm.move:225: overflow_u256_add_incorrect
+    =         x = <redacted>
+    =         y = <redacted>
+    =     at tests/sources/functional/arithm.move:226: overflow_u256_add_incorrect
+    =         ABORTED
+
+error: abort not covered by any of the `aborts_if` clauses
+    ┌─ tests/sources/functional/arithm.move:327:5
+    │
+325 │           x * y
+    │             - abort happened here with execution failure
+326 │       }
+327 │ ╭     spec overflow_u256_mul_incorrect {
+328 │ │         aborts_if false;
+329 │ │     }
+    │ ╰─────^
+    │
+    =     at tests/sources/functional/arithm.move:324: overflow_u256_mul_incorrect
+    =         x = <redacted>
+    =         y = <redacted>
+    =     at tests/sources/functional/arithm.move:325: overflow_u256_mul_incorrect
+    =         ABORTED
+
+error: abort not covered by any of the `aborts_if` clauses
+    ┌─ tests/sources/functional/arithm.move:180:5
+    │
+178 │           x + y
+    │             - abort happened here with execution failure
+179 │       }
+180 │ ╭     spec overflow_u32_add_incorrect {
+181 │ │         aborts_if false;
+182 │ │     }
+    │ ╰─────^
+    │
+    =     at tests/sources/functional/arithm.move:177: overflow_u32_add_incorrect
+    =         x = <redacted>
+    =         y = <redacted>
+    =     at tests/sources/functional/arithm.move:178: overflow_u32_add_incorrect
+    =         ABORTED
+
+error: abort not covered by any of the `aborts_if` clauses
+    ┌─ tests/sources/functional/arithm.move:281:5
+    │
+279 │           x * y
+    │             - abort happened here with execution failure
+280 │       }
+281 │ ╭     spec overflow_u32_mul_incorrect {
+282 │ │         aborts_if false;
+283 │ │     }
+    │ ╰─────^
+    │
+    =     at tests/sources/functional/arithm.move:278: overflow_u32_mul_incorrect
+    =         x = <redacted>
+    =         y = <redacted>
+    =     at tests/sources/functional/arithm.move:279: overflow_u32_mul_incorrect
+    =         ABORTED
+
+error: abort not covered by any of the `aborts_if` clauses
+    ┌─ tests/sources/functional/arithm.move:196:5
+    │
+194 │           x + y
+    │             - abort happened here with execution failure
+195 │       }
+196 │ ╭     spec overflow_u64_add_incorrect {
+197 │ │         aborts_if false;
+198 │ │     }
+    │ ╰─────^
+    │
+    =     at tests/sources/functional/arithm.move:193: overflow_u64_add_incorrect
+    =         x = <redacted>
+    =         y = <redacted>
+    =     at tests/sources/functional/arithm.move:194: overflow_u64_add_incorrect
+    =         ABORTED
+
+error: abort not covered by any of the `aborts_if` clauses
+    ┌─ tests/sources/functional/arithm.move:297:5
+    │
+295 │           x * y
+    │             - abort happened here with execution failure
+296 │       }
+297 │ ╭     spec overflow_u64_mul_incorrect {
+298 │ │         aborts_if false;
+299 │ │     }
+    │ ╰─────^
+    │
+    =     at tests/sources/functional/arithm.move:294: overflow_u64_mul_incorrect
+    =         x = <redacted>
+    =         y = <redacted>
+    =     at tests/sources/functional/arithm.move:295: overflow_u64_mul_incorrect
     =         ABORTED
 
 error: abort not covered by any of the `aborts_if` clauses
@@ -102,18 +204,18 @@ error: abort not covered by any of the `aborts_if` clauses
     =         ABORTED
 
 error: abort not covered by any of the `aborts_if` clauses
-    ┌─ tests/sources/functional/arithm.move:201:5
+    ┌─ tests/sources/functional/arithm.move:249:5
     │
-199 │           x * y
+247 │           x * y
     │             - abort happened here with execution failure
-200 │       }
-201 │ ╭     spec overflow_u8_mul_incorrect {
-202 │ │         aborts_if false;
-203 │ │     }
+248 │       }
+249 │ ╭     spec overflow_u8_mul_incorrect {
+250 │ │         aborts_if false;
+251 │ │     }
     │ ╰─────^
     │
-    =     at tests/sources/functional/arithm.move:198: overflow_u8_mul_incorrect
+    =     at tests/sources/functional/arithm.move:246: overflow_u8_mul_incorrect
     =         x = <redacted>
     =         y = <redacted>
-    =     at tests/sources/functional/arithm.move:199: overflow_u8_mul_incorrect
+    =     at tests/sources/functional/arithm.move:247: overflow_u8_mul_incorrect
     =         ABORTED

--- a/language/move-prover/tests/sources/functional/arithm.move
+++ b/language/move-prover/tests/sources/functional/arithm.move
@@ -158,6 +158,38 @@ module 0x42::TestArithmetic {
     }
 
     // fails.
+    fun overflow_u16_add_incorrect(x: u16, y: u16): u16 {
+        x + y
+    }
+    spec overflow_u16_add_incorrect {
+        aborts_if false;
+    }
+
+    // succeeds.
+    fun overflow_u16_add(x: u16, y: u16): u16 {
+        x + y
+    }
+    spec overflow_u16_add {
+        aborts_if x + y > max_u16();
+    }
+
+    // fails.
+    fun overflow_u32_add_incorrect(x: u32, y: u32): u32 {
+        x + y
+    }
+    spec overflow_u32_add_incorrect {
+        aborts_if false;
+    }
+
+    // succeeds.
+    fun overflow_u32_add(x: u32, y: u32): u32 {
+        x + y
+    }
+    spec overflow_u32_add {
+        aborts_if x + y > max_u32();
+    }
+
+    // fails.
     fun overflow_u64_add_incorrect(x: u64, y: u64): u64 {
         x + y
     }
@@ -189,6 +221,22 @@ module 0x42::TestArithmetic {
         aborts_if x + y > max_u128();
     }
 
+    // fails.
+    fun overflow_u256_add_incorrect(x: u256, y: u256): u256 {
+        x + y
+    }
+    spec overflow_u256_add_incorrect {
+        aborts_if false;
+    }
+
+    // succeeds.
+    fun overflow_u256_add(x: u256, y: u256): u256 {
+        x + y
+    }
+    spec overflow_u256_add {
+        aborts_if x + y > max_u256();
+    }
+
 
     // --------------------------
     // Overflow by multiplication
@@ -208,6 +256,38 @@ module 0x42::TestArithmetic {
     }
     spec overflow_u8_mul {
         aborts_if x * y > max_u8();
+    }
+
+    // fails.
+    fun overflow_u16_mul_incorrect(x: u16, y: u16): u16 {
+        x * y
+    }
+    spec overflow_u16_mul_incorrect {
+        aborts_if false;
+    }
+
+    // succeeds.
+    fun overflow_u16_mul(x: u16, y: u16): u16 {
+        x * y
+    }
+    spec overflow_u16_mul {
+        aborts_if x * y > max_u16();
+    }
+
+    // fails.
+    fun overflow_u32_mul_incorrect(x: u32, y: u32): u32 {
+        x * y
+    }
+    spec overflow_u32_mul_incorrect {
+        aborts_if false;
+    }
+
+    // succeeds.
+    fun overflow_u32_mul(x: u32, y: u32): u32 {
+        x * y
+    }
+    spec overflow_u32_mul {
+        aborts_if x * y > max_u32();
     }
 
     // fails.
@@ -238,6 +318,21 @@ module 0x42::TestArithmetic {
     }
     spec overflow_u128_mul {
         aborts_if x * y > max_u128(); // U128_MAX
+    }
+
+    // fails.
+    fun overflow_u256_mul_incorrect(x: u256, y: u256): u256 {
+        x * y
+    }
+    spec overflow_u256_mul_incorrect {
+        aborts_if false;
+    }
+
+    fun overflow_u256_mul(x: u256, y: u256): u256 {
+        x * y
+    }
+    spec overflow_u256_mul {
+        aborts_if x * y > max_u256(); // U256_MAX
     }
 
 }

--- a/language/move-prover/tests/sources/functional/cast.exp
+++ b/language/move-prover/tests/sources/functional/cast.exp
@@ -1,32 +1,64 @@
 Move prover returns: exiting with verification errors
 error: abort not covered by any of the `aborts_if` clauses
-   ┌─ tests/sources/functional/cast.move:47:5
+   ┌─ tests/sources/functional/cast.move:67:5
    │
-45 │           (x as u64)
+65 │           (x as u16)
    │           ---------- abort happened here with execution failure
-46 │       }
-47 │ ╭     spec aborting_u64_cast_incorrect {
-48 │ │         aborts_if false;
-49 │ │     }
+66 │       }
+67 │ ╭     spec aborting_u16_cast_incorrect {
+68 │ │         aborts_if false;
+69 │ │     }
    │ ╰─────^
    │
-   =     at tests/sources/functional/cast.move:44: aborting_u64_cast_incorrect
+   =     at tests/sources/functional/cast.move:64: aborting_u16_cast_incorrect
    =         x = <redacted>
-   =     at tests/sources/functional/cast.move:45: aborting_u64_cast_incorrect
+   =     at tests/sources/functional/cast.move:65: aborting_u16_cast_incorrect
    =         ABORTED
 
 error: abort not covered by any of the `aborts_if` clauses
-   ┌─ tests/sources/functional/cast.move:33:5
+   ┌─ tests/sources/functional/cast.move:81:5
    │
-31 │           (x as u8)
-   │           --------- abort happened here with execution failure
-32 │       }
-33 │ ╭     spec aborting_u8_cast_incorrect {
-34 │ │         aborts_if false;
-35 │ │     }
+79 │           (x as u32)
+   │           ---------- abort happened here with execution failure
+80 │       }
+81 │ ╭     spec aborting_u32_cast_incorrect {
+82 │ │         aborts_if false;
+83 │ │     }
    │ ╰─────^
    │
-   =     at tests/sources/functional/cast.move:30: aborting_u8_cast_incorrect
+   =     at tests/sources/functional/cast.move:78: aborting_u32_cast_incorrect
    =         x = <redacted>
-   =     at tests/sources/functional/cast.move:31: aborting_u8_cast_incorrect
+   =     at tests/sources/functional/cast.move:79: aborting_u32_cast_incorrect
+   =         ABORTED
+
+error: abort not covered by any of the `aborts_if` clauses
+    ┌─ tests/sources/functional/cast.move:109:5
+    │
+ 93 │           (x as u64)
+    │           ---------- abort happened here with execution failure
+    ·
+109 │ ╭     spec aborting_u64_cast_incorrect {
+110 │ │         aborts_if false;
+111 │ │     }
+    │ ╰─────^
+    │
+    =     at tests/sources/functional/cast.move:92: aborting_u64_cast_incorrect
+    =         x = <redacted>
+    =     at tests/sources/functional/cast.move:93: aborting_u64_cast_incorrect
+    =         ABORTED
+
+error: abort not covered by any of the `aborts_if` clauses
+   ┌─ tests/sources/functional/cast.move:53:5
+   │
+51 │           (x as u8)
+   │           --------- abort happened here with execution failure
+52 │       }
+53 │ ╭     spec aborting_u8_cast_incorrect {
+54 │ │         aborts_if false;
+55 │ │     }
+   │ ╰─────^
+   │
+   =     at tests/sources/functional/cast.move:50: aborting_u8_cast_incorrect
+   =         x = <redacted>
+   =     at tests/sources/functional/cast.move:51: aborting_u8_cast_incorrect
    =         ABORTED

--- a/language/move-prover/tests/sources/functional/cast.move
+++ b/language/move-prover/tests/sources/functional/cast.move
@@ -15,6 +15,20 @@ module 0x42::TestCast {
         aborts_if false;
     }
 
+    fun u16_cast_incorrect(x: u16): u64 {
+        (x as u64)
+    }
+    spec u16_cast_incorrect {
+        aborts_if false;
+    }
+
+    fun u32_cast_incorrect(x: u32): u64 {
+        (x as u64)
+    }
+    spec u8_cast_incorrect {
+        aborts_if false;
+    }
+
     fun u64_cast(x: u64): u128 {
         (x as u128)
     }
@@ -22,6 +36,12 @@ module 0x42::TestCast {
         aborts_if false;
     }
 
+    fun u128_cast(x: u128): u256 {
+        (x as u256)
+    }
+    spec aborting_u128_cast {
+        aborts_if false;
+    }
 
     // -------------
     // Type demotion
@@ -41,6 +61,34 @@ module 0x42::TestCast {
         aborts_if x > 255;
     }
 
+    fun aborting_u16_cast_incorrect(x: u64): u16 {
+        (x as u16)
+    }
+    spec aborting_u16_cast_incorrect {
+        aborts_if false;
+    }
+
+    fun aborting_u16_cast(x: u64): u16 {
+        (x as u16)
+    }
+    spec aborting_u16_cast {
+        aborts_if x > 65535;
+    }
+
+    fun aborting_u32_cast_incorrect(x: u64): u32 {
+        (x as u32)
+    }
+    spec aborting_u32_cast_incorrect {
+        aborts_if false;
+    }
+
+    fun aborting_u32_cast(x: u64): u32 {
+        (x as u32)
+    }
+    spec aborting_u16_cast {
+        aborts_if x > 4294967295;
+    }
+
     fun aborting_u64_cast_incorrect(x: u128): u64 {
         (x as u64)
     }
@@ -54,4 +102,19 @@ module 0x42::TestCast {
     spec aborting_u64_cast {
         aborts_if x > 18446744073709551615;
     }
+
+    fun aborting_u128_cast_incorrect(x: u256): u128 {
+        (x as u128)
+    }
+    spec aborting_u64_cast_incorrect {
+        aborts_if false;
+    }
+
+    fun aborting_u128_cast(x: u256): u128 {
+        (x as u128)
+    }
+    spec aborting_u128_cast {
+        aborts_if x > 340282366920938463463374607431768211455;
+    }
+
 }

--- a/language/move-prover/tests/sources/functional/loops_with_memory_ops.exp
+++ b/language/move-prover/tests/sources/functional/loops_with_memory_ops.exp
@@ -44,11 +44,10 @@ error: unknown assertion failed
    =     at tests/sources/functional/loops_with_memory_ops.move:80: nested_loop2
    =     at tests/sources/functional/loops_with_memory_ops.move:81: nested_loop2
    =         b = <redacted>
+   =         b = <redacted>
    =     at <internal>:1
    =     at tests/sources/functional/loops_with_memory_ops.move:81: nested_loop2
    =         a = <redacted>
-   =     at <internal>:1
-   =     at tests/sources/functional/loops_with_memory_ops.move:81: nested_loop2
    =     at tests/sources/functional/loops_with_memory_ops.move:85: nested_loop2
    =         i = <redacted>
    =     at tests/sources/functional/loops_with_memory_ops.move:86: nested_loop2
@@ -98,9 +97,12 @@ error: induction case of the loop invariant does not hold
    =         y = <redacted>
    =     at tests/sources/functional/loops_with_memory_ops.move:80: nested_loop2
    =     at tests/sources/functional/loops_with_memory_ops.move:81: nested_loop2
-   =         b = <redacted>
-   =         b = <redacted>
-   =         a = <redacted>
+   =     at <internal>:1
+   =     at tests/sources/functional/loops_with_memory_ops.move:81: nested_loop2
+   =     at <internal>:1
+   =     at tests/sources/functional/loops_with_memory_ops.move:81: nested_loop2
+   =     at <internal>:1
+   =     at tests/sources/functional/loops_with_memory_ops.move:81: nested_loop2
    =         a = <redacted>
    =     at tests/sources/functional/loops_with_memory_ops.move:85: nested_loop2
    =         i = <redacted>


### PR DESCRIPTION
## Motivation

There were some missing bits in the bytecode translator and in the Boogie prelude file that this PR is attempting to add.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes

