### PR TITLE
[absint] Bring back associated error type

### DIFF
--- a/language/move-bytecode-verifier/src/locals_safety/mod.rs
+++ b/language/move-bytecode-verifier/src/locals_safety/mod.rs
@@ -12,7 +12,7 @@ use crate::absint::{AbstractInterpreter, TransferFunctions};
 use abstract_state::{AbstractState, LocalState};
 use move_binary_format::{
     binary_views::{BinaryIndexedView, FunctionView},
-    errors::PartialVMResult,
+    errors::{PartialVMError, PartialVMResult},
     file_format::{Bytecode, CodeOffset},
 };
 use move_core_types::vm_status::StatusCode;
@@ -160,6 +160,7 @@ struct LocalsSafetyAnalysis();
 
 impl TransferFunctions for LocalsSafetyAnalysis {
     type State = AbstractState;
+    type Error = PartialVMError;
 
     fn execute(
         &mut self,

--- a/language/move-bytecode-verifier/src/reference_safety/mod.rs
+++ b/language/move-bytecode-verifier/src/reference_safety/mod.rs
@@ -409,6 +409,7 @@ fn execute_inner(
 
 impl<'a> TransferFunctions for ReferenceSafetyAnalysis<'a> {
     type State = AbstractState;
+    type Error = PartialVMError;
 
     fn execute(
         &mut self,


### PR DESCRIPTION
- The associated type for errors is necessary for custom verifier passes using absint

## Motivation

Custom adapter verifier passes struggle when they want to use the same absint infrastructure, but with a custom error type. This adds back the type that was previously there.

## Test Plan

- Non functional change. ran tests