### PR TITLE
Limits for defs in a module

### DIFF
--- a/language/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/signature_tests.rs
+++ b/language/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/signature_tests.rs
@@ -224,7 +224,10 @@ fn big_signature_test() {
             max_value_stack_size: 1024,
             max_type_nodes: Some(256),
             max_push_size: Some(10000),
-            max_dependency_depth: 100,
+            max_dependency_depth: Some(100),
+            max_struct_definitions: Some(200),
+            max_fields_in_struct: Some(30),
+            max_function_definitions: Some(1000),
         },
         &module,
     )

--- a/language/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/vec_pack_tests.rs
+++ b/language/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/vec_pack_tests.rs
@@ -68,7 +68,10 @@ fn test_vec_pack() {
             max_value_stack_size: 1024,
             max_type_nodes: Some(256),
             max_push_size: Some(10000),
-            max_dependency_depth: 100,
+            max_dependency_depth: Some(100),
+            max_struct_definitions: Some(200),
+            max_fields_in_struct: Some(30),
+            max_function_definitions: Some(1000),
         },
         &m,
     )

--- a/language/move-bytecode-verifier/src/verifier.rs
+++ b/language/move-bytecode-verifier/src/verifier.rs
@@ -26,7 +26,10 @@ pub struct VerifierConfig {
     pub max_value_stack_size: usize,
     pub max_type_nodes: Option<usize>,
     pub max_push_size: Option<usize>,
-    pub max_dependency_depth: u64,
+    pub max_dependency_depth: Option<usize>,
+    pub max_struct_definitions: Option<usize>,
+    pub max_fields_in_struct: Option<usize>,
+    pub max_function_definitions: Option<usize>,
 }
 
 /// Helper for a "canonical" verification of a module.
@@ -97,9 +100,22 @@ impl Default for VerifierConfig {
             max_type_nodes: None,
             // Max size set to 1024 to match the size limit in the interpreter.
             max_value_stack_size: 1024,
+            // Max number of pushes in one function
+            max_push_size: None,
+            // Max depth in dependency tree for both direct and friend dependencies
+            max_dependency_depth: None,
+            // Max count of structs in a module
+            max_struct_definitions: None,
+            // Max count of fields in a struct
+            max_fields_in_struct: None,
+            // Max count of functions in a module
+            max_function_definitions: None,
             // Max size set to 10000 to restrict number of pushes in one function
-            max_push_size: Some(10000),
-            max_dependency_depth: 100,
+            // max_push_size: Some(10000),
+            // max_dependency_depth: Some(100),
+            // max_struct_definitions: Some(200),
+            // max_fields_in_struct: Some(30),
+            // max_function_definitions: Some(1000),
         }
     }
 }

--- a/language/move-core/types/src/vm_status.rs
+++ b/language/move-core/types/src/vm_status.rs
@@ -604,6 +604,10 @@ pub enum StatusCode {
     VALUE_STACK_OVERFLOW = 1115,
     TOO_MANY_TYPE_NODES = 1116,
     VALUE_STACK_PUSH_OVERFLOW = 1117,
+    MAX_DEPENDENCY_DEPTH_REACHED = 1118,
+    MAX_FUNCTION_DEFINITIONS_REACHED = 1119,
+    MAX_STRUCT_DEFINITIONS_REACHED = 1120,
+    MAX_FIELD_DEFINITIONS_REACHED = 1121,
 
     // These are errors that the VM might raise if a violation of internal
     // invariants takes place.
@@ -675,7 +679,6 @@ pub enum StatusCode {
     STORAGE_WRITE_LIMIT_REACHED = 4027,
     MEMORY_LIMIT_EXCEEDED = 4028,
     VM_MAX_TYPE_NODES_REACHED = 4029,
-    VM_MAX_DEPENDENCY_DEPTH_REACHED = 4030,
 
     // A reserved status to represent an unknown vm status.
     // this is std::u64::MAX, but we can't pattern match on that, so put the hardcoded value in

--- a/language/move-vm/integration-tests/src/tests/loader_tests.rs
+++ b/language/move-vm/integration-tests/src/tests/loader_tests.rs
@@ -9,12 +9,13 @@ use move_binary_format::{
     },
     CompiledModule,
 };
+use move_bytecode_verifier::VerifierConfig;
 use move_core_types::{
     account_address::AccountAddress,
     identifier::{IdentStr, Identifier},
     language_storage::ModuleId,
 };
-use move_vm_runtime::move_vm::MoveVM;
+use move_vm_runtime::{config::VMConfig, move_vm::MoveVM};
 use move_vm_test_utils::InMemoryStorage;
 use move_vm_types::gas::UnmeteredGasMeter;
 
@@ -53,17 +54,31 @@ impl Adapter {
                 Identifier::new("just_c").unwrap(),
             ),
         ];
+        let config = VMConfig {
+            verifier: VerifierConfig {
+                max_dependency_depth: Some(100),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
         Self {
             store,
-            vm: Arc::new(MoveVM::new(vec![]).unwrap()),
+            vm: Arc::new(MoveVM::new_with_config(vec![], config).unwrap()),
             functions,
         }
     }
 
     fn fresh(self) -> Self {
+        let config = VMConfig {
+            verifier: VerifierConfig {
+                max_dependency_depth: Some(100),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
         Self {
             store: self.store,
-            vm: Arc::new(MoveVM::new(vec![]).unwrap()),
+            vm: Arc::new(MoveVM::new_with_config(vec![], config).unwrap()),
             functions: self.functions,
         }
     }


### PR DESCRIPTION
## Motivation
This introduces a limit for all definitions in a module: structs, fields and functions.
We have some quadratic algorithm in the loader (fields of a type defined in the module) and possibly more.
This reduces the chances of possible attacks and it is a reasonable limitation to add (in fact a great one in my opinion with open publishing).
Also there is some cleanup where we added some config values that were not `Option` as the others. Making everything `Option`.
Finally there is a fix in the limits check in the verifier to run `verify_type_nodes` for scripts

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?
Yes

## Test Plan
Added unit tests
