### PR TITLE
[Documentation] Correct bitwise 'or' operator

### DIFF
--- a/language/documentation/book/src/integers.md
+++ b/language/documentation/book/src/integers.md
@@ -87,7 +87,7 @@ Bitwise operations do not abort.
 | Syntax | Operation  | Description
 |--------|------------|------------
 | `&`    | bitwise and| Performs a boolean and for each bit pairwise
-| `\|`   | bitwise or | Performs a boolean or for each bit pairwise
+| `|`   | bitwise or | Performs a boolean or for each bit pairwise
 | `^`    | bitwise xor| Performs a boolean exclusive or for each bit pairwise
 
 ### Bit Shifts


### PR DESCRIPTION
Correct me if I'm wrong, but I believe the bitwise OR operator syntax is '|' rather than '\|'

Did this get changed at some point recently?