### PR TITLE
Update dev_setup.sh

### DIFF
--- a/scripts/dev_setup.sh
+++ b/scripts/dev_setup.sh
@@ -239,7 +239,7 @@ function install_toolchain {
 function install_dotnet {
   echo "Installing .Net"
   mkdir -p "${DOTNET_INSTALL_DIR}" || true
-  if [[ $("${DOTNET_INSTALL_DIR}/dotnet" --list-sdks | grep -c "^${DOTNET_VERSION}" || true) == "0" ]]; then
+  if [[ $("${DOTNET_INSTALL_DIR}dotnet" --list-sdks | grep -c "^${DOTNET_VERSION}" || true) == "0" ]]; then
     if [[ "$(uname)" == "Linux" ]]; then
       # Install various prerequisites for .dotnet. There are known bugs
       # in the dotnet installer to warn even if they are present. We try


### PR DESCRIPTION
DOTNET_INSTALL_DIR="${HOME}/.dotnet/"  already had `/`，so "${DOTNET_INSTALL_DIR}dotnet" should be removed `/`

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Move Language.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

(Write your answer here.)

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)
