### PR TITLE
[language] Add catch_unwind panic handling

### DIFF
--- a/language/move-binary-format/src/deserializer.rs
+++ b/language/move-binary-format/src/deserializer.rs
@@ -4,7 +4,7 @@
 
 use crate::{check_bounds::BoundsChecker, errors::*, file_format::*, file_format_common::*};
 use move_core_types::{
-    account_address::AccountAddress, identifier::Identifier, metadata::Metadata,
+    account_address::AccountAddress, identifier::Identifier, metadata::Metadata, state::VMState,
     vm_status::StatusCode,
 };
 use std::{collections::HashSet, convert::TryInto, io::Read};
@@ -43,9 +43,21 @@ impl CompiledModule {
         binary: &[u8],
         max_binary_format_version: u32,
     ) -> BinaryLoaderResult<Self> {
-        let module = deserialize_compiled_module(binary, max_binary_format_version)?;
-        BoundsChecker::verify_module(&module)?;
-        Ok(module)
+        let prev_state = move_core_types::state::set_state(VMState::DESERIALIZER);
+        let result = std::panic::catch_unwind(|| {
+            let module = deserialize_compiled_module(binary, max_binary_format_version)?;
+            BoundsChecker::verify_module(&module)?;
+
+            Ok(module)
+        })
+        .unwrap_or_else(|_| {
+            Err(PartialVMError::new(
+                StatusCode::VERIFIER_INVARIANT_VIOLATION,
+            ))
+        });
+        move_core_types::state::set_state(prev_state);
+
+        result
     }
 
     // exposed as a public function to enable testing the deserializer

--- a/language/move-bytecode-verifier/src/verifier.rs
+++ b/language/move-bytecode-verifier/src/verifier.rs
@@ -13,9 +13,10 @@ use crate::{
 };
 use move_binary_format::{
     check_bounds::BoundsChecker,
-    errors::{Location, VMResult},
+    errors::{Location, PartialVMError, VMResult},
     file_format::{CompiledModule, CompiledScript},
 };
+use move_core_types::{state::VMState, vm_status::StatusCode};
 
 #[derive(Debug, Clone)]
 pub struct VerifierConfig {
@@ -44,22 +45,34 @@ pub fn verify_module(module: &CompiledModule) -> VMResult<()> {
 }
 
 pub fn verify_module_with_config(config: &VerifierConfig, module: &CompiledModule) -> VMResult<()> {
-    BoundsChecker::verify_module(module).map_err(|e| {
-        // We can't point the error at the module, because if bounds-checking
-        // failed, we cannot safely index into module's handle to itself.
-        e.finish(Location::Undefined)
-    })?;
-    LimitsVerifier::verify_module(config, module)?;
-    DuplicationChecker::verify_module(module)?;
-    SignatureChecker::verify_module(module)?;
-    InstructionConsistency::verify_module(module)?;
-    constants::verify_module(module)?;
-    friends::verify_module(module)?;
-    ability_field_requirements::verify_module(module)?;
-    RecursiveStructDefChecker::verify_module(module)?;
-    InstantiationLoopChecker::verify_module(module)?;
-    CodeUnitVerifier::verify_module(config, module)?;
-    script_signature::verify_module(module, no_additional_script_signature_checks)
+    let prev_state = move_core_types::state::set_state(VMState::VERIFIER);
+    let result = std::panic::catch_unwind(|| {
+        BoundsChecker::verify_module(module).map_err(|e| {
+            // We can't point the error at the module, because if bounds-checking
+            // failed, we cannot safely index into module's handle to itself.
+            e.finish(Location::Undefined)
+        })?;
+        LimitsVerifier::verify_module(config, module)?;
+        DuplicationChecker::verify_module(module)?;
+        SignatureChecker::verify_module(module)?;
+        InstructionConsistency::verify_module(module)?;
+        constants::verify_module(module)?;
+        friends::verify_module(module)?;
+        ability_field_requirements::verify_module(module)?;
+        RecursiveStructDefChecker::verify_module(module)?;
+        InstantiationLoopChecker::verify_module(module)?;
+        CodeUnitVerifier::verify_module(config, module)?;
+        script_signature::verify_module(module, no_additional_script_signature_checks)
+    })
+    .unwrap_or_else(|_| {
+        Err(
+            PartialVMError::new(StatusCode::VERIFIER_INVARIANT_VIOLATION)
+                .finish(Location::Undefined),
+        )
+    });
+    move_core_types::state::set_state(prev_state);
+
+    result
 }
 
 /// Helper for a "canonical" verification of a script.
@@ -77,14 +90,26 @@ pub fn verify_script(script: &CompiledScript) -> VMResult<()> {
 }
 
 pub fn verify_script_with_config(config: &VerifierConfig, script: &CompiledScript) -> VMResult<()> {
-    BoundsChecker::verify_script(script).map_err(|e| e.finish(Location::Script))?;
-    LimitsVerifier::verify_script(config, script)?;
-    DuplicationChecker::verify_script(script)?;
-    SignatureChecker::verify_script(script)?;
-    InstructionConsistency::verify_script(script)?;
-    constants::verify_script(script)?;
-    CodeUnitVerifier::verify_script(config, script)?;
-    script_signature::verify_script(script, no_additional_script_signature_checks)
+    let prev_state = move_core_types::state::set_state(VMState::VERIFIER);
+    let result = std::panic::catch_unwind(|| {
+        BoundsChecker::verify_script(script).map_err(|e| e.finish(Location::Script))?;
+        LimitsVerifier::verify_script(config, script)?;
+        DuplicationChecker::verify_script(script)?;
+        SignatureChecker::verify_script(script)?;
+        InstructionConsistency::verify_script(script)?;
+        constants::verify_script(script)?;
+        CodeUnitVerifier::verify_script(config, script)?;
+        script_signature::verify_script(script, no_additional_script_signature_checks)
+    })
+    .unwrap_or_else(|_| {
+        Err(
+            PartialVMError::new(StatusCode::VERIFIER_INVARIANT_VIOLATION)
+                .finish(Location::Undefined),
+        )
+    });
+    move_core_types::state::set_state(prev_state);
+
+    result
 }
 
 impl Default for VerifierConfig {

--- a/language/move-core/types/src/lib.rs
+++ b/language/move-core/types/src/lib.rs
@@ -17,6 +17,7 @@ pub mod parser;
 #[cfg(any(test, feature = "fuzzing"))]
 pub mod proptest_types;
 pub mod resolver;
+pub mod state;
 pub mod transaction_argument;
 pub mod u256;
 #[cfg(test)]

--- a/language/move-core/types/src/state.rs
+++ b/language/move-core/types/src/state.rs
@@ -1,0 +1,21 @@
+use std::cell::RefCell;
+
+#[derive(Clone, Copy, Debug)]
+pub enum VMState {
+    DESERIALIZER,
+    VERIFIER,
+    RUNTIME,
+    OTHER,
+}
+
+thread_local! {
+    static STATE: RefCell<VMState> = RefCell::new(VMState::OTHER);
+}
+
+pub fn set_state(state: VMState) -> VMState {
+    STATE.with(|s| s.replace(state))
+}
+
+pub fn get_state() -> VMState {
+    STATE.with(|s| *s.borrow())
+}

--- a/language/move-core/types/src/state.rs
+++ b/language/move-core/types/src/state.rs
@@ -1,3 +1,7 @@
+// Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::cell::RefCell;
 
 #[derive(Clone, Copy, Debug)]


### PR DESCRIPTION
## Motivation

This helps harden the VM attack surface by catching panics that happen in Move deserialization and verification, similar to #704. All objects passed across the `catch_unwind` boundary are read-only and thus [UnwindSafe](https://doc.rust-lang.org/std/panic/trait.UnwindSafe.html)[^1]. 

This PR also exposes an API to set and query the state of the Move VM via a shared thread-local. This can be useful for custom panic handlers that want to abort _unless_ the code is executing inside a known panic handler (such as deserialization or verification). 

## Test Plan

Not super familiar with the workflows here, open to ideas for what tests should be added. 

[^1] A stronger argument for safety is as follows. 

`catch_unwind` can [never lead to soundness violations](https://doc.rust-lang.org/core/panic/trait.UnwindSafe.html#what-is-unwindsafe).

To break a logical invariant, we need to persist state. This implies that we need to be concerned about two types of modifications. 
1. Objects that are passed through the `catch_unwind` boundary. All objects are fully immutable (including interior mutability), meaning this isn't a concern. 
2. Global state. Rust's implementation of `std::thread` also [uses catch_unwind](https://github.com/rust-lang/rust/blob/master/library/std/src/thread/mod.rs#L549), implying that functions that are safe to run on threads also can't violate logical invariants on panic. The one exception would be thread local data, but if we're concerned can also get around that by spawning a separate thread. 
