### PR TITLE
[cfg][BUGFIX] Check for empty code units on bytecode v5 and below.

### DIFF
--- a/language/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/control_flow_tests.rs
+++ b/language/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/control_flow_tests.rs
@@ -40,6 +40,28 @@ fn verify_module(verifier_config: &VerifierConfig, module: &CompiledModule) -> P
 //**************************************************************************************************
 
 #[test]
+fn empty_bytecode() {
+    let module = dummy_procedure_module(vec![]);
+    let result = verify_module(&Default::default(), &module);
+    assert_eq!(
+        result.unwrap_err().major_status(),
+        StatusCode::EMPTY_CODE_UNIT,
+    );
+}
+
+#[test]
+fn empty_bytecode_v5() {
+    let mut module = dummy_procedure_module(vec![]);
+    module.version = 5;
+
+    let result = verify_module(&Default::default(), &module);
+    assert_eq!(
+        result.unwrap_err().major_status(),
+        StatusCode::EMPTY_CODE_UNIT,
+    );
+}
+
+#[test]
 fn invalid_fallthrough_br_true() {
     let module = dummy_procedure_module(vec![Bytecode::LdFalse, Bytecode::BrTrue(1)]);
     let result = verify_module(&Default::default(), &module);


### PR DESCRIPTION
Recent changes to the CFG verifier missed the check that bytecode was non-empty and ended with a unconditional branch, for older bytecode versions.  Adding that back.

Test Plan:

New unit tests:

```
move-bytecode-verifier$ cargo nextest -- control_flow_tests
```