### PR TITLE
[move-compiler] capture variable usages in spec blocks

### DIFF
--- a/language/move-prover/tests/sources/functional/inline_fun.move
+++ b/language/move-prover/tests/sources/functional/inline_fun.move
@@ -1,0 +1,30 @@
+module 0x42::Test {
+    use std::vector;
+
+    public inline fun filter<X: drop>(v: &mut vector<X>, predicate: |&X| bool) {
+        let i = 0;
+        while ({
+            spec {
+                invariant forall k in 0..i: !predicate(v[k]);
+                // TODO: complete the set of loop invariants
+            };
+            (i < vector::length(v))
+        }) {
+            if (predicate(vector::borrow(v, i))) {
+                vector::swap_remove(v, i);
+            } else {
+                i = i + 1;
+            };
+        }
+    }
+
+    public fun test_filter(): vector<u64> {
+        let v = vector[1u64, 2, 3];
+        filter(&mut v, |e| *e > 1);
+        v
+    }
+    spec test_filter {
+        pragma verify = false;
+        // TODO: turn-on the verification once inlining on spec side is done
+    }
+}


### PR DESCRIPTION
This is a minor fix that allow function local variables used in inline specs (e.g., loop invariants) to be captured in the inline phase and processed in subsequent phases.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Move Language.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Fix minor issue while adopting inline functions into prover

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes

## Test Plan

CI, with a new test case