### PR TITLE
[4/x][move-package/lock] Fix error message from parse_package_manifest

### DIFF
--- a/language/tools/move-cli/tests/build_tests/unbound_dependency/args.evm.exp
+++ b/language/tools/move-cli/tests/build_tests/unbound_dependency/args.evm.exp
@@ -4,4 +4,5 @@ Error: Unable to resolve packages for package 'A'
 Caused by:
     0: While resolving dependency 'Foo' in package 'A'
     1: While processing dependency 'Foo'
-    2: Unable to find package manifest for 'Foo' at "Move.toml/./foo"
+    2: Unable to find package manifest for 'Foo' at "./foo/Move.toml"
+    3: No such file or directory (os error 2)

--- a/language/tools/move-cli/tests/build_tests/unbound_dependency/args.exp
+++ b/language/tools/move-cli/tests/build_tests/unbound_dependency/args.exp
@@ -4,4 +4,5 @@ Error: Unable to resolve packages for package 'A'
 Caused by:
     0: While resolving dependency 'Foo' in package 'A'
     1: While processing dependency 'Foo'
-    2: Unable to find package manifest for 'Foo' at "Move.toml/./foo"
+    2: Unable to find package manifest for 'Foo' at "./foo/Move.toml"
+    3: No such file or directory (os error 2)

--- a/language/tools/move-package/tests/test_sources/parsing/full_manifest/Move.resolved
+++ b/language/tools/move-package/tests/test_sources/parsing/full_manifest/Move.resolved
@@ -1,1 +1,1 @@
-Unable to resolve packages for package 'name': While resolving dependency 'A' in package 'name': While processing dependency 'A': Unable to find package manifest for 'A' at "Move.toml/tests/test_sources/parsing/full_manifest/../a"
+Unable to resolve packages for package 'name': While resolving dependency 'A' in package 'name': While processing dependency 'A': Unable to find package manifest for 'A' at "tests/test_sources/parsing/full_manifest/../a/Move.toml": No such file or directory (os error 2)

--- a/language/tools/move-package/tests/test_sources/parsing/full_manifest_with_extra_field/Move.resolved
+++ b/language/tools/move-package/tests/test_sources/parsing/full_manifest_with_extra_field/Move.resolved
@@ -1,1 +1,1 @@
-Unable to resolve packages for package 'name': While resolving dependency 'A' in package 'name': While processing dependency 'A': Unable to find package manifest for 'A' at "Move.toml/tests/test_sources/parsing/full_manifest_with_extra_field/../a"
+Unable to resolve packages for package 'name': While resolving dependency 'A' in package 'name': While processing dependency 'A': Unable to find package manifest for 'A' at "tests/test_sources/parsing/full_manifest_with_extra_field/../a/Move.toml": No such file or directory (os error 2)

--- a/language/tools/move-package/tests/test_sources/parsing/invalid_hex_address_in_subst/Move.resolved
+++ b/language/tools/move-package/tests/test_sources/parsing/invalid_hex_address_in_subst/Move.resolved
@@ -1,1 +1,1 @@
-Unable to resolve packages for package 'name': While resolving dependency 'A' in package 'name': While processing dependency 'A': Unable to find package manifest for 'A' at "Move.toml/tests/test_sources/parsing/invalid_hex_address_in_subst/a"
+Unable to resolve packages for package 'name': While resolving dependency 'A' in package 'name': While processing dependency 'A': Unable to find package manifest for 'A' at "tests/test_sources/parsing/invalid_hex_address_in_subst/a/Move.toml": No such file or directory (os error 2)

--- a/language/tools/move-package/tests/test_sources/parsing/non_identifier_address_name_in_subst/Move.resolved
+++ b/language/tools/move-package/tests/test_sources/parsing/non_identifier_address_name_in_subst/Move.resolved
@@ -1,1 +1,1 @@
-Unable to resolve packages for package 'name': While resolving dependency 'A' in package 'name': While processing dependency 'A': Unable to find package manifest for 'A' at "Move.toml/tests/test_sources/parsing/non_identifier_address_name_in_subst/a"
+Unable to resolve packages for package 'name': While resolving dependency 'A' in package 'name': While processing dependency 'A': Unable to find package manifest for 'A' at "tests/test_sources/parsing/non_identifier_address_name_in_subst/a/Move.toml": No such file or directory (os error 2)

--- a/language/tools/move-package/tests/test_sources/parsing/unknown_toplevel_field/Move.resolved
+++ b/language/tools/move-package/tests/test_sources/parsing/unknown_toplevel_field/Move.resolved
@@ -1,1 +1,1 @@
-Unable to resolve packages for package 'name': While resolving dependency 'A' in package 'name': While processing dependency 'A': Unable to find package manifest for 'A' at "Move.toml/tests/test_sources/parsing/unknown_toplevel_field/../a"
+Unable to resolve packages for package 'name': While resolving dependency 'A' in package 'name': While processing dependency 'A': Unable to find package manifest for 'A' at "tests/test_sources/parsing/unknown_toplevel_field/../a/Move.toml": No such file or directory (os error 2)


### PR DESCRIPTION
Fix the order in which the directory and `Move.toml` are joined together (should be directory and then `Move.toml`, not the other way around as it previously was), and don't drop the context of the underlying error.

Also restructuring the function slightly to be less deeply nested, by using `?`.

## Test Plan

```
move/language/tools/move-package$ cargo nextest
```

## Stack

- #741 
- #745 
- #753 