### PR TITLE
[move-prover] explicit well-formed assumption after havoc

### DIFF
--- a/language/move-prover/boogie-backend/src/bytecode_translator.rs
+++ b/language/move-prover/boogie-backend/src/bytecode_translator.rs
@@ -1298,12 +1298,6 @@ impl<'env> FunctionTranslator<'env> {
                     Havoc(HavocKind::Value) | Havoc(HavocKind::MutationAll) => {
                         let var_str = str_local(dests[0]);
                         emitln!(writer, "havoc {};", var_str);
-                        // Insert a WellFormed check
-                        let ty = &self.get_local_type(dests[0]);
-                        let check = boogie_well_formed_check(env, &var_str, ty);
-                        if !check.is_empty() {
-                            emitln!(writer, &check);
-                        }
                     }
                     Havoc(HavocKind::MutationValue) => {
                         let ty = &self.get_local_type(dests[0]);
@@ -1317,11 +1311,6 @@ impl<'env> FunctionTranslator<'env> {
                             var_str,
                             temp_str
                         );
-                        // Insert a WellFormed check
-                        let check = boogie_well_formed_check(env, &var_str, ty);
-                        if !check.is_empty() {
-                            emitln!(writer, &check);
-                        }
                     }
                     Stop => {
                         // the two statements combined terminate any execution trace that reaches it

--- a/language/move-prover/bytecode/src/loop_analysis.rs
+++ b/language/move-prover/bytecode/src/loop_analysis.rs
@@ -9,6 +9,7 @@ use move_model::{
     ast::{self, TempIndex},
     exp_generator::ExpGenerator,
     model::FunctionEnv,
+    ty::{PrimitiveType, Type},
 };
 
 use crate::{
@@ -155,6 +156,13 @@ impl LoopAnalysisProcessor {
                                     None,
                                 )
                             });
+                            // add a well-formed assumption explicitly and immediately
+                            let exp = builder.mk_call(
+                                &Type::Primitive(PrimitiveType::Bool),
+                                ast::Operation::WellFormed,
+                                vec![builder.mk_temporary(*idx)],
+                            );
+                            builder.emit_with(move |id| Bytecode::Prop(id, PropKind::Assume, exp));
                         }
                         for (idx, havoc_all) in &loop_info.mut_targets {
                             let havoc_kind = if *havoc_all {
@@ -171,6 +179,13 @@ impl LoopAnalysisProcessor {
                                     None,
                                 )
                             });
+                            // add a well-formed assumption explicitly and immediately
+                            let exp = builder.mk_call(
+                                &Type::Primitive(PrimitiveType::Bool),
+                                ast::Operation::WellFormed,
+                                vec![builder.mk_temporary(*idx)],
+                            );
+                            builder.emit_with(move |id| Bytecode::Prop(id, PropKind::Assume, exp));
                         }
 
                         // trace implicitly reassigned variables after havocking

--- a/language/move-prover/tests/sources/functional/data_invariant_in_loop.move
+++ b/language/move-prover/tests/sources/functional/data_invariant_in_loop.move
@@ -1,0 +1,13 @@
+module 0x42::data_inv_in_loop {
+    use std::option::{Self, Option};
+    use std::vector;
+
+    public fun test() {
+        let i = 0;
+        let r = vector::empty<Option<u64>>();
+        while(i < 10) {
+            vector::push_back(&mut r, option::none());
+            i = i + 1;
+        }
+    }
+}

--- a/language/move-prover/tests/sources/functional/macro_verification.exp
+++ b/language/move-prover/tests/sources/functional/macro_verification.exp
@@ -22,6 +22,17 @@ error: post-condition does not hold
    =         `invariant forall j in 0..i: v[j] == old(v)[j] + 1;` = <redacted>
    =     at tests/sources/functional/macro_verification.move:26: foreach
    =         `invariant forall j in i..len(v): v[j] == old(v)[j];` = <redacted>
+   =         `invariant forall j in i..len(v): v[j] == old(v)[j];` = <redacted>
+   =         `invariant forall j in i..len(v): v[j] == old(v)[j];` = <redacted>
+   =         `invariant forall j in i..len(v): v[j] == old(v)[j];` = <redacted>
+   =         `invariant forall j in i..len(v): v[j] == old(v)[j];` = <redacted>
+   =         `invariant forall j in i..len(v): v[j] == old(v)[j];` = <redacted>
+   =         `invariant forall j in i..len(v): v[j] == old(v)[j];` = <redacted>
+   =         `invariant forall j in i..len(v): v[j] == old(v)[j];` = <redacted>
+   =         `invariant forall j in i..len(v): v[j] == old(v)[j];` = <redacted>
+   =         `invariant forall j in i..len(v): v[j] == old(v)[j];` = <redacted>
+   =         `invariant forall j in i..len(v): v[j] == old(v)[j];` = <redacted>
+   =         `invariant forall j in i..len(v): v[j] == old(v)[j];` = <redacted>
    =     enter loop, variable(s) v, i havocked and reassigned
    =         v = <redacted>
    =         i = <redacted>
@@ -66,6 +77,14 @@ error: post-condition does not hold
    =     at tests/sources/functional/macro_verification.move:49: reduce
    =         `invariant i >= 0 && i <= len(v);` = <redacted>
    =     at tests/sources/functional/macro_verification.move:50: reduce
+   =         `invariant sum == spec_sum(v, i);` = <redacted>
+   =         `invariant sum == spec_sum(v, i);` = <redacted>
+   =         `invariant sum == spec_sum(v, i);` = <redacted>
+   =         `invariant sum == spec_sum(v, i);` = <redacted>
+   =         `invariant sum == spec_sum(v, i);` = <redacted>
+   =         `invariant sum == spec_sum(v, i);` = <redacted>
+   =         `invariant sum == spec_sum(v, i);` = <redacted>
+   =         `invariant sum == spec_sum(v, i);` = <redacted>
    =         `invariant sum == spec_sum(v, i);` = <redacted>
    =     enter loop, variable(s) i, sum havocked and reassigned
    =         i = <redacted>


### PR DESCRIPTION
Currently well-formed check is instrumented at Boogie translation step. This commit explicitly instrument the well-formed check right after the havoc bytecode.

This should be semantically equivalent in terms of loop handling, but greatly simplifies data invariant instrumentation as the data invariant instrumentation pass looks for `WellFormed` opcode as hook-up points to instrument the data invariants.

This commit closes #716.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Move Language.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Data invariants in loops

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes

## Test Plan

- CI
- A new test case is added