### PR TITLE
[verifier] remove treat_friend_as_private from the verifier config

### DIFF
--- a/language/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/limit_tests.rs
+++ b/language/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/limit_tests.rs
@@ -247,7 +247,6 @@ fn big_vec_unpacks() {
     let res = verify_module_with_config(
         &VerifierConfig {
             max_loop_depth: Some(5),
-            treat_friend_as_private: false,
             max_generic_instantiation_length: Some(32),
             max_function_parameters: Some(128),
             max_basic_blocks: Some(1024),

--- a/language/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/signature_tests.rs
+++ b/language/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/signature_tests.rs
@@ -218,7 +218,6 @@ fn big_signature_test() {
     let res = verify_module_with_config(
         &VerifierConfig {
             max_loop_depth: Some(5),
-            treat_friend_as_private: false,
             max_generic_instantiation_length: Some(32),
             max_function_parameters: Some(128),
             max_basic_blocks: Some(1024),

--- a/language/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/vec_pack_tests.rs
+++ b/language/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/vec_pack_tests.rs
@@ -62,7 +62,6 @@ fn test_vec_pack() {
     let res = move_bytecode_verifier::verify_module_with_config(
         &VerifierConfig {
             max_loop_depth: Some(5),
-            treat_friend_as_private: true,
             max_generic_instantiation_length: Some(32),
             max_function_parameters: Some(128),
             max_basic_blocks: Some(1024),

--- a/language/move-bytecode-verifier/src/verifier.rs
+++ b/language/move-bytecode-verifier/src/verifier.rs
@@ -20,7 +20,6 @@ use move_binary_format::{
 #[derive(Debug, Clone)]
 pub struct VerifierConfig {
     pub max_loop_depth: Option<usize>,
-    pub treat_friend_as_private: bool,
     pub max_function_parameters: Option<usize>,
     pub max_generic_instantiation_length: Option<usize>,
     pub max_basic_blocks: Option<usize>,
@@ -92,7 +91,6 @@ impl Default for VerifierConfig {
     fn default() -> Self {
         Self {
             max_loop_depth: None,
-            treat_friend_as_private: false,
             max_function_parameters: None,
             max_generic_instantiation_length: None,
             max_basic_blocks: None,


### PR DESCRIPTION
`treat_friend_as_private` is now controlled on a per-publishing basis and the entry in the verifier config is no longer used. This gets it removed for cleanness.