### PR TITLE
[vm] Some reliability fixes (cherry-pick #703)

### DIFF
--- a/language/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/limit_tests.rs
+++ b/language/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/limit_tests.rs
@@ -2,8 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use move_binary_format::file_format::*;
-use move_bytecode_verifier::{limits::LimitsVerifier, VerifierConfig};
-use move_core_types::vm_status::StatusCode;
+use move_bytecode_verifier::{limits::LimitsVerifier, verify_module_with_config, VerifierConfig};
+use move_core_types::{
+    account_address::AccountAddress, identifier::Identifier, vm_status::StatusCode,
+};
 
 #[test]
 fn test_function_handle_type_instantiation() {
@@ -157,5 +159,104 @@ fn test_function_handle_parameters() {
         .unwrap_err()
         .major_status(),
         StatusCode::TOO_MANY_PARAMETERS
+    );
+}
+
+#[test]
+fn big_vec_unpacks() {
+    const N_TYPE_PARAMS: usize = 16;
+    let mut st = SignatureToken::Vector(Box::new(SignatureToken::U8));
+    let type_params = vec![st; N_TYPE_PARAMS];
+    st = SignatureToken::StructInstantiation(StructHandleIndex(0), type_params);
+    const N_VEC_PUSH: u16 = 1000;
+    let mut code = vec![];
+    // 1. CopyLoc:     ...         -> ... st
+    // 2. VecPack:     ... st      -> ... Vec<st>
+    // 3. VecUnpack:   ... Vec<st> -> ... st, st, st, ... st
+    for _ in 0..N_VEC_PUSH {
+        code.push(Bytecode::CopyLoc(0));
+        code.push(Bytecode::VecPack(SignatureIndex(1), 1));
+        code.push(Bytecode::VecUnpack(SignatureIndex(1), 1 << 15));
+    }
+    // 1. VecPack:   ... st, st, st, ... st -> ... Vec<st>
+    // 2. Pop:       ... Vec<st>            -> ...
+    for _ in 0..N_VEC_PUSH {
+        code.push(Bytecode::VecPack(SignatureIndex(1), 1 << 15));
+        code.push(Bytecode::Pop);
+    }
+    code.push(Bytecode::Ret);
+    let type_param_constraints = StructTypeParameter {
+        constraints: AbilitySet::EMPTY,
+        is_phantom: false,
+    };
+    let module = CompiledModule {
+        version: 5,
+        self_module_handle_idx: ModuleHandleIndex(0),
+        module_handles: vec![ModuleHandle {
+            address: AddressIdentifierIndex(0),
+            name: IdentifierIndex(0),
+        }],
+        struct_handles: vec![StructHandle {
+            module: ModuleHandleIndex(0),
+            name: IdentifierIndex(1),
+            abilities: AbilitySet::ALL,
+            type_parameters: vec![type_param_constraints; N_TYPE_PARAMS],
+        }],
+        function_handles: vec![FunctionHandle {
+            module: ModuleHandleIndex(0),
+            name: IdentifierIndex(0),
+            parameters: SignatureIndex(1),
+            return_: SignatureIndex(0),
+            type_parameters: vec![],
+        }],
+        field_handles: vec![],
+        friend_decls: vec![],
+        struct_def_instantiations: vec![],
+        function_instantiations: vec![],
+        field_instantiations: vec![],
+        signatures: vec![Signature(vec![]), Signature(vec![st])],
+        identifiers: vec![
+            Identifier::new("f").unwrap(),
+            Identifier::new("generic_struct").unwrap(),
+        ],
+        address_identifiers: vec![AccountAddress::ONE],
+        constant_pool: vec![],
+        metadata: vec![],
+        struct_defs: vec![StructDefinition {
+            struct_handle: StructHandleIndex(0),
+            field_information: StructFieldInformation::Native,
+        }],
+        function_defs: vec![FunctionDefinition {
+            function: FunctionHandleIndex(0),
+            visibility: Visibility::Public,
+            is_entry: true,
+            acquires_global_resources: vec![],
+            code: Some(CodeUnit {
+                locals: SignatureIndex(0),
+                code,
+            }),
+        }],
+    };
+
+    // save module and verify that it can ser/de
+    let mut mvbytes = vec![];
+    module.serialize(&mut mvbytes).unwrap();
+    let module = CompiledModule::deserialize(&mvbytes).unwrap();
+
+    // run with mainnet aptos config
+    let res = verify_module_with_config(
+        &VerifierConfig {
+            max_loop_depth: Some(5),
+            treat_friend_as_private: false,
+            max_generic_instantiation_length: Some(32),
+            max_function_parameters: Some(128),
+            max_basic_blocks: Some(1024),
+            ..Default::default()
+        },
+        &module,
+    );
+    assert_eq!(
+        res.unwrap_err().major_status(),
+        StatusCode::VALUE_STACK_OVERFLOW
     );
 }

--- a/language/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/signature_tests.rs
+++ b/language/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/signature_tests.rs
@@ -3,9 +3,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use invalid_mutations::signature::{FieldRefMutation, SignatureRefMutation};
-use move_binary_format::file_format::{Bytecode::*, CompiledModule, SignatureToken::*, *};
-use move_bytecode_verifier::{verify_module, SignatureChecker};
-use move_core_types::{account_address::AccountAddress, identifier::Identifier};
+use move_binary_format::file_format::{
+    Bytecode::*, CompiledModule, SignatureToken::*, Visibility::Public, *,
+};
+use move_bytecode_verifier::{
+    verify_module, verify_module_with_config, SignatureChecker, VerifierConfig,
+};
+use move_core_types::{
+    account_address::AccountAddress, identifier::Identifier, vm_status::StatusCode,
+};
 use proptest::{collection::vec, prelude::*, sample::Index as PropIndex};
 
 #[test]
@@ -120,4 +126,107 @@ fn no_verify_locals_good() {
         ],
     };
     assert!(verify_module(&compiled_module_good).is_ok());
+}
+
+#[test]
+fn big_signature_test() {
+    const N_TYPE_PARAMS: usize = 5;
+    const INSTANTIATION_DEPTH: usize = 3;
+    const VECTOR_DEPTH: usize = 250;
+    let mut st = SignatureToken::U8;
+    for _ in 0..VECTOR_DEPTH {
+        st = SignatureToken::Vector(Box::new(st));
+    }
+    for _ in 0..INSTANTIATION_DEPTH {
+        let type_params = vec![st; N_TYPE_PARAMS];
+        st = SignatureToken::StructInstantiation(StructHandleIndex(0), type_params);
+    }
+
+    const N_READPOP: u16 = 7500;
+
+    let mut code = vec![];
+    // 1. ImmBorrowLoc: ... ref
+    // 2. ReadRef:      ... value
+    // 3. Pop:          ...
+    for _ in 0..N_READPOP {
+        code.push(Bytecode::ImmBorrowLoc(0));
+        code.push(Bytecode::ReadRef);
+        code.push(Bytecode::Pop);
+    }
+    code.push(Bytecode::Ret);
+
+    let type_param_constraints = StructTypeParameter {
+        constraints: AbilitySet::EMPTY,
+        is_phantom: false,
+    };
+
+    let module = CompiledModule {
+        version: 5,
+        self_module_handle_idx: ModuleHandleIndex(0),
+        module_handles: vec![ModuleHandle {
+            address: AddressIdentifierIndex(0),
+            name: IdentifierIndex(0),
+        }],
+        struct_handles: vec![StructHandle {
+            module: ModuleHandleIndex(0),
+            name: IdentifierIndex(1),
+            abilities: AbilitySet::ALL,
+            type_parameters: vec![type_param_constraints; N_TYPE_PARAMS],
+        }],
+        function_handles: vec![FunctionHandle {
+            module: ModuleHandleIndex(0),
+            name: IdentifierIndex(0),
+            parameters: SignatureIndex(1),
+            return_: SignatureIndex(0),
+            type_parameters: vec![],
+        }],
+        field_handles: vec![],
+        friend_decls: vec![],
+        struct_def_instantiations: vec![],
+        function_instantiations: vec![],
+        field_instantiations: vec![],
+        signatures: vec![Signature(vec![]), Signature(vec![st])],
+        identifiers: vec![
+            Identifier::new("f").unwrap(),
+            Identifier::new("generic_struct").unwrap(),
+        ],
+        address_identifiers: vec![AccountAddress::ONE],
+        constant_pool: vec![],
+        metadata: vec![],
+        struct_defs: vec![StructDefinition {
+            struct_handle: StructHandleIndex(0),
+            field_information: StructFieldInformation::Native,
+        }],
+        function_defs: vec![FunctionDefinition {
+            function: FunctionHandleIndex(0),
+            visibility: Public,
+            is_entry: true,
+            acquires_global_resources: vec![],
+            code: Some(CodeUnit {
+                locals: SignatureIndex(0),
+                code,
+            }),
+        }],
+    };
+
+    // save module and verify that it can ser/de
+    let mut mvbytes = vec![];
+    module.serialize(&mut mvbytes).unwrap();
+    let module = CompiledModule::deserialize(&mvbytes).unwrap();
+
+    // run with mainnet aptos config
+    let res = verify_module_with_config(
+        &VerifierConfig {
+            max_loop_depth: Some(5),
+            treat_friend_as_private: false,
+            max_generic_instantiation_length: Some(32),
+            max_function_parameters: Some(128),
+            max_basic_blocks: Some(1024),
+            max_value_stack_size: 1024,
+            max_type_nodes: Some(256),
+        },
+        &module,
+    )
+    .unwrap_err();
+    assert_eq!(res.major_status(), StatusCode::TOO_MANY_TYPE_NODES);
 }

--- a/language/move-bytecode-verifier/src/code_unit_verifier.rs
+++ b/language/move-bytecode-verifier/src/code_unit_verifier.rs
@@ -26,7 +26,7 @@ use std::collections::HashMap;
 pub struct CodeUnitVerifier<'a> {
     resolver: BinaryIndexedView<'a>,
     function_view: FunctionView<'a>,
-    name_def_map: HashMap<IdentifierIndex, FunctionDefinitionIndex>,
+    name_def_map: &'a HashMap<IdentifierIndex, FunctionDefinitionIndex>,
 }
 
 impl<'a> CodeUnitVerifier<'a> {
@@ -40,12 +40,23 @@ impl<'a> CodeUnitVerifier<'a> {
 
     fn verify_module_impl(
         verifier_config: &VerifierConfig,
-        module: &'a CompiledModule,
+        module: &CompiledModule,
     ) -> PartialVMResult<()> {
+        let mut name_def_map = HashMap::new();
+        for (idx, func_def) in module.function_defs().iter().enumerate() {
+            let fh = module.function_handle_at(func_def.function);
+            name_def_map.insert(fh.name, FunctionDefinitionIndex(idx as u16));
+        }
         for (idx, function_definition) in module.function_defs().iter().enumerate() {
             let index = FunctionDefinitionIndex(idx as TableIndex);
-            Self::verify_function(verifier_config, index, function_definition, module)
-                .map_err(|err| err.at_index(IndexKind::FunctionDefinition, index.0))?
+            Self::verify_function(
+                verifier_config,
+                index,
+                function_definition,
+                module,
+                &name_def_map,
+            )
+            .map_err(|err| err.at_index(IndexKind::FunctionDefinition, index.0))?
         }
         Ok(())
     }
@@ -64,20 +75,22 @@ impl<'a> CodeUnitVerifier<'a> {
         // create `FunctionView` and `BinaryIndexedView`
         let function_view = control_flow::verify_script(verifier_config, script)?;
         let resolver = BinaryIndexedView::Script(script);
+        let name_def_map = HashMap::new();
         //verify
         let code_unit_verifier = CodeUnitVerifier {
             resolver,
             function_view,
-            name_def_map: HashMap::new(),
+            name_def_map: &name_def_map,
         };
-        code_unit_verifier.verify_common()
+        code_unit_verifier.verify_common(verifier_config)
     }
 
     fn verify_function(
         verifier_config: &VerifierConfig,
         index: FunctionDefinitionIndex,
-        function_definition: &'a FunctionDefinition,
-        module: &'a CompiledModule,
+        function_definition: &FunctionDefinition,
+        module: &CompiledModule,
+        name_def_map: &HashMap<IdentifierIndex, FunctionDefinitionIndex>,
     ) -> PartialVMResult<()> {
         // nothing to verify for native function
         let code = match &function_definition.code {
@@ -103,25 +116,20 @@ impl<'a> CodeUnitVerifier<'a> {
         }
 
         let resolver = BinaryIndexedView::Module(module);
-        let mut name_def_map = HashMap::new();
-        for (idx, func_def) in module.function_defs().iter().enumerate() {
-            let fh = module.function_handle_at(func_def.function);
-            name_def_map.insert(fh.name, FunctionDefinitionIndex(idx as u16));
-        }
         // verify
         let code_unit_verifier = CodeUnitVerifier {
             resolver,
             function_view,
             name_def_map,
         };
-        code_unit_verifier.verify_common()?;
+        code_unit_verifier.verify_common(verifier_config)?;
         AcquiresVerifier::verify(module, index, function_definition)
     }
 
-    fn verify_common(&self) -> PartialVMResult<()> {
-        StackUsageVerifier::verify(&self.resolver, &self.function_view)?;
+    fn verify_common(&self, verifier_config: &VerifierConfig) -> PartialVMResult<()> {
+        StackUsageVerifier::verify(verifier_config, &self.resolver, &self.function_view)?;
         type_safety::verify(&self.resolver, &self.function_view)?;
         locals_safety::verify(&self.resolver, &self.function_view)?;
-        reference_safety::verify(&self.resolver, &self.function_view, &self.name_def_map)
+        reference_safety::verify(&self.resolver, &self.function_view, self.name_def_map)
     }
 }

--- a/language/move-bytecode-verifier/src/limits.rs
+++ b/language/move-bytecode-verifier/src/limits.rs
@@ -5,7 +5,7 @@ use crate::VerifierConfig;
 use move_binary_format::{
     binary_views::BinaryIndexedView,
     errors::{Location, PartialVMError, PartialVMResult, VMResult},
-    file_format::{CompiledModule, CompiledScript},
+    file_format::{CompiledModule, CompiledScript, SignatureToken},
     IndexKind,
 };
 use move_core_types::vm_status::StatusCode;
@@ -28,7 +28,8 @@ impl<'a> LimitsVerifier<'a> {
             resolver: BinaryIndexedView::Module(module),
         };
         limit_check.verify_function_handles(config)?;
-        limit_check.verify_struct_handles(config)
+        limit_check.verify_struct_handles(config)?;
+        limit_check.verify_type_nodes(config)
     }
 
     pub fn verify_script(config: &VerifierConfig, module: &'a CompiledScript) -> VMResult<()> {
@@ -78,6 +79,47 @@ impl<'a> LimitsVerifier<'a> {
                         .at_index(IndexKind::FunctionHandle, idx as u16));
                 }
             };
+        }
+        Ok(())
+    }
+
+    fn verify_type_nodes(&self, config: &VerifierConfig) -> PartialVMResult<()> {
+        for sign in self.resolver.signatures() {
+            for ty in &sign.0 {
+                self.verify_type_node(config, ty)?
+            }
+        }
+        for cons in self.resolver.constant_pool() {
+            self.verify_type_node(config, &cons.type_)?
+        }
+        Ok(())
+    }
+
+    fn verify_type_node(
+        &self,
+        config: &VerifierConfig,
+        ty: &SignatureToken,
+    ) -> PartialVMResult<()> {
+        if let Some(max) = &config.max_type_nodes {
+            // Structs and Parameters can expand to an unknown number of nodes, therefore
+            // we give them a higher size weight here.
+            const STRUCT_SIZE_WEIGHT: usize = 4;
+            const PARAM_SIZE_WEIGHT: usize = 4;
+            let mut size = 0;
+            for t in ty.preorder_traversal() {
+                // Notice that the preorder traversal will iterate all type instantiations, so we
+                // why we can ignore them below.
+                match t {
+                    SignatureToken::Struct(..) | SignatureToken::StructInstantiation(..) => {
+                        size += STRUCT_SIZE_WEIGHT
+                    }
+                    SignatureToken::TypeParameter(..) => size += PARAM_SIZE_WEIGHT,
+                    _ => size += 1,
+                }
+            }
+            if size > *max {
+                return Err(PartialVMError::new(StatusCode::TOO_MANY_TYPE_NODES));
+            }
         }
         Ok(())
     }

--- a/language/move-bytecode-verifier/src/limits.rs
+++ b/language/move-bytecode-verifier/src/limits.rs
@@ -5,7 +5,7 @@ use crate::VerifierConfig;
 use move_binary_format::{
     binary_views::BinaryIndexedView,
     errors::{Location, PartialVMError, PartialVMResult, VMResult},
-    file_format::{CompiledModule, CompiledScript, SignatureToken},
+    file_format::{CompiledModule, CompiledScript, SignatureToken, StructFieldInformation},
     IndexKind,
 };
 use move_core_types::vm_status::StatusCode;
@@ -91,6 +91,15 @@ impl<'a> LimitsVerifier<'a> {
         }
         for cons in self.resolver.constant_pool() {
             self.verify_type_node(config, &cons.type_)?
+        }
+        if let Some(sdefs) = self.resolver.struct_defs() {
+            for sdef in sdefs {
+                if let StructFieldInformation::Declared(fdefs) = &sdef.field_information {
+                    for fdef in fdefs {
+                        self.verify_type_node(config, &fdef.signature.0)?
+                    }
+                }
+            }
         }
         Ok(())
     }

--- a/language/move-bytecode-verifier/src/stack_usage_verifier.rs
+++ b/language/move-bytecode-verifier/src/stack_usage_verifier.rs
@@ -9,6 +9,7 @@
 //! the stack height by the number of values returned by the function as indicated in its
 //! signature. Additionally, the stack height must not dip below that at the beginning of the
 //! block for any basic block.
+use crate::VerifierConfig;
 use move_binary_format::{
     binary_views::{BinaryIndexedView, FunctionView},
     control_flow_graph::{BlockId, ControlFlowGraph},
@@ -26,6 +27,7 @@ pub(crate) struct StackUsageVerifier<'a> {
 
 impl<'a> StackUsageVerifier<'a> {
     pub(crate) fn verify(
+        config: &VerifierConfig,
         resolver: &'a BinaryIndexedView<'a>,
         function_view: &'a FunctionView,
     ) -> PartialVMResult<()> {
@@ -37,12 +39,17 @@ impl<'a> StackUsageVerifier<'a> {
         };
 
         for block_id in function_view.cfg().blocks() {
-            verifier.verify_block(block_id, function_view.cfg())?
+            verifier.verify_block(config, block_id, function_view.cfg())?
         }
         Ok(())
     }
 
-    fn verify_block(&self, block_id: BlockId, cfg: &dyn ControlFlowGraph) -> PartialVMResult<()> {
+    fn verify_block(
+        &self,
+        config: &VerifierConfig,
+        block_id: BlockId,
+        cfg: &dyn ControlFlowGraph,
+    ) -> PartialVMResult<()> {
         let code = &self.code.code;
         let mut stack_size_increment = 0;
         let block_start = cfg.block_start(block_id);
@@ -72,6 +79,11 @@ impl<'a> StackUsageVerifier<'a> {
                         .at_code_offset(self.current_function(), block_start),
                 );
             };
+
+            if stack_size_increment > config.max_value_stack_size as u64 {
+                return Err(PartialVMError::new(StatusCode::VALUE_STACK_OVERFLOW)
+                    .at_code_offset(self.current_function(), block_start));
+            }
         }
 
         if stack_size_increment == 0 {

--- a/language/move-bytecode-verifier/src/verifier.rs
+++ b/language/move-bytecode-verifier/src/verifier.rs
@@ -17,13 +17,15 @@ use move_binary_format::{
     file_format::{CompiledModule, CompiledScript},
 };
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct VerifierConfig {
     pub max_loop_depth: Option<usize>,
     pub treat_friend_as_private: bool,
     pub max_function_parameters: Option<usize>,
     pub max_generic_instantiation_length: Option<usize>,
     pub max_basic_blocks: Option<usize>,
+    pub max_value_stack_size: usize,
+    pub max_type_nodes: Option<usize>,
 }
 
 /// Helper for a "canonical" verification of a module.
@@ -82,4 +84,19 @@ pub fn verify_script_with_config(config: &VerifierConfig, script: &CompiledScrip
     constants::verify_script(script)?;
     CodeUnitVerifier::verify_script(config, script)?;
     script_signature::verify_script(script, no_additional_script_signature_checks)
+}
+
+impl Default for VerifierConfig {
+    fn default() -> Self {
+        Self {
+            max_loop_depth: None,
+            treat_friend_as_private: false,
+            max_function_parameters: None,
+            max_generic_instantiation_length: None,
+            max_basic_blocks: None,
+            max_type_nodes: None,
+            // Max size set to 1024 to match the size limit in the interpreter.
+            max_value_stack_size: 1024,
+        }
+    }
 }

--- a/language/move-core/types/src/vm_status.rs
+++ b/language/move-core/types/src/vm_status.rs
@@ -601,6 +601,8 @@ pub enum StatusCode {
     TOO_MANY_TYPE_PARAMETERS = 1112,
     TOO_MANY_PARAMETERS = 1113,
     TOO_MANY_BASIC_BLOCKS = 1114,
+    VALUE_STACK_OVERFLOW = 1115,
+    TOO_MANY_TYPE_NODES = 1116,
 
     // These are errors that the VM might raise if a violation of internal
     // invariants takes place.

--- a/language/move-vm/runtime/src/loader.rs
+++ b/language/move-vm/runtime/src/loader.rs
@@ -1450,6 +1450,20 @@ impl<'a> Resolver<'a> {
             BinaryType::Module(module) => module.struct_instantiation_at(idx.0),
             BinaryType::Script(_) => unreachable!("Scripts cannot have type instructions"),
         };
+
+        // Before instantiating the type, count the # of nodes of all type arguments plus
+        // existing type instantiation.
+        // If that number is larger than MAX_TYPE_INSTANTIATION_NODES, refuse to construct this type.
+        // This prevents constructing larger and lager types via struct instantiation.
+        // TODO: this should be revisited for performance and unification with MAX_VALUE_DEPTH
+        let mut sum_nodes: usize = 1;
+        for ty in ty_args.iter().chain(struct_inst.instantiation.iter()) {
+            sum_nodes = sum_nodes.saturating_add(self.loader.count_type_nodes(ty));
+            if sum_nodes > MAX_TYPE_INSTANTIATION_NODES {
+                return Err(PartialVMError::new(StatusCode::VM_MAX_TYPE_NODES_REACHED));
+            }
+        }
+
         Ok(Type::StructInstantiation(
             struct_inst.def,
             struct_inst
@@ -2390,6 +2404,7 @@ struct StructInfo {
     struct_tag: Option<StructTag>,
     struct_layout: Option<MoveStructLayout>,
     annotated_struct_layout: Option<MoveStructLayout>,
+    node_count: Option<usize>,
 }
 
 impl StructInfo {
@@ -2398,6 +2413,7 @@ impl StructInfo {
             struct_tag: None,
             struct_layout: None,
             annotated_struct_layout: None,
+            node_count: None,
         }
     }
 }
@@ -2414,7 +2430,16 @@ impl TypeCache {
     }
 }
 
+/// Maximal depth of a value in terms of type depth.
 const VALUE_DEPTH_MAX: usize = 128;
+
+/// Maximal nodes which are allowed when converting to layout. This includes the the types of
+/// fields for struct types.
+const MAX_TYPE_TO_LAYOUT_NODES: usize = 256;
+
+/// Maximal nodes which are all allowed when instantiating a generic type. This does not include
+/// field types of structs.
+const MAX_TYPE_INSTANTIATION_NODES: usize = 128;
 
 impl Loader {
     fn struct_gidx_to_type_tag(
@@ -2476,7 +2501,7 @@ impl Loader {
                 return Err(
                     PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
                         .with_message(format!("no type tag for {:?}", ty)),
-                )
+                );
             }
         })
     }
@@ -2485,16 +2510,21 @@ impl Loader {
         &self,
         gidx: CachedStructIndex,
         ty_args: &[Type],
+        count: &mut usize,
         depth: usize,
     ) -> PartialVMResult<MoveStructLayout> {
         if let Some(struct_map) = self.type_cache.read().structs.get(&gidx) {
             if let Some(struct_info) = struct_map.get(ty_args) {
+                if let Some(node_count) = &struct_info.node_count {
+                    *count += *node_count
+                }
                 if let Some(layout) = &struct_info.struct_layout {
                     return Ok(layout.clone());
                 }
             }
         }
 
+        let count_before = *count;
         let struct_type = self.module_cache.read().struct_at(gidx);
         let field_tys = struct_type
             .fields
@@ -2503,50 +2533,97 @@ impl Loader {
             .collect::<PartialVMResult<Vec<_>>>()?;
         let field_layouts = field_tys
             .iter()
-            .map(|ty| self.type_to_type_layout_impl(ty, depth + 1))
+            .map(|ty| self.type_to_type_layout_impl(ty, count, depth + 1))
             .collect::<PartialVMResult<Vec<_>>>()?;
+        let field_node_count = *count - count_before;
+
         let struct_layout = MoveStructLayout::new(field_layouts);
 
-        self.type_cache
-            .write()
+        let mut cache = self.type_cache.write();
+        let info = cache
             .structs
             .entry(gidx)
             .or_insert_with(HashMap::new)
             .entry(ty_args.to_vec())
-            .or_insert_with(StructInfo::new)
-            .struct_layout = Some(struct_layout.clone());
+            .or_insert_with(StructInfo::new);
+        info.struct_layout = Some(struct_layout.clone());
+        info.node_count = Some(field_node_count);
 
         Ok(struct_layout)
     }
 
-    fn type_to_type_layout_impl(&self, ty: &Type, depth: usize) -> PartialVMResult<MoveTypeLayout> {
+    fn type_to_type_layout_impl(
+        &self,
+        ty: &Type,
+        count: &mut usize,
+        depth: usize,
+    ) -> PartialVMResult<MoveTypeLayout> {
+        if *count > MAX_TYPE_TO_LAYOUT_NODES {
+            return Err(PartialVMError::new(StatusCode::VM_MAX_TYPE_NODES_REACHED));
+        }
         if depth > VALUE_DEPTH_MAX {
             return Err(PartialVMError::new(StatusCode::VM_MAX_VALUE_DEPTH_REACHED));
         }
         Ok(match ty {
-            Type::Bool => MoveTypeLayout::Bool,
-            Type::U8 => MoveTypeLayout::U8,
-            Type::U16 => MoveTypeLayout::U16,
-            Type::U32 => MoveTypeLayout::U32,
-            Type::U64 => MoveTypeLayout::U64,
-            Type::U128 => MoveTypeLayout::U128,
-            Type::U256 => MoveTypeLayout::U256,
-            Type::Address => MoveTypeLayout::Address,
-            Type::Signer => MoveTypeLayout::Signer,
+            Type::Bool => {
+                *count += 1;
+                MoveTypeLayout::Bool
+            }
+            Type::U8 => {
+                *count += 1;
+                MoveTypeLayout::U8
+            }
+            Type::U16 => {
+                *count += 1;
+                MoveTypeLayout::U16
+            }
+            Type::U32 => {
+                *count += 1;
+                MoveTypeLayout::U32
+            }
+            Type::U64 => {
+                *count += 1;
+                MoveTypeLayout::U64
+            }
+            Type::U128 => {
+                *count += 1;
+                MoveTypeLayout::U128
+            }
+            Type::U256 => {
+                *count += 1;
+                MoveTypeLayout::U256
+            }
+            Type::Address => {
+                *count += 1;
+                MoveTypeLayout::Address
+            }
+            Type::Signer => {
+                *count += 1;
+                MoveTypeLayout::Signer
+            }
             Type::Vector(ty) => {
-                MoveTypeLayout::Vector(Box::new(self.type_to_type_layout_impl(ty, depth + 1)?))
+                *count += 1;
+                MoveTypeLayout::Vector(Box::new(self.type_to_type_layout_impl(
+                    ty,
+                    count,
+                    depth + 1,
+                )?))
             }
             Type::Struct(gidx) => {
-                MoveTypeLayout::Struct(self.struct_gidx_to_type_layout(*gidx, &[], depth)?)
+                *count += 1;
+                MoveTypeLayout::Struct(self.struct_gidx_to_type_layout(*gidx, &[], count, depth)?)
             }
             Type::StructInstantiation(gidx, ty_args) => {
-                MoveTypeLayout::Struct(self.struct_gidx_to_type_layout(*gidx, ty_args, depth)?)
+                *count += 1;
+                MoveTypeLayout::Struct(
+                    self.struct_gidx_to_type_layout(*gidx, ty_args, count, depth)?,
+                )
             }
             Type::Reference(_) | Type::MutableReference(_) | Type::TyParam(_) => {
                 return Err(
                     PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
                         .with_message(format!("no type layout for {:?}", ty)),
-                )
+                );
             }
         })
     }
@@ -2555,10 +2632,14 @@ impl Loader {
         &self,
         gidx: CachedStructIndex,
         ty_args: &[Type],
+        count: &mut usize,
         depth: usize,
     ) -> PartialVMResult<MoveStructLayout> {
         if let Some(struct_map) = self.type_cache.read().structs.get(&gidx) {
             if let Some(struct_info) = struct_map.get(ty_args) {
+                if let Some(node_count) = &struct_info.node_count {
+                    *count += *node_count
+                }
                 if let Some(layout) = &struct_info.annotated_struct_layout {
                     return Ok(layout.clone());
                 }
@@ -2574,6 +2655,7 @@ impl Loader {
                 ),
             );
         }
+        let count_before = *count;
         let struct_tag = self.struct_gidx_to_type_tag(gidx, ty_args)?;
         let field_layouts = struct_type
             .field_names
@@ -2581,20 +2663,22 @@ impl Loader {
             .zip(&struct_type.fields)
             .map(|(n, ty)| {
                 let ty = ty.subst(ty_args)?;
-                let l = self.type_to_fully_annotated_layout_impl(&ty, depth + 1)?;
+                let l = self.type_to_fully_annotated_layout_impl(&ty, count, depth + 1)?;
                 Ok(MoveFieldLayout::new(n.clone(), l))
             })
             .collect::<PartialVMResult<Vec<_>>>()?;
         let struct_layout = MoveStructLayout::with_types(struct_tag, field_layouts);
+        let field_node_count = *count - count_before;
 
-        self.type_cache
-            .write()
+        let mut cache = self.type_cache.write();
+        let info = cache
             .structs
             .entry(gidx)
             .or_insert_with(HashMap::new)
             .entry(ty_args.to_vec())
-            .or_insert_with(StructInfo::new)
-            .annotated_struct_layout = Some(struct_layout.clone());
+            .or_insert_with(StructInfo::new);
+        info.annotated_struct_layout = Some(struct_layout.clone());
+        info.node_count = Some(field_node_count);
 
         Ok(struct_layout)
     }
@@ -2602,8 +2686,12 @@ impl Loader {
     fn type_to_fully_annotated_layout_impl(
         &self,
         ty: &Type,
+        count: &mut usize,
         depth: usize,
     ) -> PartialVMResult<MoveTypeLayout> {
+        if *count > MAX_TYPE_TO_LAYOUT_NODES {
+            return Err(PartialVMError::new(StatusCode::VM_MAX_TYPE_NODES_REACHED));
+        }
         if depth > VALUE_DEPTH_MAX {
             return Err(PartialVMError::new(StatusCode::VM_MAX_VALUE_DEPTH_REACHED));
         }
@@ -2618,19 +2706,19 @@ impl Loader {
             Type::Address => MoveTypeLayout::Address,
             Type::Signer => MoveTypeLayout::Signer,
             Type::Vector(ty) => MoveTypeLayout::Vector(Box::new(
-                self.type_to_fully_annotated_layout_impl(ty, depth + 1)?,
+                self.type_to_fully_annotated_layout_impl(ty, count, depth + 1)?,
             )),
             Type::Struct(gidx) => MoveTypeLayout::Struct(
-                self.struct_gidx_to_fully_annotated_layout(*gidx, &[], depth)?,
+                self.struct_gidx_to_fully_annotated_layout(*gidx, &[], count, depth)?,
             ),
             Type::StructInstantiation(gidx, ty_args) => MoveTypeLayout::Struct(
-                self.struct_gidx_to_fully_annotated_layout(*gidx, ty_args, depth)?,
+                self.struct_gidx_to_fully_annotated_layout(*gidx, ty_args, count, depth)?,
             ),
             Type::Reference(_) | Type::MutableReference(_) | Type::TyParam(_) => {
                 return Err(
                     PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
                         .with_message(format!("no type layout for {:?}", ty)),
-                )
+                );
             }
         })
     }
@@ -2640,14 +2728,16 @@ impl Loader {
     }
 
     pub(crate) fn type_to_type_layout(&self, ty: &Type) -> PartialVMResult<MoveTypeLayout> {
-        self.type_to_type_layout_impl(ty, 1)
+        let mut count = 0;
+        self.type_to_type_layout_impl(ty, &mut count, 1)
     }
 
     pub(crate) fn type_to_fully_annotated_layout(
         &self,
         ty: &Type,
     ) -> PartialVMResult<MoveTypeLayout> {
-        self.type_to_fully_annotated_layout_impl(ty, 1)
+        let mut count = 0;
+        self.type_to_fully_annotated_layout_impl(ty, &mut count, 1)
     }
 }
 


### PR DESCRIPTION
* Add checks for max stack usage during stack balance analysis

* avoid duplicating name_def_map

* Type node bounds

This adds two measurements to limit the number of type nodes:

- in the bytecode verifier, module `limits, we restrict the number of nodes in a `SignatureToken` to 256 (configurable). Since at this point we neither know type instantiations nor struct definitions, we choose some weight factor for structs and type parameters. This measurement is mainly there to prevent and algorithms running out of time or memory which are part of the bytecode verifier.
- in the VM loader, we now not only count the depth of a type term but also the number of nodes in computation of type layouts. This includes type instantiation and struct definitions.

Co-authored-by: Zhou Runtian <runtian@aptoslabs.com>
Co-authored-by: Zekun Li <li.zekun@gmail.com>
