### PR TITLE
Move vector<u64> easy casting to rust Vec<u64>

### DIFF
--- a/language/move-vm/types/src/values/value_tests.rs
+++ b/language/move-vm/types/src/values/value_tests.rs
@@ -220,5 +220,8 @@ fn legacy_val_abstract_memory_size_consistency() -> PartialVMResult<()> {
 
 #[test]
 fn test_vm_value_vector_u64_casting() {
-    assert_eq!(vec![1, 2, 3], Value::vector_u64([1, 2, 3]).value_as::<Vec<u64>>().unwrap());
+    assert_eq!(
+        vec![1, 2, 3],
+        Value::vector_u64([1, 2, 3]).value_as::<Vec<u64>>().unwrap()
+    );
 }

--- a/language/move-vm/types/src/values/value_tests.rs
+++ b/language/move-vm/types/src/values/value_tests.rs
@@ -219,7 +219,6 @@ fn legacy_val_abstract_memory_size_consistency() -> PartialVMResult<()> {
 }
 
 #[test]
-fn test_vector_u64_retrieval() {
-    let val = Value::vector_u64([1, 2, 3]);
-    assert_eq!(vec![1, 2, 3], val.value_as::<Vec<u64>>().unwrap());
+fn test_vm_value_vector_u64_casting() {
+    assert_eq!(vec![1, 2, 3], Value::vector_u64([1, 2, 3]).value_as::<Vec<u64>>().unwrap());
 }

--- a/language/move-vm/types/src/values/value_tests.rs
+++ b/language/move-vm/types/src/values/value_tests.rs
@@ -217,3 +217,9 @@ fn legacy_val_abstract_memory_size_consistency() -> PartialVMResult<()> {
 
     Ok(())
 }
+
+#[test]
+fn test_vector_u64_retrieval() {
+    let val = Value::vector_u64([1, 2, 3]);
+    assert_eq!(vec![1, 2, 3], val.value_as::<Vec<u64>>().unwrap());
+}

--- a/language/move-vm/types/src/values/values_impl.rs
+++ b/language/move-vm/types/src/values/values_impl.rs
@@ -1289,6 +1289,16 @@ impl VMValueCast<Vec<u8>> for Value {
     }
 }
 
+impl VMValueCast<Vec<u64>> for Value {
+    fn cast(self) -> PartialVMResult<Vec<u64>> {
+        match self.0 {
+            ValueImpl::Container(Container::VecU64(r)) => take_unique_ownership(r),
+            v => Err(PartialVMError::new(StatusCode::INTERNAL_TYPE_ERROR)
+                .with_message(format!("cannot cast {:?} to vector<u64>", v,))),
+        }
+    }
+}
+
 impl VMValueCast<Vec<Value>> for Value {
     fn cast(self) -> PartialVMResult<Vec<Value>> {
         match self.0 {


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Move Language.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

This allows move values of type `vector<u64>` to be easily cast to `Vec<u64>` in rust using the `pop_arg` macro.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes.

## Test Plan

UT test case should be sufficient.
