### PR TITLE
[move-prover] customized encoding for map equality and contains to length relation

### DIFF
--- a/language/move-prover/boogie-backend/src/prelude/native.bpl
+++ b/language/move-prover/boogie-backend/src/prelude/native.bpl
@@ -243,10 +243,21 @@ axiom (
 {%- set SV = "'" ~ instance.1.suffix ~ "'" -%}
 {%- set ENC = "$EncodeKey'" ~ instance.0.suffix ~ "'" -%}
 
+{%- if options.native_equality -%}
 function $IsEqual'{{Type}}{{S}}'(t1: {{Self}}, t2: {{Self}}): bool {
-    // TODO: do we need to encode table identity?
     t1 == t2
 }
+{%- else -%}
+function $IsEqual'{{Type}}{{S}}'(t1: {{Self}}, t2: {{Self}}): bool {
+    LenTable(t1) == LenTable(t2) &&
+    (forall k: int :: (
+        ContainsTable(t1, k) ==> (
+            ContainsTable(t2, k) && GetTable(t1, k) == GetTable(t2, k)
+        ) &&
+        ContainsTable(t2, k) ==> ContainsTable(t1, k)
+    ))
+}
+{%- endif %}
 
 // Not inlined.
 function $IsValid'{{Type}}{{S}}'(t: {{Self}}): bool {

--- a/language/move-prover/boogie-backend/src/prelude/table-array-theory.bpl
+++ b/language/move-prover/boogie-backend/src/prelude/table-array-theory.bpl
@@ -53,3 +53,10 @@ function {:inline} RemoveTable<K,V>(t: Table K V, k: K): Table K V {
     // Similar as above, we only need to consider the case where the key is in the table.
     Table(v#Table(t), e#Table(t)[k := false], l#Table(t) - 1)
 }
+
+axiom {:ctor "Table"} (forall<K,V> t: Table K V :: {LenTable(t)}
+    (exists k: K :: {ContainsTable(t, k)} ContainsTable(t, k)) ==> LenTable(t) >= 1
+);
+// TODO: we might want to encoder a stronger property that the length of table
+// must be more than N given a set of N items. Currently we don't see a need here
+// and the above axiom seems to be sufficient.

--- a/language/move-prover/tests/sources/functional/loops_with_memory_ops.exp
+++ b/language/move-prover/tests/sources/functional/loops_with_memory_ops.exp
@@ -43,8 +43,7 @@ error: unknown assertion failed
    =         y = <redacted>
    =     at tests/sources/functional/loops_with_memory_ops.move:80: nested_loop2
    =     at tests/sources/functional/loops_with_memory_ops.move:81: nested_loop2
-   =     at <internal>:1
-   =     at tests/sources/functional/loops_with_memory_ops.move:81: nested_loop2
+   =         b = <redacted>
    =         b = <redacted>
    =         a = <redacted>
    =         a = <redacted>
@@ -97,12 +96,12 @@ error: induction case of the loop invariant does not hold
    =         y = <redacted>
    =     at tests/sources/functional/loops_with_memory_ops.move:80: nested_loop2
    =     at tests/sources/functional/loops_with_memory_ops.move:81: nested_loop2
-   =         b = <redacted>
-   =         b = <redacted>
    =     at <internal>:1
    =     at tests/sources/functional/loops_with_memory_ops.move:81: nested_loop2
    =     at <internal>:1
    =     at tests/sources/functional/loops_with_memory_ops.move:81: nested_loop2
+   =         a = <redacted>
+   =         a = <redacted>
    =     at tests/sources/functional/loops_with_memory_ops.move:85: nested_loop2
    =         i = <redacted>
    =     at tests/sources/functional/loops_with_memory_ops.move:86: nested_loop2

--- a/language/move-prover/tests/sources/functional/table_contais_to_length.move
+++ b/language/move-prover/tests/sources/functional/table_contais_to_length.move
@@ -1,0 +1,9 @@
+module 0x42::table_contains_to_length {
+    use extensions::table;
+
+    fun test(_t: &mut table::Table<address, u64>, _k: address) {}
+    spec test {
+        ensures table::spec_contains(old(_t), _k) ==> table::spec_len(old(_t)) > 0;
+        ensures table::spec_contains(old(_t), _k) ==> table::spec_len(_t) > 0;
+    }
+}

--- a/language/move-prover/tests/sources/functional/trace.exp
+++ b/language/move-prover/tests/sources/functional/trace.exp
@@ -27,7 +27,7 @@ error: global memory invariant does not hold
    │
    = Related Global Memory:
    =         Resource name: TestTracing_R
-   =         Values:  {Address(0): <redacted>, Default: TestTracing.R{x = 5}}
+   =         Values:  {Address(0): <redacted>, Default: empty}
    =     at tests/sources/functional/trace.move:29: publish_invalid
    =     at tests/sources/functional/trace.move:33: publish_invalid (spec)
    =         `let addr = signer::address_of(s);` = <redacted>
@@ -45,7 +45,7 @@ error: post-condition does not hold
    │
    = Related Global Memory:
    =         Resource name: TestTracing_R
-   =         Values:  {Address(18467): <redacted>, Default: TestTracing.R{x = 4}}
+   =         Values:  {Address(18467): <redacted>, Default: empty}
    = Related Bindings:
    =         addr = <redacted>
    =         exists<R>(addr) = <redacted>

--- a/language/move-prover/tests/sources/regression/map_equality_encoding.move
+++ b/language/move-prover/tests/sources/regression/map_equality_encoding.move
@@ -1,0 +1,9 @@
+module 0x42::map_equality {
+    use extensions::table;
+
+    fun test(_t: &mut table::Table<address, u64>, _k: address) {}
+    spec test {
+        let old_v = table::spec_get(_t, _k);
+        ensures table::spec_contains(old(_t), _k) ==> _t == table::spec_set(old(_t), _k, old_v + 0);
+    }
+}


### PR DESCRIPTION
### First commit:
Similar to vector equality, the map equality encoding should be customized unless the `options.native_equality` is set.

### Second commit:

Add an axiom for relating table contains to length
```
axiom forall<K,V> t: Table<K,V> ::
    (exists k: V :: Contains(t, k)) ==> Len(t) >= 1;
```

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Move Language.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Both commits combined fix #673

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes

## Test Plan

Two new test case ported from #673 are added