### PR TITLE
[verifier] check type instantiations behind a reference or inside vec…

### DIFF
--- a/language/move-bytecode-verifier/transactional-tests/tests/struct_defs/ref_in_struct.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/struct_defs/ref_in_struct.exp
@@ -1,0 +1,37 @@
+processed 4 tasks
+
+task 0 'publish'. lines 1-4:
+Error: Unable to publish module '00000000000000000000000000000042::M1'. Got VMError: {
+    major_status: INVALID_SIGNATURE_TOKEN,
+    sub_status: None,
+    location: 0x42::M1,
+    indices: [(FieldDefinition, 0), (StructDefinition, 0)],
+    offsets: [],
+}
+
+task 1 'publish'. lines 6-9:
+Error: Unable to publish module '00000000000000000000000000000042::M2'. Got VMError: {
+    major_status: INVALID_SIGNATURE_TOKEN,
+    sub_status: None,
+    location: 0x42::M2,
+    indices: [(FieldDefinition, 0), (StructDefinition, 0)],
+    offsets: [],
+}
+
+task 2 'publish'. lines 11-14:
+Error: Unable to publish module '00000000000000000000000000000042::M3'. Got VMError: {
+    major_status: INVALID_SIGNATURE_TOKEN,
+    sub_status: None,
+    location: 0x42::M3,
+    indices: [(FieldDefinition, 0), (StructDefinition, 0)],
+    offsets: [],
+}
+
+task 3 'publish'. lines 16-19:
+Error: Unable to publish module '00000000000000000000000000000042::M4'. Got VMError: {
+    major_status: INVALID_SIGNATURE_TOKEN,
+    sub_status: None,
+    location: 0x42::M4,
+    indices: [(FieldDefinition, 0), (StructDefinition, 0)],
+    offsets: [],
+}

--- a/language/move-bytecode-verifier/transactional-tests/tests/struct_defs/ref_in_struct.mvir
+++ b/language/move-bytecode-verifier/transactional-tests/tests/struct_defs/ref_in_struct.mvir
@@ -1,0 +1,19 @@
+//# publish
+module 0x42.M1 {
+    struct S { x: &u64 }
+}
+
+//# publish
+module 0x42.M2 {
+    struct S { x: &mut u64 }
+}
+
+//# publish
+module 0x42.M3 {
+    struct S<T> { t: &T }
+}
+
+//# publish
+module 0x42.M4 {
+    struct S<T> { t: &mut T }
+}

--- a/language/move-bytecode-verifier/transactional-tests/tests/type_safety/ref_type_param.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/type_safety/ref_type_param.exp
@@ -1,0 +1,37 @@
+processed 4 tasks
+
+task 0 'publish'. lines 1-10:
+Error: Unable to publish module '00000000000000000000000000000042::M1'. Got VMError: {
+    major_status: CONSTRAINT_NOT_SATISFIED,
+    sub_status: None,
+    location: 0x42::M1,
+    indices: [(Signature, 0), (FunctionHandle, 0)],
+    offsets: [],
+}
+
+task 1 'publish'. lines 12-21:
+Error: Unable to publish module '00000000000000000000000000000042::M2'. Got VMError: {
+    major_status: CONSTRAINT_NOT_SATISFIED,
+    sub_status: None,
+    location: 0x42::M2,
+    indices: [(Signature, 0), (FunctionHandle, 0)],
+    offsets: [],
+}
+
+task 2 'publish'. lines 23-32:
+Error: Unable to publish module '00000000000000000000000000000042::M3'. Got VMError: {
+    major_status: NUMBER_OF_TYPE_ARGUMENTS_MISMATCH,
+    sub_status: None,
+    location: undefined,
+    indices: [],
+    offsets: [],
+}
+
+task 3 'publish'. lines 34-44:
+Error: Unable to publish module '00000000000000000000000000000042::M4'. Got VMError: {
+    major_status: CONSTRAINT_NOT_SATISFIED,
+    sub_status: None,
+    location: 0x42::M4,
+    indices: [(Signature, 0), (FunctionHandle, 0)],
+    offsets: [],
+}

--- a/language/move-bytecode-verifier/transactional-tests/tests/type_safety/ref_type_param.mvir
+++ b/language/move-bytecode-verifier/transactional-tests/tests/type_safety/ref_type_param.mvir
@@ -1,0 +1,44 @@
+//# publish
+module 0x42.M1 {
+    struct S<T: copy> { t: T }
+
+    // should get flagged w/ constraint not satisfied--T does not have copy
+    public bad_sig<T>(s: &Self.S<T>) {
+    label b0:
+        return;
+    }
+}
+
+//# publish
+module 0x42.M2 {
+    struct S<T: copy> { t: T }
+
+    // should get flagged w/ constraint not satisfied--T does not have copy
+    public bad_sig<T>(s: &mut Self.S<T>) {
+    label b0:
+        return;
+    }
+}
+
+//# publish
+module 0x42.M3 {
+    struct S<T: copy> { t: T }
+
+    // should get flagged--missing type argument
+    public bad_sig<T>(s: &Self.S) {
+    label b0:
+        return;
+    }
+}
+
+//# publish
+module 0x42.M4 {
+    struct Box<T> { t: T }
+    struct S<T: copy> { t: T }
+
+    // should be rejected
+    public bad_sig<T>(v: Self.Box<Self.S<T>>): Self.Box<Self.S<T>> {
+    label b0:
+        return move(v);
+    }
+}

--- a/language/move-bytecode-verifier/transactional-tests/tests/type_safety/ref_type_param_exploits.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/type_safety/ref_type_param_exploits.exp
@@ -1,0 +1,46 @@
+processed 5 tasks
+
+task 0 'publish'. lines 1-11:
+Error: Unable to publish module '00000000000000000000000000000042::M1'. Got VMError: {
+    major_status: CONSTRAINT_NOT_SATISFIED,
+    sub_status: None,
+    location: 0x42::M1,
+    indices: [(Signature, 0), (FunctionHandle, 0)],
+    offsets: [],
+}
+
+task 1 'publish'. lines 13-23:
+Error: Unable to publish module '00000000000000000000000000000042::M2'. Got VMError: {
+    major_status: CONSTRAINT_NOT_SATISFIED,
+    sub_status: None,
+    location: 0x42::M2,
+    indices: [(Signature, 0), (FunctionHandle, 0)],
+    offsets: [],
+}
+
+task 2 'publish'. lines 25-36:
+Error: Unable to publish module '00000000000000000000000000000042::M3'. Got VMError: {
+    major_status: CONSTRAINT_NOT_SATISFIED,
+    sub_status: None,
+    location: 0x42::M3,
+    indices: [(Signature, 0), (FunctionHandle, 0)],
+    offsets: [],
+}
+
+task 3 'publish'. lines 38-54:
+Error: Unable to publish module '00000000000000000000000000000042::M4'. Got VMError: {
+    major_status: CONSTRAINT_NOT_SATISFIED,
+    sub_status: None,
+    location: 0x42::M4,
+    indices: [(Signature, 0), (FunctionHandle, 0)],
+    offsets: [],
+}
+
+task 4 'publish'. lines 56-72:
+Error: Unable to publish module '00000000000000000000000000000042::M5'. Got VMError: {
+    major_status: CONSTRAINT_NOT_SATISFIED,
+    sub_status: None,
+    location: 0x42::M5,
+    indices: [(Signature, 0), (FunctionHandle, 0)],
+    offsets: [],
+}

--- a/language/move-bytecode-verifier/transactional-tests/tests/type_safety/ref_type_param_exploits.mvir
+++ b/language/move-bytecode-verifier/transactional-tests/tests/type_safety/ref_type_param_exploits.mvir
@@ -1,0 +1,72 @@
+//# publish
+module 0x42.M1 {
+    struct S<T: copy> { t: T }
+
+    // note: T does not have copy
+    // if this worked, it would be very bad because `T` can be (e.g.) a Coin
+    public copy_inner<T>(s: &Self.S<T>): T { // should get flagged w/ constraint not satisfied
+    label b0:
+        return *&move(s).S<T>::t;
+    }
+}
+
+//# publish
+module 0x42.M2 {
+    struct S<T: copy> has copy { t: T }
+
+    // note: T does not have copy
+    // if this worked, it would be very bad because `T` can be (e.g.) a Coin
+    public copy_direct<T>(s: &Self.S<T>): Self.S<T> { // should get flagged w/ constraint not satisfied
+    label b0:
+        return *move(s);
+    }
+}
+
+//# publish
+module 0x42.M3 {
+    struct S<T: store> has store { t: T }
+
+    // note: T does not have store
+    // if this worked, it would be very bad because `T` can be (e.g.) a hot potato
+    public store_inner<T>(s: &mut Self.S<T>, t: T) { // should get flagged w/ constraint not satisfied
+    label b0:
+        *&mut move(s).S<T>::t = move(t);
+        return;
+    }
+}
+
+//# publish
+module 0x42.M4 {
+    struct S<T: copy> { t: T }
+
+    public bad_sig<T>(s: &Self.S<T>) { // should get flagged w/ constraint not satisfied
+    label b0:
+        return;
+    }
+
+    public call(): Self.S<u64> {
+    let x: Self.S<u64>;
+    label b0:
+        x = S<u64> { t: 10 };
+        Self.bad_sig(&x);
+        return move(x);
+    }
+}
+
+//# publish
+module 0x42.M5 {
+    struct S<T: copy> { t: T }
+
+    public bad_sig<T>(s: &Self.S<T>) { // should get flagged w/ constraint not satisfied
+    label b0:
+        return;
+    }
+
+    public call(s: signer): Self.S<signer> {
+    let x: Self.S<signer>;
+    label b0:
+        x = S<u64> { t: move(s) };
+        Self.bad_sig(&x);
+        return move(x);
+    }
+}

--- a/language/move-bytecode-verifier/transactional-tests/tests/type_safety/vector_type_param.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/type_safety/vector_type_param.exp
@@ -1,0 +1,28 @@
+processed 3 tasks
+
+task 0 'publish'. lines 1-10:
+Error: Unable to publish module '00000000000000000000000000000042::M1'. Got VMError: {
+    major_status: CONSTRAINT_NOT_SATISFIED,
+    sub_status: None,
+    location: 0x42::M1,
+    indices: [(Signature, 0), (FunctionHandle, 0)],
+    offsets: [],
+}
+
+task 1 'publish'. lines 12-21:
+Error: Unable to publish module '00000000000000000000000000000042::M2'. Got VMError: {
+    major_status: CONSTRAINT_NOT_SATISFIED,
+    sub_status: None,
+    location: 0x42::M2,
+    indices: [(Signature, 0), (FunctionHandle, 0)],
+    offsets: [],
+}
+
+task 2 'publish'. lines 23-32:
+Error: Unable to publish module '00000000000000000000000000000042::M3'. Got VMError: {
+    major_status: CONSTRAINT_NOT_SATISFIED,
+    sub_status: None,
+    location: 0x42::M3,
+    indices: [(Signature, 0), (FunctionHandle, 0)],
+    offsets: [],
+}

--- a/language/move-bytecode-verifier/transactional-tests/tests/type_safety/vector_type_param.mvir
+++ b/language/move-bytecode-verifier/transactional-tests/tests/type_safety/vector_type_param.mvir
@@ -1,0 +1,32 @@
+//# publish
+module 0x42.M1 {
+    struct S<T: copy> { t: T }
+
+    // should get flagged w/ constraint not satisfied--T does not have copy
+    public bad_sig<T>(v: vector<Self.S<T>>): vector<Self.S<T>> {
+    label b0:
+        return move(v);
+    }
+}
+
+//# publish
+module 0x42.M2 {
+    struct S<T: copy> { t: T }
+
+    // should get flagged w/ constraint not satisfied--T does not have copy
+    public bad_sig<T>(v: &vector<Self.S<T>>) {
+    label b0:
+        return;
+    }
+}
+
+//# publish
+module 0x42.M3 {
+    struct S<T: copy> { t: T }
+
+    // should get flagged w/ constraint not satisfied--T does not have copy
+    public bad_sig<T>(v: &mut vector<Self.S<T>>) {
+    label b0:
+        return;
+    }
+}

--- a/language/move-bytecode-verifier/transactional-tests/tests/type_safety/vector_type_param_exploits.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/type_safety/vector_type_param_exploits.exp
@@ -1,0 +1,37 @@
+processed 4 tasks
+
+task 0 'publish'. lines 1-11:
+Error: Unable to publish module '00000000000000000000000000000042::M1'. Got VMError: {
+    major_status: CONSTRAINT_NOT_SATISFIED,
+    sub_status: None,
+    location: 0x42::M1,
+    indices: [(Signature, 0), (FunctionHandle, 0)],
+    offsets: [],
+}
+
+task 1 'publish'. lines 13-22:
+Error: Unable to publish module '00000000000000000000000000000042::M2'. Got VMError: {
+    major_status: CONSTRAINT_NOT_SATISFIED,
+    sub_status: None,
+    location: 0x42::M2,
+    indices: [(Signature, 0), (FunctionHandle, 0)],
+    offsets: [],
+}
+
+task 2 'publish'. lines 24-40:
+Error: Unable to publish module '00000000000000000000000000000042::M3'. Got VMError: {
+    major_status: CONSTRAINT_NOT_SATISFIED,
+    sub_status: None,
+    location: 0x42::M3,
+    indices: [(Signature, 0), (FunctionHandle, 0)],
+    offsets: [],
+}
+
+task 3 'publish'. lines 42-58:
+Error: Unable to publish module '00000000000000000000000000000042::M4'. Got VMError: {
+    major_status: CONSTRAINT_NOT_SATISFIED,
+    sub_status: None,
+    location: 0x42::M4,
+    indices: [(Signature, 0), (FunctionHandle, 0)],
+    offsets: [],
+}

--- a/language/move-bytecode-verifier/transactional-tests/tests/type_safety/vector_type_param_exploits.mvir
+++ b/language/move-bytecode-verifier/transactional-tests/tests/type_safety/vector_type_param_exploits.mvir
@@ -1,0 +1,58 @@
+//# publish
+module 0x42.M1 {
+    struct S<T: copy + drop> has copy, drop { t: T }
+
+    // it would be bad if this worked because T could be (e.g.) a coin
+    // should get flagged w/ constraint not satisfied--T does not have copy
+    public bad_sig<T>(v: vector<Self.S<T>>): vector<Self.S<T>> {
+    label b0:
+        return copy(v);
+    }
+}
+
+//# publish
+module 0x42.M2 {
+    struct S<T: drop> has drop { t: T }
+
+    // it would be bad if this worked because T could be (e.g.) a hot potato
+    public bad_sig<T>(v: vector<Self.S<T>>) {
+    label b0:
+        return;
+    }
+}
+
+//# publish
+module 0x42.M3 {
+    struct S<T: copy> { t: T }
+
+    public bad_sig<T>(s: vector<Self.S<T>>) { // should get flagged w/ constraint not satisfied
+    label b0:
+        return;
+    }
+
+    public call(): vector<Self.S<u64>> {
+    let x: vector<Self.S<u64>>;
+    label b0:
+        x = vec_pack_0<Self.S<u64>>();
+        Self.bad_sig(&x);
+        return move(x);
+    }
+}
+
+//# publish
+module 0x42.M4 {
+    struct S<T: copy> { t: T }
+
+    public bad_sig<T>(s: vector<Self.S<T>>) { // should get flagged w/ constraint not satisfied
+    label b0:
+        return;
+    }
+
+    public call(): vector<Self.S<signer>> {
+    let x: vector<Self.S<signer>>;
+    label b0:
+        x = vec_pack_0<Self.S<signer>>();
+        Self.bad_sig(&x);
+        return move(x);
+    }
+}


### PR DESCRIPTION
…tor generics

The verifier current doesn't check ability constraints on types that are behind a reference, or inside a vector (i.e., the `T` in `&T`, `&mut T`, or `vector<T>`). This sounds alarming, but is fortunately not possible to take advantage of because doing so always creates a bad struct instantiation that will be flagged b the ability checker.

Fix the bug in version 7--left it in version 6 and below because it is (to the best of our understanding) harmless and the fix is a breaking change in the verifier--it will reject some function declarations that were previously accepted.