### PR TITLE
[move-prover] allow annotations to mark whether a fixedpoint is reached

### DIFF
--- a/language/move-prover/bytecode/src/borrow_analysis.rs
+++ b/language/move-prover/bytecode/src/borrow_analysis.rs
@@ -386,9 +386,10 @@ impl FunctionTargetProcessor for BorrowAnalysisProcessor {
             analyzer.analyze(&data.code)
         };
         // Annotate function target with computed borrow data.
+        // TODO(mengxu): manually calculate the fixedpoint marker
         data.annotations
             .borrow_mut()
-            .set::<BorrowAnnotation>(borrow_annotation);
+            .set::<BorrowAnnotation>(borrow_annotation, true);
         data.annotations.borrow_mut().remove::<LiveVarAnnotation>();
         data
     }

--- a/language/move-prover/bytecode/src/global_invariant_analysis.rs
+++ b/language/move-prover/bytecode/src/global_invariant_analysis.rs
@@ -4,14 +4,9 @@
 
 // Analysis pass which analyzes how to injects global invariants into the bytecode.
 
-use crate::{
-    function_target::{FunctionData, FunctionTarget},
-    function_target_pipeline::{
-        FunctionTargetProcessor, FunctionTargetsHolder, FunctionVariant, VerificationFlavor,
-    },
-    stackless_bytecode::{BorrowNode, Bytecode, Operation, PropKind},
-    usage_analysis,
-    verification_analysis::{is_invariant_suspendable, InvariantAnalysisData},
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fmt,
 };
 
 use move_binary_format::file_format::CodeOffset;
@@ -21,9 +16,14 @@ use move_model::{
     ty::{Type, TypeDisplayContext, TypeInstantiationDerivation, TypeUnificationAdapter, Variance},
 };
 
-use std::{
-    collections::{BTreeMap, BTreeSet},
-    fmt,
+use crate::{
+    function_target::{FunctionData, FunctionTarget},
+    function_target_pipeline::{
+        FunctionTargetProcessor, FunctionTargetsHolder, FunctionVariant, VerificationFlavor,
+    },
+    stackless_bytecode::{BorrowNode, Bytecode, Operation, PropKind},
+    usage_analysis,
+    verification_analysis::{is_invariant_suspendable, InvariantAnalysisData},
 };
 
 /// A named struct for holding the information on how an invariant is relevant to a bytecode.
@@ -101,7 +101,9 @@ impl FunctionTargetProcessor for GlobalInvariantAnalysisProcessor {
         // Analyze invariants
         let target = FunctionTarget::new(fun_env, &data);
         let analysis_result = PerFunctionRelevance::analyze(&target, targets);
-        data.annotations.set(analysis_result);
+        // TODO(mengxu): re-verify that recursive functions do not impact how  global invariant
+        // analysis are performed.
+        data.annotations.set(analysis_result, true);
 
         // This is an analysis pass, nothing gets changed
         data

--- a/language/move-prover/bytecode/src/packed_types_analysis.rs
+++ b/language/move-prover/bytecode/src/packed_types_analysis.rs
@@ -2,6 +2,15 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::BTreeSet;
+
+use move_binary_format::file_format::CodeOffset;
+use move_core_types::language_storage::{StructTag, TypeTag};
+use move_model::{
+    model::{FunctionEnv, GlobalEnv},
+    ty::Type,
+};
+
 use crate::{
     compositional_analysis::{CompositionalAnalysis, SummaryCache},
     dataflow_analysis::{DataflowAnalysis, TransferFunctions},
@@ -10,13 +19,6 @@ use crate::{
     function_target_pipeline::{FunctionTargetProcessor, FunctionTargetsHolder, FunctionVariant},
     stackless_bytecode::{Bytecode, Operation},
 };
-use move_binary_format::file_format::CodeOffset;
-use move_core_types::language_storage::{StructTag, TypeTag};
-use move_model::{
-    model::{FunctionEnv, GlobalEnv},
-    ty::Type,
-};
-use std::collections::BTreeSet;
 
 /// Get all closed types that may be packed by (1) genesis and (2) all transaction scripts.
 /// This makes some simplifying assumptions that are not correct in general, but hold for the
@@ -143,6 +145,7 @@ impl<'a> TransferFunctions for PackedTypesAnalysis<'a> {
                             }
                         }
                     }
+                    // TODO(mengxu, sam): fix the recursive function case
                 }
                 OpaqueCallBegin(_, _, _) | OpaqueCallEnd(_, _, _) => {
                     // skip
@@ -183,7 +186,9 @@ impl FunctionTargetProcessor for PackedTypesProcessor {
         let cache = SummaryCache::new(targets, func_env.module_env.env);
         let analysis = PackedTypesAnalysis { cache };
         let summary = analysis.summarize(&fun_target, initial_state);
-        data.annotations.set(summary);
+        // TODO(mengxu, sam): recursion seems to have an impact on how this analysis are conducted,
+        // resolve the TODO item above in the code and update the fixedpoint calculation logic here.
+        data.annotations.set(summary, true);
         data
     }
 

--- a/language/move-prover/bytecode/src/read_write_set_analysis.rs
+++ b/language/move-prover/bytecode/src/read_write_set_analysis.rs
@@ -755,7 +755,9 @@ impl FunctionTargetProcessor for ReadWriteSetProcessor {
         let cache = SummaryCache::new(targets, func_env.module_env.env);
         let analysis = ReadWriteSetAnalysis { cache, func_env };
         let summary = analysis.summarize(&fun_target, initial_state);
-        data.annotations.set(summary);
+        // TODO(mengxu, sam): recursion seems to have an impact on how this analysis are conducted,
+        // revisit the code logic and update the fixedpoint calculation logic here.
+        data.annotations.set(summary, true);
         data
     }
 

--- a/language/move-prover/bytecode/src/usage_analysis.rs
+++ b/language/move-prover/bytecode/src/usage_analysis.rs
@@ -2,6 +2,18 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use std::{collections::BTreeSet, fmt, fmt::Formatter};
+
+use itertools::Itertools;
+use paste::paste;
+
+use move_binary_format::file_format::CodeOffset;
+use move_model::{
+    ast::{ConditionKind, Spec},
+    model::{FunctionEnv, GlobalEnv, QualifiedId, QualifiedInstId, StructId},
+    ty::Type,
+};
+
 use crate::{
     compositional_analysis::{CompositionalAnalysis, SummaryCache},
     dataflow_analysis::{DataflowAnalysis, TransferFunctions},
@@ -10,17 +22,6 @@ use crate::{
     function_target_pipeline::{FunctionTargetProcessor, FunctionTargetsHolder, FunctionVariant},
     stackless_bytecode::{BorrowNode, Bytecode, Operation, PropKind},
 };
-
-use move_binary_format::file_format::CodeOffset;
-use move_model::{
-    model::{FunctionEnv, GlobalEnv, QualifiedId, QualifiedInstId, StructId},
-    ty::Type,
-};
-
-use itertools::Itertools;
-use move_model::ast::{ConditionKind, Spec};
-use paste::paste;
-use std::{collections::BTreeSet, fmt, fmt::Formatter};
 
 pub fn get_memory_usage<'env>(target: &FunctionTarget<'env>) -> &'env UsageState {
     target
@@ -331,7 +332,8 @@ impl FunctionTargetProcessor for UsageProcessor {
         mut data: FunctionData,
     ) -> FunctionData {
         let summary = Self::analyze(targets, func_env, &data);
-        data.annotations.set(summary);
+        // TODO(mengxu): re-check the code on whether recursion have an impact on the analysis here.
+        data.annotations.set(summary, true);
         data
     }
 

--- a/language/move-prover/bytecode/src/verification_analysis.rs
+++ b/language/move-prover/bytecode/src/verification_analysis.rs
@@ -369,7 +369,10 @@ impl VerificationAnalysisProcessor {
         data: &mut FunctionData,
         targets: &mut FunctionTargetsHolder,
     ) {
-        let mut info = data.annotations.get_or_default_mut::<VerificationInfo>();
+        // TODO(mengxu): re-check the treatment of fixedpoint here
+        let mut info = data
+            .annotations
+            .get_or_default_mut::<VerificationInfo>(true);
         if !info.verified {
             info.verified = true;
             Self::mark_callees_inlined(fun_env, targets);
@@ -388,7 +391,10 @@ impl VerificationAnalysisProcessor {
         // at this time, we only have the `baseline` variant in the targets
         let variant = FunctionVariant::Baseline;
         if let Some(data) = targets.get_data_mut(&fun_env.get_qualified_id(), &variant) {
-            let info = data.annotations.get_or_default_mut::<VerificationInfo>();
+            // TODO(mengxu): re-check the treatment of fixedpoint here
+            let info = data
+                .annotations
+                .get_or_default_mut::<VerificationInfo>(true);
             if !info.inlined {
                 info.inlined = true;
                 Self::mark_callees_inlined(fun_env, targets);


### PR DESCRIPTION
This commit allows the `Annotations` struct which resides in
`FunctionData` to mark whether an annotation has reached a fixedpoint
status in the presence of recursive calls.

The core of change is this:

```diff
pub struct Annotations {
-    map: BTreeMap<TypeId, Data>,
+    map: BTreeMap<TypeId, (Data, bool)>,
}
```

Currently all annotations, when set, are marked as already reached
fixedpoint status. This is consistent with the current assumption of
no-recursive calls.

Subsequent commits will relax this unsound assumption by examining the
annotation structure produced by different passes in the transformation
pipeline.

This commit depends on PR #698. A better way to review this PR is
to just look at the second commit: 7ecd599bd95fbd9ea2fb51ae68949d10c303dd57

## Motivation

More systematic supporting of recursive functions

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes

## Test Plan

CI