### PR TITLE
[compiler] warn on unused `&mut` qualifier in parameters

### DIFF
--- a/language/move-compiler/src/diagnostics/codes.rs
+++ b/language/move-compiler/src/diagnostics/codes.rs
@@ -218,6 +218,7 @@ codes!(
         DeadCode: { msg: "dead or unreachable code", severity: Warning },
         StructTypeParam: { msg: "unused struct type parameter", severity: Warning },
         Attribute: { msg: "unused attribute", severity: Warning },
+        MutQualifier: { msg: "unused &mut qualifier", severity: Warning }
     ],
     Attributes: [
         Duplicate: { msg: "invalid duplicate attribute", severity: NonblockingError },

--- a/language/move-compiler/src/hlir/ast.rs
+++ b/language/move-compiler/src/hlir/ast.rs
@@ -424,6 +424,28 @@ impl Exp {
     pub fn is_unit(&self) -> bool {
         self.exp.value.is_unit()
     }
+
+    pub fn exp_at_index(&self, idx: usize) -> &Self {
+        match &self.exp.value {
+            UnannotatedExp_::ExpList(items) => {
+                assert!(idx < items.len());
+                &items[idx].exp()
+            }
+            _ => {
+                assert!(idx == 0);
+                self
+            }
+        }
+    }
+}
+
+impl ExpListItem {
+    pub fn exp(&self) -> &Exp {
+        match self {
+            ExpListItem::Single(e, _) |
+            ExpListItem::Splat(_, e, _) => e,
+        }
+    }
 }
 
 impl UnannotatedExp_ {
@@ -542,6 +564,13 @@ impl SingleType_ {
             SingleType_::Base(b) => b.value.abilities(loc),
         }
     }
+
+    pub fn is_mut_ref(&self) -> bool {
+        match self {
+            SingleType_::Ref(is_mut, _) => *is_mut,
+            &SingleType_::Base(_) => false,
+        }
+    }
 }
 
 impl Type_ {
@@ -606,6 +635,14 @@ impl Type_ {
             _ => Type_::Multiple(ss),
         };
         sp(loc, t_)
+    }
+
+    /// Return `true` if `self` is a single mutable reference type
+    pub fn is_mut_ref(&self) -> bool {
+        match self {
+            Type_::Single(s) => s.value.is_mut_ref(),
+            Type_::Unit | Type_::Multiple(_) => false,
+        }
     }
 }
 

--- a/language/move-compiler/tests/move_check/unused_mut/borrow_ok.move
+++ b/language/move-compiler/tests/move_check/unused_mut/borrow_ok.move
@@ -1,0 +1,24 @@
+module 0x1::borrow_ok {
+    use std::vector;
+
+    struct S {
+        f: bool
+    }
+
+    fun ret_param(f: &mut vector<u64>): &mut u64 {
+        vector::borrow_mut(f, 0)
+    }
+
+    fun ret_field(s: &mut S): &mut bool {
+        &mut s.f
+    }
+
+    fun borrow_param(f: &mut vector<u64>) {
+        let _ = vector::borrow_mut(f, 0);
+    }
+
+    fun borrow_field(s: &mut S) {
+        let _ = &mut s.f;
+    }
+
+}

--- a/language/move-compiler/tests/move_check/unused_mut/borrow_warn.exp
+++ b/language/move-compiler/tests/move_check/unused_mut/borrow_warn.exp
@@ -1,0 +1,12 @@
+warning[W09008]: unused &mut qualifier
+  ┌─ tests/move_check/unused_mut/borrow_warn.move:7:22
+  │
+7 │     fun borrow_param(f: &mut vector<u64>): &u64 {
+  │                      ^ Unused '&mut' qualifier on parameter 'f'. Consider replacing with an immutable qualifer: '&'
+
+warning[W09008]: unused &mut qualifier
+   ┌─ tests/move_check/unused_mut/borrow_warn.move:11:22
+   │
+11 │     fun borrow_field(s: &mut S): &bool {
+   │                      ^ Unused '&mut' qualifier on parameter 's'. Consider replacing with an immutable qualifer: '&'
+

--- a/language/move-compiler/tests/move_check/unused_mut/borrow_warn.move
+++ b/language/move-compiler/tests/move_check/unused_mut/borrow_warn.move
@@ -1,0 +1,14 @@
+module 0x1::borrow_warn {
+
+    struct S {
+        f: bool
+    }
+
+    fun borrow_param(f: &mut vector<u64>): &u64 {
+        std::vector::borrow(f, 0)
+    }
+
+    fun borrow_field(s: &mut S): &bool {
+        &s.f
+    }
+}

--- a/language/move-compiler/tests/move_check/unused_mut/call_ok.move
+++ b/language/move-compiler/tests/move_check/unused_mut/call_ok.move
@@ -1,0 +1,18 @@
+module 0x1::call_ok {
+
+    struct S {
+        f: bool
+    }
+
+    native fun mutate_vector(f: &mut vector<u64>);
+
+    native fun mutate_field(s: &mut S);
+
+    fun call_mutate_vector(f: &mut vector<u64>) {
+        mutate_vector(f)
+    }
+
+    fun call_mutate_field(s: &mut S) {
+        mutate_field(s)
+    }
+}

--- a/language/move-compiler/tests/move_check/unused_mut/call_warn.exp
+++ b/language/move-compiler/tests/move_check/unused_mut/call_warn.exp
@@ -1,0 +1,12 @@
+warning[W09008]: unused &mut qualifier
+   ┌─ tests/move_check/unused_mut/call_warn.move:11:26
+   │
+11 │     fun call_read_vector(f: &mut vector<u64>) {
+   │                          ^ Unused '&mut' qualifier on parameter 'f'. Consider replacing with an immutable qualifer: '&'
+
+warning[W09008]: unused &mut qualifier
+   ┌─ tests/move_check/unused_mut/call_warn.move:15:25
+   │
+15 │     fun call_read_field(s: &mut S) {
+   │                         ^ Unused '&mut' qualifier on parameter 's'. Consider replacing with an immutable qualifer: '&'
+

--- a/language/move-compiler/tests/move_check/unused_mut/call_warn.move
+++ b/language/move-compiler/tests/move_check/unused_mut/call_warn.move
@@ -1,0 +1,18 @@
+module 0x1::call_warn {
+
+    struct S {
+        f: bool
+    }
+
+    native fun read_vector(f: &vector<u64>);
+
+    native fun read_field(s: &S);
+
+    fun call_read_vector(f: &mut vector<u64>) {
+        read_vector(f)
+    }
+
+    fun call_read_field(s: &mut S) {
+        read_field(s)
+    }
+}

--- a/language/move-compiler/tests/move_check/unused_mut/id_ok.move
+++ b/language/move-compiler/tests/move_check/unused_mut/id_ok.move
@@ -1,0 +1,6 @@
+module 0x1::id_ok {
+
+    fun id(f: &mut u64): &mut u64 {
+        f
+    }
+}

--- a/language/move-compiler/tests/move_check/unused_mut/id_warn.exp
+++ b/language/move-compiler/tests/move_check/unused_mut/id_warn.exp
@@ -1,0 +1,6 @@
+warning[W09008]: unused &mut qualifier
+  ┌─ tests/move_check/unused_mut/id_warn.move:3:12
+  │
+3 │     fun id(f: &mut u64): &u64 {
+  │            ^ Unused '&mut' qualifier on parameter 'f'. Consider replacing with an immutable qualifer: '&'
+

--- a/language/move-compiler/tests/move_check/unused_mut/id_warn.move
+++ b/language/move-compiler/tests/move_check/unused_mut/id_warn.move
@@ -1,0 +1,6 @@
+module 0x1::id_ok {
+
+    fun id(f: &mut u64): &u64 {
+        f
+    }
+}

--- a/language/move-compiler/tests/move_check/unused_mut/mutate_ok.move
+++ b/language/move-compiler/tests/move_check/unused_mut/mutate_ok.move
@@ -1,0 +1,19 @@
+module 0x1::mutate_ok {
+    use std::vector;
+
+    struct S has drop {
+        f: bool
+    }
+
+    fun mutate_vector(f: &mut vector<u64>) {
+        vector::push_back(f, 7)
+    }
+
+    fun mutate_field(s: &mut S) {
+        s.f = false
+    }
+
+    fun mutate_direct(s: &mut S) {
+        *s = S { f: true }
+    }
+}


### PR DESCRIPTION
Add new warning type: unused `&mut` qualifier. A qualifier is considered unused if the corresponding variable is not:
- mutated
- used in an expression that mutably borrows a field
- passed as an argument to a call that requires a parameter of `&mut` type
- returned from a function with a `&mut` return type

Added tests for each of these cases.

- Note 1: there are 45 existing compiler tests that are failing because they now (correctly) get flagged with unused `&mut` warnings. My inclination is to to update the expected values rather than modifying the tests, but let me know if that doesn't sound right.
- Note 2: I added this warning inside translate.rs because that's where very similar unused variables warning lives, but the file is perhaps getting a bit crowded. Maybe both of these warnings want to be separate passes in the future, but I'm not sure.