### PR TITLE
[inlining] Adding combinators to vector + fixing bugs

### DIFF
--- a/language/move-compiler/src/diagnostics/codes.rs
+++ b/language/move-compiler/src/diagnostics/codes.rs
@@ -244,7 +244,7 @@ codes!(
     // errors for inlining
     Inlining: [
         Recursion: { msg: "recursion during function inlining not allowed", severity: BlockingError },
-        InvalidBorrow: { msg: "inlined parameter cannot be borrowed", severity: BlockingError },
+        InvalidLValue: { msg: "inlined parameter cannot be l-value", severity: BlockingError },
     ],
 );
 

--- a/language/move-compiler/src/parser/ast.rs
+++ b/language/move-compiler/src/parser/ast.rs
@@ -593,7 +593,7 @@ pub enum Exp_ {
 
     // { seq }
     Block(Sequence),
-    // fun (x1, ..., xn) e
+    // |x1, ..., xn| e
     Lambda(BindList, Box<Exp>), // spec only
     // forall/exists x1 : e1, ..., xn [{ t1, .., tk } *] [where cond]: en.
     Quant(

--- a/language/move-compiler/tests/move_check/inlining/parameter_assign.exp
+++ b/language/move-compiler/tests/move_check/inlining/parameter_assign.exp
@@ -1,0 +1,9 @@
+error[E14002]: inlined parameter cannot be l-value
+   ┌─ tests/move_check/inlining/parameter_assign.move:13:16
+   │
+ 4 │         t = vector[1,2,3];
+   │         - inlined parameter appearing in lvalue position
+   ·
+13 │         assign(vector[1,2,3])
+   │                ^^^^^^^^^^^^^ cannot inline `assign`: expression is not an lvalue
+

--- a/language/move-compiler/tests/move_check/inlining/parameter_assign.move
+++ b/language/move-compiler/tests/move_check/inlining/parameter_assign.move
@@ -1,0 +1,15 @@
+module 0x42::Test {
+
+    public inline fun assign(t: vector<u64>) {
+        t = vector[1,2,3];
+    }
+
+    public fun correct_usage() {
+        let v = vector[];
+        assign(v)
+    }
+
+    public fun incorrect_usage() {
+        assign(vector[1,2,3])
+    }
+}

--- a/language/move-compiler/tests/move_check/inlining/parameter_borrow.exp
+++ b/language/move-compiler/tests/move_check/inlining/parameter_borrow.exp
@@ -1,9 +1,9 @@
-error[E14002]: inlined parameter cannot be borrowed
-   ┌─ tests/move_check/inlining/parameter_borrow.move:13:9
+error[E14002]: inlined parameter cannot be l-value
+   ┌─ tests/move_check/inlining/parameter_borrow.move:13:17
    │
  4 │         let _x = &t;
-   │                   - expression passed to a borrowed parameter
+   │                   - inlined parameter appearing in lvalue position
    ·
 13 │         borrows(vector[1,2,3])
-   │         ^^^^^^^^^^^^^^^^^^^^^^ cannot inline `borrows`
+   │                 ^^^^^^^^^^^^^ cannot inline `borrows`: expression is not an lvalue
 

--- a/language/move-stdlib/sources/option.move
+++ b/language/move-stdlib/sources/option.move
@@ -169,6 +169,14 @@ module std::option {
         }
     }
 
+    /// Updates the content of an option if it is set.
+    public inline fun update<Element>(t: &mut Option<Element>, f: |&mut Element|) {
+        let l = t;
+        if (is_some(l)) {
+            f(borrow_mut(l))
+        }
+    }
+
     /// Return a mutable reference to the value inside `t`
     /// Aborts if `t` does not hold a value
     public fun borrow_mut<Element>(t: &mut Option<Element>): &mut Element {

--- a/language/move-stdlib/sources/vector.move
+++ b/language/move-stdlib/sources/vector.move
@@ -159,6 +159,67 @@ module std::vector {
         pragma intrinsic = true;
     }
 
+    /// Apply the function to each element in the vector, consuming it.
+    public inline fun foreach<Element>(v: vector<Element>, f: |Element|) {
+        reverse(&mut v); // We need to reverse the vector to consume it efficiently
+        while (!is_empty(&v)) {
+            let e = pop_back(&mut v);
+            f(e);
+        };
+    }
+
+    /// Apply the function to a reference of each element in the vector.
+    public inline fun foreach_ref<Element>(v: &vector<Element>, f: |&Element|) {
+        let i = 0;
+        while (i < length(v)) {
+            f(borrow(v, i));
+            i = i + 1
+        }
+    }
+
+    /// Apply the function to a mutable reference to each element in the vector.
+    public inline fun foreach_mut<Element>(v: &mut vector<Element>, f: |&mut Element|) {
+        let i = 0;
+        while (i < length(v)) {
+            f(borrow_mut(v, i));
+            i = i + 1
+        }
+    }
+
+    /// Fold the function over the elements. For example, `fold(vector[1,2,3], 0, f)` will execute
+    /// `f(f(f(0, 1), 2), 3)`
+    public inline fun fold<Accumulator, Element>(
+        v: vector<Element>,
+        init: Accumulator,
+        f: |Accumulator,Element|Accumulator
+    ): Accumulator {
+        let accu = init;
+        foreach(v, |elem| accu = f(accu, elem));
+        accu
+    }
+
+    /// Map the function over the elements of the vector, producing a new vector.
+    public inline fun map<Element, NewElement>(
+        v: vector<Element>,
+        f: |Element|NewElement
+    ): vector<NewElement> {
+        let result = vector<NewElement>[];
+        foreach(v, |elem| push_back(&mut result, f(elem)));
+        result
+    }
+
+    /// Filter the vector using the boolean function, removing all elements for which `p(e)` is not true.
+    public inline fun filter<Element:drop>(
+        v: vector<Element>,
+        p: |&Element|bool
+    ): vector<Element> {
+        let result = vector<Element>[];
+        foreach(v, |elem| {
+            if (p(&elem)) push_back(&mut result, elem);
+        });
+        result
+    }
+
     // =================================================================
     // Module Specification
 

--- a/language/move-stdlib/tests/option_tests.move
+++ b/language/move-stdlib/tests/option_tests.move
@@ -180,4 +180,12 @@ module std::option_tests {
         let x = option::filter(option::some(1), |e| *e != 1);
         assert!(option::is_none(&x), 0);
     }
+
+    #[test]
+    fun update_some() {
+        let x = option::some(1);
+        // TODO: avoid the let below (https://github.com/move-language/move/issues/806)
+        option::update(&mut x, |e| { let e : &mut u64 = e; *e = *e + 1 });
+        assert!(option::extract(&mut x) == 2, 0);
+    }
 }

--- a/language/move-stdlib/tests/vector_tests.move
+++ b/language/move-stdlib/tests/vector_tests.move
@@ -503,4 +503,49 @@ module std::vector_tests {
             NotDroppable {}
         );
     }
+
+    #[test]
+    fun test_foreach() {
+        let v = vector[1, 2, 3];
+        let s = 0;
+        V::foreach(v, |e| s = s + e);
+        assert!(s == 6, 0)
+    }
+
+    #[test]
+    fun test_foreach_ref() {
+        let v = vector[1, 2, 3];
+        let s = 0;
+        V::foreach_ref(&v, |e| s = s + *e);
+        assert!(s == 6, 0)
+    }
+
+    #[test]
+    fun test_foreach_mut() {
+        let v = vector[1, 2, 3];
+        let s = 2;
+        V::foreach_mut(&mut v, |e| { *e = s; s = s + 1 });
+        assert!(v == vector[2, 3, 4], 0)
+    }
+
+    #[test]
+    fun test_fold() {
+        let v = vector[1, 2, 3];
+        let s = V::fold(v, 0, |r, e| r + e);
+        assert!(s == 6 , 0)
+    }
+
+    #[test]
+    fun test_map() {
+        let v = vector[1, 2, 3];
+        let s = V::map(v, |x| x + 1);
+        assert!(s == vector[2, 3, 4] , 0)
+    }
+
+    #[test]
+    fun test_filter() {
+        let v = vector[1, 2, 3];
+        let s = V::filter(v, |x| *x % 2 == 0);
+        assert!(s == vector[2] , 0)
+    }
 }


### PR DESCRIPTION
This fixes a few more bugs in inlining discovered while adding foreach/fold/map/filter to `vector.move`. With this, test coverage of this feature should be fairly complete. The new vector (and option) functions will go into an AIP.

