### PR TITLE
[move-prover] special casing havoc in reach-def annalysis

### DIFF
--- a/language/evm/move-to-yul/tests/AccountStateMachine.exp
+++ b/language/evm/move-to-yul/tests/AccountStateMachine.exp
@@ -516,7 +516,7 @@ object "A3_AccountStateMachine" {
             }
 
             function A1_vector_remove$A3_AccountStateMachine_PendingTransfer$(v, i) -> $result {
-                let tmp_$2, tmp_$3, len, $t5, $t6, $t7, $t8, $t9, $t10, $t11, $t12, $t13, $t14
+                let tmp_$2, tmp_$3, len, $t5, $t6, $t7, $t8, $t9, $t10, $t11, $t12, $t13, $t14, $t15
                 let $block := 4
                 for {} true {} {
                     switch $block
@@ -565,22 +565,24 @@ object "A3_AccountStateMachine" {
                     }
                     case 7 {
                         // label L2
-                        // $t14 := vector::pop_back<#0>($t0)
-                        $t14 := A1_vector_pop_back$A3_AccountStateMachine_PendingTransfer$(v)
-                        // return $t14
-                        $result := $t14
+                        // $t15 := vector::pop_back<#0>($t0)
+                        $t15 := A1_vector_pop_back$A3_AccountStateMachine_PendingTransfer$(v)
+                        // return $t15
+                        $result := $t15
                         leave
                     }
                     case 8 {
                         // label L4
-                        // $t12 := 1
-                        $t12 := 1
-                        // $t13 := +($t1, $t12)
-                        $t13 := $AddU64(i, $t12)
-                        // $t1 := $t13
-                        i := $t13
-                        // vector::swap<#0>($t0, $t13, $t13)
-                        A1_vector_swap$A3_AccountStateMachine_PendingTransfer$(v, $t13, $t13)
+                        // $t12 := copy($t1)
+                        $t12 := i
+                        // $t13 := 1
+                        $t13 := 1
+                        // $t14 := +($t1, $t13)
+                        $t14 := $AddU64(i, $t13)
+                        // $t1 := $t14
+                        i := $t14
+                        // vector::swap<#0>($t0, $t12, $t14)
+                        A1_vector_swap$A3_AccountStateMachine_PendingTransfer$(v, $t12, $t14)
                         // goto L5
                         $block := 5
                     }

--- a/language/move-prover/tests/sources/regression/bug_828.move
+++ b/language/move-prover/tests/sources/regression/bug_828.move
@@ -1,0 +1,24 @@
+module 0x42::test {
+    fun foo(i: u64) {
+        assert!(i == 50, 0);
+        let old_i = i;
+        spec {
+            assert old_i == 50;
+        };
+        while ({
+            spec {
+                invariant old_i <= i && i <= 100;
+            };
+            i < 100
+        }) {
+            spec {
+                // fail to prove before the fix
+                assert old_i == 50;
+            };
+            i = i + 1;
+        };
+        spec {
+            assert i == 100;
+        };
+    }
+}


### PR DESCRIPTION
This commit contains two changes to the reach-def analysis pass:
- if a local variable `x := a` and later we discover that `a := b` too, then mark that `x` might alias both `a` and `b`. This is done in the intra-procedural abstract interpretation so the def of `x` will be updated (joined) on a later stage.
- if a local variable `x := a` and `a` might take the value of both original and havoc-ed, then mark that `x` is not uniquely aliased.

Both changes prevents copy propogated from `a` to `x`.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Move Language.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Fix #828 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes

## Test Plan

The test case in #828 is added