### PR TITLE
[debug] print `std::ascii::String` as string

### DIFF
--- a/language/move-core/types/src/language_storage.rs
+++ b/language/move-core/types/src/language_storage.rs
@@ -104,6 +104,14 @@ impl StructTag {
         key
     }
 
+    /// Returns true if this is a `StructTag` for an `std::ascii::String` struct defined in the
+    /// standard library at address `move_std_addr`.
+    pub fn is_ascii_string(&self, move_std_addr: &AccountAddress) -> bool {
+        self.address == *move_std_addr
+            && self.module.as_str().eq("ascii")
+            && self.name.as_str().eq("String")
+    }
+
     /// Returns true if this is a `StructTag` for an `std::string::String` struct defined in the
     /// standard library at address `move_std_addr`.
     pub fn is_std_string(&self, move_std_addr: &AccountAddress) -> bool {

--- a/language/move-stdlib/src/natives/debug.rs
+++ b/language/move-stdlib/src/natives/debug.rs
@@ -485,6 +485,26 @@ mod testing {
 
                         let str = move_value_as_escaped_string(val)?;
                         write!(out, "\"{}\"", str).map_err(fmt_error_to_partial_vm_error)?
+                    } else if !canonicalize && type_.is_ascii_string(move_std_addr) {
+                        if fields.len() != 1 {
+                            return Err(PartialVMError::new(StatusCode::INTERNAL_TYPE_ERROR)
+                                .with_message(
+                                    "Expected std::ascii::String struct to have just one field"
+                                        .to_string(),
+                                ));
+                        }
+
+                        let (id, val) = fields.pop().unwrap();
+                        if id.into_string() != "bytes" {
+                            return Err(PartialVMError::new(StatusCode::INTERNAL_TYPE_ERROR)
+                                .with_message(
+                                    "Expected std::ascii::String struct to have a `bytes` field"
+                                        .to_string(),
+                                ));
+                        }
+
+                        let str = move_value_as_escaped_string(val)?;
+                        write!(out, "\"{}\"", str).map_err(fmt_error_to_partial_vm_error)?
                     } else {
                         write!(out, "{} ", type_tag).map_err(fmt_error_to_partial_vm_error)?;
                         write!(out, "{}", STRUCT_BEGIN).map_err(fmt_error_to_partial_vm_error)?;

--- a/language/tools/move-cli/tests/sandbox_tests/print_values/args.exp
+++ b/language/tools/move-cli/tests/sandbox_tests/print_values/args.exp
@@ -26,6 +26,8 @@ Running Move unit tests
 [debug] "test_print_string"
 [debug] 0x48656c6c6f2c2073616e65204d6f766520646562756767696e6721
 [debug] "Hello, sane Move debugging!"
+[debug] "test_print_ascii_string"
+[debug] "Hello, sane Move debugging!"
 [debug] "test_print_primitive_types"
 [debug] 255
 [debug] 65535

--- a/language/tools/move-cli/tests/sandbox_tests/print_values/sources/M.move
+++ b/language/tools/move-cli/tests/sandbox_tests/print_values/sources/M.move
@@ -1,6 +1,8 @@
 address 0x2 {
 module M {
     #[test_only]
+    use std::ascii;
+    #[test_only]
     use std::debug::print;
     #[test_only]
     use std::debug::print_string;
@@ -54,6 +56,7 @@ module M {
 
         test_print_quoted_string();
         test_print_string();
+        test_print_ascii_string();
         test_print_primitive_types();
         test_print_struct();
         test_print_vectors();
@@ -72,6 +75,12 @@ module M {
 
         let str = string::utf8(str_bytes);
         print<string::String>(&str);
+    }
+
+    #[test_only]
+    fun test_print_ascii_string() {
+        print_string(b"test_print_ascii_string");
+        print(&ascii::string(b"Hello, sane Move debugging!"));
     }
 
     #[test_only]


### PR DESCRIPTION
`debug::print` special-cases `std::string::String` (utf8 strings), but not `std::ascii::String`. Use the same logic for ascii strings.