### PR TITLE
[inline functions] Extending consistency checks and enabling memory management

### DIFF
--- a/language/move-compiler/src/diagnostics/codes.rs
+++ b/language/move-compiler/src/diagnostics/codes.rs
@@ -153,7 +153,7 @@ codes!(
     ],
     // errors for typing rules. mostly typing/translate
     TypeSafety: [
-        Visibility: { msg: "restricted visibility", severity: NonblockingError },
+        Visibility: { msg: "restricted visibility", severity: BlockingError },
         ScriptContext: { msg: "requires script context", severity: NonblockingError },
         BuiltinOperation: { msg: "built-in operation not supported", severity: BlockingError },
         ExpectedBaseType: { msg: "expected a single non-reference type", severity: BlockingError },
@@ -244,6 +244,8 @@ codes!(
     // errors for inlining
     Inlining: [
         Recursion: { msg: "recursion during function inlining not allowed", severity: BlockingError },
+        AfterExpansion: {  msg: "Inlined code invalid in this context", severity: BlockingError },
+        Unsupported: { msg: "feature not supported in inlined functions", severity: BlockingError },
     ],
 );
 

--- a/language/move-compiler/src/naming/ast.rs
+++ b/language/move-compiler/src/naming/ast.rs
@@ -600,6 +600,13 @@ impl Type_ {
             _ => None,
         }
     }
+
+    pub fn struct_name(&self) -> Option<(ModuleIdent, StructName)> {
+        match self {
+            Type_::Apply(_, sp!(_, TypeName_::ModuleType(m, s)), _) => Some((*m, *s)),
+            _ => None,
+        }
+    }
 }
 
 impl Value_ {

--- a/language/move-compiler/src/to_bytecode/context.rs
+++ b/language/move-compiler/src/to_bytecode/context.rs
@@ -249,7 +249,8 @@ impl<'a> Context<'a> {
     pub fn struct_definition_name(&self, m: &ModuleIdent, s: StructName) -> IR::StructName {
         assert!(
             self.is_current_module(m),
-            "ICE invalid struct definition lookup"
+            "ICE invalid struct definition lookup: {}",
+            m
         );
         Self::translate_struct_name(s)
     }

--- a/language/move-compiler/src/typing/core.rs
+++ b/language/move-compiler/src/typing/core.rs
@@ -71,6 +71,7 @@ pub struct Context<'env> {
 
     pub current_module: Option<ModuleIdent>,
     pub current_function: Option<FunctionName>,
+    pub current_function_inlined: bool,
     pub current_script_constants: Option<UniqueMap<ConstantName, ConstantInfo>>,
     pub return_type: Option<Type>,
     locals: UniqueMap<Var, Type>,
@@ -123,6 +124,7 @@ impl<'env> Context<'env> {
             subst: Subst::empty(),
             current_module: None,
             current_function: None,
+            current_function_inlined: false,
             current_script_constants: None,
             return_type: None,
             constraints: vec![],
@@ -313,7 +315,7 @@ impl<'env> Context<'env> {
             .expect("ICE should have failed in naming")
     }
 
-    fn function_info(&self, m: &ModuleIdent, n: &FunctionName) -> &FunctionInfo {
+    pub fn function_info(&self, m: &ModuleIdent, n: &FunctionName) -> &FunctionInfo {
         self.module_info(m)
             .functions
             .get(n)

--- a/language/move-compiler/src/typing/translate.rs
+++ b/language/move-compiler/src/typing/translate.rs
@@ -4,7 +4,7 @@
 
 use super::{
     core::{self, Context, Subst},
-    expand, globals, infinite_instantiations, recursive_structs,
+    expand, infinite_instantiations, recursive_structs,
 };
 use crate::{
     diag,
@@ -13,7 +13,7 @@ use crate::{
     naming::ast::{self as N, BuiltinTypeName_, TParam, TParamID, Type, TypeName_, Type_},
     parser::ast::{Ability_, BinOp_, ConstantName, Field, FunctionName, StructName, UnaryOp_, Var},
     shared::{unique_map::UniqueMap, *},
-    typing::{ast as T, core::InferAbilityContext},
+    typing::{ast as T, core::InferAbilityContext, globals},
     FullyCompiledProgram,
 };
 use move_ir_types::location::*;
@@ -143,6 +143,7 @@ fn function(
     assert!(context.constraints.is_empty());
     context.reset_for_module_item();
     context.current_function = Some(name);
+    context.current_function_inlined = inline;
     function_signature(context, &signature);
     if is_script {
         let mk_msg = || {

--- a/language/move-compiler/tests/move_check/inlining/private_call.exp
+++ b/language/move-compiler/tests/move_check/inlining/private_call.exp
@@ -1,0 +1,6 @@
+error[E14002]: Inlined code invalid in this context
+  ┌─ tests/move_check/inlining/private_call.move:4:9
+  │
+4 │         bar()
+  │         ^^^^^ After inlining: indirectly called function `0x42::m::bar` is private in this context
+

--- a/language/move-compiler/tests/move_check/inlining/private_call.move
+++ b/language/move-compiler/tests/move_check/inlining/private_call.move
@@ -1,0 +1,16 @@
+module 0x42::m {
+
+    public inline fun foo(): u64 {
+        bar()
+    }
+
+    fun bar(): u64 { 42 }
+}
+
+module 0x42::n {
+    use 0x42::m;
+
+    public fun test() {
+        assert!(m::foo() == 42, 1);
+    }
+}

--- a/language/move-compiler/tests/move_check/inlining/resources_invalid.exp
+++ b/language/move-compiler/tests/move_check/inlining/resources_invalid.exp
@@ -1,0 +1,12 @@
+error[E04020]: missing acquires annotation
+  ┌─ tests/move_check/inlining/resources_invalid.move:8:9
+  │
+8 │         borrow_global<T>(ref.addr)
+  │         ^^^^^^^^^^^^^^^^^^^^^^^^^^ The call acquires '0x42::token::Token', but the 'acquires' list for the current function does not contain this type. It must be present in the calling context's acquires list
+
+error[E14002]: Inlined code invalid in this context
+  ┌─ tests/move_check/inlining/resources_invalid.move:8:26
+  │
+8 │         borrow_global<T>(ref.addr)
+  │                          ^^^ After inlining: invalid storage operation on external type `0x42::objects::ReaderRef`
+

--- a/language/move-compiler/tests/move_check/inlining/resources_invalid.move
+++ b/language/move-compiler/tests/move_check/inlining/resources_invalid.move
@@ -1,0 +1,20 @@
+module 0x42::objects {
+
+    struct ReaderRef<phantom T: key> has store {
+        addr: address
+    }
+
+    public inline fun reader<T: key>(ref: &ReaderRef<T>): &T {
+        borrow_global<T>(ref.addr)
+    }
+}
+
+module 0x42::token {
+    use 0x42::objects as obj;
+
+    struct Token has key { val: u64 }
+
+    public fun get_value(ref: &obj::ReaderRef<Token>): u64 {
+        obj::reader(ref).val
+    }
+}

--- a/language/move-compiler/tests/move_check/inlining/return.exp
+++ b/language/move-compiler/tests/move_check/inlining/return.exp
@@ -1,0 +1,6 @@
+error[E14003]: feature not supported in inlined functions
+  ┌─ tests/move_check/inlining/return.move:3:9
+  │
+3 │         return 5
+  │         ^^^^^^^^ return statements currently not supported
+

--- a/language/move-compiler/tests/move_check/inlining/return.move
+++ b/language/move-compiler/tests/move_check/inlining/return.move
@@ -1,0 +1,9 @@
+module 0x42::test {
+    inline fun foo(): u32 {
+        return 5
+    }
+
+    fun test_inline() {
+        foo();
+    }
+}

--- a/language/move-compiler/tests/move_check/translated_ir_tests/move/borrow_tests/borrow_global_acquires_invalid_annotation.exp
+++ b/language/move-compiler/tests/move_check/translated_ir_tests/move/borrow_tests/borrow_global_acquires_invalid_annotation.exp
@@ -1,6 +1,0 @@
-error[E02002]: unnecessary or extraneous item
-  ┌─ tests/move_check/translated_ir_tests/move/borrow_tests/borrow_global_acquires_invalid_annotation.move:4:32
-  │
-4 │     public fun test() acquires T1 {
-  │                                ^^ Invalid 'acquires' list. The struct '0x8675309::A::T1' was never acquired by 'move_from', 'borrow_global', 'borrow_global_mut', or a transitive call
-

--- a/language/move-compiler/tests/move_check/translated_ir_tests/move/borrow_tests/borrow_global_acquires_missing_annotation.exp
+++ b/language/move-compiler/tests/move_check/translated_ir_tests/move/borrow_tests/borrow_global_acquires_missing_annotation.exp
@@ -2,8 +2,5 @@ error[E04020]: missing acquires annotation
   ┌─ tests/move_check/translated_ir_tests/move/borrow_tests/borrow_global_acquires_missing_annotation.move:6:9
   │
 6 │         borrow_global_mut<T1>(signer::address_of(account));
-  │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  │         │                 │
-  │         │                 The call acquires '0x8675309::A::T1', but the 'acquires' list for the current function does not contain this type. It must be present in the calling context's acquires list
-  │         Invalid call to borrow_global_mut.
+  │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ The call acquires '0x8675309::A::T1', but the 'acquires' list for the current function does not contain this type. It must be present in the calling context's acquires list
 

--- a/language/move-compiler/tests/move_check/translated_ir_tests/move/borrow_tests/imm_borrow_global_requires_acquire.exp
+++ b/language/move-compiler/tests/move_check/translated_ir_tests/move/borrow_tests/imm_borrow_global_requires_acquire.exp
@@ -2,8 +2,5 @@ error[E04020]: missing acquires annotation
   ┌─ tests/move_check/translated_ir_tests/move/borrow_tests/imm_borrow_global_requires_acquire.move:5:9
   │
 5 │         borrow_global<T1>(addr);
-  │         ^^^^^^^^^^^^^^^^^^^^^^^
-  │         │             │
-  │         │             The call acquires '0x8675309::A::T1', but the 'acquires' list for the current function does not contain this type. It must be present in the calling context's acquires list
-  │         Invalid call to borrow_global.
+  │         ^^^^^^^^^^^^^^^^^^^^^^^ The call acquires '0x8675309::A::T1', but the 'acquires' list for the current function does not contain this type. It must be present in the calling context's acquires list
 

--- a/language/move-compiler/tests/move_check/typing/invalid_type_acquire.exp
+++ b/language/move-compiler/tests/move_check/typing/invalid_type_acquire.exp
@@ -79,15 +79,6 @@ error[E05001]: ability constraint not satisfied
    │                          │         The type '0x2::M::S' does not have the ability 'key'
    │                          Invalid call of 'move_from'
 
-error[E04020]: missing acquires annotation
-   ┌─ tests/move_check/typing/invalid_type_acquire.move:34:26
-   │
-34 │         destroy(account, move_from<S>(a));
-   │                          ^^^^^^^^^^^^^^^
-   │                          │         │
-   │                          │         The call acquires '0x2::M::S', but the 'acquires' list for the current function does not contain this type. It must be present in the calling context's acquires list
-   │                          Invalid call to move_from.
-
 error[E04010]: cannot infer type
    ┌─ tests/move_check/typing/invalid_type_acquire.move:36:9
    │
@@ -133,15 +124,6 @@ error[E05001]: ability constraint not satisfied
    │         │             The type '0x2::M::S' does not have the ability 'key'
    │         Invalid call of 'borrow_global'
 
-error[E04020]: missing acquires annotation
-   ┌─ tests/move_check/typing/invalid_type_acquire.move:40:9
-   │
-40 │         borrow_global<S>(a);
-   │         ^^^^^^^^^^^^^^^^^^^
-   │         │             │
-   │         │             The call acquires '0x2::M::S', but the 'acquires' list for the current function does not contain this type. It must be present in the calling context's acquires list
-   │         Invalid call to borrow_global.
-
 error[E04010]: cannot infer type
    ┌─ tests/move_check/typing/invalid_type_acquire.move:42:9
    │
@@ -186,15 +168,6 @@ error[E05001]: ability constraint not satisfied
    │         │                 │
    │         │                 The type '0x2::M::S' does not have the ability 'key'
    │         Invalid call of 'borrow_global_mut'
-
-error[E04020]: missing acquires annotation
-   ┌─ tests/move_check/typing/invalid_type_acquire.move:46:9
-   │
-46 │         borrow_global_mut<S>(a);
-   │         ^^^^^^^^^^^^^^^^^^^^^^^
-   │         │                 │
-   │         │                 The call acquires '0x2::M::S', but the 'acquires' list for the current function does not contain this type. It must be present in the calling context's acquires list
-   │         Invalid call to borrow_global_mut.
 
 error[E04010]: cannot infer type
    ┌─ tests/move_check/typing/invalid_type_acquire.move:48:9

--- a/language/move-compiler/tests/move_check/typing/missing_acquire.exp
+++ b/language/move-compiler/tests/move_check/typing/missing_acquire.exp
@@ -1,36 +1,6 @@
 error[E04020]: missing acquires annotation
-   ┌─ tests/move_check/typing/missing_acquire.move:8:9
-   │
- 8 │         r1(a);
-   │         ^^^^^ Invalid call to '0x8675309::M::r1'
-   ·
-14 │     fun r1(a: address) acquires R1 {
-   │                                 -- The call acquires '0x8675309::M::R1', but the 'acquires' list for the current function does not contain this type. It must be present in the calling context's acquires list
-
-error[E04020]: missing acquires annotation
-  ┌─ tests/move_check/typing/missing_acquire.move:9:9
-  │
-9 │         borrow_global<R1>(a);
-  │         ^^^^^^^^^^^^^^^^^^^^
-  │         │             │
-  │         │             The call acquires '0x8675309::M::R1', but the 'acquires' list for the current function does not contain this type. It must be present in the calling context's acquires list
-  │         Invalid call to borrow_global.
-
-error[E04020]: missing acquires annotation
-   ┌─ tests/move_check/typing/missing_acquire.move:10:9
-   │
-10 │         borrow_global_mut<R1>(a);
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^
-   │         │                 │
-   │         │                 The call acquires '0x8675309::M::R1', but the 'acquires' list for the current function does not contain this type. It must be present in the calling context's acquires list
-   │         Invalid call to borrow_global_mut.
-
-error[E04020]: missing acquires annotation
    ┌─ tests/move_check/typing/missing_acquire.move:11:16
    │
 11 │         R1{} = move_from<R1>(a);
-   │                ^^^^^^^^^^^^^^^^
-   │                │         │
-   │                │         The call acquires '0x8675309::M::R1', but the 'acquires' list for the current function does not contain this type. It must be present in the calling context's acquires list
-   │                Invalid call to move_from.
+   │                ^^^^^^^^^^^^^^^^ The call acquires '0x8675309::M::R1', but the 'acquires' list for the current function does not contain this type. It must be present in the calling context's acquires list
 

--- a/language/move-compiler/transactional-tests/tests/inlining/objects.exp
+++ b/language/move-compiler/transactional-tests/tests/inlining/objects.exp
@@ -1,0 +1,1 @@
+processed 3 tasks

--- a/language/move-compiler/transactional-tests/tests/inlining/objects.move
+++ b/language/move-compiler/transactional-tests/tests/inlining/objects.move
@@ -1,0 +1,115 @@
+//# publish
+
+// A module which provides the functions to manage objects.
+//
+// Those are provided as inline functions which are inlined in the context of concrete object implementation.
+module 0x42::objects {
+
+    // ================================================
+    // Reference types
+
+    // Need to have public accessors for all of them so they can be accessed from outside this module
+    // in inlining context
+
+    struct OwnerRef has drop { // Hot potato -- cannot be stored
+        addr: address, // This should be a SignerCapability, in reality
+    }
+    public fun make_owner_ref(addr: address): OwnerRef { // for this test only
+        OwnerRef{addr}
+    }
+    public fun owner_addr_of(r: &OwnerRef): address {
+        r.addr
+    }
+
+    struct ReaderRef<phantom T: key> has store, drop {
+        addr: address
+    }
+
+    public fun make_reader_ref<T: key>(addr: address): ReaderRef<T> {
+        ReaderRef<T>{addr}
+    }
+    public fun reader_addr_of<T: key>(r: &ReaderRef<T>): address {
+        r.addr
+    }
+
+    struct WriterRef<phantom T: key> has store, drop {
+        addr: address,
+    }
+
+    public fun make_writer_ref<T: key>(addr: address): WriterRef<T> {
+        WriterRef{addr}
+    }
+
+    public fun writer_addr_of<T: key>(r: &WriterRef<T>): address {
+        r.addr
+    }
+
+    // ================================================
+    // Basic Operations, inlined in the object definition context
+
+    public inline fun create<T: key>(signer: &signer, _ref: &OwnerRef, val: T) {
+        // In reality, we should get the signer via the ref
+        move_to<T>(signer, val)
+    }
+
+    public inline fun reader_ref<T: key>(ref: &OwnerRef): ReaderRef<T> {
+        let addr = owner_addr_of(ref);
+        assert!(exists<T>(addr), 22);
+        make_reader_ref(addr)
+    }
+
+    public inline fun writer_ref<T: key>(ref: &OwnerRef): WriterRef<T> {
+        let addr = owner_addr_of(ref);
+        assert!(exists<T>(addr), 23);
+        make_writer_ref(addr)
+    }
+
+    public inline fun reader<T: key>(ref: &ReaderRef<T>): &T {
+        borrow_global<T>(reader_addr_of(ref))
+    }
+
+    public inline fun writer<T: key>(ref: &WriterRef<T>): &mut T {
+        borrow_global_mut<T>(writer_addr_of(ref))
+    }
+}
+
+//# publish
+module 0x42::token {
+    use 0x42::objects as obj;
+
+    struct Token has key { val: u64 }
+
+    public fun create(signer: &signer, owner: &obj::OwnerRef, val: u64) {
+        obj::create(signer, owner, Token{val})
+    }
+
+    public fun reader_ref(r: &obj::OwnerRef): obj::ReaderRef<Token> {
+        obj::reader_ref<Token>(r)
+    }
+
+    public fun writer_ref(r: &obj::OwnerRef): obj::WriterRef<Token> {
+        obj::writer_ref<Token>(r)
+    }
+
+    public fun get_value(ref: &obj::ReaderRef<Token>): u64 acquires Token {
+        obj::reader(ref).val
+    }
+
+    public fun set_value(ref: &obj::WriterRef<Token>, val: u64) acquires Token {
+        obj::writer(ref).val = val
+    }
+}
+
+//# run --signers 0x42
+script {
+    use 0x42::token;
+    fun main(s: signer) {
+        let or = 0x42::objects::make_owner_ref(@0x42);
+        token::create(&s, &or, 22);
+        let rr = token::reader_ref(&or);
+        let wr = token::writer_ref(&or);
+        assert!(token::get_value(&rr) == 22, 0);
+        token::set_value(&wr, 23);
+        assert!(token::get_value(&rr) == 23, 1)
+    }
+}

--- a/language/move-compiler/transactional-tests/tests/inlining/resources.exp
+++ b/language/move-compiler/transactional-tests/tests/inlining/resources.exp
@@ -1,0 +1,1 @@
+processed 2 tasks

--- a/language/move-compiler/transactional-tests/tests/inlining/resources.move
+++ b/language/move-compiler/transactional-tests/tests/inlining/resources.move
@@ -1,0 +1,22 @@
+//# publish
+module 0x42::M {
+
+    struct R has key { f: u64 }
+
+    public inline fun my_borrow(): &R {
+        borrow_global<R>(@0x42)
+    }
+
+    public fun test_resource(s: &signer) acquires R {
+        move_to<R>(s, R{f:1});
+        assert!(my_borrow().f == 1, 1);
+    }
+}
+
+//# run --signers 0x42
+script {
+    use 0x42::M;
+    fun main(account: signer) {
+        M::test_resource(&account)
+    }
+}


### PR DESCRIPTION
This PR refines the inline implementation to peform various tests for consistency:

- report an error if `return` is used in the inlined functions (currently not supported)
- report errors if inlining introduces inconsistency in the expansion context (calling private functions, accessing module memory, etc.)
- re-arrange the acquires analysis, allowing inline functions to access memory without decl of `acquires`. Rather, check `acquires` after inlining.

The last step, specifically, also allows to write generic inline functions which deal with memory. This has been excercised in the [objects.move](https://github.com/wrwg/move-lang/blob/lambda2/language/move-compiler/transactional-tests/tests/inlining/objects.move) testcase.

The change in the acquires leads to a different style of acquire error messages (also less followup-errors) which results in baseline changes.
