### PR TITLE
[move book & move-book-zh] fix pipe sign rendering

### DIFF
--- a/language/documentation/book/src/integers.md
+++ b/language/documentation/book/src/integers.md
@@ -84,11 +84,11 @@ The integer types support the following bitwise operations that treat each numbe
 
 Bitwise operations do not abort.
 
-| Syntax | Operation  | Description
-|--------|------------|------------
-| `&`    | bitwise and| Performs a boolean and for each bit pairwise
-| `\|`   | bitwise or | Performs a boolean or for each bit pairwise
-| `^`    | bitwise xor| Performs a boolean exclusive or for each bit pairwise
+| Syntax              | Operation   | Description                                           |
+|---------------------|-------------|-------------------------------------------------------|
+| `&`                 | bitwise and | Performs a boolean and for each bit pairwise          |
+| <code>&#124;</code> | bitwise or  | Performs a boolean or for each bit pairwise           |
+| `^`                 | bitwise xor | Performs a boolean exclusive or for each bit pairwise |
 
 ### Bit Shifts
 

--- a/language/documentation/book/translations/move-book-zh/src/integers.md
+++ b/language/documentation/book/translations/move-book-zh/src/integers.md
@@ -97,22 +97,21 @@ The integer types support the following bitwise operations that treat each numbe
 
 Bitwise operations do not abort.
 
-| Syntax | Operation  | Description
-|--------|------------|------------
-| `&`    | bitwise and| Performs a boolean and for each bit pairwise
-| `|`   | bitwise or | Performs a boolean or for each bit pairwise
-| `^`    | bitwise xor| Performs a boolean exclusive or for each bit pairwise
-
+| Syntax              | Operation   | Description                                           |
+|---------------------|-------------|-------------------------------------------------------|
+| `&`                 | bitwise and | Performs a boolean and for each bit pairwise          |
+| <code>&#124;</code> | bitwise or  | Performs a boolean or for each bit pairwise           |
+| `^`                 | bitwise xor | Performs a boolean exclusive or for each bit pairwise |
 
 整数类型支持下列位运算，即将每个数字视为一系列单独的位：0 或 1，而不是整型数值。
 
 位运算不会中止。
 
-| 句法 | 操作   | 描述                                           |
-| ------ | ----------- | ----------------------------------------------------- |
-| `&`    | 按位 和 | 对每个位成对执行布尔值和          |
-| `|`    | 按位或  | 对每个位成对执行布尔值或
-| `^`    | 按位 异与 | 对每个位成对执行布尔异或 |
+| 语法                | 操作符   | 描述                       |
+|---------------------|----------|----------------------------|
+| `&`                 | 按位和   | 对每个位成对执行布尔值和   |
+| <code>&#124;</code> | 按位或   | 对每个位成对执行布尔值或   |
+| `^`                 | 按位异或 | 对每个位成对执行布尔值异或 |
 
 ### 位移 (Bit shift)
 


### PR DESCRIPTION
Close #735

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Move Language.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Make both mdBook and GitHub correctly render pipe sign (`|`).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes

## Test Plan


