### PR TITLE
[inlining] Fixing bugs and adding first combinators to stdlib

### DIFF
--- a/language/move-compiler/src/command_line/compiler.rs
+++ b/language/move-compiler/src/command_line/compiler.rs
@@ -798,7 +798,7 @@ fn run(
         }
         PassResult::Typing(mut tprog) => {
             inlining::translate::run_inlining(compilation_env, &mut tprog);
-            compilation_env.check_diags_at_or_above_severity(Severity::Bug)?;
+            compilation_env.check_diags_at_or_above_severity(Severity::BlockingError)?;
             run(
                 compilation_env,
                 pre_compiled_lib,

--- a/language/move-compiler/src/diagnostics/codes.rs
+++ b/language/move-compiler/src/diagnostics/codes.rs
@@ -243,7 +243,8 @@ codes!(
     ],
     // errors for inlining
     Inlining: [
-        Recursion: { msg: "recursion during function inlining not allowed", severity: NonblockingError },
+        Recursion: { msg: "recursion during function inlining not allowed", severity: BlockingError },
+        InvalidBorrow: { msg: "inlined parameter cannot be borrowed", severity: BlockingError },
     ],
 );
 

--- a/language/move-compiler/src/expansion/translate.rs
+++ b/language/move-compiler/src/expansion/translate.rs
@@ -440,7 +440,7 @@ fn module_(
             P::ModuleMember::Use(_) => unreachable!(),
             P::ModuleMember::Friend(f) => friend(context, &mut friends, f),
             P::ModuleMember::Function(mut f) => {
-                if !context.is_source_definition {
+                if !context.is_source_definition && !f.inline {
                     f.body.value = P::FunctionBody_::Native
                 }
                 function(context, &mut functions, f)

--- a/language/move-compiler/src/typing/core.rs
+++ b/language/move-compiler/src/typing/core.rs
@@ -972,7 +972,6 @@ pub fn ability_not_satisified_tips<'a>(
         // Type has the ability but a type argument causes it to fail
         (_, true) => {
             let requirement = constraint.requires();
-            let mut label_added = false;
             for (ty_arg, ty_arg_abilities) in ty_args {
                 if !ty_arg_abilities.has_ability_(requirement) {
                     let ty_arg_str = error_format(ty_arg, subst);
@@ -985,11 +984,9 @@ pub fn ability_not_satisified_tips<'a>(
                         requirement = requirement,
                     );
                     diag.add_secondary_label((ty_arg.loc, msg));
-                    label_added = true;
                     break;
                 }
             }
-            assert!(label_added)
         }
     }
 }

--- a/language/move-compiler/tests/move_check/inlining/parameter_borrow.exp
+++ b/language/move-compiler/tests/move_check/inlining/parameter_borrow.exp
@@ -1,0 +1,9 @@
+error[E14002]: inlined parameter cannot be borrowed
+   ┌─ tests/move_check/inlining/parameter_borrow.move:13:9
+   │
+ 4 │         let _x = &t;
+   │                   - expression passed to a borrowed parameter
+   ·
+13 │         borrows(vector[1,2,3])
+   │         ^^^^^^^^^^^^^^^^^^^^^^ cannot inline `borrows`
+

--- a/language/move-compiler/tests/move_check/inlining/parameter_borrow.move
+++ b/language/move-compiler/tests/move_check/inlining/parameter_borrow.move
@@ -1,0 +1,15 @@
+module 0x42::Test {
+
+    public inline fun borrows(t: vector<u64>) {
+        let _x = &t;
+    }
+
+    public fun correct_usage() {
+        let v = vector[1,2,3];
+        borrows(v)
+    }
+
+    public fun incorrect_usage() {
+        borrows(vector[1,2,3])
+    }
+}

--- a/language/move-compiler/tests/move_check/inlining/recursion.exp
+++ b/language/move-compiler/tests/move_check/inlining/recursion.exp
@@ -1,6 +1,6 @@
 error[E14001]: recursion during function inlining not allowed
-   ┌─ tests/move_check/inlining/recursion.move:13:9
+   ┌─ tests/move_check/inlining/recursion.move:12:9
    │
-13 │         f()
+12 │         f()
    │         ^ cyclic inlining:  -> h -> g -> f
 

--- a/language/move-compiler/tests/move_check/inlining/recursion.move
+++ b/language/move-compiler/tests/move_check/inlining/recursion.move
@@ -1,4 +1,3 @@
-//# publish
 module 0x42::Test {
 
     public inline fun f(): u64 {
@@ -17,5 +16,3 @@ module 0x42::Test {
         f()
     }
 }
-
-//# run 0x42::Test::test

--- a/language/move-compiler/transactional-tests/tests/inlining/options.exp
+++ b/language/move-compiler/transactional-tests/tests/inlining/options.exp
@@ -1,0 +1,4 @@
+processed 3 tasks
+
+task 2 'run'. lines 26-26:
+return values: 2

--- a/language/move-compiler/transactional-tests/tests/inlining/options.move
+++ b/language/move-compiler/transactional-tests/tests/inlining/options.move
@@ -1,0 +1,26 @@
+//# publish
+module 0x42::map_opt {
+    use std::option;
+    /// Maps the content of an option
+    public inline fun map<Element, OtherElement>(t: option::Option<Element>, f: |Element|OtherElement): option::Option<OtherElement> {
+        if (option::is_some(&t)) {
+            option::some(f(option::extract(&mut t)))
+        } else {
+            option::none()
+        }
+    }
+
+}
+//# publish
+module 0x42::Test {
+    use std::option;
+    use 0x42::map_opt;
+
+    public fun test(): u64 {
+        let t = option::some(1);
+        let x = map_opt::map(t, |e| e + 1);
+        option::extract(&mut x)
+    }
+}
+
+//# run 0x42::Test::test

--- a/language/move-model/src/builder/module_builder.rs
+++ b/language/move-model/src/builder/module_builder.rs
@@ -743,7 +743,11 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
 
         // Analyze in-function spec blocks.
         for (name, fun_def) in module_def.functions.key_cloned_iter() {
-            let fun_spec_info = &function_infos.get(&name).unwrap().spec_info;
+            let fun_spec_info = if let Some(info) = &function_infos.get(&name) {
+                &info.spec_info
+            } else {
+                continue;
+            };
             let qsym = self.qualified_by_module_from_name(&name.0);
             for (spec_id, spec_block) in fun_def.specs.iter() {
                 for member in &spec_block.value.members {

--- a/language/move-stdlib/sources/option.move
+++ b/language/move-stdlib/sources/option.move
@@ -148,6 +148,27 @@ module std::option {
         ensures is_none(t);
     }
 
+    /// Maps the content of an option
+    public inline fun map<Element, OtherElement>(t: Option<Element>, f: |Element|OtherElement): Option<OtherElement> {
+        let l = t; // Ensure inlined parameter has a location
+        if (is_some(&l)) {
+            some(f(destroy_some(l)))
+        } else {
+            destroy_none(l);
+            none()
+        }
+    }
+
+    /// Filters the content of an option
+    public inline fun filter<Element:drop>(t: Option<Element>, f: |&Element|bool): Option<Element> {
+        let l = t; // Ensure inlined parameter has a location
+        if (is_some(&l) && f(borrow(&l))) {
+            l
+        } else {
+            none()
+        }
+    }
+
     /// Return a mutable reference to the value inside `t`
     /// Aborts if `t` does not hold a value
     public fun borrow_mut<Element>(t: &mut Option<Element>): &mut Element {

--- a/language/move-stdlib/sources/string.move
+++ b/language/move-stdlib/sources/string.move
@@ -85,7 +85,6 @@ module std::string {
         internal_index_of(&s.bytes, &r.bytes)
     }
 
-
     // Native API
     native fun internal_check_utf8(v: &vector<u8>): bool;
     native fun internal_is_char_boundary(v: &vector<u8>, i: u64): bool;

--- a/language/move-stdlib/tests/option_tests.move
+++ b/language/move-stdlib/tests/option_tests.move
@@ -167,4 +167,17 @@ module std::option_tests {
         let v: vector<u64> = option::to_vec(option::none());
         assert!(vector::is_empty(&v), 0);
     }
+
+    #[test]
+    fun map_some() {
+        let x = option::map(option::some(1), |e| e + 1);
+        assert!(option::extract(&mut x) == 2, 0);
+    }
+
+
+    #[test]
+    fun filter_some() {
+        let x = option::filter(option::some(1), |e| *e != 1);
+        assert!(option::is_none(&x), 0);
+    }
 }


### PR DESCRIPTION
This adds `map` and `filter` to `std::option` and make them work e2e, including unit tests in `option_tests`. At this point, we do have inlined functions working across modules and packages.

The PR also explores some conceptual questions around parameter expansion. Right now, we stick to the original simplistic viewpoint that all parameters are replaced directly by the according expression. This effectively implements 'call by expression'. It would be the responsibility (and flexibility!) of the function implementer to use `let` and similar measures to avoid duplicate evaluation of inlined parameters. This also creates a restriction: if somewhere in the code a parameter `p` is used in l-value position than also the passed parameter must be an lvalue. There is a new error message if this is not the case in `parameter_borrow.move`. An implementer can work around this restriction by avoiding `&param`, as done in the new combinators for options.

