### PR TITLE
[natives] add support for checking the existence of a resource

### DIFF
--- a/language/move-vm/runtime/src/native_functions.rs
+++ b/language/move-vm/runtime/src/native_functions.rs
@@ -5,7 +5,9 @@
 use crate::{
     interpreter::Interpreter, loader::Resolver, native_extensions::NativeContextExtensions,
 };
-use move_binary_format::errors::{ExecutionState, PartialVMError, PartialVMResult};
+use move_binary_format::errors::{
+    ExecutionState, Location, PartialVMError, PartialVMResult, VMResult,
+};
 use move_core_types::{
     account_address::AccountAddress,
     identifier::Identifier,
@@ -116,6 +118,13 @@ impl<'a, 'b> NativeContext<'a, 'b> {
     pub fn print_stack_trace<B: Write>(&self, buf: &mut B) -> PartialVMResult<()> {
         self.interpreter
             .debug_print_stack_trace(buf, self.resolver.loader())
+    }
+
+    pub fn exists_at(&mut self, address: AccountAddress, type_: &Type) -> VMResult<bool> {
+        self.data_store
+            .load_resource(address, type_)
+            .and_then(|(value, _)| value.exists())
+            .map_err(|err| err.finish(Location::Undefined))
     }
 
     pub fn save_event(


### PR DESCRIPTION
Extend native support for verifying a resource exists.

verified here: https://github.com/aptos-labs/aptos-core/pull/6416/commits

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Move Language.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

(Write your answer here.)

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)
