### PR TITLE
[bytecode-verifier] Avoid unwraps were possible when in release mode

### DIFF
--- a/language/move-bytecode-verifier/src/acquires_list_verifier.rs
+++ b/language/move-bytecode-verifier/src/acquires_list_verifier.rs
@@ -20,6 +20,7 @@ use move_binary_format::{
         Bytecode, CodeOffset, CompiledModule, FunctionDefinition, FunctionDefinitionIndex,
         FunctionHandle, FunctionHandleIndex, StructDefinitionIndex,
     },
+    safe_unwrap,
 };
 use move_core_types::vm_status::StatusCode;
 
@@ -54,10 +55,7 @@ impl<'a> AcquiresVerifier<'a> {
             handle_to_def,
         };
 
-        for (offset, instruction) in function_definition
-            .code
-            .as_ref()
-            .unwrap()
+        for (offset, instruction) in safe_unwrap!(function_definition.code.as_ref())
             .code
             .iter()
             .enumerate()
@@ -72,7 +70,7 @@ impl<'a> AcquiresVerifier<'a> {
                 ));
             }
 
-            let struct_def = module.struct_defs().get(annotation.0 as usize).unwrap();
+            let struct_def = safe_unwrap!(module.struct_defs().get(annotation.0 as usize));
             let struct_handle = module.struct_handle_at(struct_def.struct_handle);
             if !struct_handle.abilities.has_key() {
                 return Err(PartialVMError::new(StatusCode::INVALID_ACQUIRES_ANNOTATION));

--- a/language/move-bytecode-verifier/src/control_flow.rs
+++ b/language/move-bytecode-verifier/src/control_flow.rs
@@ -11,6 +11,7 @@ use crate::verifier::VerifierConfig;
 use move_binary_format::{
     errors::{PartialVMError, PartialVMResult},
     file_format::{Bytecode, CodeOffset, CodeUnit, FunctionDefinitionIndex},
+    safe_unwrap,
 };
 use move_core_types::vm_status::StatusCode;
 use std::{collections::HashSet, convert::TryInto};
@@ -138,7 +139,7 @@ fn check_code<
             Bytecode::Branch(target) | Bytecode::BrTrue(target) | Bytecode::BrFalse(target)
                 if is_back_edge(cur_instr, *target) =>
             {
-                let (_cur_loop_head, last_continue) = loop_stack.last().unwrap();
+                let (_cur_loop_head, last_continue) = safe_unwrap!(loop_stack.last());
                 if cur_instr == *last_continue {
                     loop_stack.pop();
                 }
@@ -161,7 +162,7 @@ fn check_continues(context: &ControlFlowVerifier, labels: &[Label]) -> PartialVM
             Bytecode::Branch(target) | Bytecode::BrTrue(target) | Bytecode::BrFalse(target)
                 if is_back_edge(cur_instr, *target) =>
             {
-                let (cur_loop_head, _last_continue) = loop_stack.last().unwrap();
+                let (cur_loop_head, _last_continue) = safe_unwrap!(loop_stack.last());
                 if target != cur_loop_head {
                     // Invalid back jump. Cannot back jump outside of the current loop
                     Err(context.error(StatusCode::INVALID_LOOP_CONTINUE, cur_instr))

--- a/language/move-bytecode-verifier/src/dependencies.rs
+++ b/language/move-bytecode-verifier/src/dependencies.rs
@@ -13,7 +13,7 @@ use move_binary_format::{
         StructTypeParameter, TableIndex, Visibility,
     },
     file_format_common::VERSION_5,
-    IndexKind,
+    safe_unwrap, IndexKind,
 };
 use move_core_types::{identifier::Identifier, language_storage::ModuleId, vm_status::StatusCode};
 use std::collections::{BTreeMap, BTreeSet};
@@ -226,7 +226,7 @@ fn verify_imported_structs(context: &Context) -> PartialVMResult<()> {
             .resolver
             .module_id_for_handle(context.resolver.module_handle_at(struct_handle.module));
         // TODO: remove unwrap
-        let owner_module = context.dependency_map.get(&owner_module_id).unwrap();
+        let owner_module = safe_unwrap!(context.dependency_map.get(&owner_module_id));
         let struct_name = context.resolver.identifier_at(struct_handle.name);
         match context
             .struct_id_to_handle_map
@@ -269,8 +269,7 @@ fn verify_imported_functions(context: &Context) -> PartialVMResult<()> {
             .resolver
             .module_id_for_handle(context.resolver.module_handle_at(function_handle.module));
         let function_name = context.resolver.identifier_at(function_handle.name);
-        // TODO: remove unwrap
-        let owner_module = context.dependency_map.get(&owner_module_id).unwrap();
+        let owner_module = safe_unwrap!(context.dependency_map.get(&owner_module_id));
         match context
             .func_id_to_handle_map
             .get(&(owner_module_id.clone(), function_name.to_owned()))

--- a/language/move-bytecode-verifier/src/reference_safety/abstract_state.rs
+++ b/language/move-bytecode-verifier/src/reference_safety/abstract_state.rs
@@ -11,6 +11,7 @@ use move_binary_format::{
         CodeOffset, FieldHandleIndex, FunctionDefinitionIndex, LocalIndex, Signature,
         SignatureToken, StructDefinitionIndex,
     },
+    safe_unwrap,
 };
 use move_borrow_graph::references::RefID;
 use move_core_types::vm_status::StatusCode;
@@ -284,7 +285,7 @@ impl AbstractState {
         offset: CodeOffset,
         local: LocalIndex,
     ) -> PartialVMResult<AbstractValue> {
-        match self.locals.get(&local).unwrap() {
+        match safe_unwrap!(self.locals.get(&local)) {
             AbstractValue::Reference(id) => {
                 let id = *id;
                 let new_id = self.new_ref(self.borrow_graph.is_mutable(id));
@@ -303,7 +304,7 @@ impl AbstractState {
         offset: CodeOffset,
         local: LocalIndex,
     ) -> PartialVMResult<AbstractValue> {
-        match self.locals.remove(&local).unwrap() {
+        match safe_unwrap!(self.locals.remove(&local)) {
             AbstractValue::Reference(id) => Ok(AbstractValue::Reference(id)),
             AbstractValue::NonReference if self.is_local_borrowed(local) => {
                 Err(self.error(StatusCode::MOVELOC_EXISTS_BORROW_ERROR, offset))
@@ -461,7 +462,7 @@ impl AbstractState {
         vector: AbstractValue,
         mut_: bool,
     ) -> PartialVMResult<()> {
-        let id = vector.ref_id().unwrap();
+        let id = safe_unwrap!(vector.ref_id());
         if mut_ && !self.is_writable(id) {
             return Err(self.error(StatusCode::VEC_UPDATE_EXISTS_MUTABLE_BORROW_ERROR, offset));
         }
@@ -475,7 +476,7 @@ impl AbstractState {
         vector: AbstractValue,
         mut_: bool,
     ) -> PartialVMResult<AbstractValue> {
-        let vec_id = vector.ref_id().unwrap();
+        let vec_id = safe_unwrap!(vector.ref_id());
         if mut_ && !self.is_writable(vec_id) {
             return Err(self.error(
                 StatusCode::VEC_BORROW_ELEMENT_EXISTS_MUTABLE_BORROW_ERROR,

--- a/language/move-bytecode-verifier/src/reference_safety/mod.rs
+++ b/language/move-bytecode-verifier/src/reference_safety/mod.rs
@@ -19,6 +19,7 @@ use move_binary_format::{
         Bytecode, CodeOffset, FunctionDefinitionIndex, FunctionHandle, IdentifierIndex,
         SignatureIndex, SignatureToken, StructDefinition, StructFieldInformation,
     },
+    safe_assert, safe_unwrap,
 };
 use move_core_types::vm_status::StatusCode;
 use std::collections::{BTreeSet, HashMap};
@@ -97,20 +98,28 @@ fn num_fields(struct_def: &StructDefinition) -> usize {
     }
 }
 
-fn pack(verifier: &mut ReferenceSafetyAnalysis, struct_def: &StructDefinition) {
+fn pack(
+    verifier: &mut ReferenceSafetyAnalysis,
+    struct_def: &StructDefinition,
+) -> PartialVMResult<()> {
     for _ in 0..num_fields(struct_def) {
-        assert!(verifier.stack.pop().unwrap().is_value())
+        safe_assert!(safe_unwrap!(verifier.stack.pop()).is_value())
     }
     // TODO maybe call state.value_for
-    verifier.stack.push(AbstractValue::NonReference)
+    verifier.stack.push(AbstractValue::NonReference);
+    Ok(())
 }
 
-fn unpack(verifier: &mut ReferenceSafetyAnalysis, struct_def: &StructDefinition) {
-    assert!(verifier.stack.pop().unwrap().is_value());
+fn unpack(
+    verifier: &mut ReferenceSafetyAnalysis,
+    struct_def: &StructDefinition,
+) -> PartialVMResult<()> {
+    safe_assert!(safe_unwrap!(verifier.stack.pop()).is_value());
     // TODO maybe call state.value_for
     for _ in 0..num_fields(struct_def) {
         verifier.stack.push(AbstractValue::NonReference)
     }
+    Ok(())
 }
 
 fn vec_element_type(
@@ -132,7 +141,7 @@ fn execute_inner(
     offset: CodeOffset,
 ) -> PartialVMResult<()> {
     match bytecode {
-        Bytecode::Pop => state.release_value(verifier.stack.pop().unwrap()),
+        Bytecode::Pop => state.release_value(safe_unwrap!(verifier.stack.pop())),
 
         Bytecode::CopyLoc(local) => {
             let value = state.copy_loc(offset, *local)?;
@@ -142,28 +151,30 @@ fn execute_inner(
             let value = state.move_loc(offset, *local)?;
             verifier.stack.push(value)
         }
-        Bytecode::StLoc(local) => state.st_loc(offset, *local, verifier.stack.pop().unwrap())?,
+        Bytecode::StLoc(local) => {
+            state.st_loc(offset, *local, safe_unwrap!(verifier.stack.pop()))?
+        }
 
         Bytecode::FreezeRef => {
-            let id = verifier.stack.pop().unwrap().ref_id().unwrap();
+            let id = safe_unwrap!(safe_unwrap!(verifier.stack.pop()).ref_id());
             let frozen = state.freeze_ref(offset, id)?;
             verifier.stack.push(frozen)
         }
         Bytecode::Eq | Bytecode::Neq => {
-            let v1 = verifier.stack.pop().unwrap();
-            let v2 = verifier.stack.pop().unwrap();
+            let v1 = safe_unwrap!(verifier.stack.pop());
+            let v2 = safe_unwrap!(verifier.stack.pop());
             let value = state.comparison(offset, v1, v2)?;
             verifier.stack.push(value)
         }
         Bytecode::ReadRef => {
-            let id = verifier.stack.pop().unwrap().ref_id().unwrap();
+            let id = safe_unwrap!(safe_unwrap!(verifier.stack.pop()).ref_id());
             let value = state.read_ref(offset, id)?;
             verifier.stack.push(value)
         }
         Bytecode::WriteRef => {
-            let id = verifier.stack.pop().unwrap().ref_id().unwrap();
-            let val_operand = verifier.stack.pop().unwrap();
-            assert!(val_operand.is_value());
+            let id = safe_unwrap!(safe_unwrap!(verifier.stack.pop()).ref_id());
+            let val_operand = safe_unwrap!(verifier.stack.pop());
+            safe_assert!(val_operand.is_value());
             state.write_ref(offset, id)?
         }
 
@@ -176,7 +187,7 @@ fn execute_inner(
             verifier.stack.push(value)
         }
         Bytecode::MutBorrowField(field_handle_index) => {
-            let id = verifier.stack.pop().unwrap().ref_id().unwrap();
+            let id = safe_unwrap!(safe_unwrap!(verifier.stack.pop()).ref_id());
             let value = state.borrow_field(offset, true, id, *field_handle_index)?;
             verifier.stack.push(value)
         }
@@ -184,12 +195,12 @@ fn execute_inner(
             let field_inst = verifier
                 .resolver
                 .field_instantiation_at(*field_inst_index)?;
-            let id = verifier.stack.pop().unwrap().ref_id().unwrap();
+            let id = safe_unwrap!(safe_unwrap!(verifier.stack.pop()).ref_id());
             let value = state.borrow_field(offset, true, id, field_inst.handle)?;
             verifier.stack.push(value)
         }
         Bytecode::ImmBorrowField(field_handle_index) => {
-            let id = verifier.stack.pop().unwrap().ref_id().unwrap();
+            let id = safe_unwrap!(safe_unwrap!(verifier.stack.pop()).ref_id());
             let value = state.borrow_field(offset, false, id, *field_handle_index)?;
             verifier.stack.push(value)
         }
@@ -197,40 +208,40 @@ fn execute_inner(
             let field_inst = verifier
                 .resolver
                 .field_instantiation_at(*field_inst_index)?;
-            let id = verifier.stack.pop().unwrap().ref_id().unwrap();
+            let id = safe_unwrap!(safe_unwrap!(verifier.stack.pop()).ref_id());
             let value = state.borrow_field(offset, false, id, field_inst.handle)?;
             verifier.stack.push(value)
         }
 
         Bytecode::MutBorrowGlobal(idx) => {
-            assert!(verifier.stack.pop().unwrap().is_value());
+            safe_assert!(safe_unwrap!(verifier.stack.pop()).is_value());
             let value = state.borrow_global(offset, true, *idx)?;
             verifier.stack.push(value)
         }
         Bytecode::MutBorrowGlobalGeneric(idx) => {
-            assert!(verifier.stack.pop().unwrap().is_value());
+            safe_assert!(safe_unwrap!(verifier.stack.pop()).is_value());
             let struct_inst = verifier.resolver.struct_instantiation_at(*idx)?;
             let value = state.borrow_global(offset, true, struct_inst.def)?;
             verifier.stack.push(value)
         }
         Bytecode::ImmBorrowGlobal(idx) => {
-            assert!(verifier.stack.pop().unwrap().is_value());
+            safe_assert!(safe_unwrap!(verifier.stack.pop()).is_value());
             let value = state.borrow_global(offset, false, *idx)?;
             verifier.stack.push(value)
         }
         Bytecode::ImmBorrowGlobalGeneric(idx) => {
-            assert!(verifier.stack.pop().unwrap().is_value());
+            safe_assert!(safe_unwrap!(verifier.stack.pop()).is_value());
             let struct_inst = verifier.resolver.struct_instantiation_at(*idx)?;
             let value = state.borrow_global(offset, false, struct_inst.def)?;
             verifier.stack.push(value)
         }
         Bytecode::MoveFrom(idx) => {
-            assert!(verifier.stack.pop().unwrap().is_value());
+            safe_assert!(safe_unwrap!(verifier.stack.pop()).is_value());
             let value = state.move_from(offset, *idx)?;
             verifier.stack.push(value)
         }
         Bytecode::MoveFromGeneric(idx) => {
-            assert!(verifier.stack.pop().unwrap().is_value());
+            safe_assert!(safe_unwrap!(verifier.stack.pop()).is_value());
             let struct_inst = verifier.resolver.struct_instantiation_at(*idx)?;
             let value = state.move_from(offset, struct_inst.def)?;
             verifier.stack.push(value)
@@ -249,7 +260,7 @@ fn execute_inner(
         Bytecode::Ret => {
             let mut return_values = vec![];
             for _ in 0..verifier.function_view.return_().len() {
-                return_values.push(verifier.stack.pop().unwrap());
+                return_values.push(safe_unwrap!(verifier.stack.pop()));
             }
             return_values.reverse();
 
@@ -269,13 +280,13 @@ fn execute_inner(
         | Bytecode::ExistsGeneric(_) => (),
 
         Bytecode::BrTrue(_) | Bytecode::BrFalse(_) | Bytecode::Abort => {
-            assert!(verifier.stack.pop().unwrap().is_value());
+            safe_assert!(safe_unwrap!(verifier.stack.pop()).is_value());
         }
         Bytecode::MoveTo(_) | Bytecode::MoveToGeneric(_) => {
             // resource value
-            assert!(verifier.stack.pop().unwrap().is_value());
+            safe_assert!(safe_unwrap!(verifier.stack.pop()).is_value());
             // signer reference
-            state.release_value(verifier.stack.pop().unwrap());
+            state.release_value(safe_unwrap!(verifier.stack.pop()));
         }
 
         Bytecode::LdTrue | Bytecode::LdFalse => {
@@ -308,34 +319,34 @@ fn execute_inner(
         | Bytecode::Gt
         | Bytecode::Le
         | Bytecode::Ge => {
-            assert!(verifier.stack.pop().unwrap().is_value());
-            assert!(verifier.stack.pop().unwrap().is_value());
+            safe_assert!(safe_unwrap!(verifier.stack.pop()).is_value());
+            safe_assert!(safe_unwrap!(verifier.stack.pop()).is_value());
             // TODO maybe call state.value_for
             verifier.stack.push(AbstractValue::NonReference)
         }
 
         Bytecode::Pack(idx) => {
             let struct_def = verifier.resolver.struct_def_at(*idx)?;
-            pack(verifier, struct_def)
+            pack(verifier, struct_def)?
         }
         Bytecode::PackGeneric(idx) => {
             let struct_inst = verifier.resolver.struct_instantiation_at(*idx)?;
             let struct_def = verifier.resolver.struct_def_at(struct_inst.def)?;
-            pack(verifier, struct_def)
+            pack(verifier, struct_def)?
         }
         Bytecode::Unpack(idx) => {
             let struct_def = verifier.resolver.struct_def_at(*idx)?;
-            unpack(verifier, struct_def)
+            unpack(verifier, struct_def)?
         }
         Bytecode::UnpackGeneric(idx) => {
             let struct_inst = verifier.resolver.struct_instantiation_at(*idx)?;
             let struct_def = verifier.resolver.struct_def_at(struct_inst.def)?;
-            unpack(verifier, struct_def)
+            unpack(verifier, struct_def)?
         }
 
         Bytecode::VecPack(idx, num) => {
             for _ in 0..*num {
-                assert!(verifier.stack.pop().unwrap().is_value())
+                safe_assert!(safe_unwrap!(verifier.stack.pop()).is_value())
             }
 
             let element_type = vec_element_type(verifier, *idx)?;
@@ -345,32 +356,32 @@ fn execute_inner(
         }
 
         Bytecode::VecLen(_) => {
-            let vec_ref = verifier.stack.pop().unwrap();
+            let vec_ref = safe_unwrap!(verifier.stack.pop());
             state.vector_op(offset, vec_ref, false)?;
             verifier.stack.push(state.value_for(&SignatureToken::U64));
         }
 
         Bytecode::VecImmBorrow(_) => {
-            assert!(verifier.stack.pop().unwrap().is_value());
-            let vec_ref = verifier.stack.pop().unwrap();
+            safe_assert!(safe_unwrap!(verifier.stack.pop()).is_value());
+            let vec_ref = safe_unwrap!(verifier.stack.pop());
             let elem_ref = state.vector_element_borrow(offset, vec_ref, false)?;
             verifier.stack.push(elem_ref);
         }
         Bytecode::VecMutBorrow(_) => {
-            assert!(verifier.stack.pop().unwrap().is_value());
-            let vec_ref = verifier.stack.pop().unwrap();
+            safe_assert!(safe_unwrap!(verifier.stack.pop()).is_value());
+            let vec_ref = safe_unwrap!(verifier.stack.pop());
             let elem_ref = state.vector_element_borrow(offset, vec_ref, true)?;
             verifier.stack.push(elem_ref);
         }
 
         Bytecode::VecPushBack(_) => {
-            assert!(verifier.stack.pop().unwrap().is_value());
-            let vec_ref = verifier.stack.pop().unwrap();
+            safe_assert!(safe_unwrap!(verifier.stack.pop()).is_value());
+            let vec_ref = safe_unwrap!(verifier.stack.pop());
             state.vector_op(offset, vec_ref, true)?;
         }
 
         Bytecode::VecPopBack(idx) => {
-            let vec_ref = verifier.stack.pop().unwrap();
+            let vec_ref = safe_unwrap!(verifier.stack.pop());
             state.vector_op(offset, vec_ref, true)?;
 
             let element_type = vec_element_type(verifier, *idx)?;
@@ -378,7 +389,7 @@ fn execute_inner(
         }
 
         Bytecode::VecUnpack(idx, num) => {
-            assert!(verifier.stack.pop().unwrap().is_value());
+            safe_assert!(safe_unwrap!(verifier.stack.pop()).is_value());
 
             let element_type = vec_element_type(verifier, *idx)?;
             for _ in 0..*num {
@@ -387,9 +398,9 @@ fn execute_inner(
         }
 
         Bytecode::VecSwap(_) => {
-            assert!(verifier.stack.pop().unwrap().is_value());
-            assert!(verifier.stack.pop().unwrap().is_value());
-            let vec_ref = verifier.stack.pop().unwrap();
+            safe_assert!(safe_unwrap!(verifier.stack.pop()).is_value());
+            safe_assert!(safe_unwrap!(verifier.stack.pop()).is_value());
+            let vec_ref = safe_unwrap!(verifier.stack.pop());
             state.vector_op(offset, vec_ref, true)?;
         }
     };
@@ -408,7 +419,7 @@ impl<'a> TransferFunctions for ReferenceSafetyAnalysis<'a> {
     ) -> PartialVMResult<()> {
         execute_inner(self, state, bytecode, index)?;
         if index == last_index {
-            assert!(self.stack.is_empty());
+            safe_assert!(self.stack.is_empty());
             *state = state.construct_canonical_state()
         }
         Ok(())

--- a/language/move-bytecode-verifier/src/type_safety.rs
+++ b/language/move-bytecode-verifier/src/type_safety.rs
@@ -14,6 +14,7 @@ use move_binary_format::{
         FunctionHandle, LocalIndex, Signature, SignatureToken, SignatureToken as ST,
         StructDefinition, StructDefinitionIndex, StructFieldInformation, StructHandleIndex,
     },
+    safe_unwrap,
 };
 use move_core_types::vm_status::StatusCode;
 
@@ -104,7 +105,7 @@ fn borrow_field(
     type_args: &Signature,
 ) -> PartialVMResult<()> {
     // load operand and check mutability constraints
-    let operand = verifier.stack.pop().unwrap();
+    let operand = safe_unwrap!(verifier.stack.pop());
     if mut_ && !operand.is_mutable_reference() {
         return Err(verifier.error(StatusCode::BORROWFIELD_TYPE_MISMATCH_ERROR, offset));
     }
@@ -169,7 +170,7 @@ fn borrow_global(
     type_args: &Signature,
 ) -> PartialVMResult<()> {
     // check and consume top of stack
-    let operand = verifier.stack.pop().unwrap();
+    let operand = safe_unwrap!(verifier.stack.pop());
     if operand != ST::Address {
         return Err(verifier.error(StatusCode::BORROWGLOBAL_TYPE_MISMATCH_ERROR, offset));
     }
@@ -197,7 +198,7 @@ fn call(
 ) -> PartialVMResult<()> {
     let parameters = verifier.resolver.signature_at(function_handle.parameters);
     for parameter in parameters.0.iter().rev() {
-        let arg = verifier.stack.pop().unwrap();
+        let arg = safe_unwrap!(verifier.stack.pop());
         if arg != instantiate(parameter, type_actuals) {
             return Err(verifier.error(StatusCode::CALL_TYPE_MISMATCH_ERROR, offset));
         }
@@ -238,7 +239,7 @@ fn pack(
     let struct_type = materialize_type(struct_def.struct_handle, type_args);
     let field_sig = type_fields_signature(verifier, offset, struct_def, type_args)?;
     for sig in field_sig.0.iter().rev() {
-        let arg = verifier.stack.pop().unwrap();
+        let arg = safe_unwrap!(verifier.stack.pop());
         if &arg != sig {
             return Err(verifier.error(StatusCode::PACK_TYPE_MISMATCH_ERROR, offset));
         }
@@ -258,7 +259,7 @@ fn unpack(
 
     // Pop an abstract value from the stack and check if its type is equal to the one
     // declared.
-    let arg = verifier.stack.pop().unwrap();
+    let arg = safe_unwrap!(verifier.stack.pop());
     if arg != struct_type {
         return Err(verifier.error(StatusCode::UNPACK_TYPE_MISMATCH_ERROR, offset));
     }
@@ -284,7 +285,7 @@ fn exists(
         ));
     }
 
-    let operand = verifier.stack.pop().unwrap();
+    let operand = safe_unwrap!(verifier.stack.pop());
     if operand != ST::Address {
         // TODO better error here
         return Err(verifier.error(
@@ -309,7 +310,7 @@ fn move_from(
     }
 
     let struct_type = materialize_type(struct_def.struct_handle, type_args);
-    let operand = verifier.stack.pop().unwrap();
+    let operand = safe_unwrap!(verifier.stack.pop());
     if operand != ST::Address {
         return Err(verifier.error(StatusCode::MOVEFROM_TYPE_MISMATCH_ERROR, offset));
     }
@@ -330,8 +331,8 @@ fn move_to(
     }
 
     let struct_type = materialize_type(struct_def.struct_handle, type_args);
-    let key_struct_operand = verifier.stack.pop().unwrap();
-    let signer_reference_operand = verifier.stack.pop().unwrap();
+    let key_struct_operand = safe_unwrap!(verifier.stack.pop());
+    let signer_reference_operand = safe_unwrap!(verifier.stack.pop());
     if key_struct_operand != struct_type {
         return Err(verifier.error(StatusCode::MOVETO_TYPE_MISMATCH_ERROR, offset));
     }
@@ -350,8 +351,8 @@ fn borrow_vector_element(
     offset: CodeOffset,
     mut_ref_only: bool,
 ) -> PartialVMResult<()> {
-    let operand_idx = verifier.stack.pop().unwrap();
-    let operand_vec = verifier.stack.pop().unwrap();
+    let operand_idx = safe_unwrap!(verifier.stack.pop());
+    let operand_vec = safe_unwrap!(verifier.stack.pop());
 
     // check index
     if operand_idx != ST::U64 {
@@ -380,7 +381,7 @@ fn verify_instr(
 ) -> PartialVMResult<()> {
     match bytecode {
         Bytecode::Pop => {
-            let operand = verifier.stack.pop().unwrap();
+            let operand = safe_unwrap!(verifier.stack.pop());
             let abilities = verifier
                 .resolver
                 .abilities(&operand, verifier.function_view.type_parameters());
@@ -390,21 +391,21 @@ fn verify_instr(
         }
 
         Bytecode::BrTrue(_) | Bytecode::BrFalse(_) => {
-            let operand = verifier.stack.pop().unwrap();
+            let operand = safe_unwrap!(verifier.stack.pop());
             if operand != ST::Bool {
                 return Err(verifier.error(StatusCode::BR_TYPE_MISMATCH_ERROR, offset));
             }
         }
 
         Bytecode::StLoc(idx) => {
-            let operand = verifier.stack.pop().unwrap();
+            let operand = safe_unwrap!(verifier.stack.pop());
             if &operand != verifier.local_at(*idx) {
                 return Err(verifier.error(StatusCode::STLOC_TYPE_MISMATCH_ERROR, offset));
             }
         }
 
         Bytecode::Abort => {
-            let operand = verifier.stack.pop().unwrap();
+            let operand = safe_unwrap!(verifier.stack.pop());
             if operand != ST::U64 {
                 return Err(verifier.error(StatusCode::ABORT_TYPE_MISMATCH_ERROR, offset));
             }
@@ -413,7 +414,7 @@ fn verify_instr(
         Bytecode::Ret => {
             let return_ = &verifier.function_view.return_().0;
             for return_type in return_.iter().rev() {
-                let operand = verifier.stack.pop().unwrap();
+                let operand = safe_unwrap!(verifier.stack.pop());
                 if &operand != return_type {
                     return Err(verifier.error(StatusCode::RET_TYPE_MISMATCH_ERROR, offset));
                 }
@@ -423,7 +424,7 @@ fn verify_instr(
         Bytecode::Branch(_) | Bytecode::Nop => (),
 
         Bytecode::FreezeRef => {
-            let operand = verifier.stack.pop().unwrap();
+            let operand = safe_unwrap!(verifier.stack.pop());
             match operand {
                 ST::MutableReference(inner) => verifier.stack.push(ST::Reference(inner)),
                 _ => return Err(verifier.error(StatusCode::FREEZEREF_TYPE_MISMATCH_ERROR, offset)),
@@ -553,7 +554,7 @@ fn verify_instr(
         }
 
         Bytecode::ReadRef => {
-            let operand = verifier.stack.pop().unwrap();
+            let operand = safe_unwrap!(verifier.stack.pop());
             match operand {
                 ST::Reference(inner) | ST::MutableReference(inner) => {
                     if !verifier.abilities(&inner)?.has_copy() {
@@ -568,8 +569,8 @@ fn verify_instr(
         }
 
         Bytecode::WriteRef => {
-            let ref_operand = verifier.stack.pop().unwrap();
-            let val_operand = verifier.stack.pop().unwrap();
+            let ref_operand = safe_unwrap!(verifier.stack.pop());
+            let val_operand = safe_unwrap!(verifier.stack.pop());
             let ref_inner_signature = match ref_operand {
                 ST::MutableReference(inner) => *inner,
                 _ => {
@@ -588,21 +589,21 @@ fn verify_instr(
         }
 
         Bytecode::CastU8 => {
-            let operand = verifier.stack.pop().unwrap();
+            let operand = safe_unwrap!(verifier.stack.pop());
             if !operand.is_integer() {
                 return Err(verifier.error(StatusCode::INTEGER_OP_TYPE_MISMATCH_ERROR, offset));
             }
             verifier.stack.push(ST::U8);
         }
         Bytecode::CastU64 => {
-            let operand = verifier.stack.pop().unwrap();
+            let operand = safe_unwrap!(verifier.stack.pop());
             if !operand.is_integer() {
                 return Err(verifier.error(StatusCode::INTEGER_OP_TYPE_MISMATCH_ERROR, offset));
             }
             verifier.stack.push(ST::U64);
         }
         Bytecode::CastU128 => {
-            let operand = verifier.stack.pop().unwrap();
+            let operand = safe_unwrap!(verifier.stack.pop());
             if !operand.is_integer() {
                 return Err(verifier.error(StatusCode::INTEGER_OP_TYPE_MISMATCH_ERROR, offset));
             }
@@ -617,8 +618,8 @@ fn verify_instr(
         | Bytecode::BitOr
         | Bytecode::BitAnd
         | Bytecode::Xor => {
-            let operand1 = verifier.stack.pop().unwrap();
-            let operand2 = verifier.stack.pop().unwrap();
+            let operand1 = safe_unwrap!(verifier.stack.pop());
+            let operand2 = safe_unwrap!(verifier.stack.pop());
             if operand1.is_integer() && operand1 == operand2 {
                 verifier.stack.push(operand1);
             } else {
@@ -627,8 +628,8 @@ fn verify_instr(
         }
 
         Bytecode::Shl | Bytecode::Shr => {
-            let operand1 = verifier.stack.pop().unwrap();
-            let operand2 = verifier.stack.pop().unwrap();
+            let operand1 = safe_unwrap!(verifier.stack.pop());
+            let operand2 = safe_unwrap!(verifier.stack.pop());
             if operand2.is_integer() && operand1 == ST::U8 {
                 verifier.stack.push(operand2);
             } else {
@@ -637,8 +638,8 @@ fn verify_instr(
         }
 
         Bytecode::Or | Bytecode::And => {
-            let operand1 = verifier.stack.pop().unwrap();
-            let operand2 = verifier.stack.pop().unwrap();
+            let operand1 = safe_unwrap!(verifier.stack.pop());
+            let operand2 = safe_unwrap!(verifier.stack.pop());
             if operand1 == ST::Bool && operand2 == ST::Bool {
                 verifier.stack.push(ST::Bool);
             } else {
@@ -647,7 +648,7 @@ fn verify_instr(
         }
 
         Bytecode::Not => {
-            let operand = verifier.stack.pop().unwrap();
+            let operand = safe_unwrap!(verifier.stack.pop());
             if operand == ST::Bool {
                 verifier.stack.push(ST::Bool);
             } else {
@@ -656,8 +657,8 @@ fn verify_instr(
         }
 
         Bytecode::Eq | Bytecode::Neq => {
-            let operand1 = verifier.stack.pop().unwrap();
-            let operand2 = verifier.stack.pop().unwrap();
+            let operand1 = safe_unwrap!(verifier.stack.pop());
+            let operand2 = safe_unwrap!(verifier.stack.pop());
             if verifier.abilities(&operand1)?.has_drop() && operand1 == operand2 {
                 verifier.stack.push(ST::Bool);
             } else {
@@ -666,8 +667,8 @@ fn verify_instr(
         }
 
         Bytecode::Lt | Bytecode::Gt | Bytecode::Le | Bytecode::Ge => {
-            let operand1 = verifier.stack.pop().unwrap();
-            let operand2 = verifier.stack.pop().unwrap();
+            let operand1 = safe_unwrap!(verifier.stack.pop());
+            let operand2 = safe_unwrap!(verifier.stack.pop());
             if operand1.is_integer() && operand1 == operand2 {
                 verifier.stack.push(ST::Bool)
             } else {
@@ -734,7 +735,7 @@ fn verify_instr(
         Bytecode::VecPack(idx, num) => {
             let element_type = &verifier.resolver.signature_at(*idx).0[0];
             for _ in 0..*num {
-                let operand_type = verifier.stack.pop().unwrap();
+                let operand_type = safe_unwrap!(verifier.stack.pop());
                 if element_type != &operand_type {
                     return Err(verifier.error(StatusCode::TYPE_MISMATCH, offset));
                 }
@@ -745,7 +746,7 @@ fn verify_instr(
         }
 
         Bytecode::VecLen(idx) => {
-            let operand = verifier.stack.pop().unwrap();
+            let operand = safe_unwrap!(verifier.stack.pop());
             let declared_element_type = &verifier.resolver.signature_at(*idx).0[0];
             match get_vector_element_type(operand, false) {
                 Some(derived_element_type) if &derived_element_type == declared_element_type => {
@@ -765,8 +766,8 @@ fn verify_instr(
         }
 
         Bytecode::VecPushBack(idx) => {
-            let operand_elem = verifier.stack.pop().unwrap();
-            let operand_vec = verifier.stack.pop().unwrap();
+            let operand_elem = safe_unwrap!(verifier.stack.pop());
+            let operand_vec = safe_unwrap!(verifier.stack.pop());
             let declared_element_type = &verifier.resolver.signature_at(*idx).0[0];
             if declared_element_type != &operand_elem {
                 return Err(verifier.error(StatusCode::TYPE_MISMATCH, offset));
@@ -778,7 +779,7 @@ fn verify_instr(
         }
 
         Bytecode::VecPopBack(idx) => {
-            let operand_vec = verifier.stack.pop().unwrap();
+            let operand_vec = safe_unwrap!(verifier.stack.pop());
             let declared_element_type = &verifier.resolver.signature_at(*idx).0[0];
             match get_vector_element_type(operand_vec, true) {
                 Some(derived_element_type) if &derived_element_type == declared_element_type => {
@@ -789,7 +790,7 @@ fn verify_instr(
         }
 
         Bytecode::VecUnpack(idx, num) => {
-            let operand_vec = verifier.stack.pop().unwrap();
+            let operand_vec = safe_unwrap!(verifier.stack.pop());
             let declared_element_type = &verifier.resolver.signature_at(*idx).0[0];
             if operand_vec != ST::Vector(Box::new(declared_element_type.clone())) {
                 return Err(verifier.error(StatusCode::TYPE_MISMATCH, offset));
@@ -800,9 +801,9 @@ fn verify_instr(
         }
 
         Bytecode::VecSwap(idx) => {
-            let operand_idx2 = verifier.stack.pop().unwrap();
-            let operand_idx1 = verifier.stack.pop().unwrap();
-            let operand_vec = verifier.stack.pop().unwrap();
+            let operand_idx2 = safe_unwrap!(verifier.stack.pop());
+            let operand_idx1 = safe_unwrap!(verifier.stack.pop());
+            let operand_vec = safe_unwrap!(verifier.stack.pop());
             if operand_idx1 != ST::U64 || operand_idx2 != ST::U64 {
                 return Err(verifier.error(StatusCode::TYPE_MISMATCH, offset));
             }
@@ -813,21 +814,21 @@ fn verify_instr(
             };
         }
         Bytecode::CastU16 => {
-            let operand = verifier.stack.pop().unwrap();
+            let operand = safe_unwrap!(verifier.stack.pop());
             if !operand.is_integer() {
                 return Err(verifier.error(StatusCode::INTEGER_OP_TYPE_MISMATCH_ERROR, offset));
             }
             verifier.stack.push(ST::U16);
         }
         Bytecode::CastU32 => {
-            let operand = verifier.stack.pop().unwrap();
+            let operand = safe_unwrap!(verifier.stack.pop());
             if !operand.is_integer() {
                 return Err(verifier.error(StatusCode::INTEGER_OP_TYPE_MISMATCH_ERROR, offset));
             }
             verifier.stack.push(ST::U32);
         }
         Bytecode::CastU256 => {
-            let operand = verifier.stack.pop().unwrap();
+            let operand = safe_unwrap!(verifier.stack.pop());
             if !operand.is_integer() {
                 return Err(verifier.error(StatusCode::INTEGER_OP_TYPE_MISMATCH_ERROR, offset));
             }


### PR DESCRIPTION
This introduces new macros `safe_unpack!` and `safe_assert!` which can be used in contexts which have a `PartialVMResult` as a return value. Those macros panic when debug assertions are enabled, but otherwise generate an internal invariant violation error. They are applied where an obvious substitution is possible.

