### PR TITLE
[move-prover] check data invariants for a &mut param ...

### DIFF
--- a/language/move-prover/bytecode/tests/data_invariant_instrumentation/params.exp
+++ b/language/move-prover/bytecode/tests/data_invariant_instrumentation/params.exp
@@ -14,6 +14,12 @@ public fun Test::test_param($t0|_simple_R: Test::R, $t1|_ref_R: Test::R, $t2|_si
   2: assume And(WellFormed($t2), Gt(select Test::S.y($t2), 0))
   3: assume And(WellFormed($t3), And(Gt(select Test::R.x($t3), select Test::S.y(select Test::R.s($t3))), Gt(select Test::S.y(select Test::R.s($t3)), 0)))
   4: trace_local[_mut_R]($t3)
-  5: label L1
-  6: return ()
+     # data invariant at tests/data_invariant_instrumentation/params.move:12:9+18
+     # VC: data invariant does not hold at tests/data_invariant_instrumentation/params.move:12:9+18
+  5: assert Gt(select Test::R.x($t3), select Test::S.y(select Test::R.s($t3)))
+     # data invariant at tests/data_invariant_instrumentation/params.move:16:9+16
+     # VC: data invariant does not hold at tests/data_invariant_instrumentation/params.move:16:9+16
+  6: assert Gt(select Test::S.y(select Test::R.s($t3)), 0)
+  7: label L1
+  8: return ()
 }

--- a/language/move-prover/tests/sources/functional/data_invariant_for_mut_ref_arg.exp
+++ b/language/move-prover/tests/sources/functional/data_invariant_for_mut_ref_arg.exp
@@ -9,6 +9,8 @@ error: data invariant does not hold
   =         s = <redacted>
   =     at tests/sources/functional/data_invariant_for_mut_ref_arg.move:17: push_1
   =     at tests/sources/functional/data_invariant_for_mut_ref_arg.move:19: push_1
+  =         s = <redacted>
+  =         s = <redacted>
   =     at tests/sources/functional/data_invariant_for_mut_ref_arg.move:8
 
 error: data invariant does not hold
@@ -21,6 +23,10 @@ error: data invariant does not hold
   =         s = <redacted>
   =     at tests/sources/functional/data_invariant_for_mut_ref_arg.move:24: push_2
   =     at tests/sources/functional/data_invariant_for_mut_ref_arg.move:26: push_2
+  =         s = <redacted>
+  =     at tests/sources/functional/data_invariant_for_mut_ref_arg.move:27: push_2
+  =     at tests/sources/functional/data_invariant_for_mut_ref_arg.move:28: push_2
+  =         s = <redacted>
   =     at tests/sources/functional/data_invariant_for_mut_ref_arg.move:8
 
 error: data invariant does not hold
@@ -33,16 +39,8 @@ error: data invariant does not hold
   =         s = <redacted>
   =     at tests/sources/functional/data_invariant_for_mut_ref_arg.move:33: push_3
   =     at tests/sources/functional/data_invariant_for_mut_ref_arg.move:35: push_3
-  =     at tests/sources/functional/data_invariant_for_mut_ref_arg.move:8
-
-error: data invariant does not hold
-  ┌─ tests/sources/functional/data_invariant_for_mut_ref_arg.move:8:9
-  │
-8 │         invariant len(v) == 0;
-  │         ^^^^^^^^^^^^^^^^^^^^^^
-  │
-  =     at tests/sources/functional/data_invariant_for_mut_ref_arg.move:39: push_and_pop_violation
   =         s = <redacted>
-  =     at tests/sources/functional/data_invariant_for_mut_ref_arg.move:41: push_and_pop_violation
-  =     at tests/sources/functional/data_invariant_for_mut_ref_arg.move:43: push_and_pop_violation
+  =     at tests/sources/functional/data_invariant_for_mut_ref_arg.move:36: push_3
+  =         result = <redacted>
+  =         s = <redacted>
   =     at tests/sources/functional/data_invariant_for_mut_ref_arg.move:8

--- a/language/move-prover/tests/sources/functional/mut_ref.exp
+++ b/language/move-prover/tests/sources/functional/mut_ref.exp
@@ -36,8 +36,6 @@ error: data invariant does not hold
   =     at tests/sources/functional/mut_ref.move:91: return_ref_different_path_vec2
   =         result = <redacted>
   =         x = <redacted>
-  =         x = <redacted>
-  =         x = <redacted>
   =     at tests/sources/functional/mut_ref.move:92: return_ref_different_path_vec2
   =         r = <redacted>
   =     at tests/sources/functional/mut_ref.move:122: call_return_ref_different_path_vec2_incorrect


### PR DESCRIPTION
... when and only when the param goes out of scope.

Previously, the approach is to check data invariants **on every write-back to a &mut param**. This is by definition more restrictive as this is essentially saying that data invariants are not allowed to be violated even temporarily in funciton body, which might not be a practical assumption (as shown in the newly added test case.)

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Move Language.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Intuitive data invariant checking

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes

## Test Plan

CI, test cases updated