### PR TITLE
[RFC] [bytecode-verifier] Use separate thread for bytecode verifier

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3010,6 +3010,7 @@ name = "move-bytecode-verifier"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "crossbeam-utils",
  "hex-literal",
  "invalid-mutations",
  "move-binary-format",

--- a/language/move-bytecode-verifier/Cargo.toml
+++ b/language/move-bytecode-verifier/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0.52"
 petgraph = "0.5.1"
+crossbeam-utils = "0.8.8"
 
 move-borrow-graph = { path = "../move-borrow-graph" }
 move-binary-format = { path = "../move-binary-format" }


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Move Language.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Add an option to run the bytecode verifier in a separate thread. Bytecode verifier is one of the most critical piece of code in the Move ecosystem and yet a panic in the bytecode verifier will crash the MoveVM and has a cascading effect over the entire upstream software. This PR introduces a flag to run the bytecode verifier to run on a separate thread. Thus even when a panic is encountered, the runtime should still be able to capture such failure without crashing the node software.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes

## Test Plan

TBD. Ran the benchmark suite on Aptos side and observed no significant regression in performance.
