### PR TITLE
[resolver] Add a way for storage to return error code

### DIFF
--- a/language/move-core/types/src/resolver.rs
+++ b/language/move-core/types/src/resolver.rs
@@ -5,6 +5,7 @@
 use crate::{
     account_address::AccountAddress,
     language_storage::{ModuleId, StructTag},
+    vm_status::StatusCode,
 };
 use std::fmt::Debug;
 
@@ -42,6 +43,10 @@ pub trait ResourceResolver {
         address: &AccountAddress,
         typ: &StructTag,
     ) -> Result<Option<Vec<u8>>, Self::Error>;
+
+    fn convert_error(_err: Self::Error) -> StatusCode {
+        StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR
+    }
 }
 
 /// A persistent storage implementation that can resolve both resources and modules

--- a/language/move-vm/runtime/src/data_cache.rs
+++ b/language/move-vm/runtime/src/data_cache.rs
@@ -211,10 +211,7 @@ impl<'r, 'l, S: MoveResolver> DataStore for TransactionDataCache<'r, 'l, S> {
                 }
                 Err(err) => {
                     let msg = format!("Unexpected storage error: {:?}", err);
-                    return Err(
-                        PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
-                            .with_message(msg),
-                    );
+                    return Err(PartialVMError::new(S::convert_error(err)).with_message(msg));
                 }
             };
 


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Move Language.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Added a method for the resolver such that resolver can pick which error code to return on storage error.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes
## Test Plan

`cargo build`
