### PR TITLE
[compiler] Added info about function attributes as annotations

### DIFF
--- a/language/move-compiler/src/compiled_unit.rs
+++ b/language/move-compiler/src/compiled_unit.rs
@@ -5,7 +5,7 @@
 use crate::{
     diag,
     diagnostics::Diagnostics,
-    expansion::ast::{ModuleIdent, ModuleIdent_, SpecId},
+    expansion::ast::{Attributes, ModuleIdent, ModuleIdent_, SpecId},
     hlir::ast as H,
     parser::ast::{FunctionName, ModuleName, Var},
     shared::{unique_map::UniqueMap, Name, NumericalAddress},
@@ -41,6 +41,7 @@ pub struct SpecInfo {
 pub struct FunctionInfo {
     pub spec_info: BTreeMap<SpecId, SpecInfo>,
     pub parameters: Vec<(Var, VarInfo)>,
+    pub attributes: Attributes,
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
## Motivation

This is another take at adding information about function attributes (specifically to find out if they are meant for testing) to make it available as part of compilation output. The previous take (https://github.com/move-language/move/pull/693) was aiming to add it in the file format, this one adds the required info into the annotated compiled units instead. I followed @wrwg's suggestions from the previous IR and instead of encoding just the fact if the function is involved in tests, this take encodes all function attributes.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes

