### PR TITLE
[move-prover] better type info scheme

### DIFF
--- a/language/move-model/src/well_known.rs
+++ b/language/move-model/src/well_known.rs
@@ -14,3 +14,4 @@ pub const TYPE_NAME_MOVE: &str = "type_info::type_name";
 pub const TYPE_NAME_SPEC: &str = "type_info::$type_name";
 pub const TYPE_INFO_MOVE: &str = "type_info::type_of";
 pub const TYPE_INFO_SPEC: &str = "type_info::$type_of";
+pub const TYPE_SPEC_IS_STRUCT: &str = "type_info::spec_is_struct";

--- a/language/move-prover/boogie-backend/src/boogie_helpers.rs
+++ b/language/move-prover/boogie-backend/src/boogie_helpers.rs
@@ -722,3 +722,12 @@ pub fn boogie_reflection_type_info(env: &GlobalEnv, ty: &Type) -> (String, Strin
         ),
     }
 }
+
+/// Encode the test on whether a type is a struct in a format that can be recognized by Boogie
+pub fn boogie_reflection_type_is_struct(env: &GlobalEnv, ty: &Type) -> String {
+    match type_name_to_info_pack(env, ty) {
+        None => "false".to_string(),
+        Some(TypeInfoPack::Struct(..)) => "true".to_string(),
+        Some(TypeInfoPack::Symbolic(idx)) => format!("is#$TypeParamStruct(#{}_info)", idx),
+    }
+}

--- a/language/move-prover/boogie-backend/src/prelude/native.bpl
+++ b/language/move-prover/boogie-backend/src/prelude/native.bpl
@@ -23,6 +23,18 @@ function $IsEqual'vec{{S}}'(v1: Vec ({{T}}), v2: Vec ({{T}})): bool {
 {%- endif %}
 
 // Not inlined.
+function $IsPrefix'vec{{S}}'(v: Vec ({{T}}), prefix: Vec ({{T}})): bool {
+    LenVec(v) >= LenVec(prefix) &&
+    (forall i: int:: InRangeVec(prefix, i) ==> $IsEqual{{S}}(ReadVec(v, i), ReadVec(prefix, i)))
+}
+
+// Not inlined.
+function $IsSuffix'vec{{S}}'(v: Vec ({{T}}), suffix: Vec ({{T}})): bool {
+    LenVec(v) >= LenVec(suffix) &&
+    (forall i: int:: InRangeVec(suffix, i) ==> $IsEqual{{S}}(ReadVec(v, LenVec(v) - LenVec(suffix) + i), ReadVec(suffix, i)))
+}
+
+// Not inlined.
 function $IsValid'vec{{S}}'(v: Vec ({{T}})): bool {
     $IsValid'u64'(LenVec(v)) &&
     (forall i: int:: InRangeVec(v, i) ==> $IsValid{{S}}(ReadVec(v, i)))

--- a/language/move-prover/boogie-backend/src/prelude/prelude.bpl
+++ b/language/move-prover/boogie-backend/src/prelude/prelude.bpl
@@ -1024,3 +1024,20 @@ axiom $EventStore__is_empty($EmptyEventStore);
 procedure {:inline 1} $InitEventStore() {
 }
 {%- endif %}
+
+// ============================================================================================
+// Type Reflection on Type Parameters
+
+type {:datatype} $TypeParamInfo;
+
+function {:constructor} $TypeParamBool(): $TypeParamInfo;
+function {:constructor} $TypeParamU8(): $TypeParamInfo;
+function {:constructor} $TypeParamU16(): $TypeParamInfo;
+function {:constructor} $TypeParamU32(): $TypeParamInfo;
+function {:constructor} $TypeParamU64(): $TypeParamInfo;
+function {:constructor} $TypeParamU128(): $TypeParamInfo;
+function {:constructor} $TypeParamU256(): $TypeParamInfo;
+function {:constructor} $TypeParamAddress(): $TypeParamInfo;
+function {:constructor} $TypeParamSigner(): $TypeParamInfo;
+function {:constructor} $TypeParamVector(e: $TypeParamInfo): $TypeParamInfo;
+function {:constructor} $TypeParamStruct(a: int, m: Vec int, s: Vec int): $TypeParamInfo;

--- a/language/move-prover/boogie-backend/src/spec_translator.rs
+++ b/language/move-prover/boogie-backend/src/spec_translator.rs
@@ -27,7 +27,7 @@ use move_model::{
     },
     symbol::Symbol,
     ty::{PrimitiveType, Type},
-    well_known::{TYPE_INFO_SPEC, TYPE_NAME_SPEC},
+    well_known::{TYPE_INFO_SPEC, TYPE_NAME_SPEC, TYPE_SPEC_IS_STRUCT},
 };
 use move_stackless_bytecode::mono_analysis::MonoInfo;
 
@@ -35,9 +35,10 @@ use crate::{
     boogie_helpers::{
         boogie_address_blob, boogie_byte_blob, boogie_choice_fun_name, boogie_declare_global,
         boogie_field_sel, boogie_inst_suffix, boogie_modifies_memory_name,
-        boogie_reflection_type_info, boogie_reflection_type_name, boogie_resource_memory_name,
-        boogie_spec_fun_name, boogie_spec_var_name, boogie_struct_name, boogie_type,
-        boogie_type_suffix, boogie_value_blob, boogie_well_formed_expr,
+        boogie_reflection_type_info, boogie_reflection_type_is_struct, boogie_reflection_type_name,
+        boogie_resource_memory_name, boogie_spec_fun_name, boogie_spec_var_name,
+        boogie_struct_name, boogie_type, boogie_type_suffix, boogie_value_blob,
+        boogie_well_formed_expr,
     },
     options::BoogieOptions,
 };
@@ -905,6 +906,14 @@ impl<'env> SpecTranslator<'env> {
                 // invoking `type_info` on a primitive type like: `type_info<bool>`.
                 let (_, info) = boogie_reflection_type_info(self.env, &inst[0]);
                 emit!(self.writer, "{}", info);
+                processed = true;
+            } else if qualified_name == TYPE_SPEC_IS_STRUCT {
+                assert_eq!(inst.len(), 1);
+                emit!(
+                    self.writer,
+                    "{}",
+                    boogie_reflection_type_is_struct(self.env, &inst[0])
+                );
                 processed = true;
             }
         }

--- a/language/move-prover/bytecode/src/mono_analysis.rs
+++ b/language/move-prover/bytecode/src/mono_analysis.rs
@@ -22,7 +22,9 @@ use move_model::{
     },
     pragmas::INTRINSIC_TYPE_MAP,
     ty::{Type, TypeDisplayContext, TypeInstantiationDerivation, TypeUnificationAdapter, Variance},
-    well_known::{TYPE_INFO_MOVE, TYPE_INFO_SPEC, TYPE_NAME_MOVE, TYPE_NAME_SPEC},
+    well_known::{
+        TYPE_INFO_MOVE, TYPE_INFO_SPEC, TYPE_NAME_MOVE, TYPE_NAME_SPEC, TYPE_SPEC_IS_STRUCT,
+    },
 };
 
 use crate::{
@@ -467,7 +469,10 @@ impl<'a> Analyzer<'a> {
                         module.get_name().name().display(self.env.symbol_pool()),
                         spec_fun.name.display(self.env.symbol_pool()),
                     );
-                    if qualified_name == TYPE_NAME_SPEC || qualified_name == TYPE_INFO_SPEC {
+                    if qualified_name == TYPE_NAME_SPEC
+                        || qualified_name == TYPE_INFO_SPEC
+                        || qualified_name == TYPE_SPEC_IS_STRUCT
+                    {
                         self.add_type(&actuals[0]);
                     }
                 }

--- a/language/move-prover/tests/sources/functional/loops_with_memory_ops.exp
+++ b/language/move-prover/tests/sources/functional/loops_with_memory_ops.exp
@@ -43,10 +43,10 @@ error: unknown assertion failed
    =         y = <redacted>
    =     at tests/sources/functional/loops_with_memory_ops.move:80: nested_loop2
    =     at tests/sources/functional/loops_with_memory_ops.move:81: nested_loop2
-   =         b = <redacted>
-   =         b = <redacted>
    =     at <internal>:1
    =     at tests/sources/functional/loops_with_memory_ops.move:81: nested_loop2
+   =         b = <redacted>
+   =         a = <redacted>
    =         a = <redacted>
    =     at tests/sources/functional/loops_with_memory_ops.move:85: nested_loop2
    =         i = <redacted>
@@ -98,10 +98,11 @@ error: induction case of the loop invariant does not hold
    =     at tests/sources/functional/loops_with_memory_ops.move:80: nested_loop2
    =     at tests/sources/functional/loops_with_memory_ops.move:81: nested_loop2
    =         b = <redacted>
+   =         b = <redacted>
    =     at <internal>:1
    =     at tests/sources/functional/loops_with_memory_ops.move:81: nested_loop2
-   =         a = <redacted>
-   =         a = <redacted>
+   =     at <internal>:1
+   =     at tests/sources/functional/loops_with_memory_ops.move:81: nested_loop2
    =     at tests/sources/functional/loops_with_memory_ops.move:85: nested_loop2
    =         i = <redacted>
    =     at tests/sources/functional/loops_with_memory_ops.move:86: nested_loop2

--- a/language/move-prover/tests/sources/functional/type_reflection.exp
+++ b/language/move-prover/tests/sources/functional/type_reflection.exp
@@ -1,15 +1,15 @@
 Move prover returns: exiting with verification errors
 error: abort not covered by any of the `aborts_if` clauses
-    ┌─ tests/sources/functional/type_reflection.move:98:5
+    ┌─ tests/sources/functional/type_reflection.move:99:5
     │
- 96 │           type_info::type_of<T>()
+ 97 │           type_info::type_of<T>()
     │           ----------------------- abort happened here with execution failure
- 97 │       }
- 98 │ ╭     spec test_type_info_can_abort {
- 99 │ │         // this should not pass
-100 │ │         aborts_if false;
-101 │ │     }
+ 98 │       }
+ 99 │ ╭     spec test_type_info_can_abort {
+100 │ │         // this should not pass
+101 │ │         aborts_if false;
+102 │ │     }
     │ ╰─────^
     │
-    =     at tests/sources/functional/type_reflection.move:96: test_type_info_can_abort
+    =     at tests/sources/functional/type_reflection.move:97: test_type_info_can_abort
     =         ABORTED

--- a/language/move-prover/tests/sources/functional/type_reflection.move
+++ b/language/move-prover/tests/sources/functional/type_reflection.move
@@ -10,6 +10,7 @@ module extensions::type_info {
     // these are mocks of the type reflection scheme
     public native fun type_of<T>(): TypeInfo;
     public native fun type_name<T>(): string::String;
+    spec native fun spec_is_struct<T>(): bool;
 
     public fun account_address(type_info: &TypeInfo): address {
         type_info.account_address
@@ -100,14 +101,21 @@ module 0x42::test {
         aborts_if false;
     }
 
-    fun test_type_info_can_abort_if<T>(): (type_info::TypeInfo, string::String) {
+    fun test_type_info_aborts_if_partial<T>(): (type_info::TypeInfo, string::String) {
         (type_info::type_of<T>(), type_info::type_name<T>())
     }
-    spec test_type_info_can_abort_if {
+    spec test_type_info_aborts_if_partial {
         pragma aborts_if_is_partial = true;
         aborts_if type_info::type_name<T>().bytes == b"bool";
         aborts_if type_info::type_name<T>().bytes == b"u64";
         aborts_if type_info::type_name<T>().bytes == b"signer";
         aborts_if type_info::type_name<T>().bytes == b"vector<address>";
+    }
+
+    fun test_type_info_aborts_if_full<T>(): (type_info::TypeInfo, string::String) {
+        (type_info::type_of<T>(), type_info::type_name<T>())
+    }
+    spec test_type_info_aborts_if_full {
+        aborts_if !type_info::spec_is_struct<T>();
     }
 }

--- a/language/move-prover/tests/sources/functional/type_reflection.move
+++ b/language/move-prover/tests/sources/functional/type_reflection.move
@@ -99,4 +99,15 @@ module 0x42::test {
         // this should not pass
         aborts_if false;
     }
+
+    fun test_type_info_can_abort_if<T>(): (type_info::TypeInfo, string::String) {
+        (type_info::type_of<T>(), type_info::type_name<T>())
+    }
+    spec test_type_info_can_abort_if {
+        pragma aborts_if_is_partial = true;
+        aborts_if type_info::type_name<T>().bytes == b"bool";
+        aborts_if type_info::type_name<T>().bytes == b"u64";
+        aborts_if type_info::type_name<T>().bytes == b"signer";
+        aborts_if type_info::type_name<T>().bytes == b"vector<address>";
+    }
 }


### PR DESCRIPTION
This PR improves the type reflection modeling in Move Prover/

In this PR, the type info for a type parameter is modeled as a Boogie Datatype:

```
var #0_info: $TypeParamInfo;

// where $TypeParamInfo is defined as:

type {:datatype} $TypeParamInfo;

function {:constructor} $TypeParamBool(): $TypeParamInfo;
function {:constructor} $TypeParamU8(): $TypeParamInfo;
function {:constructor} $TypeParamU16(): $TypeParamInfo;
function {:constructor} $TypeParamU32(): $TypeParamInfo;
function {:constructor} $TypeParamU64(): $TypeParamInfo;
function {:constructor} $TypeParamU128(): $TypeParamInfo;
function {:constructor} $TypeParamU256(): $TypeParamInfo;
function {:constructor} $TypeParamAddress(): $TypeParamInfo;
function {:constructor} $TypeParamSigner(): $TypeParamInfo;
function {:constructor} $TypeParamVector(e: $TypeParamInfo): $TypeParamInfo;
function {:constructor} $TypeParamStruct(a: int, m: Vec int, s: Vec int): $TypeParamInfo;
```

This is a more elegant and more expressive encoding than the previous approach where the type info is modeled by a series of variables:

```
var #0_name: Vec int;
var #0_is_struct: bool;
var #0_account_address: int;
var #0_module_name: Vec int;
var #0_struct_name: Vec int;
```

The second improvement of this commit is the axiomitization of the relation between a type and its name. This is achieved by defining type name as an uninterpreted function and using `axiom` to define its semantics:

```
function $TypeName(t: $TypeParamInfo): Vec int;

axiom is#$TypeParamBool(t) <==> $TypeName(t) == "bool";
axiom is#$TypeParamU8(t) <==> $TypeName(t) == "u8";
axiom is#$TypeParamU16(t) <==> $TypeName(t) == "u16";
axiom is#$TypeParamU32(t) <==> $TypeName(t) == "u32";
axiom is#$TypeParamU64(t) <==> $TypeName(t) == "u64";
axiom is#$TypeParamU128(t) <==> $TypeName(t) == "u128";
axiom is#$TypeParamU256(t) <==> $TypeName(t) == "u256";
axiom is#$TypeParamAddress(t) <==> $TypeName(t) == "address";
axiom is#$TypeParamSigner(t) <==> $TypeName(t) == "signer";

// NOTE: for vector, the axiomization does not parse the vector element name
axiom is#$TypeParamVector(t) ==> $TypeName(t) == "vector<" ++ $TypeName(e#t) ++ ">";
axiom $TypeName(t).starts_with("vector<") && $TypeName(t).ends_with(">") ==> is#$TypeParamVector(t);

// NOTE: for struct, the axiomization does not parse the module and struct name
axiom is#$TypeParamStruct(t) ==> $TypeName(t) == "0x" ++ a#t ++ "::" ++ m#t ++ "::" ++ s#t;
axiom $TypeName(t).starts_with("0x") ==> is#$TypeParamStruct(t);
```

This allows for partial specification of aborts conditions where `type_info<T>` call is involved (it aborts when `T` is not a struct). But this is only partial.

The last important piece in this PR is the introduction of  `spec fun spec_is_struct<T>(): bool` primitive to capture this semantics. In the translation level, `spec_is_struct<T>()` is simply translated to
- either "true" or "false" if `T` is known after monomorphization or
- `is#$TypeParamStruct(#<N>)` if `T` is unknown

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Move Language.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Close #645

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes

## Test Plan

- CI
- a new test case is added
