### PR TITLE
[move-prover] model `type_name::get` in stdlib

### DIFF
--- a/language/move-model/src/ast.rs
+++ b/language/move-model/src/ast.rs
@@ -6,14 +6,22 @@
 //! Note that in this crate, specs are represented in AST form, whereas code is represented
 //! as bytecodes. Therefore we do not need an AST for the Move code itself.
 
+use std::{
+    borrow::Borrow,
+    cell::RefCell,
+    collections::{BTreeMap, BTreeSet, HashSet},
+    fmt,
+    fmt::{Debug, Error, Formatter},
+    hash::Hash,
+    ops::Deref,
+};
+
+use internment::LocalIntern;
+use itertools::Itertools;
 use num::{BigInt, BigUint, Num};
+use once_cell::sync::Lazy;
 
 use move_binary_format::file_format::CodeOffset;
-use std::{
-    collections::{BTreeMap, BTreeSet},
-    fmt,
-    fmt::{Error, Formatter},
-};
 
 use crate::{
     exp_rewriter::ExpRewriterFunctions,
@@ -24,12 +32,6 @@ use crate::{
     },
     symbol::{Symbol, SymbolPool},
     ty::{Type, TypeDisplayContext},
-};
-use internment::LocalIntern;
-use itertools::Itertools;
-use once_cell::sync::Lazy;
-use std::{
-    borrow::Borrow, cell::RefCell, collections::HashSet, fmt::Debug, hash::Hash, ops::Deref,
 };
 
 // =================================================================================================

--- a/language/move-model/src/well_known.rs
+++ b/language/move-model/src/well_known.rs
@@ -15,3 +15,11 @@ pub const TYPE_NAME_SPEC: &str = "type_info::$type_name";
 pub const TYPE_INFO_MOVE: &str = "type_info::type_of";
 pub const TYPE_INFO_SPEC: &str = "type_info::$type_of";
 pub const TYPE_SPEC_IS_STRUCT: &str = "type_info::spec_is_struct";
+
+pub const TYPE_NAME_GET_MOVE: &str = "type_name::get";
+pub const TYPE_NAME_GET_SPEC: &str = "type_name::$get";
+
+// NOTE: `type_info::type_name` and `type_name::get` are very similar.
+// The main difference (from a prover's perspective) include:
+// - formatting of an address (part of the struct name), and
+// - whether it is in `stdlib` or `extlib`.

--- a/language/move-prover/boogie-backend/src/boogie_helpers.rs
+++ b/language/move-prover/boogie-backend/src/boogie_helpers.rs
@@ -672,17 +672,47 @@ impl TypeIdentToken {
         }
         cursor
     }
+}
 
-    pub fn convert_to_string(std_address: BigUint, tokens: Vec<TypeIdentToken>) -> String {
-        format!(
-            "${}_string_String({})",
-            std_address,
-            Self::convert_to_bytes(tokens)
-        )
+/// A formatter for address
+pub struct AddressFormatter {
+    /// whether the `0x` prefix is needed
+    pub prefix: bool,
+    /// whether to include leading zeros
+    pub full_length: bool,
+    /// whether to capitalize the hex repr
+    pub capitalized: bool,
+}
+
+impl AddressFormatter {
+    pub fn format(&self, addr: &BigUint) -> String {
+        let result = addr.to_str_radix(16);
+        // into correct length
+        let result = if self.full_length {
+            format!("{:0>32}", result)
+        } else {
+            result
+        };
+        // into correct case
+        let result = if self.capitalized {
+            result.to_uppercase()
+        } else {
+            result
+        };
+        // with or without prefix
+        if self.prefix {
+            format!("0x{}", result)
+        } else {
+            result
+        }
     }
 }
 
-fn type_name_to_ident_tokens(env: &GlobalEnv, ty: &Type) -> Vec<TypeIdentToken> {
+fn type_name_to_ident_tokens(
+    env: &GlobalEnv,
+    ty: &Type,
+    formatter: &AddressFormatter,
+) -> Vec<TypeIdentToken> {
     match ty {
         Type::Primitive(PrimitiveType::Bool) => TypeIdentToken::make("bool"),
         Type::Primitive(PrimitiveType::U8) => TypeIdentToken::make("u8"),
@@ -695,7 +725,7 @@ fn type_name_to_ident_tokens(env: &GlobalEnv, ty: &Type) -> Vec<TypeIdentToken> 
         Type::Primitive(PrimitiveType::Signer) => TypeIdentToken::make("signer"),
         Type::Vector(element) => {
             let mut tokens = TypeIdentToken::make("vector<");
-            tokens.extend(type_name_to_ident_tokens(env, element));
+            tokens.extend(type_name_to_ident_tokens(env, element, formatter));
             tokens.extend(TypeIdentToken::make(">"));
             tokens
         }
@@ -703,8 +733,8 @@ fn type_name_to_ident_tokens(env: &GlobalEnv, ty: &Type) -> Vec<TypeIdentToken> 
             let module_env = env.get_module(*mid);
             let struct_env = module_env.get_struct(*sid);
             let type_name = format!(
-                "0x{}::{}::{}",
-                module_env.get_name().addr().to_str_radix(16),
+                "{}::{}::{}",
+                formatter.format(module_env.get_name().addr()),
                 module_env
                     .get_name()
                     .name()
@@ -716,7 +746,7 @@ fn type_name_to_ident_tokens(env: &GlobalEnv, ty: &Type) -> Vec<TypeIdentToken> 
                 tokens.extend(TypeIdentToken::make("<"));
                 let ty_args_tokens = ty_args
                     .iter()
-                    .map(|t| type_name_to_ident_tokens(env, t))
+                    .map(|t| type_name_to_ident_tokens(env, t, formatter))
                     .collect();
                 tokens.extend(TypeIdentToken::join(", ", ty_args_tokens));
                 tokens.extend(TypeIdentToken::make(">"));
@@ -750,9 +780,36 @@ fn type_name_to_ident_tokens(env: &GlobalEnv, ty: &Type) -> Vec<TypeIdentToken> 
 }
 
 /// Convert a type name into a format that can be recognized by Boogie
-pub fn boogie_reflection_type_name(env: &GlobalEnv, ty: &Type) -> String {
-    let tokens = type_name_to_ident_tokens(env, ty);
-    TypeIdentToken::convert_to_string(env.get_stdlib_address(), tokens)
+///
+/// The `stdlib` bool flag represents whether this type name is intended for
+/// - true  --> `std::type_name` and
+/// - false --> `ext::type_info`.
+/// TODO(mengxu): the above is a very hacky, we need a better way to differentiate
+pub fn boogie_reflection_type_name(env: &GlobalEnv, ty: &Type, stdlib: bool) -> String {
+    let formatter = if stdlib {
+        AddressFormatter {
+            prefix: false,
+            full_length: true,
+            capitalized: false,
+        }
+    } else {
+        AddressFormatter {
+            prefix: true,
+            full_length: false,
+            capitalized: false,
+        }
+    };
+    let bytes = TypeIdentToken::convert_to_bytes(type_name_to_ident_tokens(env, ty, &formatter));
+    if stdlib {
+        format!(
+            "${}_type_name_TypeName(${}_ascii_String({}))",
+            env.get_stdlib_address(),
+            env.get_stdlib_address(),
+            bytes
+        )
+    } else {
+        format!("${}_string_String({})", env.get_stdlib_address(), bytes)
+    }
 }
 
 enum TypeInfoPack {

--- a/language/move-prover/boogie-backend/src/bytecode_translator.rs
+++ b/language/move-prover/boogie-backend/src/bytecode_translator.rs
@@ -18,7 +18,7 @@ use move_model::{
     model::{FieldId, GlobalEnv, Loc, NodeId, QualifiedInstId, StructEnv, StructId},
     pragmas::{ADDITION_OVERFLOW_UNCHECKED_PRAGMA, SEED_PRAGMA, TIMEOUT_PRAGMA},
     ty::{PrimitiveType, Type, TypeDisplayContext, BOOL_TYPE},
-    well_known::{TYPE_INFO_MOVE, TYPE_NAME_MOVE},
+    well_known::{TYPE_INFO_MOVE, TYPE_NAME_GET_MOVE, TYPE_NAME_MOVE},
 };
 use move_stackless_bytecode::{
     function_target::FunctionTarget,
@@ -1215,14 +1215,14 @@ impl<'env> FunctionTranslator<'env> {
                                     emitln!(
                                         writer,
                                         "{}",
-                                        boogie_reflection_type_name(env, &inst[0])
+                                        boogie_reflection_type_name(env, &inst[0], false)
                                     );
                                 } else {
                                     emitln!(
                                         writer,
                                         "{} := {};",
                                         dest_str,
-                                        boogie_reflection_type_name(env, &inst[0])
+                                        boogie_reflection_type_name(env, &inst[0], false)
                                     );
                                 }
                                 processed = true;
@@ -1238,6 +1238,32 @@ impl<'env> FunctionTranslator<'env> {
                                         emitln!(writer, "{} := {};", dest_str, info)
                                     });
                                     emitln!(writer, "}");
+                                }
+                                processed = true;
+                            }
+                        }
+
+                        if env.get_stdlib_address() == *module_env.get_name().addr() {
+                            let qualified_name = format!(
+                                "{}::{}",
+                                module_env.get_name().name().display(env.symbol_pool()),
+                                callee_env.get_name().display(env.symbol_pool()),
+                            );
+                            if qualified_name == TYPE_NAME_GET_MOVE {
+                                assert_eq!(inst.len(), 1);
+                                if dest_str.is_empty() {
+                                    emitln!(
+                                        writer,
+                                        "{}",
+                                        boogie_reflection_type_name(env, &inst[0], true)
+                                    );
+                                } else {
+                                    emitln!(
+                                        writer,
+                                        "{} := {};",
+                                        dest_str,
+                                        boogie_reflection_type_name(env, &inst[0], true)
+                                    );
                                 }
                                 processed = true;
                             }

--- a/language/move-prover/boogie-backend/src/spec_translator.rs
+++ b/language/move-prover/boogie-backend/src/spec_translator.rs
@@ -28,7 +28,7 @@ use move_model::{
     pragmas::INTRINSIC_TYPE_MAP,
     symbol::Symbol,
     ty::{PrimitiveType, Type},
-    well_known::{TYPE_INFO_SPEC, TYPE_NAME_SPEC, TYPE_SPEC_IS_STRUCT},
+    well_known::{TYPE_INFO_SPEC, TYPE_NAME_GET_SPEC, TYPE_NAME_SPEC, TYPE_SPEC_IS_STRUCT},
 };
 use move_stackless_bytecode::{
     mono_analysis::MonoInfo,
@@ -947,7 +947,7 @@ impl<'env> SpecTranslator<'env> {
                 emit!(
                     self.writer,
                     "{}",
-                    boogie_reflection_type_name(self.env, &inst[0])
+                    boogie_reflection_type_name(self.env, &inst[0], false)
                 );
                 processed = true;
             } else if qualified_name == TYPE_INFO_SPEC {
@@ -964,6 +964,23 @@ impl<'env> SpecTranslator<'env> {
                     self.writer,
                     "{}",
                     boogie_reflection_type_is_struct(self.env, &inst[0])
+                );
+                processed = true;
+            }
+        }
+
+        if self.env.get_stdlib_address() == *module_env.get_name().addr() {
+            let qualified_name = format!(
+                "{}::{}",
+                module_env.get_name().name().display(self.env.symbol_pool()),
+                fun_decl.name.display(self.env.symbol_pool()),
+            );
+            if qualified_name == TYPE_NAME_GET_SPEC {
+                assert_eq!(inst.len(), 1);
+                emit!(
+                    self.writer,
+                    "{}",
+                    boogie_reflection_type_name(self.env, &inst[0], true)
                 );
                 processed = true;
             }

--- a/language/move-prover/bytecode/src/mono_analysis.rs
+++ b/language/move-prover/bytecode/src/mono_analysis.rs
@@ -23,7 +23,8 @@ use move_model::{
     pragmas::INTRINSIC_TYPE_MAP,
     ty::{Type, TypeDisplayContext, TypeInstantiationDerivation, TypeUnificationAdapter, Variance},
     well_known::{
-        TYPE_INFO_MOVE, TYPE_INFO_SPEC, TYPE_NAME_MOVE, TYPE_NAME_SPEC, TYPE_SPEC_IS_STRUCT,
+        TYPE_INFO_MOVE, TYPE_INFO_SPEC, TYPE_NAME_GET_MOVE, TYPE_NAME_GET_SPEC, TYPE_NAME_MOVE,
+        TYPE_NAME_SPEC, TYPE_SPEC_IS_STRUCT,
     },
 };
 
@@ -384,6 +385,16 @@ impl<'a> Analyzer<'a> {
                         self.add_type(&actuals[0]);
                     }
                 }
+                if self.env.get_stdlib_address() == *module_env.get_name().addr() {
+                    let qualified_name = format!(
+                        "{}::{}",
+                        module_env.get_name().name().display(self.env.symbol_pool()),
+                        callee_env.get_name().display(self.env.symbol_pool()),
+                    );
+                    if qualified_name == TYPE_NAME_GET_MOVE {
+                        self.add_type(&actuals[0]);
+                    }
+                }
 
                 if callee_env.is_native_or_intrinsic() && !actuals.is_empty() {
                     // Mark the associated module to be instantiated with the given actuals.
@@ -467,6 +478,16 @@ impl<'a> Analyzer<'a> {
                         || qualified_name == TYPE_INFO_SPEC
                         || qualified_name == TYPE_SPEC_IS_STRUCT
                     {
+                        self.add_type(&actuals[0]);
+                    }
+                }
+                if self.env.get_stdlib_address() == *module.get_name().addr() {
+                    let qualified_name = format!(
+                        "{}::{}",
+                        module.get_name().name().display(self.env.symbol_pool()),
+                        spec_fun.name.display(self.env.symbol_pool()),
+                    );
+                    if qualified_name == TYPE_NAME_GET_SPEC {
                         self.add_type(&actuals[0]);
                     }
                 }

--- a/language/move-prover/tests/sources/functional/nonlinear_arithm.move
+++ b/language/move-prover/tests/sources/functional/nonlinear_arithm.move
@@ -1,6 +1,6 @@
 // exclude_for: simplify
 // exclude_for: cvc5
-// simplify and cvc5 are exculded due to timeout
+// flag: --timeout=160
 module 0x42::TestNonlinearArithmetic {
 
     spec module {

--- a/language/move-prover/tests/sources/functional/type_reflection.exp
+++ b/language/move-prover/tests/sources/functional/type_reflection.exp
@@ -1,15 +1,15 @@
 Move prover returns: exiting with verification errors
 error: abort not covered by any of the `aborts_if` clauses
-    ┌─ tests/sources/functional/type_reflection.move:99:5
-    │
- 97 │           type_info::type_of<T>()
-    │           ----------------------- abort happened here with execution failure
- 98 │       }
- 99 │ ╭     spec test_type_info_can_abort {
-100 │ │         // this should not pass
-101 │ │         aborts_if false;
-102 │ │     }
-    │ ╰─────^
-    │
-    =     at tests/sources/functional/type_reflection.move:97: test_type_info_can_abort
-    =         ABORTED
+   ┌─ tests/sources/functional/type_reflection.move:86:5
+   │
+84 │           type_info::type_of<T>()
+   │           ----------------------- abort happened here with execution failure
+85 │       }
+86 │ ╭     spec test_type_info_can_abort {
+87 │ │         // this should not pass
+88 │ │         aborts_if false;
+89 │ │     }
+   │ ╰─────^
+   │
+   =     at tests/sources/functional/type_reflection.move:84: test_type_info_can_abort
+   =         ABORTED

--- a/language/move-prover/tests/sources/functional/type_reflection.move
+++ b/language/move-prover/tests/sources/functional/type_reflection.move
@@ -41,19 +41,6 @@ module 0x42::test {
         ensures result.bytes == b"0x42::test::MyTable<vector<bool>, address>";
     }
 
-    fun test_type_name_symbolic<T>(): string::String {
-        spec {
-            assert type_info::type_name<T>().bytes == type_info::type_name<T>().bytes;
-        };
-        type_info::type_name<MyTable<T, T>>()
-    }
-    spec test_type_name_symbolic {
-        ensures result.bytes != b"vector<bool>";
-        // TODO(mengxu): however, this ensures fails to verify.
-        // Further investigation needed, could be issues with ConcatVec.
-        // ensures result != type_info::type_name<vector<T>>();
-    }
-
     fun test_type_info_concrete(): type_info::TypeInfo {
         spec {
             assert type_info::type_of<MyTable<address, u128>>().account_address == @0x42;
@@ -117,5 +104,33 @@ module 0x42::test {
     }
     spec test_type_info_aborts_if_full {
         aborts_if !type_info::spec_is_struct<T>();
+    }
+}
+
+module 0x43::test {
+    use std::ascii;
+    use std::type_name;
+
+    struct Pair<phantom K, phantom V> {}
+
+    fun test_type_name_concrete_simple(): ascii::String {
+        type_name::into_string(type_name::get<bool>())
+    }
+    spec test_type_name_concrete_simple {
+        ensures result.bytes == b"bool";
+    }
+
+    fun test_type_name_concrete_vector(): ascii::String {
+        type_name::into_string(type_name::get<vector<vector<u8>>>())
+    }
+    spec test_type_name_concrete_vector {
+        ensures result.bytes == b"vector<vector<u8>>";
+    }
+
+    fun test_type_name_concrete_struct(): ascii::String {
+        type_name::into_string(type_name::get<Pair<address, bool>>())
+    }
+    spec test_type_name_concrete_struct {
+        ensures result.bytes == b"00000000000000000000000000000043::test::Pair<address, bool>";
     }
 }

--- a/language/move-prover/tests/sources/functional/type_reflection_ext.move
+++ b/language/move-prover/tests/sources/functional/type_reflection_ext.move
@@ -1,0 +1,36 @@
+// flag: --vector-theory=SmtArrayExt
+module extensions::type_info {
+    use std::string;
+
+    // these are mocks of the type reflection scheme
+    public native fun type_name<T>(): string::String;
+}
+
+module 0x42::test {
+    use extensions::type_info;
+    use std::string;
+
+    struct MyTable<phantom K, phantom V> {}
+
+    fun test_type_name_symbolic<T>(): string::String {
+        type_info::type_name<MyTable<T, T>>()
+    }
+    spec test_type_name_symbolic {
+        ensures result.bytes != b"vector<bool>";
+        ensures result != type_info::type_name<vector<T>>();
+    }
+}
+
+module 0x43::test {
+    use std::type_name;
+
+    struct Pair<phantom K, phantom V> {}
+
+    fun test_type_name_symbolic<T>(): type_name::TypeName {
+        type_name::get<Pair<T, T>>()
+    }
+    spec test_type_name_symbolic {
+        ensures result.name.bytes != b"vector<bool>";
+        ensures result != type_name::get<vector<T>>();
+    }
+}


### PR DESCRIPTION
The majority of the Prover work was firstly introduced when Aptos introduced the `type_info` Move module. Now that the stdlib has a similar module `type_name`, we should bridge the effort here.

This PR is still a bit rough as it is using hardcoded module address / function names to identify the type-reflection schemes. We should come up with more robust / extensible approach later.

NOTE: it is hard to unify them though. `type_info::type_name<T>()` and `type_name::get<T>()` are not equivalent, primarily due to the format of module address:
- in `type_info::type_name()`, the address is `0x1` while
- in `type_name::get()`, the address is `00000000000000000000000000000001`

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Move Language.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Fix #803

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes

## Test Plan

CI, new tests added