### PR TITLE
[language] adding `string::fmt_utf8` native function

### DIFF
--- a/language/move-prover/bytecode/src/read_write_set_analysis.rs
+++ b/language/move-prover/bytecode/src/read_write_set_analysis.rs
@@ -689,7 +689,8 @@ fn call_native_function(
         ("string", "internal_check_utf8")
         | ("string", "internal_is_char_boundary")
         | ("string", "internal_sub_string")
-        | ("string", "internal_index_of") => (),
+        | ("string", "internal_index_of")
+        | ("string", "internal_fmt_utf8") => (),
         ("event", "write_to_event_store") => (),
         ("hash", "sha3_256") | ("hash", "sha2_256") => (),
         ("Signature", "ed25519_validate_pubkey") | ("Signature", "ed25519_verify") => (),

--- a/language/move-stdlib/docs/string.md
+++ b/language/move-stdlib/docs/string.md
@@ -18,10 +18,12 @@ The <code><a href="string.md#0x1_string">string</a></code> module defines the <c
 -  [Function `insert`](#0x1_string_insert)
 -  [Function `sub_string`](#0x1_string_sub_string)
 -  [Function `index_of`](#0x1_string_index_of)
+-  [Function `fmt_utf8`](#0x1_string_fmt_utf8)
 -  [Function `internal_check_utf8`](#0x1_string_internal_check_utf8)
 -  [Function `internal_is_char_boundary`](#0x1_string_internal_is_char_boundary)
 -  [Function `internal_sub_string`](#0x1_string_internal_sub_string)
 -  [Function `internal_index_of`](#0x1_string_internal_index_of)
+-  [Function `internal_fmt_utf8`](#0x1_string_internal_fmt_utf8)
 
 
 <pre><code><b>use</b> <a href="option.md#0x1_option">0x1::option</a>;
@@ -354,6 +356,31 @@ Computes the index of the first occurrence of a string. Returns <code><a href="s
 
 </details>
 
+<a name="0x1_string_fmt_utf8"></a>
+
+## Function `fmt_utf8`
+
+Returns utf8 formatted string from Move values.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="string.md#0x1_string_fmt_utf8">fmt_utf8</a>&lt;MoveValue&gt;(v: &MoveValue): <a href="string.md#0x1_string_String">string::String</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="string.md#0x1_string_fmt_utf8">fmt_utf8</a>&lt;MoveValue&gt;(v: &MoveValue): <a href="string.md#0x1_string_String">String</a> {
+    <a href="string.md#0x1_string_utf8">utf8</a>(<a href="string.md#0x1_string_internal_fmt_utf8">internal_fmt_utf8</a>(v))
+}
+</code></pre>
+
+
+
+</details>
+
 <a name="0x1_string_internal_check_utf8"></a>
 
 ## Function `internal_check_utf8`
@@ -436,6 +463,28 @@ Computes the index of the first occurrence of a string. Returns <code><a href="s
 
 
 <pre><code><b>native</b> <b>fun</b> <a href="string.md#0x1_string_internal_index_of">internal_index_of</a>(v: &<a href="vector.md#0x1_vector">vector</a>&lt;u8&gt;, r: &<a href="vector.md#0x1_vector">vector</a>&lt;u8&gt;): u64;
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_string_internal_fmt_utf8"></a>
+
+## Function `internal_fmt_utf8`
+
+
+
+<pre><code><b>fun</b> <a href="string.md#0x1_string_internal_fmt_utf8">internal_fmt_utf8</a>&lt;MoveValue&gt;(v: &MoveValue): <a href="vector.md#0x1_vector">vector</a>&lt;u8&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>native</b> <b>fun</b> <a href="string.md#0x1_string_internal_fmt_utf8">internal_fmt_utf8</a>&lt;MoveValue&gt;(v: &MoveValue): <a href="vector.md#0x1_vector">vector</a>&lt;u8&gt;;
 </code></pre>
 
 

--- a/language/move-stdlib/sources/string.move
+++ b/language/move-stdlib/sources/string.move
@@ -85,10 +85,15 @@ module std::string {
         internal_index_of(&s.bytes, &r.bytes)
     }
 
+    /// Returns utf8 formatted string from Move values.
+    public fun fmt_utf8<MoveValue>(v: &MoveValue): String {
+        utf8(internal_fmt_utf8(v))
+    }
 
     // Native API
     native fun internal_check_utf8(v: &vector<u8>): bool;
     native fun internal_is_char_boundary(v: &vector<u8>, i: u64): bool;
     native fun internal_sub_string(v: &vector<u8>, i: u64, j: u64): vector<u8>;
     native fun internal_index_of(v: &vector<u8>, r: &vector<u8>): u64;
+    native fun internal_fmt_utf8<MoveValue>(v: &MoveValue): vector<u8>;
 }

--- a/language/move-stdlib/src/natives/mod.rs
+++ b/language/move-stdlib/src/natives/mod.rs
@@ -78,6 +78,10 @@ impl GasParameters {
                     per_byte_pattern: 0.into(),
                     per_byte_searched: 0.into(),
                 },
+                fmt_utf8: string::FmtUtf8GasParameters {
+                    base: 0.into(),
+                    per_byte: 0.into(),
+                },
             },
             vector: vector::GasParameters {
                 empty: vector::EmptyGasParameters { base: 0.into() },

--- a/language/move-stdlib/src/natives/string.rs
+++ b/language/move-stdlib/src/natives/string.rs
@@ -191,6 +191,40 @@ pub fn make_native_index_of(gas_params: IndexOfGasParameters) -> NativeFunction 
 }
 
 /***************************************************************************************************
+ * native fun internal_fmt_utf8
+ *
+ *   gas cost: base_cost + unit_cost * bytes_to_return
+ *
+ **************************************************************************************************/
+#[derive(Debug, Clone)]
+pub struct FmtUtf8GasParameters {
+    pub base: InternalGas,
+    pub per_byte: InternalGasPerByte,
+}
+
+fn native_fmt_utf8(
+    gas_params: &FmtUtf8GasParameters,
+    _context: &mut NativeContext,
+    _ty_args: Vec<Type>,
+    args: VecDeque<Value>,
+) -> PartialVMResult<NativeResult> {
+    debug_assert!(args.len() == 1);
+
+    let v = Value::vector_u8("string".as_bytes().iter().cloned());
+    let cost = gas_params.base;
+
+    NativeResult::map_partial_vm_result_one(cost, Ok(v))
+}
+
+pub fn make_native_fmt_utf8(gas_params: FmtUtf8GasParameters) -> NativeFunction {
+    Arc::new(
+        move |context, ty_args, args| -> PartialVMResult<NativeResult> {
+            native_fmt_utf8(&gas_params, context, ty_args, args)
+        },
+    )
+}
+
+/***************************************************************************************************
  * module
  **************************************************************************************************/
 #[derive(Debug, Clone)]
@@ -199,6 +233,7 @@ pub struct GasParameters {
     pub is_char_boundary: IsCharBoundaryGasParameters,
     pub sub_string: SubStringGasParameters,
     pub index_of: IndexOfGasParameters,
+    pub fmt_utf8: FmtUtf8GasParameters,
 }
 
 pub fn make_all(gas_params: GasParameters) -> impl Iterator<Item = (String, NativeFunction)> {
@@ -218,6 +253,10 @@ pub fn make_all(gas_params: GasParameters) -> impl Iterator<Item = (String, Nati
         (
             "internal_index_of",
             make_native_index_of(gas_params.index_of),
+        ),
+        (
+            "internal_fmt_utf8",
+            make_native_fmt_utf8(gas_params.fmt_utf8),
         ),
     ];
 

--- a/language/move-stdlib/tests/string_tests.move
+++ b/language/move-stdlib/tests/string_tests.move
@@ -75,4 +75,10 @@ module std::string_tests {
         string::insert(&mut s, 1, string::utf8(b"xy"));
         assert!(s == string::utf8(b"axybcd"), 22)
     }
+
+    #[test]
+    fun test_fmt_utf8() {
+        let r = string::fmt_utf8<u16>(&123u16);
+        assert!(r == string::utf8(b"U16(123)"), 22)
+    }
 }


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Move Language.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

WIP

## Motivation

Updated on issue #727  (fmt_utf8 part)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes

## Test Plan

For now, simply updated doc and added move unit test `test_fmt_utf8` in `string_tests.move` running successfully.

## Questions

- Gas parameter setting
- Where to update due to the effect with this change?