### PR TITLE
[move-prover] do not assume data invariants for `&mut` params

### DIFF
--- a/language/move-prover/bytecode/tests/data_invariant_instrumentation/params.exp
+++ b/language/move-prover/bytecode/tests/data_invariant_instrumentation/params.exp
@@ -12,7 +12,7 @@ public fun Test::test_param($t0|_simple_R: Test::R, $t1|_ref_R: Test::R, $t2|_si
   0: assume And(WellFormed($t0), And(Gt(select Test::R.x($t0), select Test::S.y(select Test::R.s($t0))), Gt(select Test::S.y(select Test::R.s($t0)), 0)))
   1: assume And(WellFormed($t1), And(Gt(select Test::R.x($t1), select Test::S.y(select Test::R.s($t1))), Gt(select Test::S.y(select Test::R.s($t1)), 0)))
   2: assume And(WellFormed($t2), Gt(select Test::S.y($t2), 0))
-  3: assume And(WellFormed($t3), And(Gt(select Test::R.x($t3), select Test::S.y(select Test::R.s($t3))), Gt(select Test::S.y(select Test::R.s($t3)), 0)))
+  3: assume WellFormed($t3)
   4: trace_local[_mut_R]($t3)
   5: label L1
   6: return ()

--- a/language/move-prover/tests/sources/regression/data_invariant_for_mut_ref_arg.exp
+++ b/language/move-prover/tests/sources/regression/data_invariant_for_mut_ref_arg.exp
@@ -1,0 +1,10 @@
+Move prover returns: exiting with verification errors
+error: unknown assertion failed
+   ┌─ tests/sources/regression/data_invariant_for_mut_ref_arg.move:22:13
+   │
+22 │             assert len(s.v) == 0;
+   │             ^^^^^^^^^^^^^^^^^^^^^
+   │
+   =     at tests/sources/regression/data_invariant_for_mut_ref_arg.move:15: push_1
+   =         s = <redacted>
+   =     at tests/sources/regression/data_invariant_for_mut_ref_arg.move:22: push_1

--- a/language/move-prover/tests/sources/regression/data_invariant_for_mut_ref_arg.move
+++ b/language/move-prover/tests/sources/regression/data_invariant_for_mut_ref_arg.move
@@ -1,0 +1,26 @@
+module 0x42::struct_invariant_mut_ref_param {
+    use std::vector;
+
+    struct S {
+        v: vector<u64>,
+    }
+    spec S {
+        invariant len(v) == 0;
+    }
+
+    public fun empty(): S {
+        S { v: vector::empty<u64>() }
+    }
+
+    public fun push_1(s: &mut S) {
+        // NOTE: this inline spec block should not be
+        // proved becauuse `s: &mut S` might not be in
+        // a consistent state with the data invariant.
+        // This is because data invariants are only
+        // asserted when the mutable borrow ends.
+        spec {
+            assert len(s.v) == 0;
+        };
+        vector::push_back(&mut s.v, 1);
+    }
+}


### PR DESCRIPTION
Data invariants are only checked when the `&mut` borrow ends. During the lifetime of the `&mut` reference, the invariant can be temporarily violated and hence, assuming data invariants there can lead to inconsistency issues.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Move Language.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Fixes #780 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes

## Test Plan

- CI
- A new regression test