### PR TITLE
Implement safety check for 'balance_of' function

### DIFF
--- a/language/documentation/tutorial/step_4_sol/BasicCoin/sources/BasicCoin.move
+++ b/language/documentation/tutorial/step_4_sol/BasicCoin/sources/BasicCoin.move
@@ -9,6 +9,7 @@ module NamedAddr::BasicCoin {
     const ENOT_MODULE_OWNER: u64 = 0;
     const EINSUFFICIENT_BALANCE: u64 = 1;
     const EALREADY_HAS_BALANCE: u64 = 2;
+    const EACCOUNT_NOT_REGISTERED: u64 = 3;
 
     struct Coin has store {
         value: u64
@@ -38,6 +39,8 @@ module NamedAddr::BasicCoin {
 
     /// Returns the balance of `owner`.
     public fun balance_of(owner: address): u64 acquires Balance {
+        // checks if the address has registered or not using the 'publish_balance" function
+        assert!(exists<Balance>(owner), EACCOUNT_NOT_REGISTERED);
         borrow_global<Balance>(owner).coin.value
     }
 


### PR DESCRIPTION


With proposed changes, an error indicating that the account has not yet been registered will be thrown instead of the MISSING_DATA error.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Move Language.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Previously, a MISSING_DATA (code 4008) error would be thrown if 'balance_of' function was called but the account had not yet registered using the 'publish_balance' function.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes

## Test Plan

#[test(account = @0xCAFE)]
    fun test_balance_of(account: &signer) acquires Balance {
        publish_balance(account);
        let account_addr = signer::address_of(account);
        let account_bal = balance_of(account_addr);
        assert!(account_bal == 0, 0);
    }
