### PR TITLE
[core-types] cherry-pick: Make TypeTag enum use less memory

### DIFF
--- a/language/extensions/async/move-async-vm/src/async_vm.rs
+++ b/language/extensions/async/move-async-vm/src/async_vm.rs
@@ -179,7 +179,7 @@ impl<'r, 'l, S: MoveResolver> AsyncSession<'r, 'l, S> {
             .actor_metadata
             .get(module_id)
             .ok_or_else(|| async_extension_error(format!("actor `{}` unknown", module_id)))?;
-        let state_type_tag = TypeTag::Struct(actor.state_tag.clone());
+        let state_type_tag = TypeTag::Struct(Box::new(actor.state_tag.clone()));
         let state_type = self
             .vm_session
             .load_type(&state_type_tag)
@@ -275,7 +275,7 @@ impl<'r, 'l, S: MoveResolver> AsyncSession<'r, 'l, S> {
         })?;
 
         // Load the resource representing the actor state and add to arguments.
-        let state_type_tag = TypeTag::Struct(actor.state_tag.clone());
+        let state_type_tag = TypeTag::Struct(Box::new(actor.state_tag.clone()));
         let state_type = self
             .vm_session
             .load_type(&state_type_tag)

--- a/language/move-binary-format/src/normalized.rs
+++ b/language/move-binary-format/src/normalized.rs
@@ -224,7 +224,7 @@ impl Type {
                     module,
                     name,
                     type_arguments,
-                } => TypeTag::Struct(StructTag {
+                } => TypeTag::Struct(Box::new(StructTag {
                     address,
                     module,
                     name,
@@ -236,7 +236,7 @@ impl Type {
                             )
                         })
                         .collect(),
-                }),
+                })),
                 TypeParameter(_) => unreachable!(),
             }
         } else {
@@ -246,7 +246,7 @@ impl Type {
 
     pub fn into_struct_tag(self) -> Option<StructTag> {
         match self.into_type_tag()? {
-            TypeTag::Struct(s) => Some(s),
+            TypeTag::Struct(s) => Some(*s),
             _ => None,
         }
     }

--- a/language/move-command-line-common/src/types.rs
+++ b/language/move-command-line-common/src/types.rs
@@ -153,7 +153,7 @@ impl ParsedType {
             ParsedType::Address => TypeTag::Address,
             ParsedType::Signer => TypeTag::Signer,
             ParsedType::Vector(inner) => TypeTag::Vector(Box::new(inner.into_type_tag(mapping)?)),
-            ParsedType::Struct(s) => TypeTag::Struct(s.into_struct_tag(mapping)?),
+            ParsedType::Struct(s) => TypeTag::Struct(Box::new(s.into_struct_tag(mapping)?)),
         })
     }
 }

--- a/language/move-core/types/src/language_storage.rs
+++ b/language/move-core/types/src/language_storage.rs
@@ -39,7 +39,7 @@ pub enum TypeTag {
     #[serde(rename = "vector", alias = "Vector")]
     Vector(Box<TypeTag>),
     #[serde(rename = "struct", alias = "Struct")]
-    Struct(StructTag),
+    Struct(Box<StructTag>),
 
     // NOTE: Added in bytecode version v6, do not reorder!
     #[serde(rename = "u16", alias = "U16")]
@@ -271,7 +271,7 @@ impl Display for ResourceKey {
 
 impl From<StructTag> for TypeTag {
     fn from(t: StructTag) -> TypeTag {
-        TypeTag::Struct(t)
+        TypeTag::Struct(Box::new(t))
     }
 }
 
@@ -281,17 +281,19 @@ mod tests {
     use crate::{
         account_address::AccountAddress, identifier::Identifier, language_storage::StructTag,
     };
+    use std::mem;
 
     #[test]
     fn test_type_tag_serde() {
-        let a = TypeTag::Struct(StructTag {
+        let a = TypeTag::Struct(Box::new(StructTag {
             address: AccountAddress::ONE,
             module: Identifier::from_utf8(("abc".as_bytes()).to_vec()).unwrap(),
             name: Identifier::from_utf8(("abc".as_bytes()).to_vec()).unwrap(),
             type_params: vec![TypeTag::U8],
-        });
+        }));
         let b = serde_json::to_string(&a).unwrap();
         let c: TypeTag = serde_json::from_str(&b).unwrap();
-        assert!(a.eq(&c), "Typetag serde error")
+        assert!(a.eq(&c), "Typetag serde error");
+        assert_eq!(mem::size_of::<TypeTag>(), 16);
     }
 }

--- a/language/move-core/types/src/parser.rs
+++ b/language/move-core/types/src/parser.rs
@@ -303,12 +303,12 @@ impl<I: Iterator<Item = Token>> Parser<I> {
                                 } else {
                                     vec![]
                                 };
-                                TypeTag::Struct(StructTag {
+                                TypeTag::Struct(Box::new(StructTag {
                                     address: AccountAddress::from_hex_literal(&addr)?,
                                     module: Identifier::new(module)?,
                                     name: Identifier::new(name)?,
                                     type_params: ty_args,
-                                })
+                                }))
                             }
                             t => bail!("expected name, got {:?}", t),
                         }
@@ -388,7 +388,7 @@ pub fn parse_struct_tag(s: &str) -> Result<StructTag> {
     let type_tag = parse(s, |parser| parser.parse_type_tag())
         .map_err(|e| format_err!("invalid struct tag: {}, {}", s, e))?;
     if let TypeTag::Struct(struct_tag) = type_tag {
-        Ok(struct_tag)
+        Ok(*struct_tag)
     } else {
         bail!("invalid struct tag: {}", s)
     }

--- a/language/move-core/types/src/proptest_types.rs
+++ b/language/move-core/types/src/proptest_types.rs
@@ -38,12 +38,12 @@ impl Arbitrary for TypeTag {
                     vec(inner, 0..4),
                 )
                     .prop_map(|(address, module, name, type_params)| {
-                        Struct(StructTag {
+                        Struct(Box::new(StructTag {
                             address,
                             module,
                             name,
                             type_params,
-                        })
+                        }))
                     })
             },
         )

--- a/language/move-core/types/src/value.rs
+++ b/language/move-core/types/src/value.rs
@@ -571,7 +571,7 @@ impl TryInto<TypeTag> for &MoveTypeLayout {
                 let inner_type = &**v;
                 TypeTag::Vector(Box::new(inner_type.try_into()?))
             }
-            MoveTypeLayout::Struct(v) => TypeTag::Struct(v.try_into()?),
+            MoveTypeLayout::Struct(v) => TypeTag::Struct(Box::new(v.try_into()?)),
         })
     }
 }

--- a/language/move-prover/bytecode/src/packed_types_analysis.rs
+++ b/language/move-prover/bytecode/src/packed_types_analysis.rs
@@ -56,7 +56,7 @@ pub fn get_packed_types(
                             for coin_ty in &coin_types {
                                 match open_ty.instantiate(vec![coin_ty.clone()].as_slice()).into_type_tag(env) {
                                     Some(TypeTag::Struct(s)) =>     {
-                                        packed_types.insert(s);
+                                        packed_types.insert(*s);
                                     }
                                     _ => panic!("Invariant violation: failed to specialize tx script open type {:?} into struct", open_ty),
                                 }
@@ -137,7 +137,7 @@ impl<'a> TransferFunctions for PackedTypesAnalysis<'a> {
                             } else if let Some(TypeTag::Struct(s)) =
                                 specialized_ty.into_type_tag(self.cache.global_env())
                             {
-                                state.closed_types.insert(s);
+                                state.closed_types.insert(*s);
                             } else {
                                 panic!("Invariant violation: struct type {:?} became non-struct type after substitution", open_ty)
                             }

--- a/language/move-prover/interpreter/src/concrete/ty.rs
+++ b/language/move-prover/interpreter/src/concrete/ty.rs
@@ -462,7 +462,7 @@ impl BaseType {
             BaseType::Primitive(PrimitiveType::Address) => TypeTag::Address,
             BaseType::Primitive(PrimitiveType::Signer) => TypeTag::Signer,
             BaseType::Vector(elem) => TypeTag::Vector(Box::new(elem.to_move_type_tag())),
-            BaseType::Struct(inst) => TypeTag::Struct(inst.to_move_struct_tag()),
+            BaseType::Struct(inst) => TypeTag::Struct(Box::new(inst.to_move_struct_tag())),
         }
     }
 

--- a/language/move-prover/move-abigen/src/abigen.rs
+++ b/language/move-prover/move-abigen/src/abigen.rs
@@ -291,7 +291,7 @@ impl<'env> Abigen<'env> {
                 let struct_module_env = module_env.env.get_module(*module_id);
                 let abilities = struct_module_env.get_struct(*struct_id).get_abilities();
                 if abilities.has_ability(Ability::Copy) && !abilities.has_ability(Ability::Key) {
-                    TypeTag::Struct(StructTag {
+                    TypeTag::Struct(Box::new(StructTag {
                         address: *struct_module_env.self_address(),
                         module: struct_module_env.get_identifier(),
                         name: struct_module_env
@@ -306,7 +306,7 @@ impl<'env> Abigen<'env> {
                             })
                             .map(|e| e.unwrap_or_else(|| panic!("{}", expect_msg)))
                             .collect(),
-                    })
+                    }))
                 } else {
                     return Ok(None);
                 }

--- a/language/move-vm/runtime/src/data_cache.rs
+++ b/language/move-vm/runtime/src/data_cache.rs
@@ -93,7 +93,7 @@ impl<'r, 'l, S: MoveResolver> TransactionDataCache<'r, 'l, S> {
                 };
 
                 let struct_tag = match self.loader.type_to_type_tag(&ty)? {
-                    TypeTag::Struct(struct_tag) => struct_tag,
+                    TypeTag::Struct(struct_tag) => *struct_tag,
                     _ => return Err(PartialVMError::new(StatusCode::INTERNAL_TYPE_ERROR)),
                 };
 

--- a/language/move-vm/runtime/src/loader.rs
+++ b/language/move-vm/runtime/src/loader.rs
@@ -2273,9 +2273,11 @@ impl Loader {
             Type::Address => TypeTag::Address,
             Type::Signer => TypeTag::Signer,
             Type::Vector(ty) => TypeTag::Vector(Box::new(self.type_to_type_tag(ty)?)),
-            Type::Struct(gidx) => TypeTag::Struct(self.struct_gidx_to_type_tag(*gidx, &[])?),
+            Type::Struct(gidx) => {
+                TypeTag::Struct(Box::new(self.struct_gidx_to_type_tag(*gidx, &[])?))
+            }
             Type::StructInstantiation(gidx, ty_args) => {
-                TypeTag::Struct(self.struct_gidx_to_type_tag(*gidx, ty_args)?)
+                TypeTag::Struct(Box::new(self.struct_gidx_to_type_tag(*gidx, ty_args)?))
             }
             Type::Reference(_) | Type::MutableReference(_) | Type::TyParam(_) => {
                 return Err(

--- a/language/tools/move-cli/src/sandbox/utils/on_disk_state_view.rs
+++ b/language/tools/move-cli/src/sandbox/utils/on_disk_state_view.rs
@@ -452,7 +452,7 @@ struct Generics(Vec<TypeTag>);
 impl ToString for TypeID {
     fn to_string(&self) -> String {
         match &self.0 {
-            TypeTag::Struct(s) => StructID(s.clone()).to_string(),
+            TypeTag::Struct(s) => StructID(*s.clone()).to_string(),
             TypeTag::Vector(t) => format!("vector<{}>", TypeID(*t.clone()).to_string()),
             t => t.to_string(),
         }

--- a/language/tools/move-resource-viewer/src/fat_type.rs
+++ b/language/tools/move-resource-viewer/src/fat_type.rs
@@ -158,7 +158,7 @@ impl FatType {
             Address => TypeTag::Address,
             Signer => TypeTag::Signer,
             Vector(ty) => TypeTag::Vector(Box::new(ty.type_tag()?)),
-            Struct(struct_ty) => TypeTag::Struct(struct_ty.struct_tag()?),
+            Struct(struct_ty) => TypeTag::Struct(Box::new(struct_ty.struct_tag()?)),
 
             Reference(_) | MutableReference(_) | TyParam(_) => {
                 return Err(

--- a/language/tools/move-resource-viewer/src/lib.rs
+++ b/language/tools/move-resource-viewer/src/lib.rs
@@ -74,7 +74,7 @@ impl AnnotatedMoveValue {
             Address(_) => TypeTag::Address,
             Vector(t, _) => t.clone(),
             Bytes(_) => TypeTag::Vector(Box::new(TypeTag::U8)),
-            Struct(s) => TypeTag::Struct(s.type_.clone()),
+            Struct(s) => TypeTag::Struct(Box::new(s.type_.clone())),
         }
     }
 }

--- a/language/tools/read-write-set/dynamic/src/dynamic_analysis.rs
+++ b/language/tools/read-write-set/dynamic/src/dynamic_analysis.rs
@@ -219,8 +219,11 @@ impl ConcretizedFormals {
                 .get_resource(g, &tag)
                 .map_err(|_| anyhow!("Failed to get resource for {:?}::{:?}", g, tag))?
             {
-                let layout = TypeLayoutBuilder::build_runtime(&TypeTag::Struct(tag), module_cache)
-                    .map_err(|_| anyhow!("Failed to resolve type: {:?}", access_path.root.type_))?;
+                let layout =
+                    TypeLayoutBuilder::build_runtime(&TypeTag::Struct(Box::new(tag)), module_cache)
+                        .map_err(|_| {
+                            anyhow!("Failed to resolve type: {:?}", access_path.root.type_)
+                        })?;
 
                 let resource =
                     MoveValue::simple_deserialize(&resource_bytes, &layout).map_err(|_| {


### PR DESCRIPTION
Cherry-picking https://github.com/move-language/move/pull/525

> Currently a single TypeTag consumes 96 bytes because of the inlined StructTag (88 bytes), it starts to bloat up with nested TypeTag::Vector(TypeTag).
This commit reduces the size from 96 to 16 bytes, it doesn't fully solve the problem but reduces the impact by 6x.
