### PR TITLE
[RFC][2/x][move-package/lock] Extend handling of Dependency subdir

### DIFF
--- a/language/tools/move-package/src/resolution/mod.rs
+++ b/language/tools/move-package/src/resolution/mod.rs
@@ -278,6 +278,7 @@ fn repository_path(kind: &DependencyKind) -> PathBuf {
             node_url,
             package_address,
             package_name,
+            subdir: _,
         }) => [
             &*MOVE_HOME,
             &format!(
@@ -296,7 +297,9 @@ fn repository_path(kind: &DependencyKind) -> PathBuf {
 fn local_path(kind: &DependencyKind) -> PathBuf {
     let mut repo_path = repository_path(kind);
 
-    if let DependencyKind::Git(GitInfo { subdir, .. }) = kind {
+    if let DependencyKind::Git(GitInfo { subdir, .. })
+    | DependencyKind::Custom(CustomDepInfo { subdir, .. }) = kind
+    {
         repo_path.push(subdir);
     }
 

--- a/language/tools/move-package/src/source_package/parsed_manifest.rs
+++ b/language/tools/move-package/src/source_package/parsed_manifest.rs
@@ -70,8 +70,10 @@ pub struct CustomDepInfo {
     /// The address where the package is published. The representation depends
     /// on the registered node resolver.
     pub package_address: Symbol,
-    /// The address where the package is published.
+    /// The package's name (i.e. the dependency name).
     pub package_name: Symbol,
+    /// The path under this repo where the move package can be found
+    pub subdir: PathBuf,
 }
 
 #[derive(Default, Debug, Clone, Eq, PartialEq)]

--- a/language/tools/move-package/tests/test_runner.rs
+++ b/language/tools/move-package/tests/test_runner.rs
@@ -151,11 +151,12 @@ impl PackageHooks for TestHooks {
         info: &CustomDepInfo,
     ) -> anyhow::Result<()> {
         bail!(
-            "TestHooks resolve dep {} = {} {} {}",
+            "TestHooks resolve dep {:?} = {:?} {:?} {:?} {:?}",
             dep_name,
             info.node_url,
             info.package_name,
-            info.package_address
+            info.package_address,
+            info.subdir.to_string_lossy(),
         )
     }
 }

--- a/language/tools/move-package/tests/test_sources/resolution/package_hooks/Move.exp
+++ b/language/tools/move-package/tests/test_sources/resolution/package_hooks/Move.exp
@@ -1,1 +1,1 @@
-Unable to resolve packages for package 'test': While resolving dependency 'Pkg' in package 'test': TestHooks resolve dep Pkg = localhost:8080 Pkg 0x1
+Unable to resolve packages for package 'test': While resolving dependency 'Pkg' in package 'test': TestHooks resolve dep "Pkg" = "localhost:8080" "Pkg" "0x1" ""

--- a/language/tools/move-package/tests/test_sources/resolution/package_hooks/Move.toml
+++ b/language/tools/move-package/tests/test_sources/resolution/package_hooks/Move.toml
@@ -3,4 +3,4 @@ name = "test"
 version = "0.0.0"
 
 [dependencies]
-Pkg = { custom = "localhost:8080", address = "0x1", package = "framework" }
+Pkg = { custom = "localhost:8080", address = "0x1" }

--- a/language/tools/move-package/tests/test_sources/resolution/package_hooks_subdir/Move.exp
+++ b/language/tools/move-package/tests/test_sources/resolution/package_hooks_subdir/Move.exp
@@ -1,0 +1,1 @@
+Unable to resolve packages for package 'test': While resolving dependency 'Pkg' in package 'test': TestHooks resolve dep "Pkg" = "localhost:8080" "Pkg" "0x1" "foo/bar"

--- a/language/tools/move-package/tests/test_sources/resolution/package_hooks_subdir/Move.toml
+++ b/language/tools/move-package/tests/test_sources/resolution/package_hooks_subdir/Move.toml
@@ -1,0 +1,6 @@
+[package]
+name = "test"
+version = "0.0.0"
+
+[dependencies]
+Pkg = { custom = "localhost:8080", address = "0x1", subdir = "foo/bar" }


### PR DESCRIPTION
Proposing a more general handling of the `subdir` field for dependencies, which boils down to:

- Explicitly disallowing the field on `local` dependencies (this will produce an error, where previously it would be silently ignored).
- Enabling its use with custom dependencies.

The second change is not likely to be used directly in `Move.toml` (although it could be), but instead is intended to be used with lock files (which are designed to serialize/deserialize dependencies in a format that can be parsed by the existing `manifest_parser::parse_dependency`), in the context of dependency re-rooting, which already occurs implicitly for `git` dependencies, when:

- `a`, depends on `b`, a git dependency, with subdir `s`, and
- `b`, depends on `c`, a local dependency, with relative path `r`.

From `a`'s perspective, `c` is a git dependency with `subdir` `s.push(r)`, which should still be a path within `b`'s git repo (if it is not, resolution will fail, but with an internal error).

When introducing a lock file, this operation becomes explicit, i.e. in the lock file for `a`, `c` will appear as a git dependency with the aforementioned subdir, which is referred to as "re-rooting" `c`, and the error case of `c`'s path falling outside of `b`'s will become an explicit error.

This raises a question for custom dependencies -- can they have local transitive dependencies?  If so, they need a `subdir` field to be written to the lock file, which this commit proposes, and this makes the `Move.toml` format slightly more expressive as well.  If not, that case can be treated as an error, but this seems overly restrictive.

## Test Plan

New unit test:

```
move-package$ cargo nextest
```

## Stack

- #741 