### PR TITLE
[u256] minor fixes

### DIFF
--- a/language/move-core/types/src/u256.rs
+++ b/language/move-core/types/src/u256.rs
@@ -95,7 +95,7 @@ impl fmt::Display for U256FromStrError {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash, Copy, PartialOrd, Ord)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Copy, PartialOrd, Ord, Default)]
 pub struct U256(PrimitiveU256);
 
 impl fmt::Display for U256 {

--- a/language/move-vm/types/src/values/values_impl.rs
+++ b/language/move-vm/types/src/values/values_impl.rs
@@ -3461,7 +3461,7 @@ pub mod prop {
             L::U32 => any::<u32>().prop_map(Value::u32).boxed(),
             L::U64 => any::<u64>().prop_map(Value::u64).boxed(),
             L::U128 => any::<u128>().prop_map(Value::u128).boxed(),
-            L::U256 => any::<u256>().prop_map(Value::u256).boxed(),
+            L::U256 => any::<u256::U256>().prop_map(Value::u256).boxed(),
             L::Bool => any::<bool>().prop_map(Value::bool).boxed(),
             L::Address => any::<AccountAddress>().prop_map(Value::address).boxed(),
             L::Signer => any::<AccountAddress>().prop_map(Value::signer).boxed(),


### PR DESCRIPTION
This includes two minor fixes related to u256:
1. It fixes a build error in the fuzzing code
2. It implements Default for u256 so to make it consistent with other primitive integer types. This is also needed by some other downstream tools