### PR TITLE
[move-prover] deterministic ordering of worklist with recursive calls

### DIFF
--- a/language/move-prover/bytecode/src/function_target_pipeline.rs
+++ b/language/move-prover/bytecode/src/function_target_pipeline.rs
@@ -3,10 +3,19 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use core::fmt;
-use std::{cmp::Ordering, collections::BTreeMap, fmt::Formatter, fs};
+use std::{
+    cmp::Ordering,
+    collections::{btree_map::Entry as MapEntry, BTreeMap, BTreeSet},
+    fmt::Formatter,
+    fs,
+};
 
-use itertools::Itertools;
+use itertools::{Either, Itertools};
 use log::{debug, info};
+use petgraph::{
+    algo::has_path_connecting,
+    graph::{DiGraph, NodeIndex},
+};
 
 use move_model::model::{FunId, FunctionEnv, GlobalEnv, QualifiedId};
 
@@ -292,14 +301,87 @@ impl FunctionTargetPipeline {
             .as_ref()
     }
 
-    /// Sort functions in topological order. This is important for the function target processors.
-    /// In programs without recursion or mutual recursion, processing functions in topological order
-    /// means that when a processor sees a caller function, it is guaranteed that all the callees
-    /// have already been analyzed.
-    pub fn sort_targets_in_topological_order<'env>(
-        env: &'env GlobalEnv,
+    /// Build the call graph
+    fn build_call_graph(
+        env: &GlobalEnv,
         targets: &FunctionTargetsHolder,
-    ) -> Vec<FunctionEnv<'env>> {
+    ) -> (
+        DiGraph<QualifiedId<FunId>, ()>,
+        BTreeMap<QualifiedId<FunId>, NodeIndex>,
+    ) {
+        let mut graph = DiGraph::new();
+        let mut nodes = BTreeMap::new();
+        for fun_id in targets.get_funs() {
+            let node_idx = graph.add_node(fun_id);
+            nodes.insert(fun_id, node_idx);
+        }
+        for fun_id in targets.get_funs() {
+            let src_idx = nodes.get(&fun_id).unwrap();
+            let fun_env = env.get_function(fun_id);
+            for callee in fun_env.get_called_functions() {
+                let dst_idx = nodes
+                    .get(&callee)
+                    .expect("callee is not in function targets");
+                graph.add_edge(*src_idx, *dst_idx, ());
+            }
+        }
+        (graph, nodes)
+    }
+
+    /// Collect strongly connected components (SCCs) from the call graph.
+    fn derive_call_graph_sccs(
+        env: &GlobalEnv,
+        graph: &DiGraph<QualifiedId<FunId>, ()>,
+    ) -> BTreeMap<QualifiedId<FunId>, Option<BTreeSet<QualifiedId<FunId>>>> {
+        let mut sccs = BTreeMap::new();
+        for scc in petgraph::algo::tarjan_scc(graph) {
+            let mut part = BTreeSet::new();
+            let mut is_cyclic = scc.len() > 1;
+            for node_idx in scc {
+                let fun_id = *graph.node_weight(node_idx).unwrap();
+                let fun_env = env.get_function(fun_id);
+                if !is_cyclic && fun_env.get_called_functions().contains(&fun_id) {
+                    is_cyclic = true;
+                }
+                let inserted = part.insert(fun_id);
+                assert!(inserted);
+            }
+
+            if is_cyclic {
+                for fun_id in &part {
+                    let existing = sccs.insert(*fun_id, Some(part.clone()));
+                    assert!(existing.is_none());
+                }
+            } else {
+                let fun_id = part.into_iter().next().unwrap();
+                let existing = sccs.insert(fun_id, None);
+                assert!(existing.is_none());
+            }
+        }
+        sccs
+    }
+
+    /// Sort the call graph in topological order with strongly connected components (SCCs)
+    /// to represent recursive calls.
+    fn sort_targets_in_topological_order(
+        env: &GlobalEnv,
+        targets: &FunctionTargetsHolder,
+    ) -> Vec<Either<QualifiedId<FunId>, Vec<QualifiedId<FunId>>>> {
+        // collect sccs
+        let (graph, nodes) = Self::build_call_graph(env, targets);
+        let sccs = Self::derive_call_graph_sccs(env, &graph);
+
+        let mut scc_staging = BTreeMap::new();
+        for scc_opt in sccs.values() {
+            match scc_opt.as_ref() {
+                None => (),
+                Some(scc) => {
+                    scc_staging.insert(scc, vec![]);
+                }
+            }
+        }
+
+        // construct the work list (with a deterministic ordering)
         let mut worklist = vec![];
         for fun in targets.get_funs() {
             let fun_env = env.get_function(fun);
@@ -310,40 +392,70 @@ impl FunctionTargetPipeline {
         }
 
         // analyze bottom-up from the leaves of the call graph
+        // NOTE: this algorithm produces a deterministic ordering of functions to be analyzed
         let mut dep_ordered = vec![];
         while !worklist.is_empty() {
-            // Put functions with 0 calls first in line, at the end of the vector
-            worklist.sort_by(|(_, callees1), (caller2, callees2)| {
-                // The following logic ensures that a recursive function will be handled before a non-recursive one if they have same
-                // size of callees
-                if Ordering::Equal == callees2.len().cmp(&callees1.len()) {
-                    if callees2.contains(caller2) {
-                        Ordering::Less
-                    } else {
+            worklist.sort_by(|(caller1, callees1), (caller2, callees2)| {
+                // rules of ordering:
+                // - if function A depends on B (i.e., calls B), put B towards the end of the worklist
+                // - if there are no dependencies among A and B, rank them by callee size
+
+                let node1 = *nodes.get(caller1).unwrap();
+                let node2 = *nodes.get(caller2).unwrap();
+                match (
+                    has_path_connecting(&graph, node1, node2, None),
+                    has_path_connecting(&graph, node2, node1, None),
+                ) {
+                    (true, true) => Ordering::Equal,
+                    (true, false) => Ordering::Less,
+                    (false, true) => Ordering::Greater,
+                    (false, false) => {
+                        // Put functions with 0 calls first in line, at the end of the vector
                         callees2.len().cmp(&callees1.len())
                     }
-                } else {
-                    callees2.len().cmp(&callees1.len())
                 }
             });
 
-            let (call_id, _) = worklist.pop().unwrap();
+            let (call_id, callees) = worklist.pop().unwrap();
 
             // At this point, one of two things is true:
             // 1. callees is empty (common case)
             // 2. callees is nonempty and call_id is part of a recursive or mutually recursive function group
 
+            match sccs.get(&call_id).unwrap().as_ref() {
+                None => {
+                    // case 1: non-recursive call
+                    assert!(callees.is_empty());
+                    dep_ordered.push(Either::Left(call_id));
+                }
+                Some(scc) => {
+                    // case 2: recursive call group
+                    match scc_staging.entry(scc) {
+                        MapEntry::Vacant(_) => {
+                            panic!("all scc groups should be in staging")
+                        }
+                        MapEntry::Occupied(mut entry) => {
+                            let scc_vec = entry.get_mut();
+                            scc_vec.push(call_id);
+                            if scc_vec.len() == scc.len() {
+                                dep_ordered.push(Either::Right(entry.remove()));
+                            }
+                        }
+                    }
+                }
+            }
+
+            // update the worklist
             for (_, callees) in worklist.iter_mut() {
                 callees.retain(|e| e != &call_id);
             }
-            dep_ordered.push(call_id);
         }
 
-        // map the call_id into function env
+        // ensure that everything is cleared
+        assert!(scc_staging.is_empty());
+
+        // return the ordered dep list
         dep_ordered
-            .into_iter()
-            .map(|qid| env.get_function(qid))
-            .collect()
     }
 
     /// Runs the pipeline on all functions in the targets holder. Processors are run on each
@@ -367,8 +479,20 @@ impl FunctionTargetPipeline {
                 processor.run(env, targets);
             } else {
                 processor.initialize(env, targets);
-                for func_env in &topological_order {
-                    targets.process(func_env, processor.as_ref());
+                for item in &topological_order {
+                    match item {
+                        Either::Left(fid) => {
+                            let func_env = env.get_function(*fid);
+                            targets.process(&func_env, processor.as_ref());
+                        }
+                        Either::Right(scc) => {
+                            // TODO(mengxu): loop into fixedpoint
+                            for fid in scc {
+                                let func_env = env.get_function(*fid);
+                                targets.process(&func_env, processor.as_ref());
+                            }
+                        }
+                    }
                 }
                 processor.finalize(env, targets);
             }
@@ -435,7 +559,7 @@ impl FunctionTargetPipeline {
             ProcessorResultDisplay {
                 env,
                 targets,
-                processor
+                processor,
             }
         );
         if !processor.is_single_run() {


### PR DESCRIPTION
This commit is the first step in adding a systematic support for
recursive function calls in the Prover.

In this commit, the problem we try to solve is enforcing a deterministic
(and yet, bottom-up) ordering of functions to process.

More formally:

Imagine we construct a call graph `G` where two nodes, `A ---> B` means
`A` calls `B` directly or transitively. By this definition, if we have
both `A ---> B` and `B ---> A` then we know both `A` and `B` belong to
the same recursive call grouh, which forms a strongly-connected
component (SCC) in `G`.

When processing all functions in the bytecode transformation pipeline,
we aim to achieve the following property:

- If `A ---> B` and `B -x-> A` (i.e., `B` does not depends on `A`), we
  are sure that `B` gets processed first before `A`
- If `A -x-> B` and `B -x-> A`, we are sure that `A` and `B` gets
  processed in the order as they are defined in the program (which is
  the order they are added to the `FunctionTargetsHolder`)
- Similarly, if `A ---> B` and `B ---> A` (i.e., they are in an SCC),
  they are processed in the order as they are defined in the program.

This is a deterministic ordering which was previously well enforced with
the `worklist` algorithm, **with the assumption that there is no
recursive calls**.

With the introduction of recursive calls, the worklist algorithm will
start to fail in the following example case:

- `A` has only one callee `B`.
- `B` has two callees, `C` and `D` and `B, C, D` forms an SCC.

The correct handling is `B, C, D` and then `A`, but the `worklist`
algorithm will handle `A` first before `B` (because `A` has a smaller
number of callees).

This commit fixes this problem by augmenting the worklist algorithm
with a graph structure to
1) query reachability information around two nodes and
2) group recursive functions into correspondings SCCs

The worklist algorithm is still needed to determine the processing
order among functions (and SCCs) that do not have dependency
information. It is also used to give a deterministic ordering among
functions in the same SCC. Neither of the ordering is guaranteed by
the topological sorting algorithm in `petgraph`.

## Motivation

More systematic supporting of recursive functions

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes

## Test Plan

CI