### PR TITLE
Cherry picks TypeTag bounds from old aptos branch (#791)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2819,9 +2819,9 @@ checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 
 [[package]]
 name = "memchr"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
+checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memoffset"

--- a/language/move-core/types/src/lib.rs
+++ b/language/move-core/types/src/lib.rs
@@ -17,6 +17,7 @@ pub mod parser;
 #[cfg(any(test, feature = "fuzzing"))]
 pub mod proptest_types;
 pub mod resolver;
+mod safe_serialize;
 pub mod transaction_argument;
 pub mod u256;
 #[cfg(test)]

--- a/language/move-core/types/src/parser.rs
+++ b/language/move-core/types/src/parser.rs
@@ -267,7 +267,11 @@ impl<I: Iterator<Item = Token>> Parser<I> {
         })
     }
 
-    fn parse_type_tag(&mut self) -> Result<TypeTag> {
+    fn parse_type_tag(&mut self, depth: u8) -> Result<TypeTag> {
+        if depth >= crate::safe_serialize::MAX_TYPE_TAG_NESTING {
+            bail!("Exceeded TypeTag nesting limit during parsing: {}", depth);
+        }
+
         Ok(match self.next()? {
             Token::U8Type => TypeTag::U8,
             Token::U16Type => TypeTag::U16,
@@ -280,7 +284,7 @@ impl<I: Iterator<Item = Token>> Parser<I> {
             Token::SignerType => TypeTag::Signer,
             Token::VectorType => {
                 self.consume(Token::Lt)?;
-                let ty = self.parse_type_tag()?;
+                let ty = self.parse_type_tag(depth + 1)?;
                 self.consume(Token::Gt)?;
                 TypeTag::Vector(Box::new(ty))
             }
@@ -294,7 +298,7 @@ impl<I: Iterator<Item = Token>> Parser<I> {
                                 let ty_args = if self.peek() == Some(&Token::Lt) {
                                     self.next()?;
                                     let ty_args = self.parse_comma_list(
-                                        |parser| parser.parse_type_tag(),
+                                        |parser| parser.parse_type_tag(depth + 1),
                                         Token::Gt,
                                         true,
                                     )?;
@@ -362,12 +366,12 @@ pub fn parse_string_list(s: &str) -> Result<Vec<String>> {
 
 pub fn parse_type_tags(s: &str) -> Result<Vec<TypeTag>> {
     parse(s, |parser| {
-        parser.parse_comma_list(|parser| parser.parse_type_tag(), Token::EOF, true)
+        parser.parse_comma_list(|parser| parser.parse_type_tag(0), Token::EOF, true)
     })
 }
 
 pub fn parse_type_tag(s: &str) -> Result<TypeTag> {
-    parse(s, |parser| parser.parse_type_tag())
+    parse(s, |parser| parser.parse_type_tag(0))
 }
 
 pub fn parse_transaction_arguments(s: &str) -> Result<Vec<TransactionArgument>> {
@@ -385,7 +389,7 @@ pub fn parse_transaction_argument(s: &str) -> Result<TransactionArgument> {
 }
 
 pub fn parse_struct_tag(s: &str) -> Result<StructTag> {
-    let type_tag = parse(s, |parser| parser.parse_type_tag())
+    let type_tag = parse(s, |parser| parser.parse_type_tag(0))
         .map_err(|e| format_err!("invalid struct tag: {}, {}", s, e))?;
     if let TypeTag::Struct(struct_tag) = type_tag {
         Ok(*struct_tag)
@@ -547,6 +551,7 @@ mod tests {
             "vector<vector<u128>>",
             "vector<u256>",
             "vector<vector<u256>>",
+            "vector<vector<vector<vector<vector<vector<vector<u64>>>>>>>",
             "signer",
             "0x1::M::S",
             "0x2::M::S_",
@@ -570,6 +575,14 @@ mod tests {
         ] {
             assert!(parse_type_tag(s).is_ok(), "Failed to parse tag {}", s);
         }
+
+        let s =
+            "vector<vector<vector<vector<vector<vector<vector<vector<vector<vector<u64>>>>>>>>>>";
+        assert!(
+            parse_type_tag(s).is_err(),
+            "Should have failed to parse type tag {}",
+            s
+        );
     }
 
     #[test]
@@ -602,6 +615,7 @@ mod tests {
             "0x1::Diem::Diem<u8 , bool  ,    vector<u8>,address,signer>",
             "0x1::Diem::Diem<vector<0x1::Diem::Struct<0x1::XUS::XUS>>>",
             "0x1::Diem::Diem<0x1::Diem::Struct<vector<0x1::XUS::XUS>, 0x1::Diem::Diem<vector<0x1::Diem::Struct<0x1::XUS::XUS>>>>>",
+            "0x1::Diem::Diem<vector<0x1::XDX::XDX<vector<vector<vector<0x1::XDX::XDX<vector<u64>>>>>>>>",
         ];
         for text in valid {
             let st = parse_struct_tag(text).expect("valid StructTag");
@@ -613,5 +627,12 @@ mod tests {
                 st
             );
         }
+
+        let s = "0x1::Diem::Diem<vector<0x1::XDX::XDX<vector<vector<vector<0x1::XDX::XDX<vector<vector<u64>>>>>>>>>";
+        assert!(
+            parse_struct_tag(s).is_err(),
+            "Should have failed to parse type tag {}",
+            s
+        );
     }
 }

--- a/language/move-core/types/src/safe_serialize.rs
+++ b/language/move-core/types/src/safe_serialize.rs
@@ -1,0 +1,69 @@
+// Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Custom serializers which track recursion nesting with a thread local,
+//! and otherwise delegate to the derived serializers.
+//!
+//! This is currently only implemented for type tags, but can be easily
+//! generalized, as the the only type-tag specific thing is the allowed nesting.
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::cell::RefCell;
+
+pub(crate) const MAX_TYPE_TAG_NESTING: u8 = 9;
+
+thread_local! {
+    static TYPE_TAG_DEPTH: RefCell<u8> = RefCell::new(0);
+}
+
+pub(crate) fn type_tag_recursive_serialize<S, T>(t: &T, s: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+    T: Serialize,
+{
+    use serde::ser::Error;
+
+    TYPE_TAG_DEPTH.with(|depth| {
+        let mut r = depth.borrow_mut();
+        if *r >= MAX_TYPE_TAG_NESTING {
+            // for testability, we allow one level more
+            return Err(S::Error::custom(
+                "type tag nesting exceeded during serialization",
+            ));
+        }
+        *r += 1;
+        Ok(())
+    })?;
+    let res = t.serialize(s);
+    TYPE_TAG_DEPTH.with(|depth| {
+        let mut r = depth.borrow_mut();
+        *r -= 1;
+    });
+    res
+}
+
+pub(crate) fn type_tag_recursive_deserialize<'de, D, T>(d: D) -> Result<T, D::Error>
+where
+    D: Deserializer<'de>,
+    T: Deserialize<'de>,
+{
+    use serde::de::Error;
+    TYPE_TAG_DEPTH.with(|depth| {
+        let mut r = depth.borrow_mut();
+        // For testability, we allow to serialize one more level than deserialize.
+        if *r >= MAX_TYPE_TAG_NESTING - 1 {
+            return Err(D::Error::custom(
+                "type tag nesting exceeded during deserialization",
+            ));
+        }
+        *r += 1;
+        Ok(())
+    })?;
+    let res = T::deserialize(d);
+    TYPE_TAG_DEPTH.with(|depth| {
+        let mut r = depth.borrow_mut();
+        *r -= 1;
+    });
+    res
+}

--- a/language/move-prover/tests/sources/functional/nonlinear_arithm.move
+++ b/language/move-prover/tests/sources/functional/nonlinear_arithm.move
@@ -94,7 +94,7 @@ module 0x42::TestNonlinearArithmetic {
     fun overflow_u64_mul_4(a: u64, b: u64, c: u64, d: u64): u64 {
         a * b * c * d
     }
-    spec overflow_u64_mul_4 {
+    spec overflow_u64_mul_4 { pragma verify = false; // Timeout
         aborts_if a * b > max_u64();
         aborts_if a * b * c > max_u64();
         aborts_if a * b * c * d > max_u64();
@@ -154,7 +154,7 @@ module 0x42::TestNonlinearArithmetic {
     fun overflow_u64_mul_5(a: u64, b: u64, c: u64, d: u64, e: u64): u64 {
         a * b * c * d * e
     }
-    spec overflow_u64_mul_5 {
+    spec overflow_u64_mul_5 { pragma verify = false; // TIMEOUT
         aborts_if a * b > max_u64();
         aborts_if a * b * c > max_u64();
         aborts_if a * b * c * d > max_u64();


### PR DESCRIPTION
* [types] make type tag nesting limited

There's limited value and a lot of wasted resources by leaving this limited to serde's limits. Recursion is dangerous.

* [types] limit nesting of types via state (#532)

Cherry picked from #529.

This is an alternative version of what #528 and the previous for limitation of nesting provides, having a significant lower footprint.

This approach installs custom serializers at the recursion points of the `TypeTag` enum. Those serializer use a thread local to track the nesting of the type tag, both for serialization and deserialization.

The usage of a thread local is safe and a common technique to provide extra state for implementations which miss it (e.g. serde). A given thread has a single execution stack and this will always count the depth counter consistently up and down. Because Rust has no exceptions are other exit points, this cannot be corrupted. Possibly, thread locals may cause inefficiency. However, we expect TypeTags to be small (a few constructors, limited nestings).

The technique used for type tags can be generalized for any other recursive type if needed. Eventually, we hope serde will support per-type nesting, and possibly we should talk with the author if we can add it ourselves.

This uses and passes the tests from #528.

* [types] limit parsing of nested TypeTag

There's limited value and a lot of wasted resources by leaving this limited to serde's limits. Recursion is dangerous.

Co-authored-by: David Wolinsky <isaac.wolinsky@gmail.com>

