### PR TITLE
[move-prover] only allow move types when computing type insts for axioms

### DIFF
--- a/language/move-prover/bytecode/src/mono_analysis.rs
+++ b/language/move-prover/bytecode/src/mono_analysis.rs
@@ -271,13 +271,7 @@ impl<'a> Analyzer<'a> {
         let all_types = self
             .done_types
             .iter()
-            .filter(|t| {
-                use Type::*;
-                matches!(
-                    t,
-                    TypeParameter(..) | Primitive(..) | Vector(..) | Struct(..)
-                )
-            })
+            .filter(|t| t.can_be_type_argument())
             .cloned()
             .collect::<Vec<_>>();
         for module_env in self.env.get_modules() {

--- a/language/move-prover/tests/sources/regression/mono_on_axiom_spec_type.move
+++ b/language/move-prover/tests/sources/regression/mono_on_axiom_spec_type.move
@@ -1,0 +1,22 @@
+module 0x42::mono_on_axiom_spec_type {
+    struct SetByVec {
+        elems: vector<u8>,
+    }
+    spec SetByVec {
+        invariant forall i in 0..len(elems), j in 0..len(elems):
+            elems[i] == elems[j] ==> i == j;
+    }
+
+    fun new_set(): SetByVec {
+        SetByVec {
+            elems: std::vector::empty(),
+        }
+    }
+
+    spec module {
+        fun deserialize<T>(bytes: vector<u8>): T;
+
+        axiom<T> forall b1: vector<u8>, b2: vector<u8>:
+            (deserialize<T>(b1) == deserialize<T>(b2) ==> b1 == b2);
+    }
+}


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Move Language.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Fixes #700 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes

## Test Plan

- CI
- test case in #700 is minimized and added as a regression test