### PR TITLE
[loader] Fixed a node counting problem

### DIFF
--- a/language/move-vm/runtime/src/loader.rs
+++ b/language/move-vm/runtime/src/loader.rs
@@ -2429,6 +2429,7 @@ struct StructInfo {
     struct_layout: Option<MoveStructLayout>,
     annotated_struct_layout: Option<MoveStructLayout>,
     node_count: Option<usize>,
+    annotated_node_count: Option<usize>,
 }
 
 impl StructInfo {
@@ -2438,6 +2439,7 @@ impl StructInfo {
             struct_layout: None,
             annotated_struct_layout: None,
             node_count: None,
+            annotated_node_count: None,
         }
     }
 }
@@ -2682,8 +2684,8 @@ impl Loader {
     ) -> PartialVMResult<MoveStructLayout> {
         if let Some(struct_map) = self.type_cache.read().structs.get(&gidx) {
             if let Some(struct_info) = struct_map.get(ty_args) {
-                if let Some(node_count) = &struct_info.node_count {
-                    *count += *node_count
+                if let Some(annotated_node_count) = &struct_info.annotated_node_count {
+                    *count += *annotated_node_count
                 }
                 if let Some(layout) = &struct_info.annotated_struct_layout {
                     return Ok(layout.clone());
@@ -2723,7 +2725,7 @@ impl Loader {
             .entry(ty_args.to_vec())
             .or_insert_with(StructInfo::new);
         info.annotated_struct_layout = Some(struct_layout.clone());
-        info.node_count = Some(field_node_count);
+        info.annotated_node_count = Some(field_node_count);
 
         Ok(struct_layout)
     }


### PR DESCRIPTION
## Motivation

This fixes a rather subtle bug in the loader implementation. Without adding an extra field to count annotated nodes, initial statement attempting to use the cached data in `struct_gidx_to_fully_annotated_layout` and in `struct_gidx_to_type_layout` could update the node count with the one retrieved from cache  but then NOT return the cached value (as it was cached from a different unannotated/annotated version and as such `struct_info.struct_layout`/`struct_info.annotated_struct_layout` would be, unexpectedly, 'None`). This would lead to spurious (larger) count values.


### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes

