### PR TITLE
[1/x][move-package/lock] Preparing for Lock file

### DIFF
--- a/language/tools/move-package/src/lib.rs
+++ b/language/tools/move-package/src/lib.rs
@@ -208,7 +208,7 @@ impl BuildConfig {
         // This should be locked as it inspects the environment for `MOVE_HOME` which could
         // possibly be set by a different process in parallel.
         let manifest = manifest_parser::parse_source_manifest(toml_manifest)?;
-        ResolutionGraph::download_dependency_repos(&manifest, self, &path, writer)?;
+        resolution::download_dependency_repos(&manifest, self, &path, writer)?;
         mutx.unlock();
         Ok(())
     }

--- a/language/tools/move-package/src/resolution/mod.rs
+++ b/language/tools/move-package/src/resolution/mod.rs
@@ -2,5 +2,310 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use anyhow::{Context, Result};
+use colored::Colorize;
+use move_command_line_common::env::MOVE_HOME;
+use std::{
+    ffi::OsStr,
+    fs,
+    io::Write,
+    path::{Path, PathBuf},
+    process::{Command, Stdio},
+};
+
+use crate::{
+    package_hooks,
+    source_package::{
+        layout::SourcePackageLayout,
+        manifest_parser::{parse_move_manifest_string, parse_source_manifest},
+        parsed_manifest::{
+            CustomDepInfo, Dependencies, Dependency, DependencyKind, GitInfo, PackageName,
+            SourceManifest,
+        },
+    },
+    BuildConfig,
+};
+
 mod digest;
 pub mod resolution_graph;
+
+pub fn download_dependency_repos<Progress: Write>(
+    manifest: &SourceManifest,
+    build_options: &BuildConfig,
+    root_path: &Path,
+    progress_output: &mut Progress,
+) -> Result<()> {
+    // include dev dependencies if in dev mode
+    let empty_deps;
+    let additional_deps = if build_options.dev_mode {
+        &manifest.dev_dependencies
+    } else {
+        empty_deps = Dependencies::new();
+        &empty_deps
+    };
+
+    for (dep_name, dep) in manifest.dependencies.iter().chain(additional_deps.iter()) {
+        download_and_update_if_remote(
+            *dep_name,
+            dep,
+            build_options.skip_fetch_latest_git_deps,
+            progress_output,
+        )?;
+
+        let (dep_manifest, _) = parse_package_manifest(dep, dep_name, root_path.to_path_buf())
+            .with_context(|| format!("While processing dependency '{}'", *dep_name))?;
+        // download dependencies of dependencies
+        download_dependency_repos(&dep_manifest, build_options, root_path, progress_output)?;
+    }
+    Ok(())
+}
+
+fn parse_package_manifest(
+    dep: &Dependency,
+    dep_name: &PackageName,
+    mut root_path: PathBuf,
+) -> Result<(SourceManifest, PathBuf)> {
+    root_path.push(local_path(&dep.kind));
+    match fs::read_to_string(&root_path.join(SourcePackageLayout::Manifest.path())) {
+        Ok(contents) => {
+            let source_package: SourceManifest =
+                parse_move_manifest_string(contents).and_then(parse_source_manifest)?;
+            Ok((source_package, root_path))
+        }
+        Err(_) => Err(anyhow::format_err!(
+            "Unable to find package manifest for '{}' at {:?}",
+            dep_name,
+            SourcePackageLayout::Manifest.path().join(root_path),
+        )),
+    }
+}
+
+fn download_and_update_if_remote<Progress: Write>(
+    dep_name: PackageName,
+    dep: &Dependency,
+    skip_fetch_latest_git_deps: bool,
+    progress_output: &mut Progress,
+) -> Result<()> {
+    match &dep.kind {
+        DependencyKind::Local(_) => Ok(()),
+
+        DependencyKind::Custom(node_info) => {
+            package_hooks::resolve_custom_dependency(dep_name, node_info)
+        }
+
+        kind @ DependencyKind::Git(GitInfo {
+            git_url,
+            git_rev,
+            subdir: _,
+        }) => {
+            let git_path = repository_path(kind);
+            let os_git_url = OsStr::new(git_url.as_str());
+            let os_git_rev = OsStr::new(git_rev.as_str());
+
+            if !git_path.exists() {
+                writeln!(
+                    progress_output,
+                    "{} {}",
+                    "FETCHING GIT DEPENDENCY".bold().green(),
+                    git_url,
+                )?;
+
+                // If the cached folder does not exist, download and clone accordingly
+                Command::new("git")
+                    .args([OsStr::new("clone"), os_git_url, git_path.as_os_str()])
+                    .output()
+                    .map_err(|_| {
+                        anyhow::anyhow!("Failed to clone Git repository for package '{}'", dep_name)
+                    })?;
+
+                Command::new("git")
+                    .args([
+                        OsStr::new("-C"),
+                        git_path.as_os_str(),
+                        OsStr::new("checkout"),
+                        os_git_rev,
+                    ])
+                    .output()
+                    .map_err(|_| {
+                        anyhow::anyhow!(
+                            "Failed to checkout Git reference '{}' for package '{}'",
+                            git_rev,
+                            dep_name
+                        )
+                    })?;
+            } else if !skip_fetch_latest_git_deps {
+                // Update the git dependency
+                // Check first that it isn't a git rev (if it doesn't work, just continue with the
+                // fetch)
+                if let Ok(rev) = Command::new("git")
+                    .args([
+                        OsStr::new("-C"),
+                        git_path.as_os_str(),
+                        OsStr::new("rev-parse"),
+                        OsStr::new("--verify"),
+                        os_git_rev,
+                    ])
+                    .output()
+                {
+                    if let Ok(parsable_version) = String::from_utf8(rev.stdout) {
+                        // If it's exactly the same, then it's a git rev
+                        if parsable_version.trim().starts_with(git_rev.as_str()) {
+                            return Ok(());
+                        }
+                    }
+                }
+
+                let tag = Command::new("git")
+                    .args([
+                        OsStr::new("-C"),
+                        git_path.as_os_str(),
+                        OsStr::new("tag"),
+                        OsStr::new("--list"),
+                        os_git_rev,
+                    ])
+                    .output();
+
+                if let Ok(tag) = tag {
+                    if let Ok(parsable_version) = String::from_utf8(tag.stdout) {
+                        // If it's exactly the same, then it's a git tag, for now tags won't be updated
+                        // Tags don't easily update locally and you can't use reset --hard to cleanup
+                        // any extra files
+                        if parsable_version.trim().starts_with(git_rev.as_str()) {
+                            return Ok(());
+                        }
+                    }
+                }
+
+                writeln!(
+                    progress_output,
+                    "{} {}",
+                    "UPDATING GIT DEPENDENCY".bold().green(),
+                    git_url,
+                )?;
+
+                // If the current folder exists, do a fetch and reset to ensure that the branch
+                // is up to date.
+                //
+                // NOTE: this means that you must run the package system with a working network
+                // connection.
+                let status = Command::new("git")
+                    .args([
+                        OsStr::new("-C"),
+                        git_path.as_os_str(),
+                        OsStr::new("fetch"),
+                        OsStr::new("origin"),
+                    ])
+                    .stdout(Stdio::null())
+                    .stderr(Stdio::null())
+                    .status()
+                    .map_err(|_| {
+                        anyhow::anyhow!(
+                            "Failed to fetch latest Git state for package '{}', to skip set \
+                             --skip-fetch-latest-git-deps",
+                            dep_name
+                        )
+                    })?;
+
+                if !status.success() {
+                    return Err(anyhow::anyhow!(
+                        "Failed to fetch to latest Git state for package '{}', to skip set \
+                         --skip-fetch-latest-git-deps | Exit status: {}",
+                        dep_name,
+                        status
+                    ));
+                }
+
+                let status = Command::new("git")
+                    .args([
+                        OsStr::new("-C"),
+                        git_path.as_os_str(),
+                        OsStr::new("reset"),
+                        OsStr::new("--hard"),
+                        OsStr::new(&format!("origin/{}", git_rev)),
+                    ])
+                    .stdout(Stdio::null())
+                    .stderr(Stdio::null())
+                    .status()
+                    .map_err(|_| {
+                        anyhow::anyhow!(
+                            "Failed to reset to latest Git state '{}' for package '{}', to skip \
+                             set --skip-fetch-latest-git-deps",
+                            git_rev,
+                            dep_name
+                        )
+                    })?;
+
+                if !status.success() {
+                    return Err(anyhow::anyhow!(
+                        "Failed to reset to latest Git state '{}' for package '{}', to skip set \
+                         --skip-fetch-latest-git-deps | Exit status: {}",
+                        git_rev,
+                        dep_name,
+                        status
+                    ));
+                }
+            }
+
+            Ok(())
+        }
+    }
+}
+
+/// The local location of the repository containing the dependency of kind `kind` (and potentially
+/// other, related dependencies).
+fn repository_path(kind: &DependencyKind) -> PathBuf {
+    match kind {
+        DependencyKind::Local(path) => path.clone(),
+
+        // Downloaded packages are of the form <sanitized_git_url>_<rev_name>
+        DependencyKind::Git(GitInfo {
+            git_url,
+            git_rev,
+            subdir: _,
+        }) => [
+            &*MOVE_HOME,
+            &format!(
+                "{}_{}",
+                url_to_file_name(git_url.as_str()),
+                git_rev.replace('/', "__"),
+            ),
+        ]
+        .iter()
+        .collect(),
+
+        // Downloaded packages are of the form <sanitized_node_url>_<address>_<package>
+        DependencyKind::Custom(CustomDepInfo {
+            node_url,
+            package_address,
+            package_name,
+        }) => [
+            &*MOVE_HOME,
+            &format!(
+                "{}_{}_{}",
+                url_to_file_name(node_url.as_str()),
+                package_address.as_str(),
+                package_name.as_str(),
+            ),
+        ]
+        .iter()
+        .collect(),
+    }
+}
+
+/// The path that the dependency of kind `kind` is found at locally, after it is fetched.
+fn local_path(kind: &DependencyKind) -> PathBuf {
+    let mut repo_path = repository_path(kind);
+
+    if let DependencyKind::Git(GitInfo { subdir, .. }) = kind {
+        repo_path.push(subdir);
+    }
+
+    repo_path
+}
+
+fn url_to_file_name(url: &str) -> String {
+    regex::Regex::new(r"/|:|\.|@")
+        .unwrap()
+        .replace_all(url, "_")
+        .to_string()
+}

--- a/language/tools/move-package/src/source_package/manifest_parser.rs
+++ b/language/tools/move-package/src/source_package/manifest_parser.rs
@@ -3,8 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{package_hooks, source_package::parsed_manifest as PM, Architecture};
-use anyhow::{bail, format_err, Context, Result};
-use move_command_line_common::env::MOVE_HOME;
+use anyhow::{anyhow, bail, format_err, Context, Result};
 use move_core_types::account_address::{AccountAddress, AccountAddressParseError};
 use move_symbol_pool::symbol::Symbol;
 use std::{
@@ -306,155 +305,118 @@ fn parse_address_literal(address_str: &str) -> Result<AccountAddress, AccountAdd
     AccountAddress::from_hex_literal(address_str)
 }
 
-fn parse_dependency(dep_name: &str, tval: TV) -> Result<PM::Dependency> {
-    match tval {
-        TV::Table(mut table) => {
-            let mut known_fields = vec![
-                "addr_subst",
-                "version",
-                "local",
-                "digest",
-                "git",
-                "rev",
-                "subdir",
-                "address",
-            ];
-            let custom_key_opt = &package_hooks::custom_dependency_key();
-            if let Some(key) = custom_key_opt {
-                known_fields.push(key.as_ref())
-            }
-            warn_if_unknown_field_names(&table, known_fields.as_slice());
-            let subst = table
-                .remove("addr_subst")
-                .map(parse_substitution)
-                .transpose()?;
-            let version = table.remove("version").map(parse_version).transpose()?;
-            let digest = table.remove("digest").map(parse_digest).transpose()?;
-            let mut git_info = None;
-            let mut node_info = None;
-            match (
-                table.remove("local"),
-                table.remove("git"),
-                if let Some(key) = custom_key_opt {
-                    table.remove(key)
-                } else {
-                    None
-                },
-            ) {
-                (Some(local), None, None) => {
-                    let local_str = local
-                        .as_str()
-                        .ok_or_else(|| format_err!("Local source path not a string"))?;
-                    let local_path = PathBuf::from(local_str);
-                    Ok(PM::Dependency {
-                        subst,
-                        version,
-                        digest,
-                        local: local_path,
-                        git_info,
-                        node_info,
-                    })
-                }
-                (None, Some(git), None) => {
-                    let move_home = MOVE_HOME.clone();
-                    let rev_name = match table.remove("rev") {
-                        None => bail!("Git revision not supplied for dependency"),
-                        Some(r) => Symbol::from(
-                            r.as_str()
-                                .ok_or_else(|| format_err!("Git revision not a string"))?,
-                        ),
-                    };
-                    // Downloaded packages are of the form <sanitized_git_url>_<rev_name>
-                    let git_url = git
-                        .as_str()
-                        .ok_or_else(|| anyhow::anyhow!("Git URL not a string"))?;
-                    let local_path = PathBuf::from(move_home).join(format!(
-                        "{}_{}",
-                        url_to_file_name(git_url),
-                        rev_name.replace('/', "__")
-                    ));
-                    let subdir = PathBuf::from(match table.remove("subdir") {
-                        None => "".to_string(),
-                        Some(path) => path
-                            .as_str()
-                            .ok_or_else(|| format_err!("'subdir' not a string"))?
-                            .to_string(),
-                    });
-                    git_info = Some(PM::GitInfo {
-                        git_url: Symbol::from(git_url),
-                        git_rev: rev_name,
-                        subdir: subdir.clone(),
-                        download_to: local_path.clone(),
-                    });
+fn parse_dependency(dep_name: &str, mut tval: TV) -> Result<PM::Dependency> {
+    let Some(table) = tval.as_table_mut() else {
+        bail!("Malformed dependency {}", tval);
+    };
 
-                    Ok(PM::Dependency {
-                        subst,
-                        version,
-                        digest,
-                        local: local_path.join(subdir),
-                        git_info,
-                        node_info,
-                    })
-                }
-                (None, None, Some(custom_key)) => {
-                    let package_name = Symbol::from(dep_name);
-                    let address = match table.remove("address") {
-                        None => bail!("Address not supplied for 'node' dependency"),
-                        Some(r) => Symbol::from(
-                            r.as_str()
-                                .ok_or_else(|| format_err!("Node address not a string"))?,
-                        ),
-                    };
-                    // Downloaded packages are of the form <sanitized_node_url>_<address>_<package>
-                    let node_url = custom_key
-                        .as_str()
-                        .ok_or_else(|| anyhow::anyhow!("Git URL not a string"))?;
-                    let local_path = PathBuf::from(MOVE_HOME.clone()).join(format!(
-                        "{}_{}_{}",
-                        url_to_file_name(node_url),
-                        address,
-                        package_name
-                    ));
-                    node_info = Some(PM::CustomDepInfo {
-                        node_url: Symbol::from(node_url),
-                        package_address: address,
-                        package_name,
-                        download_to: local_path.clone(),
-                    });
-                    Ok(PM::Dependency {
-                        subst,
-                        version,
-                        digest,
-                        local: local_path,
-                        git_info,
-                        node_info,
-                    })
-                }
-                _ => {
-                    let mut keys = vec!["local", "git"];
-                    if let Some(k) = custom_key_opt {
-                        keys.push(k.as_str())
-                    }
-                    let keys = keys
-                        .into_iter()
-                        .map(|s| format!("'{}'", s))
-                        .collect::<Vec<_>>();
-                    bail!(
-                        "must provide exactly one of {} for dependency.",
-                        keys.join(" or ")
-                    )
-                }
-            }
-        }
-        x => bail!("Malformed dependency {}", x),
+    let mut known_fields = vec![
+        "addr_subst",
+        "version",
+        "local",
+        "digest",
+        "git",
+        "rev",
+        "subdir",
+        "address",
+    ];
+
+    let custom_key_opt = &package_hooks::custom_dependency_key();
+    if let Some(key) = custom_key_opt {
+        known_fields.push(key.as_ref())
     }
-}
 
-fn url_to_file_name(url: &str) -> String {
-    regex::Regex::new(r"/|:|\.|@")
-        .unwrap()
-        .replace_all(url, "_")
-        .to_string()
+    warn_if_unknown_field_names(table, known_fields.as_slice());
+
+    let subst = table
+        .remove("addr_subst")
+        .map(parse_substitution)
+        .transpose()?;
+    let version = table.remove("version").map(parse_version).transpose()?;
+    let digest = table.remove("digest").map(parse_digest).transpose()?;
+
+    let kind = match (
+        table.remove("local"),
+        table.remove("git"),
+        custom_key_opt.as_ref().and_then(|k| table.remove(k)),
+    ) {
+        (Some(local), None, None) => {
+            let Some(local) = local.as_str().map(PathBuf::from) else {
+                bail!("Local source path not a string")
+            };
+
+            PM::DependencyKind::Local(local)
+        }
+
+        (None, Some(git_url), None) => {
+            let Some(git_rev) = table.remove("rev") else {
+                bail!("Git revision not supplied for dependency")
+            };
+
+            let Some(git_rev) = git_rev.as_str().map(Symbol::from) else {
+                bail!("Git revision not a string")
+            };
+
+            let Some(git_url) = git_url.as_str().map(Symbol::from) else {
+                bail!("Git URL not a string")
+            };
+
+            let subdir = match table.remove("subdir") {
+                None => PathBuf::new(),
+                Some(path) => path
+                    .as_str()
+                    .map(PathBuf::from)
+                    .ok_or_else(|| anyhow!("'subdir' not a string"))?,
+            };
+
+            PM::DependencyKind::Git(PM::GitInfo {
+                git_url,
+                git_rev,
+                subdir,
+            })
+        }
+
+        (None, None, Some(custom_key)) => {
+            let Some(package_address) = table.remove("address") else {
+                bail!("Address not supplied for 'node' dependency");
+            };
+
+            let Some(package_address) = package_address.as_str().map(Symbol::from) else {
+                bail!("Node address not a string")
+            };
+
+            let Some(node_url) = custom_key.as_str().map(Symbol::from) else {
+                bail!("Git URL not a string")
+            };
+
+            let package_name = Symbol::from(dep_name);
+
+            PM::DependencyKind::Custom(PM::CustomDepInfo {
+                node_url,
+                package_address,
+                package_name,
+            })
+        }
+
+        _ => {
+            let mut keys = vec!["'local'", "'git'"];
+            let quoted_custom_key = custom_key_opt.as_ref().map(|k| format!("'{}'", k));
+            if let Some(k) = &quoted_custom_key {
+                keys.push(k.as_str())
+            }
+            bail!(
+                "must provide exactly one of {} for dependency.",
+                keys.join(" or ")
+            )
+        }
+    };
+
+    Ok(PM::Dependency {
+        kind,
+        subst,
+        version,
+        digest,
+    })
 }
 
 fn parse_substitution(tval: TV) -> Result<PM::Substitution> {

--- a/language/tools/move-package/src/source_package/parsed_manifest.rs
+++ b/language/tools/move-package/src/source_package/parsed_manifest.rs
@@ -39,12 +39,17 @@ pub struct PackageInfo {
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Dependency {
-    pub local: PathBuf,
+    pub kind: DependencyKind,
     pub subst: Option<Substitution>,
     pub version: Option<Version>,
     pub digest: Option<PackageDigest>,
-    pub git_info: Option<GitInfo>,
-    pub node_info: Option<CustomDepInfo>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum DependencyKind {
+    Local(PathBuf),
+    Git(GitInfo),
+    Custom(CustomDepInfo),
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -56,8 +61,6 @@ pub struct GitInfo {
     /// The path under this repo where the move package can be found -- e.g.,
     /// 'language/move-stdlib`
     pub subdir: PathBuf,
-    /// Where the git repo is downloaded to.
-    pub download_to: PathBuf,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -69,8 +72,6 @@ pub struct CustomDepInfo {
     pub package_address: Symbol,
     /// The address where the package is published.
     pub package_name: Symbol,
-    /// Where the package is downloaded to.
-    pub download_to: PathBuf,
 }
 
 #[derive(Default, Debug, Clone, Eq, PartialEq)]

--- a/language/tools/move-package/tests/test_sources/resolution/dep_good_digest/Move.exp
+++ b/language/tools/move-package/tests/test_sources/resolution/dep_good_digest/Move.exp
@@ -37,7 +37,9 @@ ResolutionGraph {
         build: None,
         dependencies: {
             "OtherDep": Dependency {
-                local: "./deps_only/other_dep",
+                kind: Local(
+                    "./deps_only/other_dep",
+                ),
                 subst: Some(
                     {
                         "A": RenameFrom(
@@ -49,8 +51,6 @@ ResolutionGraph {
                 digest: Some(
                     "6A88B7888D6049EB0121900E22B6FA2C0E702F042C8C8D4FD62AD5C990B9F9A8",
                 ),
-                git_info: None,
-                node_info: None,
             },
         },
         dev_dependencies: {},
@@ -126,7 +126,9 @@ ResolutionGraph {
                 build: None,
                 dependencies: {
                     "OtherDep": Dependency {
-                        local: "./deps_only/other_dep",
+                        kind: Local(
+                            "./deps_only/other_dep",
+                        ),
                         subst: Some(
                             {
                                 "A": RenameFrom(
@@ -138,8 +140,6 @@ ResolutionGraph {
                         digest: Some(
                             "6A88B7888D6049EB0121900E22B6FA2C0E702F042C8C8D4FD62AD5C990B9F9A8",
                         ),
-                        git_info: None,
-                        node_info: None,
                     },
                 },
                 dev_dependencies: {},

--- a/language/tools/move-package/tests/test_sources/resolution/diamond_problem_backflow_resolution/Move.exp
+++ b/language/tools/move-package/tests/test_sources/resolution/diamond_problem_backflow_resolution/Move.exp
@@ -31,15 +31,17 @@ ResolutionGraph {
         build: None,
         dependencies: {
             "A": Dependency {
-                local: "./deps_only/A",
+                kind: Local(
+                    "./deps_only/A",
+                ),
                 subst: None,
                 version: None,
                 digest: None,
-                git_info: None,
-                node_info: None,
             },
             "B": Dependency {
-                local: "./deps_only/B",
+                kind: Local(
+                    "./deps_only/B",
+                ),
                 subst: Some(
                     {
                         "BA": Assign(
@@ -49,8 +51,6 @@ ResolutionGraph {
                 ),
                 version: None,
                 digest: None,
-                git_info: None,
-                node_info: None,
             },
         },
         dev_dependencies: {},
@@ -117,7 +117,9 @@ ResolutionGraph {
                 build: None,
                 dependencies: {
                     "C": Dependency {
-                        local: "../C",
+                        kind: Local(
+                            "../C",
+                        ),
                         subst: Some(
                             {
                                 "AA": RenameFrom(
@@ -127,8 +129,6 @@ ResolutionGraph {
                         ),
                         version: None,
                         digest: None,
-                        git_info: None,
-                        node_info: None,
                     },
                 },
                 dev_dependencies: {},
@@ -164,7 +164,9 @@ ResolutionGraph {
                 build: None,
                 dependencies: {
                     "C": Dependency {
-                        local: "../C",
+                        kind: Local(
+                            "../C",
+                        ),
                         subst: Some(
                             {
                                 "BA": RenameFrom(
@@ -174,8 +176,6 @@ ResolutionGraph {
                         ),
                         version: None,
                         digest: None,
-                        git_info: None,
-                        node_info: None,
                     },
                 },
                 dev_dependencies: {},
@@ -242,15 +242,17 @@ ResolutionGraph {
                 build: None,
                 dependencies: {
                     "A": Dependency {
-                        local: "./deps_only/A",
+                        kind: Local(
+                            "./deps_only/A",
+                        ),
                         subst: None,
                         version: None,
                         digest: None,
-                        git_info: None,
-                        node_info: None,
                     },
                     "B": Dependency {
-                        local: "./deps_only/B",
+                        kind: Local(
+                            "./deps_only/B",
+                        ),
                         subst: Some(
                             {
                                 "BA": Assign(
@@ -260,8 +262,6 @@ ResolutionGraph {
                         ),
                         version: None,
                         digest: None,
-                        git_info: None,
-                        node_info: None,
                     },
                 },
                 dev_dependencies: {},

--- a/language/tools/move-package/tests/test_sources/resolution/diamond_problem_no_conflict/Move.exp
+++ b/language/tools/move-package/tests/test_sources/resolution/diamond_problem_no_conflict/Move.exp
@@ -31,7 +31,9 @@ ResolutionGraph {
         build: None,
         dependencies: {
             "A": Dependency {
-                local: "./deps_only/A",
+                kind: Local(
+                    "./deps_only/A",
+                ),
                 subst: Some(
                     {
                         "AA": Assign(
@@ -41,11 +43,11 @@ ResolutionGraph {
                 ),
                 version: None,
                 digest: None,
-                git_info: None,
-                node_info: None,
             },
             "B": Dependency {
-                local: "./deps_only/B",
+                kind: Local(
+                    "./deps_only/B",
+                ),
                 subst: Some(
                     {
                         "BA": Assign(
@@ -55,8 +57,6 @@ ResolutionGraph {
                 ),
                 version: None,
                 digest: None,
-                git_info: None,
-                node_info: None,
             },
         },
         dev_dependencies: {},
@@ -123,7 +123,9 @@ ResolutionGraph {
                 build: None,
                 dependencies: {
                     "C": Dependency {
-                        local: "../C",
+                        kind: Local(
+                            "../C",
+                        ),
                         subst: Some(
                             {
                                 "AA": RenameFrom(
@@ -133,8 +135,6 @@ ResolutionGraph {
                         ),
                         version: None,
                         digest: None,
-                        git_info: None,
-                        node_info: None,
                     },
                 },
                 dev_dependencies: {},
@@ -170,7 +170,9 @@ ResolutionGraph {
                 build: None,
                 dependencies: {
                     "C": Dependency {
-                        local: "../C",
+                        kind: Local(
+                            "../C",
+                        ),
                         subst: Some(
                             {
                                 "BA": RenameFrom(
@@ -180,8 +182,6 @@ ResolutionGraph {
                         ),
                         version: None,
                         digest: None,
-                        git_info: None,
-                        node_info: None,
                     },
                 },
                 dev_dependencies: {},
@@ -248,7 +248,9 @@ ResolutionGraph {
                 build: None,
                 dependencies: {
                     "A": Dependency {
-                        local: "./deps_only/A",
+                        kind: Local(
+                            "./deps_only/A",
+                        ),
                         subst: Some(
                             {
                                 "AA": Assign(
@@ -258,11 +260,11 @@ ResolutionGraph {
                         ),
                         version: None,
                         digest: None,
-                        git_info: None,
-                        node_info: None,
                     },
                     "B": Dependency {
-                        local: "./deps_only/B",
+                        kind: Local(
+                            "./deps_only/B",
+                        ),
                         subst: Some(
                             {
                                 "BA": Assign(
@@ -272,8 +274,6 @@ ResolutionGraph {
                         ),
                         version: None,
                         digest: None,
-                        git_info: None,
-                        node_info: None,
                     },
                 },
                 dev_dependencies: {},

--- a/language/tools/move-package/tests/test_sources/resolution/multiple_deps_rename/Move.exp
+++ b/language/tools/move-package/tests/test_sources/resolution/multiple_deps_rename/Move.exp
@@ -31,7 +31,9 @@ ResolutionGraph {
         build: None,
         dependencies: {
             "C": Dependency {
-                local: "./deps_only/C",
+                kind: Local(
+                    "./deps_only/C",
+                ),
                 subst: Some(
                     {
                         "CA": RenameFrom(
@@ -41,11 +43,11 @@ ResolutionGraph {
                 ),
                 version: None,
                 digest: None,
-                git_info: None,
-                node_info: None,
             },
             "D": Dependency {
-                local: "./deps_only/D",
+                kind: Local(
+                    "./deps_only/D",
+                ),
                 subst: Some(
                     {
                         "DA": RenameFrom(
@@ -55,8 +57,6 @@ ResolutionGraph {
                 ),
                 version: None,
                 digest: None,
-                git_info: None,
-                node_info: None,
             },
         },
         dev_dependencies: {},
@@ -171,7 +171,9 @@ ResolutionGraph {
                 build: None,
                 dependencies: {
                     "C": Dependency {
-                        local: "./deps_only/C",
+                        kind: Local(
+                            "./deps_only/C",
+                        ),
                         subst: Some(
                             {
                                 "CA": RenameFrom(
@@ -181,11 +183,11 @@ ResolutionGraph {
                         ),
                         version: None,
                         digest: None,
-                        git_info: None,
-                        node_info: None,
                     },
                     "D": Dependency {
-                        local: "./deps_only/D",
+                        kind: Local(
+                            "./deps_only/D",
+                        ),
                         subst: Some(
                             {
                                 "DA": RenameFrom(
@@ -195,8 +197,6 @@ ResolutionGraph {
                         ),
                         version: None,
                         digest: None,
-                        git_info: None,
-                        node_info: None,
                     },
                 },
                 dev_dependencies: {},

--- a/language/tools/move-package/tests/test_sources/resolution/one_dep/Move.exp
+++ b/language/tools/move-package/tests/test_sources/resolution/one_dep/Move.exp
@@ -37,7 +37,9 @@ ResolutionGraph {
         build: None,
         dependencies: {
             "OtherDep": Dependency {
-                local: "./deps_only/other_dep",
+                kind: Local(
+                    "./deps_only/other_dep",
+                ),
                 subst: Some(
                     {
                         "A": RenameFrom(
@@ -47,8 +49,6 @@ ResolutionGraph {
                 ),
                 version: None,
                 digest: None,
-                git_info: None,
-                node_info: None,
             },
         },
         dev_dependencies: {},
@@ -124,7 +124,9 @@ ResolutionGraph {
                 build: None,
                 dependencies: {
                     "OtherDep": Dependency {
-                        local: "./deps_only/other_dep",
+                        kind: Local(
+                            "./deps_only/other_dep",
+                        ),
                         subst: Some(
                             {
                                 "A": RenameFrom(
@@ -134,8 +136,6 @@ ResolutionGraph {
                         ),
                         version: None,
                         digest: None,
-                        git_info: None,
-                        node_info: None,
                     },
                 },
                 dev_dependencies: {},

--- a/language/tools/move-package/tests/test_sources/resolution/one_dep_assigned_address/Move.exp
+++ b/language/tools/move-package/tests/test_sources/resolution/one_dep_assigned_address/Move.exp
@@ -31,7 +31,9 @@ ResolutionGraph {
         build: None,
         dependencies: {
             "OtherDep": Dependency {
-                local: "./deps_only/other_dep",
+                kind: Local(
+                    "./deps_only/other_dep",
+                ),
                 subst: Some(
                     {
                         "A": RenameFrom(
@@ -41,8 +43,6 @@ ResolutionGraph {
                 ),
                 version: None,
                 digest: None,
-                git_info: None,
-                node_info: None,
             },
         },
         dev_dependencies: {},
@@ -114,7 +114,9 @@ ResolutionGraph {
                 build: None,
                 dependencies: {
                     "OtherDep": Dependency {
-                        local: "./deps_only/other_dep",
+                        kind: Local(
+                            "./deps_only/other_dep",
+                        ),
                         subst: Some(
                             {
                                 "A": RenameFrom(
@@ -124,8 +126,6 @@ ResolutionGraph {
                         ),
                         version: None,
                         digest: None,
-                        git_info: None,
-                        node_info: None,
                     },
                 },
                 dev_dependencies: {},

--- a/language/tools/move-package/tests/test_sources/resolution/one_dep_multiple_of_same_name/Move.exp
+++ b/language/tools/move-package/tests/test_sources/resolution/one_dep_multiple_of_same_name/Move.exp
@@ -37,7 +37,9 @@ ResolutionGraph {
         build: None,
         dependencies: {
             "OtherDep": Dependency {
-                local: "./deps_only/other_dep",
+                kind: Local(
+                    "./deps_only/other_dep",
+                ),
                 subst: Some(
                     {
                         "A": RenameFrom(
@@ -47,8 +49,6 @@ ResolutionGraph {
                 ),
                 version: None,
                 digest: None,
-                git_info: None,
-                node_info: None,
             },
         },
         dev_dependencies: {},
@@ -124,7 +124,9 @@ ResolutionGraph {
                 build: None,
                 dependencies: {
                     "OtherDep": Dependency {
-                        local: "./deps_only/other_dep",
+                        kind: Local(
+                            "./deps_only/other_dep",
+                        ),
                         subst: Some(
                             {
                                 "A": RenameFrom(
@@ -134,8 +136,6 @@ ResolutionGraph {
                         ),
                         version: None,
                         digest: None,
-                        git_info: None,
-                        node_info: None,
                     },
                 },
                 dev_dependencies: {},

--- a/language/tools/move-package/tests/test_sources/resolution/one_dep_reassigned_address/Move.exp
+++ b/language/tools/move-package/tests/test_sources/resolution/one_dep_reassigned_address/Move.exp
@@ -37,7 +37,9 @@ ResolutionGraph {
         build: None,
         dependencies: {
             "OtherDep": Dependency {
-                local: "./deps_only/other_dep",
+                kind: Local(
+                    "./deps_only/other_dep",
+                ),
                 subst: Some(
                     {
                         "A": RenameFrom(
@@ -47,8 +49,6 @@ ResolutionGraph {
                 ),
                 version: None,
                 digest: None,
-                git_info: None,
-                node_info: None,
             },
         },
         dev_dependencies: {},
@@ -126,7 +126,9 @@ ResolutionGraph {
                 build: None,
                 dependencies: {
                     "OtherDep": Dependency {
-                        local: "./deps_only/other_dep",
+                        kind: Local(
+                            "./deps_only/other_dep",
+                        ),
                         subst: Some(
                             {
                                 "A": RenameFrom(
@@ -136,8 +138,6 @@ ResolutionGraph {
                         ),
                         version: None,
                         digest: None,
-                        git_info: None,
-                        node_info: None,
                     },
                 },
                 dev_dependencies: {},

--- a/language/tools/move-package/tests/test_sources/resolution/one_dep_unification_across_local_renamings/Move.exp
+++ b/language/tools/move-package/tests/test_sources/resolution/one_dep_unification_across_local_renamings/Move.exp
@@ -37,7 +37,9 @@ ResolutionGraph {
         build: None,
         dependencies: {
             "OtherDep": Dependency {
-                local: "./deps_only/other_dep",
+                kind: Local(
+                    "./deps_only/other_dep",
+                ),
                 subst: Some(
                     {
                         "A": RenameFrom(
@@ -47,8 +49,6 @@ ResolutionGraph {
                 ),
                 version: None,
                 digest: None,
-                git_info: None,
-                node_info: None,
             },
         },
         dev_dependencies: {},
@@ -124,7 +124,9 @@ ResolutionGraph {
                 build: None,
                 dependencies: {
                     "OtherDep": Dependency {
-                        local: "./deps_only/other_dep",
+                        kind: Local(
+                            "./deps_only/other_dep",
+                        ),
                         subst: Some(
                             {
                                 "A": RenameFrom(
@@ -134,8 +136,6 @@ ResolutionGraph {
                         ),
                         version: None,
                         digest: None,
-                        git_info: None,
-                        node_info: None,
                     },
                 },
                 dev_dependencies: {},


### PR DESCRIPTION
A number of behaviour preserving changes to make it easier to integrate a lock file into the package resolution process.  See [[RFC] Move.lock](https://docs.google.com/document/d/1OV3te-SnpZv2Yxv7uxGQH6NFhE-CdqiCjB66JmYAGKs/edit) for more context.

## Refactor `parsed_manifest::Dependency`, introducing `DependencyKind`

This can be one of `Local`, `Git` or `Custom`, each containing the relevant information for resolving a dependency of that kind, replacing the previous structure where `Dependency` had optional fields for `git_info` and (custom) `node_info`.

This was motivated by two factors:

- Introducing another variant for dependencies (handled by third party package managers), which will be easier to manage when the type is described by an `enum` rather than struct of optionals.
- A new operation that needs to be implemented on dependencies before they are serialized in the lock file, re-rooting:  In the manifest, local dependencies are described relative to the manifest's directory, but the lock file may be for a transitive dependent package, in which case the dependency's root will need to be adjusted (e.g. if it were a local dependency of a git dependency, it will become a git depedency in the lock file).  This operation is also easier to describe with the enum format.

## Extracting functions to download remote dependencies

Previously member functions of `resolution_graph::ResolutionGraph`, but this operation will also be needed while discovering the set of transitive dependencies to write to the lock file, so these were moved to the `resolution` module as top-level (free) functions.

## Removing `download_to` and `local` fields for remote dependencies

These were previously set during manifest parsing, but:

  - They can always be derived from the other fields.
  - They are not read often (i.e. they are read as often as they are written).
  - Their existence complicates the previously mentioned re-rooting operation.
  - They contain absolute paths which should not be reserialized into the lock file, which should be stable across development environments.

So, they have been replaced with more top-level functions in the `resolution` module for figuring out what the local and repository paths should be given a dependency.

## General clean-ups

- Rename `writer: impl Write` to `progress_output` to indicate what gets written to it (as future commits may introduce other streams to write to).
- Use `let .. else { }` to unnest some of the logic in dependency parsing.
- Use `OsStr` when creating git commands, to avoid paths being converted to `&str` and back, which is a lossy operation on some platforms.

# Test Plan

```
move/language/tools/move-package$ cargo nextest
```
