### PR TITLE
[move-lang] Inlined functions (formerly macros): parsing and type checking (rebased for new aptos branch)

### DIFF
--- a/language/move-compiler/src/attr_derivation/mod.rs
+++ b/language/move-compiler/src/attr_derivation/mod.rs
@@ -107,6 +107,7 @@ pub fn new_native_fun(
         signature,
         acquires: vec![],
         name,
+        inline: false,
         body: sp(loc, FunctionBody_::Native),
     }
 }
@@ -129,6 +130,7 @@ pub fn new_fun(
         signature,
         acquires: vec![],
         name,
+        inline: false,
         body: sp(
             loc,
             FunctionBody_::Defined((vec![], vec![], None, Box::new(Some(def)))),

--- a/language/move-compiler/src/cfgir/optimize/constant_fold.rs
+++ b/language/move-compiler/src/cfgir/optimize/constant_fold.rs
@@ -204,7 +204,7 @@ fn is_valid_const_builtin_type(sp!(_, bt_): &BuiltinTypeName) -> bool {
         N::Address | N::U8 | N::U16 | N::U32 | N::U64 | N::U128 | N::U256 | N::Vector | N::Bool => {
             true
         }
-        N::Signer => false,
+        N::Signer | N::Fun => false,
     }
 }
 

--- a/language/move-compiler/src/diagnostics/codes.rs
+++ b/language/move-compiler/src/diagnostics/codes.rs
@@ -150,7 +150,6 @@ codes!(
         UnboundVariable: { msg: "unbound variable", severity: BlockingError },
         UnboundField: { msg: "unbound field", severity: BlockingError },
         ReservedName: { msg: "invalid use of reserved name", severity: BlockingError },
-        UnboundMacro: { msg: "unbound macro", severity: BlockingError },
     ],
     // errors for typing rules. mostly typing/translate
     TypeSafety: [
@@ -182,6 +181,8 @@ codes!(
                 (NOTE: this may become an error in the future)",
             severity: Warning
         },
+        InvalidCallTarget: { msg: "invalid call target", severity: BlockingError },
+        InvalidFunctionType: { msg: "invalid usage of function type", severity: BlockingError },
     ],
     // errors for ability rules. mostly typing/translate
     AbilitySafety: [
@@ -235,6 +236,7 @@ codes!(
     Bug: [
         BytecodeGeneration: { msg: "BYTECODE GENERATION FAILED", severity: Bug },
         BytecodeVerification: { msg: "BYTECODE VERIFICATION FAILED", severity: Bug },
+        Unimplemented: { msg: "Not yet implemented", severity: BlockingError },
     ],
     Derivation: [
         DeriveFailed: { msg: "attribute derivation failed", severity: BlockingError }

--- a/language/move-compiler/src/expansion/translate.rs
+++ b/language/move-compiler/src/expansion/translate.rs
@@ -1198,6 +1198,7 @@ fn function_(context: &mut Context, pfunction: P::Function) -> (FunctionName, E:
     let P::Function {
         attributes: pattributes,
         loc,
+        inline,
         name,
         visibility: pvisibility,
         entry,
@@ -1218,6 +1219,7 @@ fn function_(context: &mut Context, pfunction: P::Function) -> (FunctionName, E:
     let fdef = E::Function {
         attributes,
         loc,
+        inline,
         visibility,
         entry,
         signature,
@@ -1588,17 +1590,9 @@ fn type_(context: &mut Context, sp!(loc, pt_): P::Type) -> E::Type {
         }
         PT::Ref(mut_, inner) => ET::Ref(mut_, Box::new(type_(context, *inner))),
         PT::Fun(args, result) => {
-            if context.in_spec_context {
-                let args = types(context, args);
-                let result = type_(context, *result);
-                ET::Fun(args, Box::new(result))
-            } else {
-                context.env.add_diag(diag!(
-                    Syntax::SpecContextRestricted,
-                    (loc, "`|_|_` function type only allowed in specifications")
-                ));
-                ET::UnresolvedError
-            }
+            let args = types(context, args);
+            let result = type_(context, *result);
+            ET::Fun(args, Box::new(result))
         }
     };
     sp(loc, t_)
@@ -1882,21 +1876,13 @@ fn exp_(context: &mut Context, sp!(loc, pe_): P::Exp) -> E::Exp {
         PE::Loop(ploop) => EE::Loop(exp(context, *ploop)),
         PE::Block(seq) => EE::Block(sequence(context, loc, seq)),
         PE::Lambda(pbs, pe) => {
-            if !context.in_spec_context {
-                context.env.add_diag(diag!(
-                    Syntax::SpecContextRestricted,
-                    (loc, "lambda expression only allowed in specifications"),
-                ));
-                EE::UnresolvedError
-            } else {
-                let bs_opt = bind_list(context, pbs);
-                let e = exp_(context, *pe);
-                match bs_opt {
-                    Some(bs) => EE::Lambda(bs, Box::new(e)),
-                    None => {
-                        assert!(context.env.has_errors());
-                        EE::UnresolvedError
-                    }
+            let bs_opt = bind_list(context, pbs);
+            let e = exp_(context, *pe);
+            match bs_opt {
+                Some(bs) => EE::Lambda(bs, Box::new(e)),
+                None => {
+                    assert!(context.env.has_errors());
+                    EE::UnresolvedError
                 }
             }
         }

--- a/language/move-compiler/src/hlir/ast.rs
+++ b/language/move-compiler/src/hlir/ast.rs
@@ -452,6 +452,7 @@ impl BaseType_ {
                 )
                 .unwrap()
             }
+            Fun => panic!("ICE unexpected function type"),
         };
         let n = sp(loc, TypeName_::Builtin(sp(loc, b_)));
         sp(loc, BaseType_::Apply(kind, n, ty_args))

--- a/language/move-compiler/src/hlir/translate.rs
+++ b/language/move-compiler/src/hlir/translate.rs
@@ -277,9 +277,11 @@ fn script(context: &mut Context, tscript: T::Script) -> H::Script {
 //**************************************************************************************************
 
 fn function(context: &mut Context, _name: FunctionName, f: T::Function) -> H::Function {
+    assert!(!f.inline, "ICE unexpected macro definition");
     assert!(context.has_empty_locals());
     assert!(context.tmp_counter == 0);
     let T::Function {
+        inline: _,
         attributes,
         visibility,
         entry,
@@ -1182,11 +1184,13 @@ fn exp_impl(
             let T::ModuleCall {
                 module,
                 name,
+                is_macro,
                 type_arguments,
                 arguments,
                 parameter_types,
                 acquires,
             } = *call;
+            assert!(!is_macro, "ICE unexpanded macro call");
             let expected_type = H::Type_::from_vec(eloc, single_types(context, parameter_types));
             let htys = base_types(context, type_arguments);
             let harg = exp(context, result, Some(&expected_type), *arguments);
@@ -1199,6 +1203,7 @@ fn exp_impl(
             };
             HE::ModuleCall(Box::new(call))
         }
+        TE::VarCall(..) => panic!("ICE unexpected local call"),
         TE::Builtin(bf, targ) => builtin(context, result, eloc, *bf, targ),
         TE::Vector(vec_loc, n, tty, targ) => {
             let ty = Box::new(base_type(context, *tty));
@@ -1365,6 +1370,7 @@ fn exp_impl(
                 .collect();
             HE::Spec(u, used_locals)
         }
+        TE::Lambda(..) => panic!("ICE unexpected lambda"),
         TE::UnresolvedError => {
             assert!(context.env.has_errors());
             HE::UnresolvedError
@@ -1705,7 +1711,7 @@ fn freeze_single(sp!(sloc, s): H::SingleType) -> H::SingleType {
 fn bind_for_short_circuit(e: &T::Exp) -> bool {
     use T::UnannotatedExp_ as TE;
     match &e.exp.value {
-        TE::Use(_) => panic!("ICE should have been expanded"),
+        TE::Use(_) | TE::VarCall(..) => panic!("ICE should have been expanded"),
         TE::Value(_)
         | TE::Constant(_, _)
         | TE::Move { .. }
@@ -1740,7 +1746,8 @@ fn bind_for_short_circuit(e: &T::Exp) -> bool {
         | TE::Vector(_, _, _, _)
         | TE::BorrowLocal(_, _)
         | TE::ExpList(_)
-        | TE::Cast(_, _) => panic!("ICE unexpected exp in short circuit check: {:?}", e),
+        | TE::Cast(_, _)
+        | TE::Lambda(..) => panic!("ICE unexpected exp in short circuit check: {:?}", e),
     }
 }
 

--- a/language/move-compiler/src/naming/ast.rs
+++ b/language/move-compiler/src/naming/ast.rs
@@ -109,6 +109,7 @@ pub type FunctionBody = Spanned<FunctionBody_>;
 #[derive(PartialEq, Debug, Clone)]
 pub struct Function {
     pub attributes: Attributes,
+    pub inline: bool,
     pub visibility: Visibility,
     pub entry: Option<Loc>,
     pub signature: FunctionSignature,
@@ -154,6 +155,8 @@ pub enum BuiltinTypeName_ {
     Vector,
     // bool
     Bool,
+    // Function (last type arg is result type)
+    Fun,
 }
 pub type BuiltinTypeName = Spanned<BuiltinTypeName_>;
 
@@ -166,6 +169,12 @@ pub enum TypeName_ {
     ModuleType(ModuleIdent, StructName),
 }
 pub type TypeName = Spanned<TypeName_>;
+
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
+pub enum Variance {
+    Covariant,
+    ContraVariant,
+}
 
 #[derive(Debug, Hash, Eq, PartialEq, Ord, PartialOrd, Copy, Clone)]
 pub struct TParamID(pub u64);
@@ -239,9 +248,11 @@ pub enum Exp_ {
     ModuleCall(
         ModuleIdent,
         FunctionName,
+        bool,
         Option<Vec<Type>>,
         Spanned<Vec<Exp>>,
     ),
+    VarCall(Var, Spanned<Vec<Exp>>),
     Builtin(BuiltinFunction, Spanned<Vec<Exp>>),
     Vector(Loc, Option<Type>, Spanned<Vec<Exp>>),
 
@@ -249,6 +260,7 @@ pub enum Exp_ {
     While(Box<Exp>, Box<Exp>),
     Loop(Box<Exp>),
     Block(Sequence),
+    Lambda(LValueList, Box<Exp>),
 
     Assign(LValueList, Box<Exp>),
     FieldMutate(ExpDotted, Box<Exp>),
@@ -343,6 +355,7 @@ impl BuiltinTypeName_ {
     pub const U_256: &'static str = "u256";
     pub const BOOL: &'static str = "bool";
     pub const VECTOR: &'static str = "vector";
+    pub const FUN: &'static str = "|..|..";
 
     pub fn all_names() -> &'static BTreeSet<Symbol> {
         &BUILTIN_TYPE_ALL_NAMES
@@ -390,10 +403,11 @@ impl BuiltinTypeName_ {
             }
             B::Signer => AbilitySet::signer(loc),
             B::Vector => AbilitySet::collection(loc),
+            B::Fun => AbilitySet::functions(),
         }
     }
 
-    pub fn tparam_constraints(&self, _loc: Loc) -> Vec<AbilitySet> {
+    pub fn tparam_constraints(&self, _loc: Loc, arity: usize) -> Vec<AbilitySet> {
         use BuiltinTypeName_ as B;
         // Match here to make sure this function is fixed when collections are added
         match self {
@@ -407,6 +421,25 @@ impl BuiltinTypeName_ {
             | B::U256
             | B::Bool => vec![],
             B::Vector => vec![AbilitySet::empty()],
+            B::Fun => (0..arity).map(|_| AbilitySet::empty()).collect(),
+        }
+    }
+
+    pub fn variance(&self, pos: usize, arity: usize) -> Variance {
+        match self {
+            // Function variance: given g: T1 -> R1 and f: T2 -> R2, then
+            // f can substitute g if T2 >= T1 && R1 <= R2
+            BuiltinTypeName_::Fun if pos < arity - 1 => Variance::ContraVariant,
+            _ => Variance::Covariant,
+        }
+    }
+}
+
+impl TypeName_ {
+    pub fn variance(&self, pos: usize, arity: usize) -> Variance {
+        match self {
+            TypeName_::Builtin(bn) => bn.value.variance(pos, arity),
+            _ => Variance::Covariant,
         }
     }
 }
@@ -486,7 +519,7 @@ impl Type_ {
                 Some(AbilitySet::primitives(b.loc))
             }
             B::Signer => Some(AbilitySet::signer(b.loc)),
-            B::Vector => None,
+            B::Vector | B::Fun => None,
         };
         let n = sp(b.loc, TypeName_::Builtin(b));
         Type_::Apply(abilities, n, ty_args)
@@ -595,6 +628,7 @@ impl fmt::Display for BuiltinTypeName_ {
                 BT::U256 => BT::U_256,
                 BT::Bool => BT::BOOL,
                 BT::Vector => BT::VECTOR,
+                BT::Fun => BT::FUN,
             }
         )
     }
@@ -732,6 +766,7 @@ impl AstDebug for (FunctionName, &Function) {
             name,
             Function {
                 attributes,
+                inline,
                 visibility,
                 entry,
                 signature,
@@ -747,7 +782,11 @@ impl AstDebug for (FunctionName, &Function) {
         if let FunctionBody_::Native = &body.value {
             w.write("native ");
         }
-        w.write(&format!("fun {}", name));
+        if *inline {
+            w.write(&format!("inline fun {}", name));
+        } else {
+            w.write(&format!("fun {}", name));
+        }
         signature.ast_debug(w);
         if !acquires.is_empty() {
             w.write(" acquires ");
@@ -959,13 +998,22 @@ impl AstDebug for Exp_ {
             E::Use(v) => w.write(&format!("{}", v)),
             E::Constant(None, c) => w.write(&format!("{}", c)),
             E::Constant(Some(m), c) => w.write(&format!("{}::{}", m, c)),
-            E::ModuleCall(m, f, tys_opt, sp!(_, rhs)) => {
+            E::ModuleCall(m, f, is_macro, tys_opt, sp!(_, rhs)) => {
                 w.write(&format!("{}::{}", m, f));
+                if *is_macro {
+                    w.write("!");
+                }
                 if let Some(ss) = tys_opt {
                     w.write("<");
                     ss.ast_debug(w);
                     w.write(">");
                 }
+                w.write("(");
+                w.comma(rhs, |w, e| e.ast_debug(w));
+                w.write(")");
+            }
+            E::VarCall(var, sp!(_, rhs)) => {
+                w.write(&format!("{}", var));
                 w.write("(");
                 w.comma(rhs, |w, e| e.ast_debug(w));
                 w.write(")");
@@ -1021,6 +1069,12 @@ impl AstDebug for Exp_ {
                 e.ast_debug(w);
             }
             E::Block(seq) => w.block(|w| seq.ast_debug(w)),
+            E::Lambda(sp!(_, bs), e) => {
+                w.write("|");
+                bs.ast_debug(w);
+                w.write("|");
+                e.ast_debug(w);
+            }
             E::ExpList(es) => {
                 w.write("(");
                 w.comma(es, |w, e| e.ast_debug(w));

--- a/language/move-compiler/src/naming/translate.rs
+++ b/language/move-compiler/src/naming/translate.rs
@@ -488,6 +488,7 @@ fn function(
     let E::Function {
         attributes,
         loc: _,
+        inline,
         visibility,
         entry,
         signature,
@@ -500,6 +501,7 @@ fn function(
     let body = function_body(context, body);
     let f = N::Function {
         attributes,
+        inline,
         visibility,
         entry,
         signature,
@@ -762,7 +764,7 @@ fn type_(context: &mut Context, sp!(loc, ety_): E::Type) -> N::Type {
             Some(RT::BuiltinType) => {
                 let bn_ = N::BuiltinTypeName_::resolve(&n.value).unwrap();
                 let name_f = || format!("{}", &bn_);
-                let arity = bn_.tparam_constraints(loc).len();
+                let arity = bn_.tparam_constraints(loc, tys.len()).len();
                 let tys = types(context, tys);
                 let tys = check_type_argument_arity(context, loc, name_f, tys, arity);
                 NT::builtin_(sp(loc, bn_), tys)
@@ -779,6 +781,11 @@ fn type_(context: &mut Context, sp!(loc, ety_): E::Type) -> N::Type {
                 }
             }
         },
+        ET::Fun(args, result) => {
+            let mut args = types(context, args);
+            args.push(type_(context, *result));
+            NT::builtin_(sp(loc, N::BuiltinTypeName_::Fun), args)
+        }
         ET::Apply(sp!(nloc, EN::ModuleAccess(m, n)), tys) => {
             match context.resolve_module_type(nloc, &m, &n) {
                 None => {
@@ -794,7 +801,6 @@ fn type_(context: &mut Context, sp!(loc, ety_): E::Type) -> N::Type {
                 }
             }
         }
-        ET::Fun(_, _) => panic!("ICE only allowed in spec context"),
     };
     sp(loc, ty_)
 }
@@ -909,7 +915,16 @@ fn exp_(context: &mut Context, e: E::Exp) -> N::Exp {
         EE::While(eb, el) => NE::While(exp(context, *eb), exp(context, *el)),
         EE::Loop(el) => NE::Loop(exp(context, *el)),
         EE::Block(seq) => NE::Block(sequence(context, seq)),
-
+        EE::Lambda(args, body) => {
+            let bind_opt = bind_list(context, args);
+            match bind_opt {
+                None => {
+                    assert!(context.env.has_errors());
+                    N::Exp_::UnresolvedError
+                }
+                Some(bind) => NE::Lambda(bind, Box::new(exp_(context, *body))),
+            }
+        }
         EE::Assign(a, e) => {
             let na_opt = assign_list(context, a);
             let ne = exp(context, *e);
@@ -991,25 +1006,20 @@ fn exp_(context: &mut Context, e: E::Exp) -> N::Exp {
         EE::Cast(e, t) => NE::Cast(exp(context, *e), type_(context, t)),
         EE::Annotate(e, t) => NE::Annotate(exp(context, *e), type_(context, t)),
 
-        EE::Call(sp!(mloc, ma_), true, tys_opt, rhs) => {
-            use E::ModuleAccess_ as EA;
+        EE::Call(sp!(mloc, E::ModuleAccess_::Name(n)), true, tys_opt, rhs)
+            if n.value.as_str() == N::BuiltinFunction_::ASSERT_MACRO =>
+        {
             use N::BuiltinFunction_ as BF;
-            assert!(tys_opt.is_none(), "ICE macros do not have type arguments");
-            let nes = call_args(context, rhs);
-            match ma_ {
-                EA::Name(n) if n.value.as_str() == BF::ASSERT_MACRO => {
-                    NE::Builtin(sp(mloc, BF::Assert(true)), nes)
-                }
-                ma_ => {
-                    context.env.add_diag(diag!(
-                        NameResolution::UnboundMacro,
-                        (mloc, format!("Unbound macro '{}'", ma_)),
-                    ));
-                    NE::UnresolvedError
-                }
+            if tys_opt.is_some() {
+                context.env.add_diag(diag!(
+                    TypeSafety::TooManyArguments,
+                    (eloc, "expected zero type arguments")
+                ));
             }
+            let nes = call_args(context, rhs);
+            NE::Builtin(sp(mloc, BF::Assert(true)), nes)
         }
-        EE::Call(sp!(mloc, ma_), false, tys_opt, rhs) => {
+        EE::Call(sp!(mloc, ma_), is_macro, tys_opt, rhs) => {
             use E::ModuleAccess_ as EA;
             let ty_args = tys_opt.map(|tys| types(context, tys));
             let nes = call_args(context, rhs);
@@ -1024,19 +1034,13 @@ fn exp_(context: &mut Context, e: E::Exp) -> N::Exp {
                     }
                 }
 
-                EA::Name(n) => {
-                    context.env.add_diag(diag!(
-                        NameResolution::UnboundUnscopedName,
-                        (n.loc, format!("Unbound function '{}' in current scope", n)),
-                    ));
-                    NE::UnresolvedError
-                }
+                EA::Name(n) => NE::VarCall(Var(n), nes),
                 EA::ModuleAccess(m, n) => match context.resolve_module_function(mloc, &m, &n) {
                     None => {
                         assert!(context.env.has_errors());
                         NE::UnresolvedError
                     }
-                    Some(_) => NE::ModuleCall(m, FunctionName(n), ty_args, nes),
+                    Some(_) => NE::ModuleCall(m, FunctionName(n), is_macro, ty_args, nes),
                 },
             }
         }
@@ -1067,8 +1071,8 @@ fn exp_(context: &mut Context, e: E::Exp) -> N::Exp {
             assert!(context.env.has_errors());
             NE::UnresolvedError
         }
-        // `Name` matches name variants only allowed in specs (we handle the allowed ones above)
-        EE::Index(..) | EE::Lambda(..) | EE::Quant(..) | EE::Name(_, Some(_)) => {
+        // Matches variants only allowed in specs (we handle the allowed ones above)
+        EE::Index(..) | EE::Quant(..) | EE::Name(_, Some(_)) => {
             panic!("ICE unexpected specification construct")
         }
     };

--- a/language/move-compiler/src/parser/ast.rs
+++ b/language/move-compiler/src/parser/ast.rs
@@ -268,6 +268,7 @@ pub struct Function {
     pub signature: FunctionSignature,
     pub acquires: Vec<NameAccessChain>,
     pub name: FunctionName,
+    pub inline: bool,
     pub body: FunctionBody,
 }
 
@@ -1464,6 +1465,7 @@ impl AstDebug for Function {
             entry,
             signature,
             acquires,
+            inline,
             name,
             body,
         } = self;
@@ -1475,7 +1477,11 @@ impl AstDebug for Function {
         if let FunctionBody_::Native = &body.value {
             w.write("native ");
         }
-        w.write(&format!("fun {}", name));
+        if *inline {
+            w.write(&format!("inline fun {}", name));
+        } else {
+            w.write(&format!("fun {}", name));
+        }
         signature.ast_debug(w);
         if !acquires.is_empty() {
             w.write(" acquires ");
@@ -1763,9 +1769,9 @@ impl AstDebug for Exp_ {
             }
             E::Block(seq) => w.block(|w| seq.ast_debug(w)),
             E::Lambda(sp!(_, bs), e) => {
-                w.write("fun ");
+                w.write("|");
                 bs.ast_debug(w);
-                w.write(" ");
+                w.write("|");
                 e.ast_debug(w);
             }
             E::Quant(kind, sp!(_, rs), trs, c_opt, e) => {

--- a/language/move-compiler/src/parser/lexer.rs
+++ b/language/move-compiler/src/parser/lexer.rs
@@ -80,6 +80,7 @@ pub enum Tok {
     Friend,
     NumSign,
     AtSign,
+    Inline,
 }
 
 impl fmt::Display for Tok {
@@ -134,6 +135,7 @@ impl fmt::Display for Tok {
             Invariant => "invariant",
             Let => "let",
             Loop => "loop",
+            Inline => "inline",
             Module => "module",
             Move => "move",
             Native => "native",
@@ -627,6 +629,7 @@ fn get_name_token(name: &str) -> Tok {
         "invariant" => Tok::Invariant,
         "let" => Tok::Let,
         "loop" => Tok::Loop,
+        "inline" => Tok::Inline,
         "module" => Tok::Module,
         "move" => Tok::Move,
         "native" => Tok::Native,

--- a/language/move-compiler/src/to_bytecode/translate.rs
+++ b/language/move-compiler/src/to_bytecode/translate.rs
@@ -815,6 +815,9 @@ fn base_type(context: &mut Context, sp!(_, bt_): H::BaseType) -> IR::Type {
         B::Unreachable | B::UnresolvedError => {
             panic!("ICE should not have reached compilation if there are errors")
         }
+        B::Apply(_, sp!(_, TN::Builtin(sp!(_, BT::Fun))), _) => {
+            panic!("ICE should not have reached compilation if there are function types")
+        }
         B::Apply(_, sp!(_, TN::Builtin(sp!(_, BT::Address))), _) => IRT::Address,
         B::Apply(_, sp!(_, TN::Builtin(sp!(_, BT::Signer))), _) => IRT::Signer,
         B::Apply(_, sp!(_, TN::Builtin(sp!(_, BT::U8))), _) => IRT::U8,
@@ -1103,7 +1106,7 @@ fn exp_(context: &mut Context, code: &mut IR::BytecodeBlock, e: H::Exp) {
                 BT::U64 => B::CastU64,
                 BT::U128 => B::CastU128,
                 BT::U256 => B::CastU256,
-                BT::Address | BT::Signer | BT::Vector | BT::Bool => {
+                BT::Address | BT::Signer | BT::Vector | BT::Bool | BT::Fun => {
                     panic!("ICE type checking failed. unexpected cast")
                 }
             };

--- a/language/move-compiler/src/typing/ast.rs
+++ b/language/move-compiler/src/typing/ast.rs
@@ -73,6 +73,7 @@ pub type FunctionBody = Spanned<FunctionBody_>;
 
 #[derive(PartialEq, Debug, Clone)]
 pub struct Function {
+    pub inline: bool,
     pub attributes: Attributes,
     pub visibility: Visibility,
     pub entry: Option<Loc>,
@@ -119,6 +120,7 @@ pub type LValueList = Spanned<LValueList_>;
 pub struct ModuleCall {
     pub module: ModuleIdent,
     pub name: FunctionName,
+    pub is_macro: bool,
     pub type_arguments: Vec<Type>,
     pub arguments: Box<Exp>,
     pub parameter_types: Vec<Type>,
@@ -147,6 +149,7 @@ pub enum UnannotatedExp_ {
     Constant(Option<ModuleIdent>, ConstantName),
 
     ModuleCall(Box<ModuleCall>),
+    VarCall(Var, Box<Exp>),
     Builtin(Box<BuiltinFunction>, Box<Exp>),
     Vector(Loc, usize, Box<Type>, Box<Exp>),
 
@@ -154,6 +157,7 @@ pub enum UnannotatedExp_ {
     While(Box<Exp>, Box<Exp>),
     Loop { has_break: bool, body: Box<Exp> },
     Block(Sequence),
+    Lambda(LValueList, Box<Exp>),
     Assign(LValueList, Vec<Option<Type>>, Box<Exp>),
     Mutate(Box<Exp>, Box<Exp>),
     Return(Box<Exp>),
@@ -338,6 +342,7 @@ impl AstDebug for (FunctionName, &Function) {
         let (
             name,
             Function {
+                inline,
                 attributes,
                 visibility,
                 entry,
@@ -355,6 +360,9 @@ impl AstDebug for (FunctionName, &Function) {
             w.write("native ");
         }
         w.write(&format!("fun {}", name));
+        if *inline {
+            w.write("!");
+        }
         signature.ast_debug(w);
         if !acquires.is_empty() {
             w.write(" acquires ");
@@ -447,6 +455,12 @@ impl AstDebug for UnannotatedExp_ {
             E::ModuleCall(mcall) => {
                 mcall.ast_debug(w);
             }
+            E::VarCall(var, rhs) => {
+                w.write(&format!("{}", var));
+                w.write("(");
+                rhs.ast_debug(w);
+                w.write(")");
+            }
             E::Builtin(bf, rhs) => {
                 bf.ast_debug(w);
                 w.write("(");
@@ -500,6 +514,12 @@ impl AstDebug for UnannotatedExp_ {
                 body.ast_debug(w);
             }
             E::Block(seq) => w.block(|w| seq.ast_debug(w)),
+            E::Lambda(sp!(_, bs), e) => {
+                w.write("|");
+                bs.ast_debug(w);
+                w.write("|");
+                e.ast_debug(w);
+            }
             E::ExpList(es) => {
                 w.write("(");
                 w.comma(es, |w, e| e.ast_debug(w));
@@ -612,12 +632,16 @@ impl AstDebug for ModuleCall {
         let ModuleCall {
             module,
             name,
+            is_macro,
             type_arguments,
             parameter_types,
             acquires,
             arguments,
         } = self;
         w.write(&format!("{}::{}", module, name));
+        if *is_macro {
+            w.write("!");
+        }
         if !acquires.is_empty() || !parameter_types.is_empty() {
             w.write("[");
             if !acquires.is_empty() {

--- a/language/move-compiler/src/typing/core.rs
+++ b/language/move-compiler/src/typing/core.rs
@@ -8,7 +8,7 @@ use crate::{
     expansion::ast::{AbilitySet, ModuleIdent, Visibility},
     naming::ast::{
         self as N, BuiltinTypeName_, FunctionSignature, StructDefinition, StructTypeParameter,
-        TParam, TParamID, TVar, Type, TypeName, TypeName_, Type_,
+        TParam, TParamID, TVar, Type, TypeName, TypeName_, Type_, Variance,
     },
     parser::ast::{Ability_, ConstantName, Field, FunctionName, StructName, Var},
     shared::{unique_map::UniqueMap, *},
@@ -42,6 +42,7 @@ pub struct FunctionInfo {
     pub visibility: Visibility,
     pub signature: FunctionSignature,
     pub acquires: BTreeMap<StructName, Loc>,
+    pub inline: bool,
 }
 
 pub struct ConstantInfo {
@@ -103,6 +104,7 @@ impl<'env> Context<'env> {
                 visibility: fdef.visibility.clone(),
                 signature: fdef.signature.clone(),
                 acquires: fdef.acquires.clone(),
+                inline: fdef.inline,
             });
             let constants = mdef.constants.ref_map(|cname, cdef| ConstantInfo {
                 defined_loc: cname.loc(),
@@ -475,6 +477,15 @@ fn error_format_impl_(b_: &Type_, subst: &Subst, nested: bool) -> String {
         Apply(_, sp!(_, TypeName_::Multiple(_)), tys) => {
             let inner = format_comma(tys.iter().map(|s| error_format_nested(s, subst)));
             format!("({})", inner)
+        }
+        Apply(_, sp!(_, TypeName_::Builtin(sp!(_, BuiltinTypeName_::Fun))), tys) => {
+            assert!(!tys.is_empty(), "ICE invalid function type");
+            let k = tys.len() - 1;
+            format!(
+                "|{}|{}",
+                format_comma(tys[0..k].iter().map(|t| error_format_nested(t, subst))),
+                error_format_nested(&tys[k], subst)
+            )
         }
         Apply(_, n, tys) => {
             let tys_str = if !tys.is_empty() {
@@ -1200,7 +1211,7 @@ fn instantiate_apply(
     ty_args: Vec<Type>,
 ) -> Type_ {
     let tparam_constraints: Vec<AbilitySet> = match &n {
-        sp!(nloc, N::TypeName_::Builtin(b)) => b.value.tparam_constraints(*nloc),
+        sp!(nloc, N::TypeName_::Builtin(b)) => b.value.tparam_constraints(*nloc, ty_args.len()),
         sp!(_, N::TypeName_::Multiple(len)) => {
             debug_assert!(abilities_opt.is_none(), "ICE instantiated expanded type");
             (0..*len).map(|_| AbilitySet::empty()).collect()
@@ -1237,6 +1248,9 @@ fn instantiate_type_args(
     let tvar_case = match n {
         Some(TypeName_::Multiple(_)) => {
             TVarCase::Single("Invalid expression list type argument".to_owned())
+        }
+        Some(TypeName_::Builtin(sp!(_, BuiltinTypeName_::Fun))) => {
+            TVarCase::Function("Invalid expression list type argument".to_owned())
         }
         None | Some(TypeName_::Builtin(_)) | Some(TypeName_::ModuleType(_, _)) => TVarCase::Base,
     };
@@ -1298,6 +1312,7 @@ fn check_type_argument_arity<F: FnOnce() -> String>(
 
 enum TVarCase {
     Single(String),
+    Function(String),
     Base,
 }
 
@@ -1307,13 +1322,20 @@ fn make_tparams(
     case: TVarCase,
     tparam_constraints: Vec<(Loc, AbilitySet)>,
 ) -> Vec<Type> {
+    let arity = tparam_constraints.len();
     tparam_constraints
         .into_iter()
-        .map(|(vloc, constraint)| {
+        .enumerate()
+        .map(|(i, (vloc, constraint))| {
             let tvar = make_tvar(context, vloc);
             context.add_ability_set_constraint(loc, None::<String>, tvar.clone(), constraint);
             match &case {
-                TVarCase::Single(msg) => context.add_single_type_constraint(loc, msg, tvar.clone()),
+                TVarCase::Function(_) if i + 1 == arity => {
+                    // Last arg (return type of a function): do not add any constraint
+                }
+                TVarCase::Function(msg) | TVarCase::Single(msg) => {
+                    context.add_single_type_constraint(loc, msg, tvar.clone())
+                }
                 TVarCase::Base => {
                     context.add_base_type_constraint(loc, "Invalid type argument", tvar.clone())
                 }
@@ -1410,7 +1432,9 @@ fn join_impl(
                 k1,
                 k2
             );
-            let (subst, tys) = join_impl_types(subst, case, tys1, tys2)?;
+            let arity = tys1.len();
+            let (subst, tys) =
+                join_impl_types(subst, case, |pos| n1.value.variance(pos, arity), tys1, tys2)?;
             Ok((subst, sp(*loc, Apply(k2.clone(), n2.clone(), tys))))
         }
         (sp!(loc1, Var(id1)), sp!(loc2, Var(id2))) => {
@@ -1464,14 +1488,18 @@ fn join_impl(
 fn join_impl_types(
     mut subst: Subst,
     case: TypingCase,
+    variance: impl Fn(usize) -> Variance,
     tys1: &[Type],
     tys2: &[Type],
 ) -> Result<(Subst, Vec<Type>), TypingError> {
     // if tys1.len() != tys2.len(), we will get an error when instantiating the type elsewhere
     // as all types are instantiated as a sanity check
     let mut tys = vec![];
-    for (ty1, ty2) in tys1.iter().zip(tys2) {
-        let (nsubst, t) = join_impl(subst, case, ty1, ty2)?;
+    for (pos, (ty1, ty2)) in tys1.iter().zip(tys2).enumerate() {
+        let (nsubst, t) = match (case, variance(pos)) {
+            (TypingCase::Subtype, Variance::ContraVariant) => join_impl(subst, case, ty2, ty1)?,
+            _ => join_impl(subst, case, ty1, ty2)?,
+        };
         subst = nsubst;
         tys.push(t)
     }
@@ -1600,5 +1628,28 @@ fn check_num_tvar_(subst: &Subst, ty: &Type) -> bool {
             }
         }
         _ => false,
+    }
+}
+//**************************************************************************************************
+// Function type check
+//**************************************************************************************************
+
+pub fn check_non_fun(context: &mut Context, ty: &Type) {
+    if let sp!(
+        loc,
+        Type_::Apply(
+            _,
+            sp!(_, TypeName_::Builtin(sp!(_, BuiltinTypeName_::Fun))),
+            _
+        )
+    ) = ty
+    {
+        context.env.add_diag(diag!(
+            TypeSafety::InvalidFunctionType,
+            (
+                *loc,
+                "function type only allowed for inline function arguments"
+            )
+        ))
     }
 }

--- a/language/move-compiler/src/typing/expand.rs
+++ b/language/move-compiler/src/typing/expand.rs
@@ -27,8 +27,18 @@ pub fn function_body_(context: &mut Context, b_: &mut T::FunctionBody_) {
 pub fn function_signature(context: &mut Context, sig: &mut FunctionSignature) {
     for (_, st) in &mut sig.parameters {
         type_(context, st);
+        core::check_non_fun(context, st)
     }
     type_(context, &mut sig.return_type);
+    core::check_non_fun(context, &sig.return_type)
+}
+
+pub fn inline_signature(context: &mut Context, sig: &mut FunctionSignature) {
+    for (_, st) in &mut sig.parameters {
+        type_(context, st);
+    }
+    type_(context, &mut sig.return_type);
+    core::check_non_fun(context, &sig.return_type)
 }
 
 //**************************************************************************************************
@@ -170,7 +180,7 @@ pub fn exp(context: &mut Context, e: &mut T::Exp) {
                 BT::U64 => u64_max,
                 BT::U128 => u128_max,
                 BT::U256 => u256_max,
-                BT::Address | BT::Signer | BT::Vector | BT::Bool => unreachable!(),
+                BT::Address | BT::Signer | BT::Vector | BT::Bool | BT::Fun => unreachable!(),
             };
             let new_exp = if v > max {
                 let msg = format!(
@@ -210,7 +220,7 @@ pub fn exp(context: &mut Context, e: &mut T::Exp) {
                     BT::U64 => Value_::U64(v.down_cast_lossy()),
                     BT::U128 => Value_::U128(v.down_cast_lossy()),
                     BT::U256 => Value_::U256(v),
-                    BT::Address | BT::Signer | BT::Vector | BT::Bool => unreachable!(),
+                    BT::Address | BT::Signer | BT::Vector | BT::Bool | BT::Fun => unreachable!(),
                 };
                 E::Value(sp(*vloc, value_))
             };
@@ -230,6 +240,7 @@ pub fn exp(context: &mut Context, e: &mut T::Exp) {
         | E::UnresolvedError => (),
 
         E::ModuleCall(call) => module_call(context, call),
+        E::VarCall(_, args) => exp(context, args),
         E::Builtin(b, args) => {
             builtin_function(context, b);
             exp(context, args);
@@ -250,6 +261,10 @@ pub fn exp(context: &mut Context, e: &mut T::Exp) {
         }
         E::Loop { body: eloop, .. } => exp(context, eloop),
         E::Block(seq) => sequence(context, seq),
+        E::Lambda(args, body) => {
+            lvalues(context, args);
+            exp(context, body);
+        }
         E::Assign(assigns, tys, er) => {
             lvalues(context, assigns);
             expected_types(context, tys);
@@ -299,6 +314,7 @@ fn lvalue(context: &mut Context, b: &mut T::LValue) {
         L::Ignore => (),
         L::Var(_, ty) => {
             type_(context, ty);
+            core::check_non_fun(context, ty.as_ref())
         }
         L::BorrowUnpack(_, _, _, bts, fields) | L::Unpack(_, _, bts, fields) => {
             types(context, bts);

--- a/language/move-compiler/src/typing/globals.rs
+++ b/language/move-compiler/src/typing/globals.rs
@@ -5,7 +5,7 @@
 use super::core::{self, Context, Subst};
 use crate::{
     diag,
-    naming::ast::{self as N, Type, TypeName_, Type_},
+    naming::ast::{self as N, BuiltinTypeName_, Type, TypeName_, Type_},
     parser::ast::{Ability_, StructName},
     typing::ast as T,
 };
@@ -111,6 +111,9 @@ fn exp(
 
             exp(context, annotated_acquires, seen, &call.arguments);
         }
+        E::VarCall(_, args) => {
+            exp(context, annotated_acquires, seen, args);
+        }
         E::Builtin(b, args) => {
             builtin_function(context, annotated_acquires, seen, &e.exp.loc, b);
             exp(context, annotated_acquires, seen, args);
@@ -128,6 +131,7 @@ fn exp(
         }
         E::Loop { body: eloop, .. } => exp(context, annotated_acquires, seen, eloop),
         E::Block(seq) => sequence(context, annotated_acquires, seen, seq),
+        E::Lambda(_, body) => exp(context, annotated_acquires, seen, body.as_ref()),
         E::Assign(_, _, er) => {
             exp(context, annotated_acquires, seen, er);
         }
@@ -273,14 +277,7 @@ where
             assert!(context.env.has_errors());
             return None;
         }
-        T::Apply(Some(abilities), sp!(_, TN::Multiple(_)), _)
-        | T::Apply(Some(abilities), sp!(_, TN::Builtin(_)), _) => {
-            // Key ability is checked by constraints
-            assert!(!abilities.has_ability_(Ability_::Key));
-            assert!(context.env.has_errors());
-            return None;
-        }
-        T::Param(_) => {
+        T::Param(_) | T::Apply(_, sp!(_, TN::Builtin(sp!(_, BuiltinTypeName_::Fun))), _) => {
             let ty_debug = core::error_format(global_type, &Subst::empty());
             let tmsg = format!(
                 "Expected a struct type. Global storage operations are restricted to struct types \
@@ -295,7 +292,13 @@ where
             ));
             return None;
         }
-
+        T::Apply(Some(abilities), sp!(_, TN::Multiple(_)), _)
+        | T::Apply(Some(abilities), sp!(_, TN::Builtin(_)), _) => {
+            // Key ability is checked by constraints
+            assert!(!abilities.has_ability_(Ability_::Key));
+            assert!(context.env.has_errors());
+            return None;
+        }
         T::Apply(Some(_), sp!(_, TN::ModuleType(m, s)), _args) => (*m, s),
     };
 

--- a/language/move-compiler/src/typing/infinite_instantiations.rs
+++ b/language/move-compiler/src/typing/infinite_instantiations.rs
@@ -228,7 +228,7 @@ fn exp(context: &mut Context, e: &T::Exp) {
             context.add_usage(e.exp.loc, &call.module, &call.name, &call.type_arguments);
             exp(context, &call.arguments)
         }
-
+        E::VarCall(_, args) => exp(context, args),
         E::IfElse(eb, et, ef) => {
             exp(context, eb);
             exp(context, et);
@@ -240,6 +240,7 @@ fn exp(context: &mut Context, e: &T::Exp) {
         }
         E::Loop { body: eloop, .. } => exp(context, eloop),
         E::Block(seq) => sequence(context, seq),
+        E::Lambda(_, body) => exp(context, body),
         E::Assign(_, _, er) => exp(context, er),
 
         E::Builtin(_, er)

--- a/language/move-compiler/src/unit_test/filter_test_members.rs
+++ b/language/move-compiler/src/unit_test/filter_test_members.rs
@@ -201,6 +201,7 @@ fn create_test_poison(mloc: Loc) -> P::ModuleMember {
         entry: None,
         acquires: vec![],
         signature,
+        inline: false,
         name: P::FunctionName(sp(mloc, "unit_test_poison".into())),
         body: sp(
             mloc,

--- a/language/move-compiler/tests/move_check/expansion/use_function_tparam_shadows.exp
+++ b/language/move-compiler/tests/move_check/expansion/use_function_tparam_shadows.exp
@@ -4,9 +4,9 @@ warning[W09001]: unused alias
 7 │     use 0x2::X::foo;
   │                 ^^^ Unused 'use' of alias 'foo'. Consider removing it
 
-error[E03005]: unbound unscoped name
+error[E03009]: unbound variable
    ┌─ tests/move_check/expansion/use_function_tparam_shadows.move:10:9
    │
 10 │         foo()
-   │         ^^^ Unbound function 'foo' in current scope
+   │         ^^^ Invalid function usage. Unbound variable 'foo'
 

--- a/language/move-compiler/tests/move_check/expansion/use_function_unbound.exp
+++ b/language/move-compiler/tests/move_check/expansion/use_function_unbound.exp
@@ -7,9 +7,9 @@ error[E03003]: unbound module member
 6 │     use 0x2::X::u;
   │                 ^ Invalid 'use'. Unbound member 'u' in module '0x2::X'
 
-error[E03005]: unbound unscoped name
+error[E03009]: unbound variable
   ┌─ tests/move_check/expansion/use_function_unbound.move:9:9
   │
 9 │         u()
-  │         ^ Unbound function 'u' in current scope
+  │         ^ Invalid function usage. Unbound variable 'u'
 

--- a/language/move-compiler/tests/move_check/naming/unbound_builtin.exp
+++ b/language/move-compiler/tests/move_check/naming/unbound_builtin.exp
@@ -1,18 +1,18 @@
-error[E03005]: unbound unscoped name
+error[E03009]: unbound variable
   ┌─ tests/move_check/naming/unbound_builtin.move:3:9
   │
 3 │         global_borrow();
-  │         ^^^^^^^^^^^^^ Unbound function 'global_borrow' in current scope
+  │         ^^^^^^^^^^^^^ Invalid function usage. Unbound variable 'global_borrow'
 
-error[E03005]: unbound unscoped name
+error[E03009]: unbound variable
   ┌─ tests/move_check/naming/unbound_builtin.move:4:9
   │
 4 │         release<u64>();
-  │         ^^^^^^^ Unbound function 'release' in current scope
+  │         ^^^^^^^ Invalid function usage. Unbound variable 'release'
 
-error[E03005]: unbound unscoped name
+error[E03009]: unbound variable
   ┌─ tests/move_check/naming/unbound_builtin.move:5:9
   │
 5 │         sudo(false);
-  │         ^^^^ Unbound function 'sudo' in current scope
+  │         ^^^^ Invalid function usage. Unbound variable 'sudo'
 

--- a/language/move-compiler/tests/move_check/naming/unbound_unqualified_function.exp
+++ b/language/move-compiler/tests/move_check/naming/unbound_unqualified_function.exp
@@ -1,18 +1,18 @@
-error[E03005]: unbound unscoped name
+error[E03009]: unbound variable
   ┌─ tests/move_check/naming/unbound_unqualified_function.move:3:9
   │
 3 │         bar();
-  │         ^^^ Unbound function 'bar' in current scope
+  │         ^^^ Invalid function usage. Unbound variable 'bar'
 
-error[E03005]: unbound unscoped name
+error[E03009]: unbound variable
   ┌─ tests/move_check/naming/unbound_unqualified_function.move:4:17
   │
 4 │         let x = bar();
-  │                 ^^^ Unbound function 'bar' in current scope
+  │                 ^^^ Invalid function usage. Unbound variable 'bar'
 
-error[E03005]: unbound unscoped name
+error[E03009]: unbound variable
   ┌─ tests/move_check/naming/unbound_unqualified_function.move:5:10
   │
 5 │         *bar() = 0;
-  │          ^^^ Unbound function 'bar' in current scope
+  │          ^^^ Invalid function usage. Unbound variable 'bar'
 

--- a/language/move-compiler/tests/move_check/parser/module_missing_rbrace.exp
+++ b/language/move-compiler/tests/move_check/parser/module_missing_rbrace.exp
@@ -5,5 +5,5 @@ error[E01002]: unexpected token
   │ ^
   │ 
   │ Unexpected end-of-file
-  │ Expected a module member: 'spec', 'use', 'friend', 'const', 'fun', or 'struct'
+  │ Expected a module member: 'spec', 'use', 'friend', 'const', 'fun', 'inline', or 'struct'
 

--- a/language/move-compiler/tests/move_check/parser/spec_parsing_fun_type_fail.exp
+++ b/language/move-compiler/tests/move_check/parser/spec_parsing_fun_type_fail.exp
@@ -1,6 +1,6 @@
-error[E01010]: syntax item restricted to spec contexts
+error[E04024]: invalid usage of function type
   ┌─ tests/move_check/parser/spec_parsing_fun_type_fail.move:2:29
   │
 2 │     fun fun_type_in_prog(p: |u64|u64) {
-  │                             ^^^^^^^^ `|_|_` function type only allowed in specifications
+  │                             ^^^^^^^^ function type only allowed for inline function arguments
 

--- a/language/move-compiler/tests/move_check/parser/spec_parsing_lambda_fail.exp
+++ b/language/move-compiler/tests/move_check/parser/spec_parsing_lambda_fail.exp
@@ -1,6 +1,0 @@
-error[E01010]: syntax item restricted to spec contexts
-  ┌─ tests/move_check/parser/spec_parsing_lambda_fail.move:3:15
-  │
-3 │       let _ = |y| x + y;
-  │               ^^^^^^^^^ lambda expression only allowed in specifications
-

--- a/language/move-compiler/tests/move_check/parser/spec_parsing_lambda_fail.move
+++ b/language/move-compiler/tests/move_check/parser/spec_parsing_lambda_fail.move
@@ -1,5 +1,0 @@
-module 0x8675309::M {
-    fun lambda_in_prog(x: u64) {
-      let _ = |y| x + y;
-    }
-}

--- a/language/move-compiler/tests/move_check/typing/constant_unsupported_exps.exp
+++ b/language/move-compiler/tests/move_check/typing/constant_unsupported_exps.exp
@@ -52,11 +52,11 @@ error[E04013]: invalid statement or expression in constant
 20 │         f_public();
    │         ^^^^^^^^^^ Module calls are not supported in constants
 
-error[E03005]: unbound unscoped name
+error[E03009]: unbound variable
    ┌─ tests/move_check/typing/constant_unsupported_exps.move:21:9
    │
 21 │         f_script();
-   │         ^^^^^^^^ Unbound function 'f_script' in current scope
+   │         ^^^^^^^^ Invalid function usage. Unbound variable 'f_script'
 
 error[E04013]: invalid statement or expression in constant
    ┌─ tests/move_check/typing/constant_unsupported_exps.move:22:9

--- a/language/move-compiler/tests/move_check/typing/lambda.exp
+++ b/language/move-compiler/tests/move_check/typing/lambda.exp
@@ -1,0 +1,99 @@
+error[E04023]: invalid call target
+   ┌─ tests/move_check/typing/lambda.move:34:37
+   │
+34 │         foreach(&v, |e| sum = sum + reduce!(*e, 0, |t, r| t + r));
+   │                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 'reduce' is not a macro but a function
+
+error[E04017]: too many arguments
+   ┌─ tests/move_check/typing/lambda.move:40:13
+   │
+40 │             action(XVector::borrow(v, i), i); // expected to have wrong argument count
+   │             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │             │     │
+   │             │     Found 2 argument(s) here
+   │             Invalid call of 'action'. The call expected 1 argument(s) but got 2
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/lambda.move:48:13
+   │
+45 │     public inline fun wrong_local_call_arg_type<T>(v: &vector<T>, action: |&T|) {
+   │                                                                            -- Expected: '&T'
+   ·
+48 │             action(i); // expected to have wrong argument type
+   │             ^^^^^^^^^ Invalid call of 'action'. Invalid argument type
+   ·
+96 │     public fun length<T>(v: &vector<T>): u64 { abort(1) }
+   │                                          --- Given: 'u64'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/lambda.move:56:19
+   │
+53 │     public inline fun wrong_local_call_result_type<T>(v: &vector<T>, action: |&T|) {
+   │                                                                              ---- Found: '()'. It is not compatible with the other type.
+   ·
+56 │             i = i + action(XVector::borrow(v, i)); // expected to have wrong result type
+   │                   ^ Incompatible arguments to '+'
+   ·
+96 │     public fun length<T>(v: &vector<T>): u64 { abort(1) }
+   │                                          --- Found: 'u64'. It is not compatible with the other type.
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/lambda.move:61:9
+   │
+61 │         x(1)
+   │         ^ Expected a function type but found 'u64'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/lambda.move:67:9
+   │
+ 4 │     public inline fun foreach<T>(v: &vector<T>, action: |&T|) { // expected to be not implemented
+   │                                                          -- Given: '&{integer}'
+   ·
+67 │         foreach(&v, |e| sum = sum + e) // expected to cannot infer type
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │         │            │
+   │         │            Expected: integer
+   │         Invalid call of '0x8675309::M::foreach'. Invalid argument for parameter 'action'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/lambda.move:73:9
+   │
+ 4 │     public inline fun foreach<T>(v: &vector<T>, action: |&T|) { // expected to be not implemented
+   │                                                         ---- Expected: '()'
+   ·
+73 │         foreach(&v, |e| { sum = sum + *e; *e }) // expected to have wrong result type of lambda
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │         │                                 │
+   │         │                                 Given: integer
+   │         Invalid call of '0x8675309::M::foreach'. Invalid argument for parameter 'action'
+
+error[E04024]: invalid usage of function type
+   ┌─ tests/move_check/typing/lambda.move:77:18
+   │
+77 │         let _x = |i| i + 1; // expected lambda not allowed
+   │                  ^^^^^^^^^ function type only allowed for inline function arguments
+
+error[E04024]: invalid usage of function type
+   ┌─ tests/move_check/typing/lambda.move:81:12
+   │
+81 │         f: |u64|u64, // expected lambda not allowed
+   │            ^^^^^^^^ function type only allowed for inline function arguments
+
+error[E04024]: invalid usage of function type
+   ┌─ tests/move_check/typing/lambda.move:84:46
+   │
+84 │     public fun fun_arg_lambda_not_allowed(x: |u64|) {} // expected lambda not allowed
+   │                                              ^^^^^ function type only allowed for inline function arguments
+
+error[E04024]: invalid usage of function type
+   ┌─ tests/move_check/typing/lambda.move:86:58
+   │
+86 │     public inline fun macro_result_lambda_not_allowed(): |u64| {  // expected lambda not allowed
+   │                                                          ^^^^^ function type only allowed for inline function arguments
+
+error[E04024]: invalid usage of function type
+   ┌─ tests/move_check/typing/lambda.move:89:49
+   │
+89 │     public fun fun_result_lambda_not_allowed(): |u64| {  // expected lambda not allowed
+   │                                                 ^^^^^ function type only allowed for inline function arguments
+

--- a/language/move-compiler/tests/move_check/typing/lambda.move
+++ b/language/move-compiler/tests/move_check/typing/lambda.move
@@ -1,0 +1,100 @@
+module 0x8675309::M {
+    use 0x1::XVector;
+
+    public inline fun foreach<T>(v: &vector<T>, action: |&T|) { // expected to be not implemented
+        let i = 0;
+        while (i < XVector::length(v)) {
+            action(XVector::borrow(v, i));
+            i = i + 1;
+        }
+    }
+
+    public inline fun reduce<R, T>(v: vector<T>, accu: R, reducer: |T, R|R): R {
+        while (!XVector::is_empty(&v)) {
+            accu = reducer(XVector::pop_back(&mut v), accu);
+        };
+        accu
+    }
+
+
+    public fun correct_foreach() {
+        let v = vector[1, 2, 3];
+        let sum = 0;
+        foreach(&v, |e| sum = sum + *e) // expected to be not implemented
+    }
+
+    public fun correct_reduce(): u64 {
+        let v = vector[1, 2, 3];
+        reduce(v, 0, |t, r| t + r)
+    }
+
+    public fun corrected_nested() {
+        let v = vector[vector[1,2], vector[3]];
+        let sum = 0;
+        foreach(&v, |e| sum = sum + reduce!(*e, 0, |t, r| t + r));
+    }
+
+    public inline fun wrong_local_call_arg_count<T>(v: &vector<T>, action: |&T|) {
+        let i = 0;
+        while (i < XVector::length(v)) {
+            action(XVector::borrow(v, i), i); // expected to have wrong argument count
+            i = i + 1;
+        }
+    }
+
+    public inline fun wrong_local_call_arg_type<T>(v: &vector<T>, action: |&T|) {
+        let i = 0;
+        while (i < XVector::length(v)) {
+            action(i); // expected to have wrong argument type
+            i = i + 1;
+        }
+    }
+
+    public inline fun wrong_local_call_result_type<T>(v: &vector<T>, action: |&T|) {
+        let i = 0;
+        while (i < XVector::length(v)) {
+            i = i + action(XVector::borrow(v, i)); // expected to have wrong result type
+        }
+    }
+
+    public fun wrong_local_call_no_fun(x: u64) {
+        x(1)
+    }
+
+    public fun wrong_lambda_inferred_type() {
+        let v = vector[1, 2, 3];
+        let sum = 0;
+        foreach(&v, |e| sum = sum + e) // expected to cannot infer type
+    }
+
+    public fun wrong_lambda_result_type() {
+        let v = vector[1, 2, 3];
+        let sum = 0;
+        foreach(&v, |e| { sum = sum + *e; *e }) // expected to have wrong result type of lambda
+    }
+
+    public fun lambda_not_allowed() {
+        let _x = |i| i + 1; // expected lambda not allowed
+    }
+
+    struct FieldFunNotAllowed {
+        f: |u64|u64, // expected lambda not allowed
+    }
+
+    public fun fun_arg_lambda_not_allowed(x: |u64|) {} // expected lambda not allowed
+
+    public inline fun macro_result_lambda_not_allowed(): |u64| {  // expected lambda not allowed
+        abort (1)
+    }
+    public fun fun_result_lambda_not_allowed(): |u64| {  // expected lambda not allowed
+        abort (1)
+    }
+
+}
+
+module 0x1::XVector {
+    public fun length<T>(v: &vector<T>): u64 { abort(1) }
+    public fun is_empty<T>(v: &vector<T>): bool { abort(1) }
+    public fun borrow<T>(v: &vector<T>, i: u64): &T { abort(1) }
+    public fun pop_back<T>(v: &mut vector<T>): T { abort(1) }
+}

--- a/language/move-compiler/tests/move_check/typing/module_call_missing_function.exp
+++ b/language/move-compiler/tests/move_check/typing/module_call_missing_function.exp
@@ -4,11 +4,11 @@ error[E03003]: unbound module member
 13 │         Self::fooo();
    │         ^^^^^^^^^^ Invalid module access. Unbound function 'fooo' in module '0x2::M'
 
-error[E03005]: unbound unscoped name
+error[E03009]: unbound variable
    ┌─ tests/move_check/typing/module_call_missing_function.move:14:9
    │
 14 │         foooo();
-   │         ^^^^^ Unbound function 'foooo' in current scope
+   │         ^^^^^ Invalid function usage. Unbound variable 'foooo'
 
 error[E03003]: unbound module member
    ┌─ tests/move_check/typing/module_call_missing_function.move:15:9

--- a/language/move-compiler/tests/move_check/unit_test/test_filter_function.exp
+++ b/language/move-compiler/tests/move_check/unit_test/test_filter_function.exp
@@ -1,6 +1,6 @@
-error[E03005]: unbound unscoped name
+error[E03009]: unbound variable
   ┌─ tests/move_check/unit_test/test_filter_function.move:6:24
   │
 6 │     public fun foo() { bar() }
-  │                        ^^^ Unbound function 'bar' in current scope
+  │                        ^^^ Invalid function usage. Unbound variable 'bar'
 

--- a/language/move-compiler/tests/move_check/verification/single_module_invalid.exp
+++ b/language/move-compiler/tests/move_check/verification/single_module_invalid.exp
@@ -10,9 +10,9 @@ error[E03004]: unbound type
 9 │         Foo {}
   │         ^^^ Unbound type 'Foo' in current scope
 
-error[E03005]: unbound unscoped name
+error[E03009]: unbound variable
    ┌─ tests/move_check/verification/single_module_invalid.move:17:24
    │
 17 │     public fun baz() { bar() }
-   │                        ^^^ Unbound function 'bar' in current scope
+   │                        ^^^ Invalid function usage. Unbound variable 'bar'
 

--- a/language/move-model/src/builder/exp_translator.rs
+++ b/language/move-model/src/builder/exp_translator.rs
@@ -563,6 +563,10 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
                         U256 => Type::new_prim(PrimitiveType::U256),
                         Vector => Type::Vector(Box::new(self.translate_hlir_base_type(&args[0]))),
                         Bool => Type::new_prim(PrimitiveType::Bool),
+                        Fun => Type::Fun(
+                            self.translate_hlir_base_types(&args[0..args.len() - 1]),
+                            Box::new(self.translate_hlir_base_type(&args[args.len() - 1])),
+                        ),
                     },
                     ModuleType(m, n) => {
                         let addr_bytes = self.parent.parent.resolve_address(&loc, &m.value.address);


### PR DESCRIPTION
This PR realizes the 1st step towards inlined functions. Inlined functions are expanded at caller site. Moreover, they can take _lambdas_ (functions) as parameters. Example:

```
    public inline fun foreach<T>(v: &vector<T>, action: |&T|) {
        let i = 0;
        while (i < Vector::length(v)) {
            action(Vector::borrow(v, i));
            i = i + 1;
        }
    }

   fun use_foreach() {
        let v = vector[1, 2, 3];
        let sum = 0;
        foreach(&v, |e| sum = sum + *e);
        assert!(sum == 6, 1);
    }

```

This PR implements parsing and type checking of this style of functions up to the typing AST. Actual inlining is not yet implemented.

The biggest change is enabling function types, lambda expressions, and calls of function values for naming and typing. Those had been supported before for the spec language, but weren't supported in move-lang beyond expansion. In the design, we represent function types by a new `BuiltinTypeName_::Fun` which allows to minimize changes to the code, as no new type variant needs to be introduced, and existing functionality for inference et. al can be adopted with minimal changes. This consistent e.g. with the treatment of function types in Rust, where they are just type constructors with some syntactic sugar.

A new test case has been added at [lambda.move](language/move-compiler/tests/move_check/typing/lambda.move) which shows usage and intends to cover all type check failure scenarios.


