### PR TITLE
[session] Expose type_to_type_tag

### DIFF
--- a/.github/workflows/ci-pre-land.yml
+++ b/.github/workflows/ci-pre-land.yml
@@ -281,9 +281,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up Ruby 2.6
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.6.x
+          ruby-version: "2.6"
       - name: Run Checks
         run: |
           gem install awesome_bot

--- a/language/move-vm/runtime/src/session.rs
+++ b/language/move-vm/runtime/src/session.rs
@@ -304,6 +304,13 @@ impl<'r, 'l, S: MoveResolver> Session<'r, 'l, S> {
             .get_fully_annotated_type_layout(type_tag, &self.data_cache)
     }
 
+    pub fn get_type_tag(&self, ty: &Type) -> VMResult<TypeTag> {
+        self.runtime
+            .loader()
+            .type_to_type_tag(ty)
+            .map_err(|e| e.finish(Location::Undefined))
+    }
+
     /// Fetch a struct type from cache, if the index is in bounds
     /// Helpful when paired with load_type, or any other API that returns 'Type'
     pub fn get_struct_type(&self, index: CachedStructIndex) -> Option<Arc<StructType>> {


### PR DESCRIPTION
- Exposed loaders type_to_type_tag function in the session API

## Motivation

- I am currently manually writing this function, but it is already exposed in the NativeContext. Seems reasonable I hope to also expose it when outside of Move (i.e. where the session is being invoked)

