### PR TITLE
[bytecode verifier] Simplify reference safety abstract state

### DIFF
--- a/language/move-bytecode-verifier/src/reference_safety/abstract_state.rs
+++ b/language/move-bytecode-verifier/src/reference_safety/abstract_state.rs
@@ -73,9 +73,8 @@ impl std::fmt::Display for Label {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct AbstractState {
     current_function: Option<FunctionDefinitionIndex>,
-    locals: BTreeMap<LocalIndex, AbstractValue>,
+    locals: Vec<AbstractValue>,
     borrow_graph: BorrowGraph,
-    num_locals: usize,
     next_id: usize,
 }
 
@@ -88,23 +87,19 @@ impl AbstractState {
         let next_id = num_locals + 1;
         let mut state = AbstractState {
             current_function: function_view.index(),
-            locals: BTreeMap::new(),
+            locals: vec![AbstractValue::NonReference; num_locals],
             borrow_graph: BorrowGraph::new(),
-            num_locals,
             next_id,
         };
 
         for (param_idx, param_ty) in function_view.parameters().0.iter().enumerate() {
-            let value = if param_ty.is_reference() {
+            if param_ty.is_reference() {
                 let id = RefID::new(param_idx);
                 state
                     .borrow_graph
                     .new_ref(id, param_ty.is_mutable_reference());
-                AbstractValue::Reference(id)
-            } else {
-                AbstractValue::NonReference
-            };
-            state.locals.insert(param_idx as LocalIndex, value);
+                state.locals[param_idx] = AbstractValue::Reference(id)
+            }
         }
         state.borrow_graph.new_ref(state.frame_root(), true);
 
@@ -114,7 +109,7 @@ impl AbstractState {
 
     /// returns the frame root id
     fn frame_root(&self) -> RefID {
-        RefID::new(self.num_locals)
+        RefID::new(self.locals.len())
     }
 
     fn error(&self, status: StatusCode, offset: CodeOffset) -> PartialVMError {
@@ -285,7 +280,7 @@ impl AbstractState {
         offset: CodeOffset,
         local: LocalIndex,
     ) -> PartialVMResult<AbstractValue> {
-        match safe_unwrap!(self.locals.get(&local)) {
+        match safe_unwrap!(self.locals.get(local as usize)) {
             AbstractValue::Reference(id) => {
                 let id = *id;
                 let new_id = self.new_ref(self.borrow_graph.is_mutable(id));
@@ -304,7 +299,11 @@ impl AbstractState {
         offset: CodeOffset,
         local: LocalIndex,
     ) -> PartialVMResult<AbstractValue> {
-        match safe_unwrap!(self.locals.remove(&local)) {
+        let value = std::mem::replace(
+            safe_unwrap!(self.locals.get_mut(local as usize)),
+            AbstractValue::NonReference,
+        );
+        match value {
             AbstractValue::Reference(id) => Ok(AbstractValue::Reference(id)),
             AbstractValue::NonReference if self.is_local_borrowed(local) => {
                 Err(self.error(StatusCode::MOVELOC_EXISTS_BORROW_ERROR, offset))
@@ -319,17 +318,17 @@ impl AbstractState {
         local: LocalIndex,
         new_value: AbstractValue,
     ) -> PartialVMResult<()> {
-        let old_value = self.locals.insert(local, new_value);
+        let old_value =
+            std::mem::replace(safe_unwrap!(self.locals.get_mut(local as usize)), new_value);
         match old_value {
-            None => Ok(()),
-            Some(AbstractValue::Reference(id)) => {
+            AbstractValue::Reference(id) => {
                 self.release(id);
                 Ok(())
             }
-            Some(AbstractValue::NonReference) if self.is_local_borrowed(local) => {
+            AbstractValue::NonReference if self.is_local_borrowed(local) => {
                 Err(self.error(StatusCode::STLOC_UNSAFE_TO_DESTROY_ERROR, offset))
             }
-            Some(AbstractValue::NonReference) => Ok(()),
+            AbstractValue::NonReference => Ok(()),
         }
     }
 
@@ -553,7 +552,7 @@ impl AbstractState {
     pub fn ret(&mut self, offset: CodeOffset, values: Vec<AbstractValue>) -> PartialVMResult<()> {
         // release all local variables
         let mut released = BTreeSet::new();
-        for (_local, stored_value) in self.locals.iter() {
+        for stored_value in self.locals.iter() {
             if let AbstractValue::Reference(id) = stored_value {
                 released.insert(*id);
             }
@@ -588,18 +587,19 @@ impl AbstractState {
         let locals = self
             .locals
             .iter()
+            .enumerate()
             .map(|(local, value)| {
                 let new_value = match value {
                     AbstractValue::Reference(old_id) => {
-                        let new_id = RefID::new(*local as usize);
+                        let new_id = RefID::new(local);
                         id_map.insert(*old_id, new_id);
                         AbstractValue::Reference(new_id)
                     }
                     AbstractValue::NonReference => AbstractValue::NonReference,
                 };
-                (*local, new_value)
+                new_value
             })
-            .collect::<BTreeMap<_, _>>();
+            .collect::<Vec<_>>();
         assert!(self.locals.len() == locals.len());
         let mut borrow_graph = self.borrow_graph.clone();
         borrow_graph.remap_refs(&id_map);
@@ -607,8 +607,7 @@ impl AbstractState {
             locals,
             borrow_graph,
             current_function: self.current_function,
-            num_locals: self.num_locals,
-            next_id: self.num_locals + 1,
+            next_id: self.locals.len() + 1,
         };
         assert!(canonical_state.is_canonical());
         canonical_state
@@ -619,66 +618,53 @@ impl AbstractState {
     }
 
     fn is_canonical(&self) -> bool {
-        self.num_locals + 1 == self.next_id
-            && self.locals.iter().all(|(local, value)| {
+        self.locals.len() + 1 == self.next_id
+            && self.locals.iter().enumerate().all(|(local, value)| {
                 value
                     .ref_id()
-                    .map(|id| RefID::new(*local as usize) == id)
+                    .map(|id| RefID::new(local) == id)
                     .unwrap_or(true)
             })
-    }
-
-    fn iter_locals(&self) -> impl Iterator<Item = LocalIndex> {
-        0..self.num_locals as LocalIndex
     }
 
     pub fn join_(&self, other: &Self) -> Self {
         assert!(self.current_function == other.current_function);
         assert!(self.is_canonical() && other.is_canonical());
         assert!(self.next_id == other.next_id);
-        assert!(self.num_locals == other.num_locals);
-        let mut locals = BTreeMap::new();
+        assert!(self.locals.len() == other.locals.len());
         let mut self_graph = self.borrow_graph.clone();
         let mut other_graph = other.borrow_graph.clone();
-        for local in self.iter_locals() {
-            let self_value = self.locals.get(&local);
-            let other_value = other.locals.get(&local);
-            match (self_value, other_value) {
-                // Unavailable on both sides, nothing to add
-                (None, None) => (),
-
-                (Some(v), None) => {
-                    // A reference exists on one side, but not the other. Release
-                    if let AbstractValue::Reference(id) = v {
+        let locals = self
+            .locals
+            .iter()
+            .zip(&other.locals)
+            .map(|(self_value, other_value)| {
+                match (self_value, other_value) {
+                    (AbstractValue::Reference(id), AbstractValue::NonReference) => {
                         self_graph.release(*id);
+                        AbstractValue::NonReference
                     }
-                }
-                (None, Some(v)) => {
-                    // A reference exists on one side, but not the other. Release
-                    if let AbstractValue::Reference(id) = v {
+                    (AbstractValue::NonReference, AbstractValue::Reference(id)) => {
                         other_graph.release(*id);
+                        AbstractValue::NonReference
+                    }
+                    // The local has a value on each side, add it to the state
+                    (v1, v2) => {
+                        assert!(v1 == v2);
+                        *v1
                     }
                 }
-
-                // The local has a value on each side, add it to the state
-                (Some(v1), Some(v2)) => {
-                    assert!(v1 == v2);
-                    assert!(!locals.contains_key(&local));
-                    locals.insert(local, *v1);
-                }
-            }
-        }
+            })
+            .collect();
 
         let borrow_graph = self_graph.join(&other_graph);
         let current_function = self.current_function;
         let next_id = self.next_id;
-        let num_locals = self.num_locals;
 
         Self {
             current_function,
             locals,
             borrow_graph,
-            num_locals,
             next_id,
         }
     }
@@ -689,10 +675,12 @@ impl AbstractDomain for AbstractState {
     fn join(&mut self, state: &AbstractState) -> JoinResult {
         let joined = Self::join_(self, state);
         assert!(joined.is_canonical());
-        assert!(self.num_locals == joined.num_locals);
+        assert!(self.locals.len() == joined.locals.len());
         let locals_unchanged = self
-            .iter_locals()
-            .all(|idx| self.locals.get(&idx) == joined.locals.get(&idx));
+            .locals
+            .iter()
+            .zip(&joined.locals)
+            .all(|(self_value, joined_value)| self_value == joined_value);
         let borrow_graph_unchanged = self.borrow_graph.leq(&joined.borrow_graph);
         if locals_unchanged && borrow_graph_unchanged {
             JoinResult::Unchanged

--- a/language/move-bytecode-verifier/transactional-tests/tests/reference_safety/borrow_in_loop.exp
+++ b/language/move-bytecode-verifier/transactional-tests/tests/reference_safety/borrow_in_loop.exp
@@ -1,0 +1,1 @@
+processed 1 task

--- a/language/move-bytecode-verifier/transactional-tests/tests/reference_safety/borrow_in_loop.mvir
+++ b/language/move-bytecode-verifier/transactional-tests/tests/reference_safety/borrow_in_loop.mvir
@@ -1,0 +1,12 @@
+
+//# publish
+module 0x42.m {
+foo() {
+    let x: u64;
+    let r: &u64;
+    label l0:
+    x = 0;
+    r = &x;
+    jump l0;
+}
+}

--- a/language/move-vm/transactional-tests/tests/references/borrow_in_loop.exp
+++ b/language/move-vm/transactional-tests/tests/references/borrow_in_loop.exp
@@ -1,0 +1,28 @@
+processed 3 tasks
+
+task 0 'publish'. lines 1-23:
+Error: Unable to publish module '00000000000000000000000000000042::m'. Got VMError: {
+    major_status: STLOC_UNSAFE_TO_DESTROY_ERROR,
+    sub_status: None,
+    location: 0x42::m,
+    indices: [(FunctionDefinition, 0)],
+    offsets: [(FunctionDefinitionIndex(0), 11)],
+}
+
+task 1 'run'. lines 25-25:
+Error: Function execution failed with VMError: {
+    major_status: LINKER_ERROR,
+    sub_status: None,
+    location: undefined,
+    indices: [],
+    offsets: [],
+}
+
+task 2 'run'. lines 27-41:
+Error: Script execution failed with VMError: {
+    major_status: STLOC_UNSAFE_TO_DESTROY_ERROR,
+    sub_status: None,
+    location: script,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 5)],
+}

--- a/language/move-vm/transactional-tests/tests/references/borrow_in_loop.mvir
+++ b/language/move-vm/transactional-tests/tests/references/borrow_in_loop.mvir
@@ -1,0 +1,41 @@
+//# publish
+module 0x42.m {
+
+struct S has copy, drop { f: u64 }
+public foo() {
+    let x: Self.S;
+    let y: Self.S;
+    let z: u64;
+    let r: &Self.S;
+    let f: &u64;
+    label l0:
+        x = S { f: 0 };
+        z = 0;
+        r = &x;
+        f = &z;
+    label l1:
+        y = S { f: 1 };
+        _ = *copy(r);
+        r = &y;
+        f = &copy(r).S::f;
+        jump l1;
+}
+}
+
+//# run 0x42::m::foo --gas-budget 100000
+
+//# run --gas-budget 100000
+main() {
+    let x: u64;
+    let y: u64;
+    let z: u64;
+    let r: &u64;
+    label l0:
+        x = 0;
+        r = &x;
+    label l1:
+        y = 0;
+        z = *copy(r);
+        r = &y;
+        jump l1;
+}

--- a/language/move-vm/transactional-tests/tests/references/borrow_in_loop_source.exp
+++ b/language/move-vm/transactional-tests/tests/references/borrow_in_loop_source.exp
@@ -1,0 +1,22 @@
+processed 2 tasks
+
+task 0 'publish'. lines 1-18:
+Error: error[E07003]: invalid operation, could create dangling a reference
+   ┌─ /var/folders/zf/5yndrchx2_7df8p5yfnkpv8r0000gn/T/.tmpMwynew:11:9
+   │
+11 │         y = S { f: 1 };
+   │         ^ Invalid assignment of variable 'y'
+12 │         assert!(r.f == *f, 0);
+13 │         r = &y;
+   │             -- It is still being borrowed by this reference
+
+
+
+task 1 'run'. lines 20-20:
+Error: Function execution failed with VMError: {
+    major_status: LINKER_ERROR,
+    sub_status: None,
+    location: undefined,
+    indices: [],
+    offsets: [],
+}

--- a/language/move-vm/transactional-tests/tests/references/borrow_in_loop_source.move
+++ b/language/move-vm/transactional-tests/tests/references/borrow_in_loop_source.move
@@ -1,0 +1,20 @@
+//# publish
+module 0x42::m {
+
+struct S has copy, drop { f: u64 }
+public fun foo() {
+    let x = S { f: 0 };
+    let z = 0;
+    let r = &x;
+    let f = &z;
+    let y;
+    loop {
+        y = S { f: 1 };
+        assert!(r.f == *f, 0);
+        r = &y;
+        f = &r.f;
+    }
+}
+}
+
+//# run 0x42::m::foo --gas-budget 100000


### PR DESCRIPTION
- Simplify reference safety checks abstract state to no longer rely on local safety.

## Motivation

- Code remains largely the same, just simplifies the abstract state to use a fully populated vector for the locals instead of a btree map
