### PR TITLE
Cherry picks TypeTag bounds from old aptos branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2819,9 +2819,9 @@ checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 
 [[package]]
 name = "memchr"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
+checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memoffset"

--- a/language/move-core/types/src/language_storage.rs
+++ b/language/move-core/types/src/language_storage.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 #[cfg(any(test, feature = "fuzzing"))]
 use proptest_derive::Arbitrary;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, Serializer};
 use std::{
     fmt::{Display, Formatter},
     str::FromStr,
@@ -18,10 +18,12 @@ use std::{
 pub const CODE_TAG: u8 = 0;
 pub const RESOURCE_TAG: u8 = 1;
 
+const MAX_TYPE_TAG_NESTING: u8 = 8;
+
 /// Hex address: 0x1
 pub const CORE_CODE_ADDRESS: AccountAddress = AccountAddress::ONE;
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Hash, Eq, Clone, PartialOrd, Ord)]
+#[derive(Deserialize, Debug, PartialEq, Hash, Eq, Clone, PartialOrd, Ord)]
 pub enum TypeTag {
     // alias for compatibility with old json serialized data.
     #[serde(rename = "bool", alias = "Bool")]
@@ -79,6 +81,82 @@ impl TypeTag {
     }
 }
 
+#[derive(Serialize)]
+enum SafeTypeTag<'a> {
+    #[serde(rename = "bool", alias = "Bool")]
+    Bool,
+    #[serde(rename = "u8", alias = "U8")]
+    U8,
+    #[serde(rename = "u64", alias = "U64")]
+    U64,
+    #[serde(rename = "u128", alias = "U128")]
+    U128,
+    #[serde(rename = "address", alias = "Address")]
+    Address,
+    #[serde(rename = "signer", alias = "Signer")]
+    Signer,
+    #[serde(rename = "vector", alias = "Vector")]
+    Vector(Box<SafeTypeTag<'a>>),
+    #[serde(rename = "struct", alias = "Struct")]
+    Struct(SafeStructTag<'a>),
+}
+
+impl<'a> From<&'a TypeTag> for SafeTypeTag<'a> {
+    fn from(type_tag: &'a TypeTag) -> Self {
+        match &type_tag {
+            TypeTag::Bool => SafeTypeTag::Bool,
+            TypeTag::U8 => SafeTypeTag::U8,
+            TypeTag::U64 => SafeTypeTag::U64,
+            TypeTag::U128 => SafeTypeTag::U128,
+            TypeTag::Address => SafeTypeTag::Address,
+            TypeTag::Signer => SafeTypeTag::Signer,
+            TypeTag::Vector(value) => SafeTypeTag::Vector(Box::new((&**value).into())),
+            TypeTag::Struct(value) => SafeTypeTag::Struct(value.into()),
+        }
+    }
+}
+
+impl Serialize for TypeTag {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match &self {
+            TypeTag::Vector(type_tag) => {
+                validate_type_tag_recursion(vec![(**type_tag).clone()].as_slice(), 1)
+            }
+            TypeTag::Struct(value) => validate_type_tag_recursion(&value.type_params, 1),
+            _ => Ok(()),
+        }
+        .map_err(serde::ser::Error::custom)?;
+
+        serializer.serialize_newtype_struct("TypeTag", &SafeTypeTag::from(self))
+    }
+}
+
+fn validate_type_tag_recursion(
+    type_tags: &[TypeTag],
+    count: u8,
+) -> std::result::Result<(), String> {
+    if count >= MAX_TYPE_TAG_NESTING {
+        return Err(format!(
+            "Hit TypeTag nesting limit during serialization: {}",
+            count
+        ));
+    }
+
+    for type_tag in type_tags {
+        match type_tag {
+            TypeTag::Vector(type_tag) => {
+                validate_type_tag_recursion(vec![(**type_tag).clone()].as_slice(), count + 1)
+            }
+            TypeTag::Struct(value) => validate_type_tag_recursion(&value.type_params, count + 1),
+            _ => Ok(()),
+        }?;
+    }
+    Ok(())
+}
+
 impl FromStr for TypeTag {
     type Err = anyhow::Error;
 
@@ -95,6 +173,31 @@ pub struct StructTag {
     // alias for compatibility with old json serialized data.
     #[serde(rename = "type_args", alias = "type_params")]
     pub type_params: Vec<TypeTag>,
+}
+
+#[derive(Serialize)]
+struct SafeStructTag<'a> {
+    address: AccountAddress,
+    module: &'a Identifier,
+    name: &'a Identifier,
+    // alias for compatibility with old json serialized data.
+    #[serde(rename = "type_args", alias = "type_params")]
+    type_params: Vec<SafeTypeTag<'a>>,
+}
+
+impl<'a> From<&'a StructTag> for SafeStructTag<'a> {
+    fn from(struct_tag: &'a StructTag) -> Self {
+        Self {
+            address: struct_tag.address,
+            module: &struct_tag.module,
+            name: &struct_tag.name,
+            type_params: struct_tag
+                .type_params
+                .iter()
+                .map(|ty_arg| ty_arg.into())
+                .collect::<Vec<_>>(),
+        }
+    }
 }
 
 impl StructTag {
@@ -295,13 +398,56 @@ mod tests {
     fn test_type_tag_serde() {
         let a = TypeTag::Struct(Box::new(StructTag {
             address: AccountAddress::ONE,
-            module: Identifier::from_utf8(("abc".as_bytes()).to_vec()).unwrap(),
-            name: Identifier::from_utf8(("abc".as_bytes()).to_vec()).unwrap(),
+            module: Identifier::new("abc").unwrap(),
+            name: Identifier::new("abc").unwrap(),
             type_params: vec![TypeTag::U8],
         }));
         let b = serde_json::to_string(&a).unwrap();
         let c: TypeTag = serde_json::from_str(&b).unwrap();
         assert!(a.eq(&c), "Typetag serde error");
         assert_eq!(mem::size_of::<TypeTag>(), 16);
+    }
+
+    #[test]
+    fn test_nested_type_tag_struct_serde() {
+        let mut type_tags = vec![make_type_tag_struct(TypeTag::U8)];
+
+        let limit = super::MAX_TYPE_TAG_NESTING - 1;
+        while type_tags.len() < limit.into() {
+            type_tags.push(make_type_tag_struct(type_tags.last().unwrap().clone()));
+        }
+
+        bcs::to_bytes(type_tags.last().unwrap()).unwrap();
+
+        let nest_limit = make_type_tag_struct(type_tags.last().unwrap().clone());
+        bcs::to_bytes(&nest_limit).unwrap_err();
+    }
+
+    #[test]
+    fn test_nested_type_tag_vector_serde() {
+        let mut type_tags = vec![make_type_tag_struct(TypeTag::U8)];
+
+        let limit = super::MAX_TYPE_TAG_NESTING - 1;
+        while type_tags.len() < limit.into() {
+            type_tags.push(make_type_tag_vector(type_tags.last().unwrap().clone()));
+        }
+
+        bcs::to_bytes(type_tags.last().unwrap()).unwrap();
+
+        let nest_limit = make_type_tag_vector(type_tags.last().unwrap().clone());
+        bcs::to_bytes(&nest_limit).unwrap_err();
+    }
+
+    fn make_type_tag_vector(type_param: TypeTag) -> TypeTag {
+        TypeTag::Vector(Box::new(type_param))
+    }
+
+    fn make_type_tag_struct(type_param: TypeTag) -> TypeTag {
+        TypeTag::Struct(StructTag {
+            address: AccountAddress::ONE,
+            module: Identifier::new("a").unwrap(),
+            name: Identifier::new("a").unwrap(),
+            type_params: vec![type_param],
+        })
     }
 }

--- a/language/move-core/types/src/language_storage.rs
+++ b/language/move-core/types/src/language_storage.rs
@@ -372,11 +372,11 @@ mod tests {
     }
 
     fn make_type_tag_struct(type_param: TypeTag) -> TypeTag {
-        TypeTag::Struct(StructTag {
+        TypeTag::Struct(Box::new(StructTag {
             address: AccountAddress::ONE,
             module: Identifier::new("a").unwrap(),
             name: Identifier::new("a").unwrap(),
             type_params: vec![type_param],
-        })
+        }))
     }
 }

--- a/language/move-core/types/src/language_storage.rs
+++ b/language/move-core/types/src/language_storage.rs
@@ -6,10 +6,11 @@ use crate::{
     account_address::AccountAddress,
     identifier::{IdentStr, Identifier},
     parser::{parse_struct_tag, parse_type_tag},
+    safe_serialize,
 };
 #[cfg(any(test, feature = "fuzzing"))]
 use proptest_derive::Arbitrary;
-use serde::{Deserialize, Serialize, Serializer};
+use serde::{Deserialize, Serialize};
 use std::{
     fmt::{Display, Formatter},
     str::FromStr,
@@ -18,12 +19,10 @@ use std::{
 pub const CODE_TAG: u8 = 0;
 pub const RESOURCE_TAG: u8 = 1;
 
-const MAX_TYPE_TAG_NESTING: u8 = 8;
-
 /// Hex address: 0x1
 pub const CORE_CODE_ADDRESS: AccountAddress = AccountAddress::ONE;
 
-#[derive(Deserialize, Debug, PartialEq, Hash, Eq, Clone, PartialOrd, Ord)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Hash, Eq, Clone, PartialOrd, Ord)]
 pub enum TypeTag {
     // alias for compatibility with old json serialized data.
     #[serde(rename = "bool", alias = "Bool")]
@@ -39,9 +38,21 @@ pub enum TypeTag {
     #[serde(rename = "signer", alias = "Signer")]
     Signer,
     #[serde(rename = "vector", alias = "Vector")]
-    Vector(Box<TypeTag>),
+    Vector(
+        #[serde(
+            serialize_with = "safe_serialize::type_tag_recursive_serialize",
+            deserialize_with = "safe_serialize::type_tag_recursive_deserialize"
+        )]
+        Box<TypeTag>,
+    ),
     #[serde(rename = "struct", alias = "Struct")]
-    Struct(Box<StructTag>),
+    Struct(
+        #[serde(
+            serialize_with = "safe_serialize::type_tag_recursive_serialize",
+            deserialize_with = "safe_serialize::type_tag_recursive_deserialize"
+        )]
+        Box<StructTag>,
+    ),
 
     // NOTE: Added in bytecode version v6, do not reorder!
     #[serde(rename = "u16", alias = "U16")]
@@ -81,82 +92,6 @@ impl TypeTag {
     }
 }
 
-#[derive(Serialize)]
-enum SafeTypeTag<'a> {
-    #[serde(rename = "bool", alias = "Bool")]
-    Bool,
-    #[serde(rename = "u8", alias = "U8")]
-    U8,
-    #[serde(rename = "u64", alias = "U64")]
-    U64,
-    #[serde(rename = "u128", alias = "U128")]
-    U128,
-    #[serde(rename = "address", alias = "Address")]
-    Address,
-    #[serde(rename = "signer", alias = "Signer")]
-    Signer,
-    #[serde(rename = "vector", alias = "Vector")]
-    Vector(Box<SafeTypeTag<'a>>),
-    #[serde(rename = "struct", alias = "Struct")]
-    Struct(SafeStructTag<'a>),
-}
-
-impl<'a> From<&'a TypeTag> for SafeTypeTag<'a> {
-    fn from(type_tag: &'a TypeTag) -> Self {
-        match &type_tag {
-            TypeTag::Bool => SafeTypeTag::Bool,
-            TypeTag::U8 => SafeTypeTag::U8,
-            TypeTag::U64 => SafeTypeTag::U64,
-            TypeTag::U128 => SafeTypeTag::U128,
-            TypeTag::Address => SafeTypeTag::Address,
-            TypeTag::Signer => SafeTypeTag::Signer,
-            TypeTag::Vector(value) => SafeTypeTag::Vector(Box::new((&**value).into())),
-            TypeTag::Struct(value) => SafeTypeTag::Struct(value.into()),
-        }
-    }
-}
-
-impl Serialize for TypeTag {
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        match &self {
-            TypeTag::Vector(type_tag) => {
-                validate_type_tag_recursion(vec![(**type_tag).clone()].as_slice(), 1)
-            }
-            TypeTag::Struct(value) => validate_type_tag_recursion(&value.type_params, 1),
-            _ => Ok(()),
-        }
-        .map_err(serde::ser::Error::custom)?;
-
-        serializer.serialize_newtype_struct("TypeTag", &SafeTypeTag::from(self))
-    }
-}
-
-fn validate_type_tag_recursion(
-    type_tags: &[TypeTag],
-    count: u8,
-) -> std::result::Result<(), String> {
-    if count >= MAX_TYPE_TAG_NESTING {
-        return Err(format!(
-            "Hit TypeTag nesting limit during serialization: {}",
-            count
-        ));
-    }
-
-    for type_tag in type_tags {
-        match type_tag {
-            TypeTag::Vector(type_tag) => {
-                validate_type_tag_recursion(vec![(**type_tag).clone()].as_slice(), count + 1)
-            }
-            TypeTag::Struct(value) => validate_type_tag_recursion(&value.type_params, count + 1),
-            _ => Ok(()),
-        }?;
-    }
-    Ok(())
-}
-
 impl FromStr for TypeTag {
     type Err = anyhow::Error;
 
@@ -173,31 +108,6 @@ pub struct StructTag {
     // alias for compatibility with old json serialized data.
     #[serde(rename = "type_args", alias = "type_params")]
     pub type_params: Vec<TypeTag>,
-}
-
-#[derive(Serialize)]
-struct SafeStructTag<'a> {
-    address: AccountAddress,
-    module: &'a Identifier,
-    name: &'a Identifier,
-    // alias for compatibility with old json serialized data.
-    #[serde(rename = "type_args", alias = "type_params")]
-    type_params: Vec<SafeTypeTag<'a>>,
-}
-
-impl<'a> From<&'a StructTag> for SafeStructTag<'a> {
-    fn from(struct_tag: &'a StructTag) -> Self {
-        Self {
-            address: struct_tag.address,
-            module: &struct_tag.module,
-            name: &struct_tag.name,
-            type_params: struct_tag
-                .type_params
-                .iter()
-                .map(|ty_arg| ty_arg.into())
-                .collect::<Vec<_>>(),
-        }
-    }
 }
 
 impl StructTag {
@@ -391,6 +301,7 @@ mod tests {
     use super::TypeTag;
     use crate::{
         account_address::AccountAddress, identifier::Identifier, language_storage::StructTag,
+        safe_serialize::MAX_TYPE_TAG_NESTING,
     };
     use std::mem;
 
@@ -412,30 +323,48 @@ mod tests {
     fn test_nested_type_tag_struct_serde() {
         let mut type_tags = vec![make_type_tag_struct(TypeTag::U8)];
 
-        let limit = super::MAX_TYPE_TAG_NESTING - 1;
+        let limit = MAX_TYPE_TAG_NESTING - 1;
         while type_tags.len() < limit.into() {
             type_tags.push(make_type_tag_struct(type_tags.last().unwrap().clone()));
         }
 
-        bcs::to_bytes(type_tags.last().unwrap()).unwrap();
+        // Note for this test serialize can handle one more nesting than deserialize
+        // Both directions work
+        let output = bcs::to_bytes(type_tags.last().unwrap()).unwrap();
+        bcs::from_bytes::<TypeTag>(&output).unwrap();
 
-        let nest_limit = make_type_tag_struct(type_tags.last().unwrap().clone());
-        bcs::to_bytes(&nest_limit).unwrap_err();
+        // One more, both should fail
+        type_tags.push(make_type_tag_struct(type_tags.last().unwrap().clone()));
+        let output = bcs::to_bytes(type_tags.last().unwrap()).unwrap();
+        bcs::from_bytes::<TypeTag>(&output).unwrap_err();
+
+        // One more and serialize fails
+        type_tags.push(make_type_tag_struct(type_tags.last().unwrap().clone()));
+        bcs::to_bytes(type_tags.last().unwrap()).unwrap_err();
     }
 
     #[test]
     fn test_nested_type_tag_vector_serde() {
         let mut type_tags = vec![make_type_tag_struct(TypeTag::U8)];
 
-        let limit = super::MAX_TYPE_TAG_NESTING - 1;
+        let limit = MAX_TYPE_TAG_NESTING - 1;
         while type_tags.len() < limit.into() {
             type_tags.push(make_type_tag_vector(type_tags.last().unwrap().clone()));
         }
 
-        bcs::to_bytes(type_tags.last().unwrap()).unwrap();
+        // Note for this test serialize can handle one more nesting than deserialize
+        // Both directions work
+        let output = bcs::to_bytes(type_tags.last().unwrap()).unwrap();
+        bcs::from_bytes::<TypeTag>(&output).unwrap();
 
-        let nest_limit = make_type_tag_vector(type_tags.last().unwrap().clone());
-        bcs::to_bytes(&nest_limit).unwrap_err();
+        // One more, serialize passes, deserialize fails
+        type_tags.push(make_type_tag_vector(type_tags.last().unwrap().clone()));
+        let output = bcs::to_bytes(type_tags.last().unwrap()).unwrap();
+        bcs::from_bytes::<TypeTag>(&output).unwrap_err();
+
+        // One more and serialize fails
+        type_tags.push(make_type_tag_vector(type_tags.last().unwrap().clone()));
+        bcs::to_bytes(type_tags.last().unwrap()).unwrap_err();
     }
 
     fn make_type_tag_vector(type_param: TypeTag) -> TypeTag {

--- a/language/move-core/types/src/lib.rs
+++ b/language/move-core/types/src/lib.rs
@@ -17,6 +17,7 @@ pub mod parser;
 #[cfg(any(test, feature = "fuzzing"))]
 pub mod proptest_types;
 pub mod resolver;
+mod safe_serialize;
 pub mod transaction_argument;
 pub mod u256;
 #[cfg(test)]

--- a/language/move-core/types/src/parser.rs
+++ b/language/move-core/types/src/parser.rs
@@ -267,7 +267,11 @@ impl<I: Iterator<Item = Token>> Parser<I> {
         })
     }
 
-    fn parse_type_tag(&mut self) -> Result<TypeTag> {
+    fn parse_type_tag(&mut self, depth: u8) -> Result<TypeTag> {
+        if depth >= crate::safe_serialize::MAX_TYPE_TAG_NESTING {
+            bail!("Exceeded TypeTag nesting limit during parsing: {}", depth);
+        }
+
         Ok(match self.next()? {
             Token::U8Type => TypeTag::U8,
             Token::U16Type => TypeTag::U16,
@@ -280,7 +284,7 @@ impl<I: Iterator<Item = Token>> Parser<I> {
             Token::SignerType => TypeTag::Signer,
             Token::VectorType => {
                 self.consume(Token::Lt)?;
-                let ty = self.parse_type_tag()?;
+                let ty = self.parse_type_tag(depth + 1)?;
                 self.consume(Token::Gt)?;
                 TypeTag::Vector(Box::new(ty))
             }
@@ -294,7 +298,7 @@ impl<I: Iterator<Item = Token>> Parser<I> {
                                 let ty_args = if self.peek() == Some(&Token::Lt) {
                                     self.next()?;
                                     let ty_args = self.parse_comma_list(
-                                        |parser| parser.parse_type_tag(),
+                                        |parser| parser.parse_type_tag(depth + 1),
                                         Token::Gt,
                                         true,
                                     )?;
@@ -362,12 +366,12 @@ pub fn parse_string_list(s: &str) -> Result<Vec<String>> {
 
 pub fn parse_type_tags(s: &str) -> Result<Vec<TypeTag>> {
     parse(s, |parser| {
-        parser.parse_comma_list(|parser| parser.parse_type_tag(), Token::EOF, true)
+        parser.parse_comma_list(|parser| parser.parse_type_tag(0), Token::EOF, true)
     })
 }
 
 pub fn parse_type_tag(s: &str) -> Result<TypeTag> {
-    parse(s, |parser| parser.parse_type_tag())
+    parse(s, |parser| parser.parse_type_tag(0))
 }
 
 pub fn parse_transaction_arguments(s: &str) -> Result<Vec<TransactionArgument>> {
@@ -385,7 +389,7 @@ pub fn parse_transaction_argument(s: &str) -> Result<TransactionArgument> {
 }
 
 pub fn parse_struct_tag(s: &str) -> Result<StructTag> {
-    let type_tag = parse(s, |parser| parser.parse_type_tag())
+    let type_tag = parse(s, |parser| parser.parse_type_tag(0))
         .map_err(|e| format_err!("invalid struct tag: {}, {}", s, e))?;
     if let TypeTag::Struct(struct_tag) = type_tag {
         Ok(*struct_tag)
@@ -547,6 +551,7 @@ mod tests {
             "vector<vector<u128>>",
             "vector<u256>",
             "vector<vector<u256>>",
+            "vector<vector<vector<vector<vector<vector<vector<u64>>>>>>>",
             "signer",
             "0x1::M::S",
             "0x2::M::S_",
@@ -570,6 +575,14 @@ mod tests {
         ] {
             assert!(parse_type_tag(s).is_ok(), "Failed to parse tag {}", s);
         }
+
+        let s =
+            "vector<vector<vector<vector<vector<vector<vector<vector<vector<vector<u64>>>>>>>>>>";
+        assert!(
+            parse_type_tag(s).is_err(),
+            "Should have failed to parse type tag {}",
+            s
+        );
     }
 
     #[test]
@@ -602,6 +615,7 @@ mod tests {
             "0x1::Diem::Diem<u8 , bool  ,    vector<u8>,address,signer>",
             "0x1::Diem::Diem<vector<0x1::Diem::Struct<0x1::XUS::XUS>>>",
             "0x1::Diem::Diem<0x1::Diem::Struct<vector<0x1::XUS::XUS>, 0x1::Diem::Diem<vector<0x1::Diem::Struct<0x1::XUS::XUS>>>>>",
+            "0x1::Diem::Diem<vector<0x1::XDX::XDX<vector<vector<vector<0x1::XDX::XDX<vector<u64>>>>>>>>",
         ];
         for text in valid {
             let st = parse_struct_tag(text).expect("valid StructTag");
@@ -613,5 +627,12 @@ mod tests {
                 st
             );
         }
+
+        let s = "0x1::Diem::Diem<vector<0x1::XDX::XDX<vector<vector<vector<0x1::XDX::XDX<vector<vector<u64>>>>>>>>>";
+        assert!(
+            parse_struct_tag(s).is_err(),
+            "Should have failed to parse type tag {}",
+            s
+        );
     }
 }

--- a/language/move-core/types/src/safe_serialize.rs
+++ b/language/move-core/types/src/safe_serialize.rs
@@ -1,0 +1,69 @@
+// Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Custom serializers which track recursion nesting with a thread local,
+//! and otherwise delegate to the derived serializers.
+//!
+//! This is currently only implemented for type tags, but can be easily
+//! generalized, as the the only type-tag specific thing is the allowed nesting.
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::cell::RefCell;
+
+pub(crate) const MAX_TYPE_TAG_NESTING: u8 = 9;
+
+thread_local! {
+    static TYPE_TAG_DEPTH: RefCell<u8> = RefCell::new(0);
+}
+
+pub(crate) fn type_tag_recursive_serialize<S, T>(t: &T, s: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+    T: Serialize,
+{
+    use serde::ser::Error;
+
+    TYPE_TAG_DEPTH.with(|depth| {
+        let mut r = depth.borrow_mut();
+        if *r >= MAX_TYPE_TAG_NESTING {
+            // for testability, we allow one level more
+            return Err(S::Error::custom(
+                "type tag nesting exceeded during serialization",
+            ));
+        }
+        *r += 1;
+        Ok(())
+    })?;
+    let res = t.serialize(s);
+    TYPE_TAG_DEPTH.with(|depth| {
+        let mut r = depth.borrow_mut();
+        *r -= 1;
+    });
+    res
+}
+
+pub(crate) fn type_tag_recursive_deserialize<'de, D, T>(d: D) -> Result<T, D::Error>
+where
+    D: Deserializer<'de>,
+    T: Deserialize<'de>,
+{
+    use serde::de::Error;
+    TYPE_TAG_DEPTH.with(|depth| {
+        let mut r = depth.borrow_mut();
+        // For testability, we allow to serialize one more level than deserialize.
+        if *r >= MAX_TYPE_TAG_NESTING - 1 {
+            return Err(D::Error::custom(
+                "type tag nesting exceeded during deserialization",
+            ));
+        }
+        *r += 1;
+        Ok(())
+    })?;
+    let res = T::deserialize(d);
+    TYPE_TAG_DEPTH.with(|depth| {
+        let mut r = depth.borrow_mut();
+        *r -= 1;
+    });
+    res
+}

--- a/language/move-prover/tests/sources/functional/nonlinear_arithm.move
+++ b/language/move-prover/tests/sources/functional/nonlinear_arithm.move
@@ -94,7 +94,7 @@ module 0x42::TestNonlinearArithmetic {
     fun overflow_u64_mul_4(a: u64, b: u64, c: u64, d: u64): u64 {
         a * b * c * d
     }
-    spec overflow_u64_mul_4 {
+    spec overflow_u64_mul_4 { pragma verify = false; // Timeout
         aborts_if a * b > max_u64();
         aborts_if a * b * c > max_u64();
         aborts_if a * b * c * d > max_u64();


### PR DESCRIPTION
These were the only changes which did not make it into the main branch, so porting them over from the old `aptos` branch.