### PR TITLE
[prover] Fix for incorrect generation of old values

### DIFF
--- a/language/move-prover/bytecode/src/spec_instrumentation.rs
+++ b/language/move-prover/bytecode/src/spec_instrumentation.rs
@@ -356,6 +356,20 @@ impl<'a> Instrumenter<'a> {
                 let saved_params = translated_spec.saved_params.clone();
                 self.emit_save_for_old(&saved_params);
             }
+        } else {
+            // The inlined variant may have an inlined spec that used "old" values - these need to
+            // be saved in both cases
+            assert!(
+                verification_analysis::get_info(&FunctionTarget::new(
+                    self.builder.fun_env,
+                    &self.builder.data
+                ))
+                .inlined
+            );
+            for translated_spec in inlined_props.values().map(|(s, _)| s) {
+                let saved_params = translated_spec.saved_params.clone();
+                self.emit_save_for_old(&saved_params);
+            }
         }
 
         // Instrument and generate new code

--- a/language/move-prover/tests/sources/functional/old_in_inlined.move
+++ b/language/move-prover/tests/sources/functional/old_in_inlined.move
@@ -1,0 +1,19 @@
+module 0x42::OldInInlined {
+
+    // tests the case when an inlined spec uses "old" and a function containing it (bar in this
+    // case) is itself called from another function (foo in this case) - "old" value must be
+    // recorded not only in the "verified" (bar) function variant but also in the baseline variant
+    // if it's called from another function
+
+    fun foo() {
+        let x = 0;
+        bar(&mut x);
+    }
+
+    fun bar(y: &mut u64) {
+        *y = *y + 2;
+        spec {
+            assert y > old(y) + 1;
+        }
+    }
+}


### PR DESCRIPTION
## Motivation

This resolves https://github.com/move-language/move/issues/717 which describes the problem and contains some discussion, but does not include Boogie generated code that explains what's going on so here is an additional explanation.

Consider the following Move code:
```
module prover_bug::old {
    fun foo() {
        let x = 0;
        bar(&mut x);
    }

    fun bar(y: &mut u64) {
        *y = *y + 2;
        spec {
            assert y > old(y) + 1;
        }
    }
}
```

The `assert` statement in the inlined spec of the `bar` function is at some point inlined into the Prover bytecode. In particular, this is the bytecode after the loop analysis (11th) pass with the assert inlined in line 5:
```
[variant baseline]
fun old::bar($t0|y: &mut u64) {
     var $t1: u64
     var $t2: u64
     var $t3: u64
  0: trace_local[y]($t0)
  1: $t1 := read_ref($t0)
  2: $t2 := 2
  3: $t3 := +($t1, $t2)
  4: write_ref($t0, $t3)
  5: assert Gt($t0, Add(Old<u64>($t0), 1))
  6: trace_local[y]($t0)
  7: return ()
}
```

The next (12th) pass, spec instrumentation, creates two variants of the `bar` function - the "verification" one and the "baseline" one.

The "verification" one is the one to be verified itself. As you will see the `Old<64>($t0)` call from the assertion in the code above will be translated to an access to variable `$t1` (line 6) that's saved at the beginning of the function (line 0):
```
[variant verification]
fun old::bar($t0|y: &mut u64) {
     var $t1: u64
     var $t2: u64
     var $t3: u64
     var $t4: u64
     var $t5: num
  0: $t1 := read_ref($t0)
  1: trace_local[y]($t0)
  2: $t2 := read_ref($t0)
  3: $t3 := 2
  4: $t4 := +($t2, $t3) on_abort goto 10 with $t5
  5: write_ref($t0, $t4)
  6: assert Gt($t0, Add($t1, 1))
  7: trace_local[y]($t0)
  8: label L1
  9: return ()
 10: label L2
 11: abort($t5)
}
```
The "baseline" variant of the `bar` function  is not subject to verification but it's nevertheless called from function `foo` and it still contains the assertion that must be satisfied. However, while  the `Old<64>($t0)` call is translated to access to variable `$t5` (line 5), this variable is never initialized anywhere, which means that it always contains Boogie's default value for uninitialized values (presumably 0), which causes Prover to fail.
```
[variant baseline]
fun old::bar($t0|y: &mut u64) {
     var $t1: u64
     var $t2: u64
     var $t3: u64
     var $t4: num
     var $t5: u64
  0: trace_local[y]($t0)
  1: $t1 := read_ref($t0)
  2: $t2 := 2
  3: $t3 := +($t1, $t2) on_abort goto 9 with $t4
  4: write_ref($t0, $t3)
  5: assert Gt($t0, Add($t5, 1))
  6: trace_local[y]($t0)
  7: label L1
  8: return ()
  9: label L2
 10: abort($t4)
}
```
And this is the failure we get:
```
error: unknown assertion failed
   ┌─ ./sources/old.move:10:13
   │
10 │             assert y > old(y) + 1;
   │             ^^^^^^^^^^^^^^^^^^^^^^
   │
   =     at ./sources/old.move:3: foo
   =         x = 0
   =     at ./sources/old.move:4: foo
   =     at ./sources/old.move:7: bar
   =         y = &0
   =     at ./sources/old.move:8: bar
   =     at ./sources/old.move:10: bar

Error: exiting with verification errors
```

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes

## Test Plan

Include the failing test provided in this PR as an example.
