### PR TITLE
[docs] update coding conventions for error codes

### DIFF
--- a/language/documentation/book/src/coding-conventions.md
+++ b/language/documentation/book/src/coding-conventions.md
@@ -7,8 +7,9 @@ This section lays out some basic coding conventions for Move that the Move team 
 - **Module names**: should be lower snake case, e.g., `fixed_point32`, `vector`.
 - **Type names**: should be camel case if they are not a native type, e.g., `Coin`, `RoleId`.
 - **Function names**: should be lower snake case, e.g., `destroy_empty`.
-- **Constant names**: should be upper snake case, e.g., `REQUIRES_CAPABILITY`.
-- Generic types should be descriptive, or anti-descriptive where appropriate, e.g., `T` or `Element` for the Vector generic type parameter. Most of the time the "main" type in a module should be the same name as the module e.g., `option::Option`, `fixed_point32::FixedPoint32`.
+- **Constant names**: should be upper camel case and begin with an `E` if they represent error codes (e.g., `EIndexOutOfBounds`) and upper snake case if they represent a non-error value (e.g., `MIN_STAKE`).
+-
+- **Generic type names**: should be descriptive, or anti-descriptive where appropriate, e.g., `T` or `Element` for the Vector generic type parameter. Most of the time the "main" type in a module should be the same name as the module e.g., `option::Option`, `fixed_point32::FixedPoint32`.
 - **Module file names**: should be the same as the module name e.g., `Option.move`.
 - **Script file names**: should be lower snake case and should match the name of the “main” function in the script.
 - **Mixed file names**: If the file contains multiple modules and/or scripts, the file name should be lower snake case, where the name does not match any particular module/script inside.


### PR DESCRIPTION
We suggest that error codes use upper camel case + start with an `E` to distinguish them from other constants