### PR TITLE
[Move-prover] Allow global spec vars to be updated in the function body

### DIFF
--- a/language/move-model/src/ast.rs
+++ b/language/move-model/src/ast.rs
@@ -145,7 +145,7 @@ impl ConditionKind {
         use ConditionKind::*;
         matches!(
             self,
-            Assert | Assume | Decreases | LoopInvariant | LetPost(..) | LetPre(..)
+            Assert | Assume | Decreases | LoopInvariant | LetPost(..) | LetPre(..) | Update
         )
     }
 

--- a/language/move-model/src/builder/module_builder.rs
+++ b/language/move-model/src/builder/module_builder.rs
@@ -780,6 +780,13 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
                                 }
                             }
                         }
+                        EA::SpecBlockMember_::Update { lhs, rhs } => {
+                            let context = SpecBlockContext::FunctionCode(
+                                qsym.clone(),
+                                &fun_spec_info[spec_id],
+                            );
+                            self.def_ana_global_var_update(loc, &context, lhs, rhs)
+                        }
                         _ => {
                             self.parent.error(loc, "item not allowed");
                         }

--- a/language/move-prover/bytecode/src/spec_instrumentation.rs
+++ b/language/move-prover/bytecode/src/spec_instrumentation.rs
@@ -465,8 +465,13 @@ impl<'a> Instrumenter<'a> {
                         self.builder.emit(Prop(id, kind, prop));
                     }
                     Some((translated_spec, exp)) => {
-                        self.emit_traces(translated_spec, exp);
-                        self.builder.emit(Prop(id, kind, exp.clone()));
+                        // Logic specifically for generating code of updating global spec variables in the function body
+                        if *exp == prop && !translated_spec.updates.is_empty() {
+                            self.emit_updates(translated_spec);
+                        } else {
+                            self.emit_traces(translated_spec, exp);
+                            self.builder.emit(Prop(id, kind, exp.clone()));
+                        }
                     }
                 }
             }

--- a/language/move-prover/bytecode/src/stackless_bytecode_generator.rs
+++ b/language/move-prover/bytecode/src/stackless_bytecode_generator.rs
@@ -182,7 +182,11 @@ impl<'a> StacklessBytecodeGenerator<'a> {
                         self.loop_invariants.insert(attr_id);
                         PropKind::Assert
                     }
-                    _ => panic!("unsupported spec condition in code"),
+                    // Updating global spec variables are translated to Assume, which will be replaced when instrumenting the spec
+                    ConditionKind::Update => PropKind::Assume,
+                    _ => {
+                        panic!("unsupported spec condition in code")
+                    }
                 };
                 self.code
                     .push(Bytecode::Prop(attr_id, kind, cond.exp.clone()));

--- a/language/move-prover/bytecode/src/usage_analysis.rs
+++ b/language/move-prover/bytecode/src/usage_analysis.rs
@@ -300,6 +300,19 @@ impl<'a> MemoryUsageAnalysis<'a> {
                 }
             }
         }
+
+        // Handle memory update of the specs in the function body
+        for impl_spec in spec.on_impl.values() {
+            for cond in &impl_spec.conditions {
+                if matches!(cond.kind, Update) && !cond.additional_exps.is_empty() {
+                    if let Some((mem, _, _)) =
+                        cond.additional_exps[0].extract_ghost_mem_access(self.cache.global_env())
+                    {
+                        state.add_direct_modified(mem);
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/language/move-prover/tests/sources/functional/global_vars.exp
+++ b/language/move-prover/tests/sources/functional/global_vars.exp
@@ -8,14 +8,14 @@ error: post-condition does not hold
    =     at tests/sources/functional/global_vars.move:37: call_add_sub_invalid
    =     at tests/sources/functional/global_vars.move:38: call_add_sub_invalid
    =     at tests/sources/functional/global_vars.move:17: add
-   =     at tests/sources/functional/global_vars.move:18: add
-   =     at tests/sources/functional/global_vars.move:20: add (spec)
+   =     at tests/sources/functional/global_vars.move:19: add
+   =     at tests/sources/functional/global_vars.move:21: add
    =     at tests/sources/functional/global_vars.move:24: sub
-   =     at tests/sources/functional/global_vars.move:25: sub
-   =     at tests/sources/functional/global_vars.move:27: sub (spec)
+   =     at tests/sources/functional/global_vars.move:26: sub
+   =     at tests/sources/functional/global_vars.move:28: sub
    =     at tests/sources/functional/global_vars.move:17: add
-   =     at tests/sources/functional/global_vars.move:18: add
-   =     at tests/sources/functional/global_vars.move:20: add (spec)
+   =     at tests/sources/functional/global_vars.move:19: add
+   =     at tests/sources/functional/global_vars.move:21: add
    =     at tests/sources/functional/global_vars.move:39: call_add_sub_invalid
    =     at tests/sources/functional/global_vars.move:41: call_add_sub_invalid (spec)
 

--- a/language/move-prover/tests/sources/functional/global_vars.move
+++ b/language/move-prover/tests/sources/functional/global_vars.move
@@ -14,17 +14,17 @@ module 0x42::TestGlobalVars {
     }
 
     fun add() acquires T {
-        borrow_global_mut<T>(@0).i = borrow_global_mut<T>(@0).i + 1
-    }
-    spec add {
-        update sum_of_T = sum_of_T + 1;
+        borrow_global_mut<T>(@0).i = borrow_global_mut<T>(@0).i + 1;
+        spec {
+            update sum_of_T = sum_of_T + 1;
+        };
     }
 
     fun sub() acquires T {
-        borrow_global_mut<T>(@0).i = borrow_global_mut<T>(@0).i - 1
-    }
-    spec sub {
-        update sum_of_T = sum_of_T - 1;
+        borrow_global_mut<T>(@0).i = borrow_global_mut<T>(@0).i - 1;
+        spec {
+            update sum_of_T = sum_of_T - 1;
+        };
     }
 
     fun call_add_sub() acquires T {


### PR DESCRIPTION
## Motivation

This PR allows users to update global specification variables in the function body.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes



