### PR TITLE
[Prover] Fix an issue in the concretization in the mono analysis

### DIFF
--- a/language/move-prover/bytecode/src/mono_analysis.rs
+++ b/language/move-prover/bytecode/src/mono_analysis.rs
@@ -508,6 +508,10 @@ impl<'a> Analyzer<'a> {
     }
 
     fn add_type(&mut self, ty: &Type) {
+        // Exclude the spec only primitive types.
+        if ty.is_spec() {
+            return;
+        }
         if !self.done_types.insert(ty.to_owned()) {
             return;
         }


### PR DESCRIPTION
Prover concretizes a type parameter `T` into `Primitive(Range)`  which eventually causes the panic (at this line: https://github.com/move-language/move/blob/main/language/move-prover/boogie-backend/src/boogie_helpers.rs#L194).

So, this commit excludes the spec only primitive types during the mono analysis.

Resolves https://github.com/move-language/move/issues/700

## Motivation

To fix an issue in the mono analysis

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

yes

## Test Plan

cargo test
