### PR TITLE
[move-model] two ways to test is_intrinsic

### DIFF
--- a/language/extensions/move-table-extension/sources/Table.spec.move
+++ b/language/extensions/move-table-extension/sources/Table.spec.move
@@ -21,42 +21,6 @@ spec extensions::table {
             map_spec_has_key = spec_contains;
     }
 
-    spec new {
-        pragma intrinsic;
-    }
-
-    spec destroy_empty {
-        pragma intrinsic;
-    }
-
-    spec add {
-        pragma intrinsic;
-    }
-
-    spec borrow {
-        pragma intrinsic;
-    }
-
-    spec borrow_mut {
-        pragma intrinsic;
-    }
-
-    spec length {
-        pragma intrinsic;
-    }
-
-    spec empty {
-        pragma intrinsic;
-    }
-
-    spec remove {
-        pragma intrinsic;
-    }
-
-    spec contains {
-        pragma intrinsic;
-    }
-
     // Specification functions for tables
 
     spec native fun spec_len<K, V>(t: Table<K, V>): num;

--- a/language/move-model/src/intrinsics.rs
+++ b/language/move-model/src/intrinsics.rs
@@ -283,6 +283,20 @@ impl IntrinsicsAnnotation {
             .map(|id| self.decls.get(id).unwrap())
     }
 
+    /// Get the intrinsic decl for a move function
+    pub fn get_decl_for_move_fun(&self, qid: &QualifiedId<FunId>) -> Option<&IntrinsicDecl> {
+        self.intrinsic_move_funs
+            .get(qid)
+            .map(|id| self.decls.get(id).unwrap())
+    }
+
+    /// Get the intrinsic decl for a spec function
+    pub fn get_decl_for_spec_fun(&self, qid: &QualifiedId<SpecFunId>) -> Option<&IntrinsicDecl> {
+        self.intrinsic_spec_funs
+            .get(qid)
+            .map(|id| self.decls.get(id).unwrap())
+    }
+
     /// Test whether a struct is an intrinsic of a specific name
     pub fn is_intrinsic_of_for_struct(
         &self,

--- a/language/move-model/src/model.rs
+++ b/language/move-model/src/model.rs
@@ -2517,7 +2517,13 @@ impl<'env> StructEnv<'env> {
 
     /// Returns true if this struct has the pragma intrinsic set to true.
     pub fn is_intrinsic(&self) -> bool {
-        self.is_pragma_true(INTRINSIC_PRAGMA, || false)
+        self.is_pragma_true(INTRINSIC_PRAGMA, || {
+            self.module_env
+                .env
+                .intrinsics
+                .get_decl_for_struct(&self.get_qualified_id())
+                .is_some()
+        })
     }
 
     /// Returns true if this is an intrinsic struct of a given name
@@ -3169,7 +3175,13 @@ impl<'env> FunctionEnv<'env> {
 
     /// Returns true if this function has the pragma intrinsic set to true.
     pub fn is_intrinsic(&self) -> bool {
-        self.is_pragma_true(INTRINSIC_PRAGMA, || false)
+        self.is_pragma_true(INTRINSIC_PRAGMA, || {
+            self.module_env
+                .env
+                .intrinsics
+                .get_decl_for_move_fun(&self.get_qualified_id())
+                .is_some()
+        })
     }
 
     /// Returns true if function is either native or intrinsic.


### PR DESCRIPTION
A function can be marked as intrinsic in two ways:

Method 1:

```
spec foo {
    pragma intrinsic;
}
```

Method 2:

```
spec Table {
    pragma intrinsic = map,
        map_foo = foo;
}
```

In both ways, `foo` should be considered as intrinsic while the current approach only treats the first one as intrinsic and forces everything declared as a intrinsic function of some struct to be re-marked as intrinsic.

This PR changes this behavior. `foo` will be recognized as intrinsic regardless of how the intrinsic property is declared.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Move Language.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Close #665

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes

## Test Plan

CI