### PR TITLE
[move-prover] data invariants for map values

### DIFF
--- a/language/move-model/src/exp_generator.rs
+++ b/language/move-model/src/exp_generator.rs
@@ -3,16 +3,17 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use itertools::Itertools;
+use num::BigUint;
 
 use crate::{
     ast::{Exp, ExpData, LocalVarDecl, Operation, QuantKind, TempIndex, Value},
     model::{
-        FieldEnv, FunctionEnv, GlobalEnv, Loc, NodeId, QualifiedId, QualifiedInstId, StructId,
+        FieldEnv, FunctionEnv, GlobalEnv, Loc, NodeId, QualifiedId, QualifiedInstId, SpecFunId,
+        StructId,
     },
     symbol::Symbol,
     ty::{PrimitiveType, Type, BOOL_TYPE, NUM_TYPE},
 };
-use num::BigUint;
 
 /// A trait that defines a generator for `Exp`.
 pub trait ExpGenerator<'env> {
@@ -202,6 +203,50 @@ pub trait ExpGenerator<'env> {
                     body,
                 )
                 .into_exp(),
+            )
+        } else {
+            None
+        }
+    }
+
+    /// Creates a quantifier over the content of a map. The passed function `f` receives
+    /// an expression representing an element of the map and returns the quantifiers predicate;
+    /// if it returns None, this function will also return None, otherwise the quantifier will be
+    /// returned.
+    ///
+    /// NOTE: the `spec_fun_get` argument is needed due to the fact that we do not have a native
+    /// operator of getting the value by key in from a map. In the `mk_vector_quant_opt` case,
+    /// we have the `Index` operator to map from an index to a value. But in the `map` case, we
+    /// need to use the spec function for the key-to-value conversion.
+    ///
+    /// Alternative design choices including:
+    /// - re-purpose the `Index` operator to take key and intrinsic maps
+    /// - add a new `Get` operator for this specific operation.
+    fn mk_map_quant_opt<F>(
+        &self,
+        kind: QuantKind,
+        map: Exp,
+        spec_fun_get: QualifiedId<SpecFunId>,
+        key_ty: &Type,
+        val_ty: &Type,
+        f: &mut F,
+    ) -> Option<Exp>
+    where
+        F: FnMut(Exp) -> Option<Exp>,
+    {
+        let key = self.mk_local("$key", key_ty.clone());
+        let val = self.mk_call_with_inst(
+            val_ty,
+            vec![key_ty.clone(), val_ty.clone()],
+            Operation::Function(spec_fun_get.module_id, spec_fun_get.id, None),
+            vec![map.clone(), key.clone()],
+        );
+        if let Some(body) = self.mk_join_opt_bool(Operation::And, f(key), f(val)) {
+            let range_decl = self.mk_decl(self.mk_symbol("$key"), key_ty.clone(), None);
+            let node_id = self.new_node(BOOL_TYPE.clone(), None);
+            Some(
+                ExpData::Quant(node_id, kind, vec![(range_decl, map)], vec![], None, body)
+                    .into_exp(),
             )
         } else {
             None

--- a/language/move-model/src/intrinsics.rs
+++ b/language/move-model/src/intrinsics.rs
@@ -54,6 +54,12 @@ impl IntrinsicDecl {
                 })
             })
     }
+
+    pub fn lookup_spec_fun(&self, env: &GlobalEnv, name: &str) -> Option<QualifiedId<SpecFunId>> {
+        let symbol_pool = env.symbol_pool();
+        let sym = symbol_pool.make(name);
+        self.intrinsic_to_spec_fun.get(&sym).cloned()
+    }
 }
 
 pub(crate) fn process_intrinsic_declaration(

--- a/language/move-prover/bytecode/src/data_invariant_instrumentation.rs
+++ b/language/move-prover/bytecode/src/data_invariant_instrumentation.rs
@@ -11,20 +11,21 @@
 //! (which depends on the compilation scheme). It also handles PackRef/PackRefDeep
 //! instructions introduced by memory instrumentation, as well as the Pack instructions.
 
+use move_model::{
+    ast,
+    ast::{ConditionKind, Exp, ExpData, QuantKind, TempIndex},
+    exp_generator::ExpGenerator,
+    model::{FunctionEnv, Loc, NodeId, StructEnv},
+    pragmas::{INTRINSIC_FUN_MAP_SPEC_GET, INTRINSIC_TYPE_MAP},
+    ty::Type,
+};
+
 use crate::{
     function_data_builder::FunctionDataBuilder,
     function_target::FunctionData,
     function_target_pipeline::{FunctionTargetProcessor, FunctionTargetsHolder},
     options::ProverOptions,
     stackless_bytecode::{Bytecode, Operation, PropKind},
-};
-
-use move_model::{
-    ast,
-    ast::{ConditionKind, Exp, ExpData, QuantKind, TempIndex},
-    exp_generator::ExpGenerator,
-    model::{FunctionEnv, Loc, NodeId, StructEnv},
-    ty::Type,
 };
 
 const INVARIANT_FAILS_MESSAGE: &str = "data invariant does not hold";
@@ -164,17 +165,53 @@ impl<'a> Instrumenter<'a> {
     }
 
     fn translate_invariant(&self, deep: bool, value: Exp) -> Vec<(Loc, Exp)> {
-        let ty = self.builder.global_env().get_node_type(value.node_id());
+        let env = self.builder.global_env();
+        let ty = env.get_node_type(value.node_id());
         match ty.skip_reference() {
             Type::Struct(mid, sid, targs) => {
-                let struct_env = self.builder.global_env().get_module(*mid).into_struct(*sid);
-                self.translate_invariant_for_struct(deep, value, struct_env, targs)
+                let struct_env = env.get_module(*mid).into_struct(*sid);
+                if struct_env.is_intrinsic_of(INTRINSIC_TYPE_MAP) {
+                    let decl = env
+                        .intrinsics
+                        .get_decl_for_struct(&mid.qualified(*sid))
+                        .expect("intrinsic declaration");
+                    let spec_fun_get = decl
+                        .lookup_spec_fun(env, INTRINSIC_FUN_MAP_SPEC_GET)
+                        .expect("intrinsic map_get function");
+
+                    // When dealing with a map, we cannot maintain individual locations for
+                    // invariants. Instead we choose just one as a representative.
+                    // TODO(refactoring): we should use the spec block position instead.
+                    let mut loc = env.unknown_loc();
+                    let quant = self.builder.mk_map_quant_opt(
+                        QuantKind::Forall,
+                        value,
+                        spec_fun_get,
+                        &targs[0],
+                        &targs[1],
+                        &mut |e| {
+                            let invs = self.translate_invariant(deep, e);
+                            if !invs.is_empty() {
+                                loc = invs[0].0.clone();
+                            }
+                            self.builder
+                                .mk_join_bool(ast::Operation::And, invs.into_iter().map(|(_, e)| e))
+                        },
+                    );
+                    if let Some(e) = quant {
+                        vec![(loc, e)]
+                    } else {
+                        vec![]
+                    }
+                } else {
+                    self.translate_invariant_for_struct(deep, value, struct_env, targs)
+                }
             }
             Type::Vector(ety) => {
                 // When dealing with a vector, we cannot maintain individual locations for
                 // invariants. Instead we choose just one as a representative.
                 // TODO(refactoring): we should use the spec block position instead.
-                let mut loc = self.builder.global_env().unknown_loc();
+                let mut loc = env.unknown_loc();
                 let quant =
                     self.builder
                         .mk_vector_quant_opt(QuantKind::Forall, value, ety, &mut |elem| {

--- a/language/move-prover/tests/sources/functional/data_invariant_in_map.exp
+++ b/language/move-prover/tests/sources/functional/data_invariant_in_map.exp
@@ -1,0 +1,14 @@
+Move prover returns: exiting with verification errors
+error: data invariant does not hold
+  ┌─ tests/sources/functional/data_invariant_in_map.move:8:9
+  │
+8 │         invariant value != 0;
+  │         ^^^^^^^^^^^^^^^^^^^^^
+  │
+  =     at tests/sources/functional/data_invariant_in_map.move:20: violation_1
+  =     at tests/sources/functional/data_invariant_in_map.move:21: violation_1
+  =         t = <redacted>
+  =     at tests/sources/functional/data_invariant_in_map.move:22: violation_1
+  =         s = <redacted>
+  =     at tests/sources/functional/data_invariant_in_map.move:23: violation_1
+  =     at tests/sources/functional/data_invariant_in_map.move:8

--- a/language/move-prover/tests/sources/functional/data_invariant_in_map.move
+++ b/language/move-prover/tests/sources/functional/data_invariant_in_map.move
@@ -1,0 +1,25 @@
+module 0x42::data_inv_in_map {
+    use extensions::table;
+
+    struct S has store {
+        value: u64
+    }
+    spec S {
+        invariant value != 0;
+    }
+
+    struct R has key {
+        map: table::Table<address, S>
+    }
+
+    fun no_violation() acquires R {
+        let t = &mut borrow_global_mut<R>(@0x42).map;
+        table::add(t, @0x43, S { value: 1 });
+    }
+
+    fun violation_1() acquires R {
+        let t = &mut borrow_global_mut<R>(@0x42).map;
+        let s = table::borrow_mut(t, @0x43);
+        *&mut s.value = 0;
+    }
+}


### PR DESCRIPTION
Added the encoding for data invariants via entrypoint assumptions and packref assertions:

```
t: Table<K, V>;

forall k: K :: $Contains(t, k) ==> (data-inv-predicate)($Get(t, k));
```

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Move Language.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Close #680 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes

## Test Plan

A new test case is added