### PR TITLE
[Move-prover] Allow bitwise operation in spec functions and tables

### DIFF
--- a/language/move-model/src/ast.rs
+++ b/language/move-model/src/ast.rs
@@ -537,6 +537,23 @@ impl ExpData {
         vars
     }
 
+    /// Returns the free local variables with node id in this expression
+    pub fn free_local_vars_with_node_id(&self) -> BTreeMap<Symbol, NodeId> {
+        let mut vars = BTreeMap::new();
+        let mut visitor = |up: bool, e: &ExpData| {
+            use ExpData::*;
+            if up {
+                if let LocalVar(id, sym) = e {
+                    if !vars.iter().any(|(s, _)| s == sym) {
+                        vars.insert(*sym, *id);
+                    }
+                }
+            }
+        };
+        self.visit_pre_post(&mut visitor);
+        vars
+    }
+
     /// Returns the used memory of this expression.
     pub fn used_memory(
         &self,

--- a/language/move-model/src/model.rs
+++ b/language/move-model/src/model.rs
@@ -2398,15 +2398,33 @@ impl<'env> ModuleEnv<'env> {
         false
     }
 
-    pub fn is_std_vector(&self) -> bool {
-        let addr = self.get_name().addr();
-        let module_is_vector = self
-            .get_name()
+    fn match_module_name(&self, module_name: &str) -> bool {
+        self.get_name()
             .name()
             .display(self.env.symbol_pool())
             .to_string()
-            == "vector";
-        *addr == self.env.get_stdlib_address() && module_is_vector
+            == module_name
+    }
+
+    fn is_module_in_std(&self, module_name: &str) -> bool {
+        let addr = self.get_name().addr();
+        *addr == self.env.get_stdlib_address() && self.match_module_name(module_name)
+    }
+
+    fn is_module_in_ext(&self, module_name: &str) -> bool {
+        let addr = self.get_name().addr();
+        *addr == self.env.get_extlib_address() && self.match_module_name(module_name)
+    }
+
+    pub fn is_std_vector(&self) -> bool {
+        self.is_module_in_std("vector")
+    }
+
+    pub fn is_table(&self) -> bool {
+        self.is_module_in_std("table")
+            || self.is_module_in_std("table_with_length")
+            || self.is_module_in_ext("table")
+            || self.is_module_in_ext("table_with_length")
     }
 }
 

--- a/language/move-prover/boogie-backend/src/boogie_helpers.rs
+++ b/language/move-prover/boogie-backend/src/boogie_helpers.rs
@@ -41,12 +41,17 @@ pub fn boogie_module_name(env: &ModuleEnv<'_>) -> String {
 
 /// Return boogie name of given structure.
 pub fn boogie_struct_name(struct_env: &StructEnv<'_>, inst: &[Type]) -> String {
+    boogie_struct_name_bv(struct_env, inst, false)
+}
+
+pub fn boogie_struct_name_bv(struct_env: &StructEnv<'_>, inst: &[Type], bv_flag: bool) -> String {
     if struct_env.is_intrinsic_of(INTRINSIC_TYPE_MAP) {
         // Map to the theory type representation, which is `Table int V`. The key
         // is encoded as an integer to avoid extensionality problems, and to support
         // $Mutation paths, which are sequences of ints.
         let env = struct_env.module_env.env;
-        format!("Table int ({})", boogie_type(env, &inst[1]))
+        let type_fun = if bv_flag { boogie_bv_type } else { boogie_type };
+        format!("Table int ({})", type_fun(env, &inst[1]))
     } else {
         format!(
             "${}_{}{}",
@@ -70,7 +75,7 @@ pub fn boogie_field_sel(field_env: &FieldEnv<'_>, inst: &[Type]) -> String {
 /// Return field selector for given field.
 pub fn boogie_field_update(field_env: &FieldEnv<'_>, inst: &[Type]) -> String {
     let struct_env = &field_env.struct_env;
-    let suffix = boogie_type_suffix_for_struct(struct_env, inst);
+    let suffix = boogie_type_suffix_for_struct(struct_env, inst, false);
     format!(
         "$Update'{}'_{}",
         suffix,
@@ -90,7 +95,11 @@ pub fn boogie_function_name(fun_env: &FunctionEnv<'_>, inst: &[Type]) -> String 
 
 /// Return boogie name of given function
 /// Currently bv_flag is used when generating vector functions
-pub fn boogie_function_bv_name(fun_env: &FunctionEnv<'_>, inst: &[Type], bv_flag: bool) -> String {
+pub fn boogie_function_bv_name(
+    fun_env: &FunctionEnv<'_>,
+    inst: &[Type],
+    bv_flag: &[bool],
+) -> String {
     format!(
         "${}_{}{}",
         boogie_module_name(&fun_env.module_env),
@@ -132,12 +141,17 @@ pub fn boogie_spec_fun_name(
     } else {
         "".to_string()
     };
+    let mut suffix = boogie_inst_suffix_bv(env.env, inst, &[bv_flag]);
+    if env.is_table() {
+        assert_eq!(inst.len(), 2);
+        suffix = boogie_inst_suffix_bv_pair(env.env, inst, &[false, bv_flag]);
+    };
     format!(
         "${}_{}{}{}",
         boogie_module_name(env),
         decl.name.display(env.symbol_pool()),
         overload_qualifier,
-        boogie_inst_suffix_bv(env.env, inst, bv_flag)
+        suffix
     )
 }
 
@@ -241,7 +255,9 @@ pub fn boogie_bv_type(env: &GlobalEnv, ty: &Type) -> String {
             Num => "<<num is not unsupported here>>".to_string(),
         },
         Vector(et) => format!("Vec ({})", boogie_bv_type(env, et)),
-        Struct(mid, sid, inst) => boogie_struct_name(&env.get_module(*mid).into_struct(*sid), inst),
+        Struct(mid, sid, inst) => {
+            boogie_struct_name_bv(&env.get_module(*mid).into_struct(*sid), inst, true)
+        }
         Reference(_, bt) => format!("$Mutation ({})", boogie_bv_type(env, bt)),
         TypeParameter(idx) => boogie_type_param(env, *idx),
         Fun(..) | Tuple(..) | TypeDomain(..) | ResourceDomain(..) | Error | Var(..) => {
@@ -327,10 +343,10 @@ pub fn boogie_type_suffix_bv(env: &GlobalEnv, ty: &Type, bv_flag: bool) -> Strin
         },
         Vector(et) => format!(
             "vec{}",
-            boogie_inst_suffix_bv(env, &[et.as_ref().to_owned()], bv_flag)
+            boogie_inst_suffix_bv(env, &[et.as_ref().to_owned()], &[bv_flag])
         ),
         Struct(mid, sid, inst) => {
-            boogie_type_suffix_for_struct(&env.get_module(*mid).into_struct(*sid), inst)
+            boogie_type_suffix_for_struct(&env.get_module(*mid).into_struct(*sid), inst, bv_flag)
         }
         TypeParameter(idx) => boogie_type_param(env, *idx),
         Fun(..) | Tuple(..) | TypeDomain(..) | ResourceDomain(..) | Error | Var(..)
@@ -343,13 +359,17 @@ pub fn boogie_type_suffix(env: &GlobalEnv, ty: &Type) -> String {
     boogie_type_suffix_bv(env, ty, false)
 }
 
-pub fn boogie_type_suffix_for_struct(struct_env: &StructEnv<'_>, inst: &[Type]) -> String {
+pub fn boogie_type_suffix_for_struct(
+    struct_env: &StructEnv<'_>,
+    inst: &[Type],
+    bv_flag: bool,
+) -> String {
     if struct_env.is_intrinsic_of(INTRINSIC_TYPE_MAP) {
         format!(
             "${}_{}{}",
             boogie_module_name(&struct_env.module_env),
             struct_env.get_name().display(struct_env.symbol_pool()),
-            boogie_inst_suffix(struct_env.module_env.env, inst)
+            boogie_inst_suffix_bv_pair(struct_env.module_env.env, inst, &[false, bv_flag])
         )
     } else {
         boogie_struct_name(struct_env, inst)
@@ -357,14 +377,35 @@ pub fn boogie_type_suffix_for_struct(struct_env: &StructEnv<'_>, inst: &[Type]) 
 }
 
 /// Generate suffix after instantiation of type parameters
-pub fn boogie_inst_suffix_bv(env: &GlobalEnv, inst: &[Type], bv_flag: bool) -> String {
+pub fn boogie_inst_suffix_bv(env: &GlobalEnv, inst: &[Type], bv_flag: &[bool]) -> String {
     if inst.is_empty() {
         "".to_owned()
     } else {
+        let suffix = if bv_flag.len() == 1 {
+            inst.iter()
+                .map(|ty| boogie_type_suffix_bv(env, ty, bv_flag[0]))
+                .join("_")
+        } else {
+            assert_eq!(inst.len(), bv_flag.len());
+            inst.iter()
+                .zip(bv_flag.iter())
+                .map(|(ty, flag)| boogie_type_suffix_bv(env, ty, *flag))
+                .join("_")
+        };
+        format!("'{}'", suffix)
+    }
+}
+
+pub fn boogie_inst_suffix_bv_pair(env: &GlobalEnv, inst: &[Type], bv_flag: &[bool]) -> String {
+    if inst.is_empty() {
+        "".to_owned()
+    } else {
+        assert_eq!(inst.len(), bv_flag.len());
         format!(
             "'{}'",
             inst.iter()
-                .map(|ty| boogie_type_suffix_bv(env, ty, bv_flag))
+                .zip(bv_flag.iter())
+                .map(|(ty, flag)| boogie_type_suffix_bv(env, ty, *flag))
                 .join("_")
         )
     }

--- a/language/move-prover/boogie-backend/src/spec_translator.rs
+++ b/language/move-prover/boogie-backend/src/spec_translator.rs
@@ -281,10 +281,31 @@ impl<'env> SpecTranslator<'env> {
             if recursive { "recursive " } else { "" },
             fun.loc.display(self.env)
         );
-        // TODO(tengzhang): add support for spec functions with bv types
-        let bv_flag = false;
-        let ty_str_fn = if bv_flag { boogie_bv_type } else { boogie_type };
-        let result_type = ty_str_fn(self.env, &self.inst(&fun.result_type));
+        let global_state = &self
+            .env
+            .get_extension::<GlobalNumberOperationState>()
+            .expect("global number operation state");
+        let bv_flag_result = if global_state
+            .spec_fun_operation_map
+            .contains_key(&(module_env.get_id(), id))
+        {
+            let ret_oper_map = &global_state
+                .spec_fun_operation_map
+                .get(&(module_env.get_id(), id))
+                .unwrap()
+                .1;
+            ret_oper_map[0] == Bitwise
+        } else {
+            false
+        };
+        let ty_str_fn = |bv_flag: bool| {
+            if bv_flag {
+                boogie_bv_type
+            } else {
+                boogie_type
+            }
+        };
+        let result_type = ty_str_fn(bv_flag_result)(self.env, &self.inst(&fun.result_type));
         // it is possible that the spec fun may refer to the same memory after monomorphization,
         // (e.g., one via concrete type and the other via type parameter being instantiated).
         // In this case, we mark the other parameter as unused
@@ -303,15 +324,28 @@ impl<'env> SpecTranslator<'env> {
                 format!("__unused_{}", param_repr)
             }
         });
-        let params = fun.params.iter().map(|(name, ty)| {
+        let params = fun.params.iter().enumerate().map(|(i, (name, ty))| {
+            let bv_flag = if global_state
+                .spec_fun_operation_map
+                .contains_key(&(module_env.get_id(), id))
+            {
+                global_state
+                    .spec_fun_operation_map
+                    .get(&(module_env.get_id(), id))
+                    .unwrap()
+                    .0[i]
+                    == Bitwise
+            } else {
+                false
+            };
             format!(
                 "{}: {}",
                 name.display(module_env.symbol_pool()),
-                ty_str_fn(self.env, &self.inst(ty))
+                ty_str_fn(bv_flag)(self.env, &self.inst(ty))
             )
         });
         self.writer.set_location(&fun.loc);
-        let boogie_name = boogie_spec_fun_name(module_env, id, &self.type_inst, bv_flag);
+        let boogie_name = boogie_spec_fun_name(module_env, id, &self.type_inst, bv_flag_result);
         let param_list = mem_params.chain(params).join(", ");
         let attrs = if fun.uninterpreted || recursive {
             ""
@@ -986,16 +1020,10 @@ impl<'env> SpecTranslator<'env> {
             }
         }
 
-        // TODO(tengzhang): handle conversion between bv and int in a more general way
-        let is_vector_module = module_env
-            .get_name()
-            .name()
-            .display(self.env.symbol_pool())
-            .to_string()
-            == "vector";
+        let is_vector_table_module = module_env.is_std_vector() || module_env.is_table();
         // regular path
         if !processed {
-            let bv_flag = if is_vector_module && !args.is_empty() {
+            let bv_flag = if is_vector_table_module && !args.is_empty() {
                 global_state.get_node_num_oper(args[0].node_id()) == Bitwise
             } else {
                 global_state.get_node_num_oper(node_id) == Bitwise

--- a/language/move-prover/bytecode/src/number_operation_analysis.rs
+++ b/language/move-prover/bytecode/src/number_operation_analysis.rs
@@ -26,6 +26,7 @@ use move_binary_format::file_format::CodeOffset;
 use move_model::{
     ast::{Exp, ExpData, TempIndex},
     model::{FunId, GlobalEnv, ModuleId},
+    ty::{PrimitiveType, Type},
 };
 use std::{
     collections::{BTreeMap, BTreeSet},
@@ -131,11 +132,36 @@ impl NumberOperationState {
     }
 }
 
+fn vector_table_funs_name_propogate_to_dest(callee_name: &str) -> bool {
+    callee_name.contains("borrow")
+        || callee_name.contains("borrow_mut")
+        || callee_name.contains("pop_back")
+        || callee_name.contains("singleton")
+        || callee_name.contains("remove")
+        || callee_name.contains("swap_remove")
+        || callee_name.contains("spec_get")
+}
+
+fn vector_funs_name_propogate_to_srcs(callee_name: &str) -> bool {
+    callee_name == "contains"
+        || callee_name == "index_of"
+        || callee_name == "append"
+        || callee_name == "push_back"
+}
+
+fn table_funs_name_propogate_to_srcs(callee_name: &str) -> bool {
+    callee_name == "add" || callee_name == "borrow_mut_with_default" || callee_name == "upsert"
+}
+
 impl<'a> NumberOperationAnalysis<'a> {
     /// Analyze the expression in the spec
-    fn handle_exp(&self, attr_id: AttrId, e: &Exp, global_state: &mut GlobalNumberOperationState) {
-        let cur_mid = self.func_target.func_env.module_env.get_id();
-        let cur_fid = self.func_target.func_env.get_id();
+    fn handle_exp(
+        &self,
+        attr_id: AttrId,
+        e: &Exp,
+        global_state: &mut GlobalNumberOperationState,
+        state: &mut NumberOperationState,
+    ) {
         // TODO(tengzhang): add logic to support converting int to bv in the spec
         let allow_merge = false;
         let opers_for_propagation = |oper: &move_model::ast::Operation| {
@@ -163,6 +189,25 @@ impl<'a> NumberOperationAnalysis<'a> {
             use move_model::ast::Operation::*;
             matches!(*oper, |BitOr| BitAnd | Xor)
         };
+        let baseline_flag = self.func_target.data.variant == FunctionVariant::Baseline;
+        let cur_mid = self.func_target.func_env.module_env.get_id();
+        let cur_fid = self.func_target.func_env.get_id();
+        let update_temporary = |arg: &Exp,
+                                oper: &NumOperation,
+                                global_state: &mut GlobalNumberOperationState,
+                                state: &mut NumberOperationState| {
+            if let ExpData::Temporary(_, idx) = arg.as_ref() {
+                let cur_oper = global_state
+                    .get_temp_index_oper(cur_mid, cur_fid, *idx, baseline_flag)
+                    .unwrap_or(&Bottom);
+                if *cur_oper != *oper {
+                    state.changed = true;
+                    *global_state
+                        .get_mut_temp_index_oper(cur_mid, cur_fid, *idx, baseline_flag)
+                        .unwrap() = *oper;
+                }
+            }
+        };
         let visitor = &mut |exp: &ExpData| {
             match exp {
                 ExpData::Temporary(id, idx) => {
@@ -172,6 +217,21 @@ impl<'a> NumberOperationAnalysis<'a> {
                         .unwrap_or(&Bottom);
                     // Update num_oper for the node for the temporary variable
                     global_state.update_node_oper(*id, *oper, true);
+                }
+                ExpData::Block(id, _, exp) => {
+                    let exp_oper = global_state.get_node_num_oper(exp.node_id());
+                    global_state.update_node_oper(*id, exp_oper, true);
+                }
+                ExpData::IfElse(id, _, true_exp, false_exp) => {
+                    let true_oper = global_state.get_node_num_oper(true_exp.node_id());
+                    let false_oper = global_state.get_node_num_oper(false_exp.node_id());
+                    if !allow_merge && true_oper.conflict(&false_oper) {
+                        self.func_target.global_env().error(
+                            &self.func_target.get_bytecode_loc(attr_id),
+                            CONFLICT_ERROR_MSG,
+                        );
+                    }
+                    global_state.update_node_oper(*id, true_oper.merge(&false_oper), true);
                 }
                 ExpData::Call(id, oper, args) => {
                     let mut arg_oper = vec![];
@@ -223,27 +283,127 @@ impl<'a> NumberOperationAnalysis<'a> {
                                 .name
                                 .display(self.func_target.global_env().symbol_pool())
                                 .to_string();
-                            if module_env.is_std_vector() {
+                            if module_env.is_std_vector() || module_env.is_table() {
                                 if !args.is_empty() {
                                     let oper_first =
                                         global_state.get_node_num_oper(args[0].node_id());
-                                    // First argument is the target vector
-                                    if callee_name == "$borrow"
-                                        || callee_name == "$borrow_mut"
-                                        || callee_name == "$pop_back"
-                                        || callee_name == "$singleton"
-                                        || callee_name == "$remove"
-                                        || callee_name == "$swap_remove"
-                                    {
+                                    // First argument is the target vector and the return type has the same NumberOperation type
+                                    if vector_table_funs_name_propogate_to_dest(&callee_name) {
                                         global_state.update_node_oper(*id, oper_first, true);
                                     } else {
-                                        // TODO(tengzhang): add analysis for checking other vector operations
-                                        global_state.update_node_oper(*id, Arithmetic, allow_merge);
+                                        global_state.update_node_oper(*id, Bottom, allow_merge);
+                                    }
+                                    // Handle the case of borrow_mut_with_default
+                                    if callee_name.contains("borrow_mut_with_default") {
+                                        assert!(args.len() >= 3);
+                                        update_temporary(
+                                            &args[2],
+                                            &oper_first,
+                                            global_state,
+                                            state,
+                                        );
+                                    }
+                                }
+                            } else {
+                                // Analysis for general spec functions.
+                                let module = &self.func_target.global_env().get_module(*mid);
+                                let callee_spec_fun = module.get_spec_fun(*sid);
+                                // Try to get num_oper for signatures
+                                // If not exists, compute num_oper for this spec fun and update the exp_operation_map and spec_fun_map
+                                if let std::collections::btree_map::Entry::Vacant(_) =
+                                    global_state.spec_fun_operation_map.entry((*mid, *sid))
+                                {
+                                    let mut para_vec = vec![];
+                                    let mut ret_vec = vec![];
+                                    // Default num oper is determined by the actual arguments
+                                    para_vec.append(&mut arg_oper);
+                                    ret_vec.push(Bottom);
+                                    if callee_spec_fun.body.is_some() {
+                                        let body_exp = callee_spec_fun.body.as_ref().unwrap();
+                                        let local_map = body_exp.free_local_vars_with_node_id();
+                                        for (i, (sym, _)) in
+                                            callee_spec_fun.params.iter().enumerate()
+                                        {
+                                            if local_map.contains_key(sym) {
+                                                let sym_node_id = local_map.get(sym).unwrap();
+                                                let oper_opt =
+                                                    global_state.exp_operation_map.get(sym_node_id);
+                                                if let Some(oper) = oper_opt {
+                                                    // Still need to check compatibility
+                                                    if !allow_merge && oper.conflict(&para_vec[i]) {
+                                                        self.func_target.global_env().error(
+                                                            &self
+                                                                .func_target
+                                                                .get_bytecode_loc(attr_id),
+                                                            CONFLICT_ERROR_MSG,
+                                                        );
+                                                    } else {
+                                                        let merged = oper.merge(&para_vec[i]);
+                                                        para_vec[i] = merged;
+                                                    }
+                                                }
+                                                global_state.update_node_oper(
+                                                    *sym_node_id,
+                                                    para_vec[i],
+                                                    true,
+                                                );
+                                            }
+                                        }
+                                        global_state
+                                            .spec_fun_operation_map
+                                            .insert((*mid, *sid), (para_vec, ret_vec));
+
+                                        // Check compatibility between formal and actual arguments
+                                        self.handle_exp(attr_id, body_exp, global_state, state);
+                                        global_state.update_node_oper(
+                                            *id,
+                                            global_state.get_node_num_oper(body_exp.node_id()),
+                                            allow_merge,
+                                        );
+                                        global_state.update_spec_ret(
+                                            mid,
+                                            sid,
+                                            global_state.get_node_num_oper(body_exp.node_id()),
+                                        );
+                                    } else {
+                                        global_state
+                                            .spec_fun_operation_map
+                                            .insert((*mid, *sid), (para_vec, ret_vec));
                                     }
                                 } else {
-                                    // TODO(tengzhang): handle functions that require inference.
+                                    // Check compatibility between formal and actual arguments
+                                    let para_oper_vec = &global_state
+                                        .spec_fun_operation_map
+                                        .get(&(*mid, *sid))
+                                        .unwrap()
+                                        .0;
+                                    assert_eq!(para_oper_vec.len(), arg_oper.len());
+                                    for (formal_oper, actual_oper) in
+                                        para_oper_vec.iter().zip(arg_oper.iter())
+                                    {
+                                        // For simplicity, only check compatibility
+                                        if !allow_merge && formal_oper.conflict(actual_oper) {
+                                            self.func_target.global_env().error(
+                                                &self.func_target.get_bytecode_loc(attr_id),
+                                                CONFLICT_ERROR_MSG,
+                                            );
+                                        }
+                                    }
                                 }
-                            } // TODO(tengzhang): add analysis for general spec functions.
+                                // Update number oper for this node based on the return value of the spec fun
+                                let ret_num_oper_vec = &global_state
+                                    .spec_fun_operation_map
+                                    .get(&(*mid, *sid))
+                                    .unwrap()
+                                    .1;
+                                if !ret_num_oper_vec.is_empty() {
+                                    global_state.update_node_oper(
+                                        *id,
+                                        ret_num_oper_vec[0],
+                                        allow_merge,
+                                    );
+                                }
+                            }
                         }
                         move_model::ast::Operation::WellFormed => {
                             global_state.update_node_oper(*id, arg_oper[0], true);
@@ -253,7 +413,21 @@ impl<'a> NumberOperationAnalysis<'a> {
                             // TODO(tengzhang): support converting int to bv
                             if opers_for_propagation(oper) {
                                 let mut merged = if bitwise_oper(oper) { Bitwise } else { Bottom };
-                                for num_oper in arg_oper {
+                                if bitwise_oper(oper) {
+                                    let ty =
+                                        self.func_target.global_env().get_node_type(exp.node_id());
+                                    if matches!(ty, Type::Primitive(PrimitiveType::Num)) {
+                                        self.func_target.global_env().update_node_type(
+                                            exp.node_id(),
+                                            self.func_target
+                                                .global_env()
+                                                .get_node_type(args[0].node_id())
+                                                .skip_reference()
+                                                .clone(),
+                                        );
+                                    }
+                                }
+                                for num_oper in &arg_oper {
                                     if !allow_merge && num_oper.conflict(&merged) {
                                         self.func_target.global_env().error(
                                             &self.func_target.get_bytecode_loc(attr_id),
@@ -262,17 +436,19 @@ impl<'a> NumberOperationAnalysis<'a> {
                                     }
                                     merged = num_oper.merge(&merged);
                                 }
-                                for arg in args.iter() {
-                                    let arg_oper = global_state.get_node_num_oper(arg.node_id());
-                                    if merged != arg_oper {
+
+                                for (arg, arg_oper) in args.iter().zip(arg_oper.iter()) {
+                                    if merged != *arg_oper {
                                         // propagate to arg if necessary
                                         global_state.update_node_oper(
                                             arg.node_id(),
                                             merged,
                                             allow_merge,
                                         );
+                                        update_temporary(arg, &merged, global_state, state);
                                     }
                                 }
+
                                 global_state.update_node_oper(*id, merged, allow_merge);
                             }
                         }
@@ -745,7 +921,7 @@ impl<'a> TransferFunctions for NumberOperationAnalysis<'a> {
                     Function(msid, fsid, _) => {
                         let module_env = &self.func_target.global_env().get_module(*msid);
                         // Vector functions are handled separately
-                        if !module_env.is_std_vector() {
+                        if !module_env.is_std_vector() && !module_env.is_table() {
                             for (i, src) in srcs.iter().enumerate() {
                                 let cur_oper = global_state
                                     .get_temp_index_oper(cur_mid, cur_fid, *src, baseline_flag)
@@ -815,55 +991,56 @@ impl<'a> TransferFunctions for NumberOperationAnalysis<'a> {
                         } else {
                             let callee = module_env.get_function(*fsid);
                             let callee_name = callee.get_name_str();
+                            let check_and_update_bitwise =
+                                |idx: &TempIndex,
+                                 global_state: &mut GlobalNumberOperationState,
+                                 state: &mut NumberOperationState| {
+                                    let cur_oper = global_state
+                                        .get_temp_index_oper(cur_mid, cur_fid, *idx, baseline_flag)
+                                        .unwrap();
+
+                                    if self.check_conflict(cur_oper, &Bitwise) {
+                                        self.func_target.func_env.module_env.env.error(
+                                            &self.func_target.get_bytecode_loc(*id),
+                                            CONFLICT_ERROR_MSG,
+                                        );
+                                    } else if *cur_oper != Bitwise {
+                                        state.changed = true;
+                                        *global_state
+                                            .get_mut_temp_index_oper(
+                                                cur_mid,
+                                                cur_fid,
+                                                *idx,
+                                                baseline_flag,
+                                            )
+                                            .unwrap() = Bitwise;
+                                    }
+                                };
                             if !srcs.is_empty() {
                                 // First element
                                 let first_oper = global_state
                                     .get_temp_index_oper(cur_mid, cur_fid, srcs[0], baseline_flag)
                                     .unwrap();
                                 // Bitwise is specified explicitly in the fun or struct spec
-                                if *first_oper == Bitwise {
-                                    if callee_name != "length"
-                                        && callee_name != "is_empty"
-                                        && callee_name != "index_of"
-                                        && callee_name != "contains"
-                                    {
-                                        for (_, dest) in dests.iter().enumerate() {
-                                            let cur_oper = global_state
-                                                .get_temp_index_oper(
-                                                    cur_mid,
-                                                    cur_fid,
-                                                    *dest,
-                                                    baseline_flag,
-                                                )
-                                                .unwrap();
-                                            if self.check_conflict(cur_oper, &Bitwise) {
-                                                self.func_target.func_env.module_env.env.error(
-                                                    &self.func_target.get_bytecode_loc(*id),
-                                                    CONFLICT_ERROR_MSG,
-                                                );
-                                            }
-                                            if *cur_oper != Bitwise {
-                                                state.changed = true;
-                                            }
-                                            *global_state
-                                                .get_mut_temp_index_oper(
-                                                    cur_mid,
-                                                    cur_fid,
-                                                    *dest,
-                                                    baseline_flag,
-                                                )
-                                                .unwrap() = Bitwise;
+                                if vector_table_funs_name_propogate_to_dest(&callee_name) {
+                                    if *first_oper == Bitwise {
+                                        // Do not consider the method remove_return_key where the first return value is k
+                                        for dest in dests.iter() {
+                                            check_and_update_bitwise(
+                                                dest,
+                                                &mut global_state,
+                                                state,
+                                            );
                                         }
                                     }
-                                    // Propagate to other srcs
-                                    // For some vector functions, the second argument needs to be checked
-                                    if callee_name == "contains"
-                                        || callee_name == "index_of"
-                                        || callee_name == "append"
-                                        || callee_name == "push_back"
+                                } else {
+                                    let mut second_oper = first_oper;
+                                    let mut src_idx = 0;
+                                    if module_env.is_std_vector()
+                                        && vector_funs_name_propogate_to_srcs(&callee_name)
                                     {
                                         assert!(srcs.len() > 1);
-                                        let cur_oper = global_state
+                                        second_oper = global_state
                                             .get_temp_index_oper(
                                                 cur_mid,
                                                 cur_fid,
@@ -871,60 +1048,30 @@ impl<'a> TransferFunctions for NumberOperationAnalysis<'a> {
                                                 baseline_flag,
                                             )
                                             .unwrap();
-                                        if self.check_conflict(cur_oper, &Bitwise) {
-                                            self.func_target.func_env.module_env.env.error(
-                                                &self.func_target.get_bytecode_loc(*id),
-                                                CONFLICT_ERROR_MSG,
-                                            );
-                                        }
-                                        if *cur_oper != Bitwise {
-                                            state.changed = true;
-                                        }
-                                        *global_state
-                                            .get_mut_temp_index_oper(
+                                        src_idx = 1;
+                                    } else if table_funs_name_propogate_to_srcs(&callee_name) {
+                                        assert!(srcs.len() > 2);
+                                        second_oper = global_state
+                                            .get_temp_index_oper(
                                                 cur_mid,
                                                 cur_fid,
-                                                srcs[1],
+                                                srcs[2],
                                                 baseline_flag,
                                             )
-                                            .unwrap() = Bitwise;
+                                            .unwrap();
+                                        src_idx = 2;
                                     }
-                                } else if callee_name == "append" {
-                                    // Second may propagate to first
-                                    let second_oper = global_state
-                                        .get_temp_index_oper(
-                                            cur_mid,
-                                            cur_fid,
-                                            srcs[1],
-                                            baseline_flag,
-                                        )
-                                        .unwrap();
-                                    if *second_oper == Bitwise {
-                                        let first_oper = global_state
-                                            .get_temp_index_oper(
-                                                cur_mid,
-                                                cur_fid,
-                                                srcs[0],
-                                                baseline_flag,
-                                            )
-                                            .unwrap();
-                                        if self.check_conflict(first_oper, &Bitwise) {
-                                            self.func_target.func_env.module_env.env.error(
-                                                &self.func_target.get_bytecode_loc(*id),
-                                                CONFLICT_ERROR_MSG,
-                                            );
-                                        }
-                                        if *first_oper != Bitwise {
-                                            state.changed = true;
-                                        }
-                                        *global_state
-                                            .get_mut_temp_index_oper(
-                                                cur_mid,
-                                                cur_fid,
-                                                srcs[0],
-                                                baseline_flag,
-                                            )
-                                            .unwrap() = Bitwise;
+                                    if *first_oper == Bitwise || *second_oper == Bitwise {
+                                        check_and_update_bitwise(
+                                            &srcs[0],
+                                            &mut global_state,
+                                            state,
+                                        );
+                                        check_and_update_bitwise(
+                                            &srcs[src_idx],
+                                            &mut global_state,
+                                            state,
+                                        );
                                     }
                                 }
                             } // empty, do nothing
@@ -934,7 +1081,7 @@ impl<'a> TransferFunctions for NumberOperationAnalysis<'a> {
                 }
             }
             Prop(id, _, exp) => {
-                self.handle_exp(*id, exp, &mut global_state);
+                self.handle_exp(*id, exp, &mut global_state, state);
             }
             _ => {}
         }

--- a/language/move-prover/tests/sources/functional/bitwise_operators.move
+++ b/language/move-prover/tests/sources/functional/bitwise_operators.move
@@ -59,6 +59,24 @@ address 0x123 {
       ensures result == (0 as u8);
     }
 
+    public fun bv_and(n: u64, e: u64): u64 {
+      if (e == 0) {
+        1
+      } else {
+        n & bv_and(n, e - 1)
+      }
+    }
+    spec bv_and {
+      pragma opaque;
+      pragma bv=b"0,1";
+      pragma bv_ret=b"0";
+      ensures result == spec_bv_and(n, e);
+    }
+
+    spec fun spec_bv_and(n: u64, e: u64): u64 {
+      if (e == (0 as u64)) { int2bv((1 as u64)) } else { n & spec_bv_and(n, e - int2bv((1 as u64))) }
+    }
+
   }
 
 }

--- a/language/move-prover/tests/sources/functional/bitwise_table.move
+++ b/language/move-prover/tests/sources/functional/bitwise_table.move
@@ -1,0 +1,130 @@
+module 0x42::VerifyBitwiseTable {
+    use extensions::table::{Self, Table};
+    use extensions::table::{spec_get, spec_len, spec_contains};
+
+    fun add(): Table<u8, u64> {
+        let t = table::new<u8, u64>();
+        table::add(&mut t, 1, 2);
+        table::add(&mut t, 2, 3);
+        table::add(&mut t, 3, 4);
+        t
+    }
+    spec add {
+        pragma bv_ret=b"0";
+        ensures spec_contains(result, 1) && spec_contains(result, 2) && spec_contains(result, 3);
+        ensures spec_len(result) == 3;
+        ensures spec_get(result, 1) == (2 as u64);
+        ensures spec_get(result, 2) == (3 as u64);
+        ensures spec_get(result, 3) == (4 as u64);
+    }
+
+    fun add_fail_exists(k1: u8, k2: u8): Table<u8, u64> {
+        let t = table::new<u8, u64>();
+        table::add(&mut t, k1, 2);
+        table::add(&mut t, k2, 3);
+        t
+    }
+    spec add_fail_exists {
+        pragma bv_ret=b"0";
+        aborts_if k1 == k2;
+    }
+
+    fun remove(): Table<u8, u64> {
+        let t = add();
+        table::remove(&mut t, 2);
+        t
+    }
+    spec remove {
+        pragma bv_ret=b"0";
+        ensures spec_contains(result, 1) && spec_contains(result, 3);
+        ensures spec_len(result) == 2;
+        ensures spec_get(result, 1) == (2 as u64);
+        ensures spec_get(result, 3) == (4 as u64);
+    }
+
+    fun contains_and_length(): (bool, bool, u64, Table<u8, u64>) {
+        let t = table::new<u8, u64>();
+        table::add(&mut t, 1, 2);
+        table::add(&mut t, 2, 3);
+        (table::contains(&t, 1), table::contains(&t, 3), table::length(&t), t)
+    }
+    spec contains_and_length {
+        pragma bv_ret=b"3";
+        ensures result_1 == true;
+        ensures result_2 == false;
+        ensures result_3 == 2;
+    }
+
+    fun borrow(): (u64, Table<u8, u64>) {
+        let t = table::new<u8, u64>();
+        table::add(&mut t, 1, 2);
+        let r = table::borrow(&t, 1);
+        (*r, t)
+    }
+    spec borrow {
+        pragma bv_ret=b"1";
+        ensures result_1 == (2 as u64);
+        ensures spec_len(result_2) == 1;
+        ensures spec_get(result_2, 1) == (2 as u64);
+    }
+
+    fun borrow_mut(): Table<u8, u64> {
+        let t = table::new<u8, u64>();
+        table::add(&mut t, 1, 2);
+        table::add(&mut t, 2, 3);
+        let r = table::borrow_mut(&mut t, 1);
+        *r = 4;
+        t
+    }
+    spec borrow_mut {
+        pragma bv_ret=b"1";
+        ensures spec_contains(result, 1) && spec_contains(result, 2);
+        ensures spec_len(result) == 2;
+        ensures spec_get(result, 1) == (4 as u64);
+        ensures spec_get(result, 2) == (3 as u64);
+    }
+
+
+    // ====================================================================================================
+    // Tables with structured keys
+
+
+    struct Key has copy, drop {
+        v: vector<u8>       // Use a vector so we do not have extensional equality
+    }
+
+    struct R {
+        t: Table<Key, u64>
+    }
+
+
+    spec R {
+        pragma bv=b"0";
+    }
+
+
+    fun make_R(): R {
+        let t = table::new<Key, u64>();
+        // let t = table::new<u8, u64>();
+        table::add(&mut t, Key{v: vector[1, 2]}, 22);
+        table::add(&mut t, Key{v: vector[2, 3]}, 23);
+        let x = table::borrow_mut(&mut t, Key{v: vector[1, 2]});
+        *x = *x & 1;
+        let r = R{t};
+        r
+    }
+
+
+    fun add_R(): R {
+        make_R()
+    }
+    spec add_R {
+        let k1 = Key{v: concat(vec(1u8), vec(2u8))};
+        let k2 = Key{v: concat(vec(2u8), vec(3u8))};
+        ensures spec_len(result.t) == 2;
+        ensures spec_contains(result.t, k1) && spec_contains(result.t, k2);
+        ensures spec_get(result.t, k1) == (0 as u64);
+        ensures spec_get(result.t, k2) == (23 as u64);
+    }
+
+}


### PR DESCRIPTION
## Motivation

This PR: 1) adds supports for specifying bitwise operations in spec functions; 2) allows bitwise operations for values in tables; and 3) adds descriptions on bitwise operators in the [MSL](https://github.com/move-language/move/blob/main/language/move-prover/doc/user/spec-lang.md) document.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes

## Test Plan

cargo test
