### PR TITLE
sui-move: [7/x][move-package/lock] Move addr_subst and digest to dependency edge

### DIFF
--- a/language/tools/move-cli/tests/build_tests/unbound_dependency/args.evm.exp
+++ b/language/tools/move-cli/tests/build_tests/unbound_dependency/args.evm.exp
@@ -3,5 +3,5 @@ Error: Failed to resolve dependencies for package 'A'
 
 Caused by:
     0: Parsing manifest for 'Foo'
-    1: Unable to find package manifest for 'Foo' at "./foo/Move.toml"
+    1: Unable to find package manifest at "./foo"
     2: No such file or directory (os error 2)

--- a/language/tools/move-cli/tests/build_tests/unbound_dependency/args.exp
+++ b/language/tools/move-cli/tests/build_tests/unbound_dependency/args.exp
@@ -3,5 +3,5 @@ Error: Failed to resolve dependencies for package 'A'
 
 Caused by:
     0: Parsing manifest for 'Foo'
-    1: Unable to find package manifest for 'Foo' at "./foo/Move.toml"
+    1: Unable to find package manifest at "./foo"
     2: No such file or directory (os error 2)

--- a/language/tools/move-package/src/lib.rs
+++ b/language/tools/move-package/src/lib.rs
@@ -13,7 +13,7 @@ use anyhow::{bail, Result};
 use clap::*;
 use move_core_types::account_address::AccountAddress;
 use move_model::model::GlobalEnv;
-use resolution::{dependency_graph::DependencyGraph, lock_file::LockFile};
+use resolution::dependency_graph::DependencyGraph;
 use serde::{Deserialize, Serialize};
 use source_package::layout::SourcePackageLayout;
 use std::{
@@ -233,7 +233,6 @@ impl BuildConfig {
 
         // This should be locked as it inspects the environment for `MOVE_HOME` which could
         // possibly be set by a different process in parallel.
-        let mut lock = LockFile::new(&path)?;
         let manifest = manifest_parser::parse_source_manifest(toml_manifest)?;
 
         let dependency_graph = DependencyGraph::new(
@@ -243,7 +242,7 @@ impl BuildConfig {
             writer,
         )?;
 
-        dependency_graph.write_to_lock(&mut lock)?;
+        let lock = dependency_graph.write_to_lock()?;
         if let Some(lock_path) = &self.lock_file {
             lock.commit(lock_path)?;
         }

--- a/language/tools/move-package/src/resolution/dependency_graph.rs
+++ b/language/tools/move-package/src/resolution/dependency_graph.rs
@@ -107,6 +107,9 @@ impl DependencyGraph {
             always_deps: BTreeSet::new(),
         };
 
+        // Ensure there's always a root node, even if it has no edges.
+        graph.package_graph.add_node(graph.root_package);
+
         graph
             .extend_graph(
                 PM::DependencyKind::default(),
@@ -144,6 +147,9 @@ impl DependencyGraph {
         let mut package_table = BTreeMap::new();
 
         let packages = schema::Packages::read(lock)?;
+
+        // Ensure there's always a root node, even if it has no edges.
+        package_graph.add_node(root_package);
 
         for schema::Dependency {
             name,

--- a/language/tools/move-package/src/resolution/dependency_graph.rs
+++ b/language/tools/move-package/src/resolution/dependency_graph.rs
@@ -14,18 +14,14 @@ use std::{
 use crate::{
     package_hooks,
     source_package::{
-        manifest_parser::parse_dependency,
-        parsed_manifest::{
-            CustomDepInfo, Dependency, DependencyKind, GitInfo, NamedAddress, PackageName,
-            SourceManifest, SubstOrRename, Substitution,
-        },
+        manifest_parser::{parse_dependency, parse_move_manifest_from_file, parse_substitution},
+        parsed_manifest as PM,
     },
 };
 
 use super::{
-    download_and_update_if_remote,
+    download_and_update_if_remote, local_path,
     lock_file::{schema, LockFile},
-    parse_package_manifest,
 };
 
 /// A representation of the transitive dependency graph of a Move package.  If successfully created,
@@ -46,34 +42,48 @@ use super::{
 #[derive(Debug)]
 pub struct DependencyGraph {
     /// Path to the root package and its name (according to its manifest)
-    root_path: PathBuf,
-    root_package: PackageName,
+    pub root_path: PathBuf,
+    pub root_package: PM::PackageName,
 
     /// Transitive dependency graph, with dependency edges `P -> Q` labelled according to whether Q
     /// is always a dependency of P or only in dev-mode.
-    package_graph: DiGraphMap<PackageName, DependencyMode>,
+    pub package_graph: DiGraphMap<PM::PackageName, Dependency>,
 
     /// The dependency that each package (keyed by name) originates from.  The root package is the
     /// only node in `package_graph` that does not have an entry in `package_table`.
-    package_table: BTreeMap<PackageName, Dependency>,
+    pub package_table: BTreeMap<PM::PackageName, Package>,
 
     /// Packages that are transitive dependencies regardless of mode (the transitive closure of
     /// `DependencyMode::Always` edges in `package_graph`).
-    pub always_deps: BTreeSet<PackageName>,
+    pub always_deps: BTreeSet<PM::PackageName>,
 }
 
-/// Edge label indicating whether one package always depends on another, or only in dev-mode.
+#[derive(Debug, PartialEq, Eq)]
+pub struct Package {
+    kind: PM::DependencyKind,
+    version: Option<PM::Version>,
+}
+
+#[derive(Debug)]
+pub struct Dependency {
+    pub mode: DependencyMode,
+    pub subst: Option<PM::Substitution>,
+    pub digest: Option<PM::PackageDigest>,
+}
+
+/// Indicates whether one package always depends on another, or only in dev-mode.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
-enum DependencyMode {
+pub enum DependencyMode {
     Always,
     DevOnly,
 }
 
-/// Wrapper struct to display a dependency as an inline table in the lock file (matching the
+/// Wrapper struct to display a package as an inline table in the lock file (matching the
 /// convention in the source manifest).  This is necessary becase the `toml` crate does not
 /// currently support serializing types as inline tables.
-struct DependencyTOML<'a>(&'a Dependency);
-struct SubstTOML<'a>(&'a Substitution);
+struct PackageTOML<'a>(&'a Package);
+struct DependencyTOML<'a>(PM::PackageName, &'a Dependency);
+struct SubstTOML<'a>(&'a PM::Substitution);
 
 impl DependencyGraph {
     /// Build a graph from the transitive dependencies and dev-dependencies of `root_package`.
@@ -84,7 +94,7 @@ impl DependencyGraph {
     /// `progress_output` is an output stream that is written to while generating the graph, to
     /// provide human-readable progress updates.
     pub fn new<Progress: Write>(
-        root_package: &SourceManifest,
+        root_package: &PM::SourceManifest,
         root_path: PathBuf,
         skip_fetch_latest_git_deps: bool,
         progress_output: &mut Progress,
@@ -99,7 +109,7 @@ impl DependencyGraph {
 
         graph
             .extend_graph(
-                DependencyKind::default(),
+                PM::DependencyKind::default(),
                 root_package,
                 skip_fetch_latest_git_deps,
                 progress_output,
@@ -127,7 +137,7 @@ impl DependencyGraph {
     /// the `lock_file::schema` module).
     pub fn read_from_lock(
         root_path: PathBuf,
-        root_package: SourceManifest,
+        root_package: PM::SourceManifest,
         lock: &mut impl Read,
     ) -> Result<DependencyGraph> {
         let mut package_graph = DiGraphMap::new();
@@ -136,49 +146,102 @@ impl DependencyGraph {
         // Seed graph with edges from the root package
         let root = root_package.package.name;
 
-        for dep in root_package.dependencies.keys() {
-            package_graph.add_edge(root, *dep, DependencyMode::Always);
+        for (pkg, mut dep) in root_package.dependencies {
+            package_graph.add_edge(
+                root,
+                pkg,
+                Dependency {
+                    mode: DependencyMode::Always,
+                    subst: dep.subst.take(),
+                    digest: dep.digest.take(),
+                },
+            );
         }
 
-        for dep in root_package.dev_dependencies.keys() {
-            package_graph.add_edge(root, *dep, DependencyMode::DevOnly);
+        for (pkg, mut dep) in root_package.dev_dependencies {
+            package_graph.add_edge(
+                root,
+                pkg,
+                Dependency {
+                    mode: DependencyMode::DevOnly,
+                    subst: dep.subst.take(),
+                    digest: dep.digest.take(),
+                },
+            );
         }
 
         // Fill in the remaining dependencies, and the package source information from the lock
         // file.
-        for schema::Dependency {
-            name,
+        for schema::Package {
+            name: pkg_name,
             source,
             dependencies,
             dev_dependencies,
-        } in schema::Dependencies::read(lock)?
+        } in schema::Packages::read(lock)?
         {
-            let package = PackageName::from(name.as_str());
-            let source = parse_dependency(package.as_str(), source)
-                .with_context(|| format!("Deserializing dependency {}", package))?;
+            let pkg_name = PM::PackageName::from(pkg_name.as_str());
+            let source = parse_dependency(pkg_name.as_str(), source)
+                .with_context(|| format!("Deserializing dependency '{pkg_name}'"))?;
 
-            match package_table.entry(package) {
+            if source.subst.is_some() {
+                bail!("Unexpected 'addr_subst' in source for '{pkg_name}'")
+            }
+
+            if source.digest.is_some() {
+                bail!("Unexpected 'digest' in source for '{pkg_name}'")
+            }
+
+            let pkg = Package {
+                kind: source.kind,
+                version: source.version,
+            };
+
+            match package_table.entry(pkg_name) {
                 Entry::Vacant(entry) => {
-                    entry.insert(source);
+                    entry.insert(pkg);
                 }
                 Entry::Occupied(entry) => {
                     bail!(
                         "Duplicate dependency in lock file:\n{0} = {1}\n{0} = {2}\n",
-                        package,
-                        DependencyTOML(entry.get()),
-                        DependencyTOML(&source),
+                        pkg_name,
+                        PackageTOML(entry.get()),
+                        PackageTOML(&pkg),
                     );
                 }
             };
 
-            for dep in dependencies.iter().flatten() {
-                let dep = PackageName::from(dep.as_str());
-                package_graph.add_edge(package, dep, DependencyMode::Always);
+            for schema::Dependency {
+                name: dep_name,
+                subst,
+                digest,
+            } in dependencies.into_iter().flatten()
+            {
+                package_graph.add_edge(
+                    pkg_name,
+                    PM::PackageName::from(dep_name.as_str()),
+                    Dependency {
+                        mode: DependencyMode::Always,
+                        subst: subst.map(parse_substitution).transpose()?,
+                        digest: digest.map(Symbol::from),
+                    },
+                );
             }
 
-            for dep in dev_dependencies.iter().flatten() {
-                let dep = PackageName::from(dep.as_str());
-                package_graph.add_edge(package, dep, DependencyMode::DevOnly);
+            for schema::Dependency {
+                name: dep_name,
+                subst,
+                digest,
+            } in dev_dependencies.into_iter().flatten()
+            {
+                package_graph.add_edge(
+                    pkg_name,
+                    PM::PackageName::from(dep_name.as_str()),
+                    Dependency {
+                        mode: DependencyMode::DevOnly,
+                        subst: subst.map(parse_substitution).transpose()?,
+                        digest: digest.map(Symbol::from),
+                    },
+                );
             }
         }
 
@@ -196,100 +259,130 @@ impl DependencyGraph {
         Ok(graph)
     }
 
-    /// Serialize this dependency graph into a lock file, consuming it in the process.
+    /// Serialize this dependency graph into a lock file.
     ///
     /// This operation fails, writing nothing, if the graph contains a cycle, and can fail with an
     /// undefined output if it cannot be represented in a TOML file.
-    pub fn write_to_lock(self, lock: &mut LockFile) -> Result<()> {
+    pub fn write_to_lock(&self, lock: &mut LockFile) -> Result<()> {
         let mut writer = BufWriter::new(&**lock);
-        for (pkg, dep) in self.package_table {
-            writeln!(writer, "\n[[move.dependency]]")?;
+        for (name, pkg) in &self.package_table {
+            writeln!(writer, "\n[[move.package]]")?;
 
-            writeln!(writer, "name = {}", str_escape(pkg.as_str())?)?;
-            writeln!(writer, "source = {}", DependencyTOML(&dep))?;
+            writeln!(writer, "name = {}", str_escape(name.as_str())?)?;
+            writeln!(writer, "source = {}", PackageTOML(pkg))?;
 
             let mut deps: Vec<_> = self
                 .package_graph
-                .edges(pkg)
-                .map(|(_, dep, kind)| (*kind, dep))
+                .edges(*name)
+                .map(|(_, pkg, dep)| (dep, pkg))
                 .collect();
 
             // Sort by kind ("always" dependencies go first), and by name, to keep the output
             // stable.
-            deps.sort();
-
+            deps.sort_by_key(|(dep, pkg)| (dep.mode, *pkg));
             let mut deps = deps.into_iter().peekable();
-            if let Some((DependencyMode::Always, _)) = deps.peek() {
-                writeln!(writer, "dependencies = [")?;
-                while let Some((DependencyMode::Always, dep)) = deps.peek() {
-                    writeln!(writer, "  {},", str_escape(dep.as_str())?)?;
-                    deps.next();
-                }
-                writeln!(writer, "]")?;
+
+            macro_rules! write_deps {
+                ($mode: pat, $label: literal) => {
+                    if let Some((Dependency { mode: $mode, .. }, _)) = deps.peek() {
+                        writeln!(writer, "{} = [", $label)?;
+                        while let Some((dep @ Dependency { mode: $mode, .. }, pkg)) = deps.peek() {
+                            writeln!(writer, "  {},", DependencyTOML(*pkg, dep))?;
+                            deps.next();
+                        }
+                        writeln!(writer, "]")?;
+                    }
+                };
             }
 
-            if let Some((DependencyMode::DevOnly, _)) = deps.peek() {
-                writeln!(writer, "dev-dependencies = [")?;
-                while let Some((DependencyMode::DevOnly, dep)) = deps.peek() {
-                    writeln!(writer, "  {},", str_escape(dep.as_str())?)?;
-                    deps.next();
-                }
-                writeln!(writer, "]")?;
-            }
+            write_deps!(DependencyMode::Always, "dependencies");
+            write_deps!(DependencyMode::DevOnly, "dev-dependencies");
         }
 
         writer.flush()?;
         Ok(())
     }
 
+    /// Return packages in the graph in topological order (a package is ordered before its
+    /// dependencies).
+    ///
+    /// The ordering is agnostic to dependency mode (dev-mode or not) and contains all packagesd
+    /// (including packages that are exclusively dev-mode-only).
+    ///
+    /// Guaranteed to succeed because `DependencyGraph` instances cannot contain cycles.
+    pub fn topological_order(&self) -> Vec<PM::PackageName> {
+        algo::toposort(&self.package_graph, None)
+            .expect("Graph is determined to be acyclic when created")
+    }
+
     /// Add the transitive dependencies and dev-dependencies from `package` to the dependency graph.
     fn extend_graph<Progress: Write>(
         &mut self,
-        parent: DependencyKind,
-        package: &SourceManifest,
+        parent: PM::DependencyKind,
+        package: &PM::SourceManifest,
         skip_fetch_latest_git_deps: bool,
         progress_output: &mut Progress,
     ) -> Result<()> {
         let from = package.package.name;
         for (to, dep) in &package.dependencies {
-            let mut dep = dep.clone();
-            dep.kind.reroot(&parent)?;
+            let mut pkg = Package {
+                kind: dep.kind.clone(),
+                version: dep.version,
+            };
 
-            self.process_dependency(dep, *to, skip_fetch_latest_git_deps, progress_output)?;
+            pkg.kind.reroot(&parent)?;
+            self.process_dependency(pkg, *to, skip_fetch_latest_git_deps, progress_output)?;
 
-            self.package_graph
-                .add_edge(from, *to, DependencyMode::Always);
+            self.package_graph.add_edge(
+                from,
+                *to,
+                Dependency {
+                    mode: DependencyMode::Always,
+                    subst: dep.subst.clone(),
+                    digest: dep.digest,
+                },
+            );
         }
 
         for (to, dep) in &package.dev_dependencies {
-            let mut dep = dep.clone();
-            dep.kind.reroot(&parent)?;
+            let mut pkg = Package {
+                kind: dep.kind.clone(),
+                version: dep.version,
+            };
 
-            self.process_dependency(dep, *to, skip_fetch_latest_git_deps, progress_output)?;
+            pkg.kind.reroot(&parent)?;
+            self.process_dependency(pkg, *to, skip_fetch_latest_git_deps, progress_output)?;
 
-            self.package_graph
-                .add_edge(from, *to, DependencyMode::DevOnly);
+            self.package_graph.add_edge(
+                from,
+                *to,
+                Dependency {
+                    mode: DependencyMode::DevOnly,
+                    subst: dep.subst.clone(),
+                    digest: dep.digest,
+                },
+            );
         }
 
         Ok(())
     }
 
-    /// Ensures that package `dep_name` and all its transitive dependencies are present in the
-    /// graph, all sourced from their respective `dep`endencies.  Fails if any of the packages in
-    /// the dependency sub-graph rooted at `dep_name` are already present in `self` but sourced from
+    /// Ensures that package `pkg_name` and all its transitive dependencies are present in the
+    /// graph, all sourced from their respective packages, `pkg`.  Fails if any of the packages in
+    /// the dependency sub-graph rooted at `pkg_name` are already present in `self` but sourced from
     /// a different dependency.
     fn process_dependency<Progress: Write>(
         &mut self,
-        dep: Dependency,
-        dep_name: PackageName,
+        pkg: Package,
+        name: PM::PackageName,
         skip_fetch_latest_git_deps: bool,
         progress_output: &mut Progress,
     ) -> Result<()> {
-        let dep = match self.package_table.entry(dep_name) {
-            Entry::Vacant(entry) => entry.insert(dep),
+        let pkg = match self.package_table.entry(name) {
+            Entry::Vacant(entry) => entry.insert(pkg),
 
             // Seeing the same package again, pointing to the same dependency: OK, return early.
-            Entry::Occupied(entry) if entry.get().kind == dep.kind => {
+            Entry::Occupied(entry) if entry.get() == &pkg => {
                 return Ok(());
             }
 
@@ -297,31 +390,32 @@ impl DependencyGraph {
             Entry::Occupied(entry) => {
                 bail!(
                     "Conflicting dependencies found:\n{0} = {1}\n{0} = {2}\n",
-                    dep_name,
-                    DependencyTOML(entry.get()),
-                    DependencyTOML(&dep),
+                    name,
+                    PackageTOML(entry.get()),
+                    PackageTOML(&pkg),
                 );
             }
         };
 
-        download_and_update_if_remote(dep_name, dep, skip_fetch_latest_git_deps, progress_output)
-            .with_context(|| format!("Fetching '{}'", dep_name))?;
+        download_and_update_if_remote(name, &pkg.kind, skip_fetch_latest_git_deps, progress_output)
+            .with_context(|| format!("Fetching '{}'", name))?;
 
-        let (manifest, _) = parse_package_manifest(dep, &dep_name, self.root_path.clone())
-            .with_context(|| format!("Parsing manifest for '{}'", dep_name))?;
+        let pkg_path = self.root_path.join(local_path(&pkg.kind));
+        let manifest = parse_move_manifest_from_file(&pkg_path)
+            .with_context(|| format!("Parsing manifest for '{}'", name))?;
 
-        if dep_name != manifest.package.name {
+        if name != manifest.package.name {
             bail!(
                 "Name of dependency declared in package '{}' \
                  does not match dependency's package name '{}'",
-                dep_name,
+                name,
                 manifest.package.name,
             )
         }
 
-        let kind = dep.kind.clone();
+        let kind = pkg.kind.clone();
         self.extend_graph(kind, &manifest, skip_fetch_latest_git_deps, progress_output)
-            .with_context(|| format!("Resolving dependencies for package '{}'", dep_name))
+            .with_context(|| format!("Resolving dependencies for package '{}'", name))
     }
 
     /// Check that every dependency in the graph, excluding the root package, is present in the
@@ -385,31 +479,26 @@ impl DependencyGraph {
             frontier.extend(
                 self.package_graph
                     .edges(package)
-                    .filter(|(_, _, mode)| **mode == DependencyMode::Always)
-                    .map(|(_, dep, _)| dep),
+                    .filter(|(_, _, dep)| dep.mode == DependencyMode::Always)
+                    .map(|(_, pkg, _)| pkg),
             );
         }
     }
 }
 
-impl<'a> fmt::Display for DependencyTOML<'a> {
+impl<'a> fmt::Display for PackageTOML<'a> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let Dependency {
-            kind,
-            subst,
-            version,
-            digest,
-        } = self.0;
+        let Package { kind, version } = self.0;
 
         f.write_str("{ ")?;
 
         match kind {
-            DependencyKind::Local(local) => {
+            PM::DependencyKind::Local(local) => {
                 write!(f, "local = ")?;
                 f.write_str(&path_escape(local)?)?;
             }
 
-            DependencyKind::Git(GitInfo {
+            PM::DependencyKind::Git(PM::GitInfo {
                 git_url,
                 git_rev,
                 subdir,
@@ -424,7 +513,7 @@ impl<'a> fmt::Display for DependencyTOML<'a> {
                 f.write_str(&path_escape(subdir)?)?;
             }
 
-            DependencyKind::Custom(CustomDepInfo {
+            PM::DependencyKind::Custom(PM::CustomDepInfo {
                 node_url,
                 package_address,
                 subdir,
@@ -448,6 +537,27 @@ impl<'a> fmt::Display for DependencyTOML<'a> {
             write!(f, ", version = \"{}.{}.{}\"", major, minor, bugfix)?;
         }
 
+        f.write_str(" }")?;
+        Ok(())
+    }
+}
+
+impl<'a> fmt::Display for DependencyTOML<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let DependencyTOML(
+            name,
+            Dependency {
+                mode: _,
+                subst,
+                digest,
+            },
+        ) = self;
+
+        f.write_str("{ ")?;
+
+        write!(f, "name = ")?;
+        f.write_str(&str_escape(name.as_str())?)?;
+
         if let Some(digest) = digest {
             write!(f, ", digest = ")?;
             f.write_str(&str_escape(digest.as_str())?)?;
@@ -467,18 +577,18 @@ impl<'a> fmt::Display for SubstTOML<'a> {
         /// Write an individual key value pair in the substitution.
         fn write_subst(
             f: &mut fmt::Formatter<'_>,
-            addr: &NamedAddress,
-            subst: &SubstOrRename,
+            addr: &PM::NamedAddress,
+            subst: &PM::SubstOrRename,
         ) -> fmt::Result {
             f.write_str(&str_escape(addr.as_str())?)?;
             write!(f, " = ")?;
 
             match subst {
-                SubstOrRename::RenameFrom(named) => {
+                PM::SubstOrRename::RenameFrom(named) => {
                     f.write_str(&str_escape(named.as_str())?)?;
                 }
 
-                SubstOrRename::Assign(account) => {
+                PM::SubstOrRename::Assign(account) => {
                     f.write_str(&str_escape(&account.to_canonical_string())?)?;
                 }
             }

--- a/language/tools/move-package/src/resolution/lock_file/schema.rs
+++ b/language/tools/move-package/src/resolution/lock_file/schema.rs
@@ -22,7 +22,13 @@ pub const VERSION: u64 = 0;
 #[derive(Deserialize)]
 pub struct Packages {
     #[serde(rename = "package")]
-    packages: Option<Vec<Package>>,
+    pub packages: Option<Vec<Package>>,
+
+    #[serde(rename = "dependencies")]
+    pub root_dependencies: Option<Vec<Dependency>>,
+
+    #[serde(rename = "dev-dependencies")]
+    pub root_dev_dependencies: Option<Vec<Dependency>>,
 }
 
 #[derive(Deserialize)]
@@ -68,7 +74,7 @@ struct Header {
 impl Packages {
     /// Read packages from the lock file, assuming the file's format matches the schema expected
     /// by this lock file, and its version is not newer than the version supported by this library.
-    pub fn read(lock: &mut impl Read) -> Result<Vec<Package>> {
+    pub fn read(lock: &mut impl Read) -> Result<Packages> {
         let contents = {
             let mut buf = String::new();
             lock.read_to_string(&mut buf).context("Reading lock file")?;
@@ -87,11 +93,10 @@ impl Packages {
             );
         }
 
-        let Schema {
-            move_: Packages { packages },
-        } = toml::de::from_str::<Schema<Packages>>(&contents).context("Deserializing packages")?;
+        let Schema { move_: packages } =
+            toml::de::from_str::<Schema<Packages>>(&contents).context("Deserializing packages")?;
 
-        Ok(packages.unwrap_or_default())
+        Ok(packages)
     }
 }
 

--- a/language/tools/move-package/src/resolution/lock_file/schema.rs
+++ b/language/tools/move-package/src/resolution/lock_file/schema.rs
@@ -20,24 +20,38 @@ use toml::value::Value;
 pub const VERSION: u64 = 0;
 
 #[derive(Deserialize)]
-pub struct Dependencies {
-    #[serde(rename = "dependency")]
-    dependencies: Option<Vec<Dependency>>,
+pub struct Packages {
+    #[serde(rename = "package")]
+    packages: Option<Vec<Package>>,
+}
+
+#[derive(Deserialize)]
+pub struct Package {
+    /// The name of the package (corresponds to the name field from its source manifest).
+    pub name: String,
+
+    /// Where to find this dependency.  Schema is not described in terms of serde-compatible
+    /// structs, so it is deserialized into a generic data structure.
+    pub source: Value,
+
+    pub dependencies: Option<Vec<Dependency>>,
+    #[serde(rename = "dev-dependencies")]
+    pub dev_dependencies: Option<Vec<Dependency>>,
 }
 
 #[derive(Deserialize)]
 pub struct Dependency {
-    /// The name of the dependency (corresponds to the key for the dependency in the source
-    /// manifest).
+    /// The name of the dependency (corresponds to the key for the dependency in the depending
+    /// package's source manifest).
     pub name: String,
 
-    /// The description of the dependency from its source manifest.  Its schema is not described in
-    /// terms of serde-compatible structs, so it is deserialized into a generic data structure.
-    pub source: Value,
+    /// Mappings for named addresses to apply to the package being depended on, when referred to by
+    /// the depending package.
+    #[serde(rename = "addr_subst")]
+    pub subst: Option<Value>,
 
-    pub dependencies: Option<Vec<String>>,
-    #[serde(rename = "dev-dependencies")]
-    pub dev_dependencies: Option<Vec<String>>,
+    /// Expected hash for the source and manifest of the package being depended upon.
+    pub digest: Option<String>,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -51,10 +65,10 @@ struct Header {
     version: u64,
 }
 
-impl Dependencies {
-    /// Read dependencies from the lock file, assuming the file's format matches the schema expected
+impl Packages {
+    /// Read packages from the lock file, assuming the file's format matches the schema expected
     /// by this lock file, and its version is not newer than the version supported by this library.
-    pub fn read(lock: &mut impl Read) -> Result<Vec<Dependency>> {
+    pub fn read(lock: &mut impl Read) -> Result<Vec<Package>> {
         let contents = {
             let mut buf = String::new();
             lock.read_to_string(&mut buf).context("Reading lock file")?;
@@ -74,11 +88,10 @@ impl Dependencies {
         }
 
         let Schema {
-            move_: Dependencies { dependencies },
-        } = toml::de::from_str::<Schema<Dependencies>>(&contents)
-            .context("Deserializing dependencies")?;
+            move_: Packages { packages },
+        } = toml::de::from_str::<Schema<Packages>>(&contents).context("Deserializing packages")?;
 
-        Ok(dependencies.unwrap_or_default())
+        Ok(packages.unwrap_or_default())
     }
 }
 

--- a/language/tools/move-package/src/resolution/mod.rs
+++ b/language/tools/move-package/src/resolution/mod.rs
@@ -49,7 +49,7 @@ pub fn download_dependency_repos<Progress: Write>(
     for (dep_name, dep) in manifest.dependencies.iter().chain(additional_deps.iter()) {
         download_and_update_if_remote(
             *dep_name,
-            dep,
+            &dep.kind,
             build_options.skip_fetch_latest_git_deps,
             progress_output,
         )?;
@@ -85,11 +85,11 @@ fn parse_package_manifest(
 
 fn download_and_update_if_remote<Progress: Write>(
     dep_name: PackageName,
-    dep: &Dependency,
+    kind: &DependencyKind,
     skip_fetch_latest_git_deps: bool,
     progress_output: &mut Progress,
 ) -> Result<()> {
-    match &dep.kind {
+    match kind {
         DependencyKind::Local(_) => Ok(()),
 
         DependencyKind::Custom(node_info) => {

--- a/language/tools/move-package/src/resolution/resolution_graph.rs
+++ b/language/tools/move-package/src/resolution/resolution_graph.rs
@@ -398,7 +398,7 @@ impl ResolvingGraph {
     ) -> Result<(Renaming, ResolvingTable)> {
         download_and_update_if_remote(
             dep_name_in_pkg,
-            &dep,
+            &dep.kind,
             self.build_options.skip_fetch_latest_git_deps,
             progress_output,
         )?;

--- a/language/tools/move-package/src/source_package/manifest_parser.rs
+++ b/language/tools/move-package/src/source_package/manifest_parser.rs
@@ -36,10 +36,11 @@ const REQUIRED_FIELDS: &[&str] = &[PACKAGE_NAME];
 
 pub fn parse_move_manifest_from_file(path: &Path) -> Result<PM::SourceManifest> {
     let file_contents = if path.is_file() {
-        std::fs::read_to_string(path)?
+        std::fs::read_to_string(path)
     } else {
-        std::fs::read_to_string(path.join(SourcePackageLayout::Manifest.path()))?
-    };
+        std::fs::read_to_string(path.join(SourcePackageLayout::Manifest.path()))
+    }
+    .with_context(|| format!("Unable to find package manifest at {:?}", path))?;
     parse_source_manifest(parse_move_manifest_string(file_contents)?)
 }
 
@@ -433,7 +434,7 @@ pub fn parse_dependency(dep_name: &str, mut tval: TV) -> Result<PM::Dependency> 
     })
 }
 
-fn parse_substitution(tval: TV) -> Result<PM::Substitution> {
+pub fn parse_substitution(tval: TV) -> Result<PM::Substitution> {
     match tval {
         TV::Table(table) => {
             let mut subst = BTreeMap::new();

--- a/language/tools/move-package/tests/test_sources/dep_dev_dep_diamond/Move.locked
+++ b/language/tools/move-package/tests/test_sources/dep_dev_dep_diamond/Move.locked
@@ -3,12 +3,23 @@
 [move]
 version = 0
 
+dependencies = [
+  { name = "A" },
+  { name = "C" },
+]
+
+dev-dependencies = [
+  { name = "B" },
+]
+
 [[move.package]]
 name = "A"
 source = { local = "deps_only/A" }
+
 dependencies = [
   { name = "B" },
 ]
+
 dev-dependencies = [
   { name = "D" },
 ]
@@ -16,6 +27,7 @@ dev-dependencies = [
 [[move.package]]
 name = "B"
 source = { local = "deps_only/B" }
+
 dev-dependencies = [
   { name = "C" },
 ]

--- a/language/tools/move-package/tests/test_sources/dep_dev_dep_diamond/Move.locked
+++ b/language/tools/move-package/tests/test_sources/dep_dev_dep_diamond/Move.locked
@@ -3,27 +3,27 @@
 [move]
 version = 0
 
-[[move.dependency]]
+[[move.package]]
 name = "A"
 source = { local = "deps_only/A" }
 dependencies = [
-  "B",
+  { name = "B" },
 ]
 dev-dependencies = [
-  "D",
+  { name = "D" },
 ]
 
-[[move.dependency]]
+[[move.package]]
 name = "B"
 source = { local = "deps_only/B" }
 dev-dependencies = [
-  "C",
+  { name = "C" },
 ]
 
-[[move.dependency]]
+[[move.package]]
 name = "C"
 source = { local = "deps_only/C" }
 
-[[move.dependency]]
+[[move.package]]
 name = "D"
 source = { local = "deps_only/D" }

--- a/language/tools/move-package/tests/test_sources/dep_good_digest/Move.locked
+++ b/language/tools/move-package/tests/test_sources/dep_good_digest/Move.locked
@@ -3,6 +3,10 @@
 [move]
 version = 0
 
+dependencies = [
+  { name = "OtherDep", digest = "6A88B7888D6049EB0121900E22B6FA2C0E702F042C8C8D4FD62AD5C990B9F9A8", addr_subst = { "A" = "B" } },
+]
+
 [[move.package]]
 name = "OtherDep"
 source = { local = "deps_only/other_dep" }

--- a/language/tools/move-package/tests/test_sources/dep_good_digest/Move.locked
+++ b/language/tools/move-package/tests/test_sources/dep_good_digest/Move.locked
@@ -3,6 +3,6 @@
 [move]
 version = 0
 
-[[move.dependency]]
+[[move.package]]
 name = "OtherDep"
-source = { local = "deps_only/other_dep", digest = "6A88B7888D6049EB0121900E22B6FA2C0E702F042C8C8D4FD62AD5C990B9F9A8", addr_subst = { "A" = "B" } }
+source = { local = "deps_only/other_dep" }

--- a/language/tools/move-package/tests/test_sources/diamond_problem_no_conflict/Move.locked
+++ b/language/tools/move-package/tests/test_sources/diamond_problem_no_conflict/Move.locked
@@ -3,20 +3,20 @@
 [move]
 version = 0
 
-[[move.dependency]]
+[[move.package]]
 name = "A"
-source = { local = "deps_only/A", addr_subst = { "AA" = "00000000000000000000000000000001" } }
+source = { local = "deps_only/A" }
 dependencies = [
-  "C",
+  { name = "C", addr_subst = { "AA" = "A" } },
 ]
 
-[[move.dependency]]
+[[move.package]]
 name = "B"
-source = { local = "deps_only/B", addr_subst = { "BA" = "00000000000000000000000000000001" } }
+source = { local = "deps_only/B" }
 dependencies = [
-  "C",
+  { name = "C", addr_subst = { "BA" = "A" } },
 ]
 
-[[move.dependency]]
+[[move.package]]
 name = "C"
-source = { local = "deps_only/C", addr_subst = { "AA" = "A" } }
+source = { local = "deps_only/C" }

--- a/language/tools/move-package/tests/test_sources/diamond_problem_no_conflict/Move.locked
+++ b/language/tools/move-package/tests/test_sources/diamond_problem_no_conflict/Move.locked
@@ -3,9 +3,15 @@
 [move]
 version = 0
 
+dependencies = [
+  { name = "A", addr_subst = { "AA" = "00000000000000000000000000000001" } },
+  { name = "B", addr_subst = { "BA" = "00000000000000000000000000000001" } },
+]
+
 [[move.package]]
 name = "A"
 source = { local = "deps_only/A" }
+
 dependencies = [
   { name = "C", addr_subst = { "AA" = "A" } },
 ]
@@ -13,6 +19,7 @@ dependencies = [
 [[move.package]]
 name = "B"
 source = { local = "deps_only/B" }
+
 dependencies = [
   { name = "C", addr_subst = { "BA" = "A" } },
 ]

--- a/language/tools/move-package/tests/test_sources/multiple_deps_no_rename/Move.locked
+++ b/language/tools/move-package/tests/test_sources/multiple_deps_no_rename/Move.locked
@@ -3,6 +3,11 @@
 [move]
 version = 0
 
+dependencies = [
+  { name = "C" },
+  { name = "D" },
+]
+
 [[move.package]]
 name = "C"
 source = { local = "deps_only/C" }

--- a/language/tools/move-package/tests/test_sources/multiple_deps_no_rename/Move.locked
+++ b/language/tools/move-package/tests/test_sources/multiple_deps_no_rename/Move.locked
@@ -3,10 +3,10 @@
 [move]
 version = 0
 
-[[move.dependency]]
+[[move.package]]
 name = "C"
 source = { local = "deps_only/C" }
 
-[[move.dependency]]
+[[move.package]]
 name = "D"
 source = { local = "deps_only/D" }

--- a/language/tools/move-package/tests/test_sources/nested_deps_git_local/Move.locked
+++ b/language/tools/move-package/tests/test_sources/nested_deps_git_local/Move.locked
@@ -3,13 +3,13 @@
 [move]
 version = 0
 
-[[move.dependency]]
+[[move.package]]
 name = "MoveNursery"
 source = { git = "https://github.com/move-language/move", rev = "781c844", subdir = "language/move-stdlib/nursery" }
 dependencies = [
-  "MoveStdlib",
+  { name = "MoveStdlib" },
 ]
 
-[[move.dependency]]
+[[move.package]]
 name = "MoveStdlib"
 source = { git = "https://github.com/move-language/move", rev = "781c844", subdir = "language/move-stdlib" }

--- a/language/tools/move-package/tests/test_sources/nested_deps_git_local/Move.locked
+++ b/language/tools/move-package/tests/test_sources/nested_deps_git_local/Move.locked
@@ -3,9 +3,14 @@
 [move]
 version = 0
 
+dependencies = [
+  { name = "MoveNursery" },
+]
+
 [[move.package]]
 name = "MoveNursery"
 source = { git = "https://github.com/move-language/move", rev = "781c844", subdir = "language/move-stdlib/nursery" }
+
 dependencies = [
   { name = "MoveStdlib" },
 ]

--- a/language/tools/move-package/tests/test_sources/nested_deps_local_local/Move.locked
+++ b/language/tools/move-package/tests/test_sources/nested_deps_local_local/Move.locked
@@ -3,13 +3,13 @@
 [move]
 version = 0
 
-[[move.dependency]]
+[[move.package]]
 name = "More"
 source = { local = "deps_only/nested/more" }
 
-[[move.dependency]]
+[[move.package]]
 name = "Nested"
 source = { local = "deps_only/nested" }
 dependencies = [
-  "More",
+  { name = "More" },
 ]

--- a/language/tools/move-package/tests/test_sources/nested_deps_local_local/Move.locked
+++ b/language/tools/move-package/tests/test_sources/nested_deps_local_local/Move.locked
@@ -3,6 +3,10 @@
 [move]
 version = 0
 
+dependencies = [
+  { name = "Nested" },
+]
+
 [[move.package]]
 name = "More"
 source = { local = "deps_only/nested/more" }
@@ -10,6 +14,7 @@ source = { local = "deps_only/nested/more" }
 [[move.package]]
 name = "Nested"
 source = { local = "deps_only/nested" }
+
 dependencies = [
   { name = "More" },
 ]

--- a/language/tools/move-package/tests/test_sources/one_dep/Move.locked
+++ b/language/tools/move-package/tests/test_sources/one_dep/Move.locked
@@ -3,6 +3,6 @@
 [move]
 version = 0
 
-[[move.dependency]]
+[[move.package]]
 name = "OtherDep"
-source = { local = "deps_only/other_dep", addr_subst = { "A" = "B" } }
+source = { local = "deps_only/other_dep" }

--- a/language/tools/move-package/tests/test_sources/one_dep/Move.locked
+++ b/language/tools/move-package/tests/test_sources/one_dep/Move.locked
@@ -3,6 +3,10 @@
 [move]
 version = 0
 
+dependencies = [
+  { name = "OtherDep", addr_subst = { "A" = "B" } },
+]
+
 [[move.package]]
 name = "OtherDep"
 source = { local = "deps_only/other_dep" }

--- a/language/tools/move-package/tests/test_sources/one_dep_bad_digest/Move.locked
+++ b/language/tools/move-package/tests/test_sources/one_dep_bad_digest/Move.locked
@@ -3,6 +3,10 @@
 [move]
 version = 0
 
+dependencies = [
+  { name = "OtherDep", digest = "BAD_DIGEST", addr_subst = { "A" = "B" } },
+]
+
 [[move.package]]
 name = "OtherDep"
 source = { local = "deps_only/other_dep" }

--- a/language/tools/move-package/tests/test_sources/one_dep_bad_digest/Move.locked
+++ b/language/tools/move-package/tests/test_sources/one_dep_bad_digest/Move.locked
@@ -3,6 +3,6 @@
 [move]
 version = 0
 
-[[move.dependency]]
+[[move.package]]
 name = "OtherDep"
-source = { local = "deps_only/other_dep", digest = "BAD_DIGEST", addr_subst = { "A" = "B" } }
+source = { local = "deps_only/other_dep" }

--- a/language/tools/move-package/tests/test_sources/parsing_full_manifest/Move.resolved
+++ b/language/tools/move-package/tests/test_sources/parsing_full_manifest/Move.resolved
@@ -1,1 +1,1 @@
-Failed to resolve dependencies for package 'name': Parsing manifest for 'A': Unable to find package manifest for 'A' at "tests/test_sources/parsing_full_manifest/../a/Move.toml": No such file or directory (os error 2)
+Failed to resolve dependencies for package 'name': Parsing manifest for 'A': Unable to find package manifest at "tests/test_sources/parsing_full_manifest/../a": No such file or directory (os error 2)

--- a/language/tools/move-package/tests/test_sources/parsing_full_manifest_with_extra_field/Move.resolved
+++ b/language/tools/move-package/tests/test_sources/parsing_full_manifest_with_extra_field/Move.resolved
@@ -1,1 +1,1 @@
-Failed to resolve dependencies for package 'name': Parsing manifest for 'A': Unable to find package manifest for 'A' at "tests/test_sources/parsing_full_manifest_with_extra_field/../a/Move.toml": No such file or directory (os error 2)
+Failed to resolve dependencies for package 'name': Parsing manifest for 'A': Unable to find package manifest at "tests/test_sources/parsing_full_manifest_with_extra_field/../a": No such file or directory (os error 2)

--- a/language/tools/move-package/tests/test_sources/parsing_invalid_hex_address_in_subst/Move.resolved
+++ b/language/tools/move-package/tests/test_sources/parsing_invalid_hex_address_in_subst/Move.resolved
@@ -1,1 +1,1 @@
-Failed to resolve dependencies for package 'name': Parsing manifest for 'A': Unable to find package manifest for 'A' at "tests/test_sources/parsing_invalid_hex_address_in_subst/a/Move.toml": No such file or directory (os error 2)
+Failed to resolve dependencies for package 'name': Parsing manifest for 'A': Unable to find package manifest at "tests/test_sources/parsing_invalid_hex_address_in_subst/a": No such file or directory (os error 2)

--- a/language/tools/move-package/tests/test_sources/parsing_non_identifier_address_name_in_subst/Move.resolved
+++ b/language/tools/move-package/tests/test_sources/parsing_non_identifier_address_name_in_subst/Move.resolved
@@ -1,1 +1,1 @@
-Failed to resolve dependencies for package 'name': Parsing manifest for 'A': Unable to find package manifest for 'A' at "tests/test_sources/parsing_non_identifier_address_name_in_subst/a/Move.toml": No such file or directory (os error 2)
+Failed to resolve dependencies for package 'name': Parsing manifest for 'A': Unable to find package manifest at "tests/test_sources/parsing_non_identifier_address_name_in_subst/a": No such file or directory (os error 2)

--- a/language/tools/move-package/tests/test_sources/parsing_unknown_toplevel_field/Move.resolved
+++ b/language/tools/move-package/tests/test_sources/parsing_unknown_toplevel_field/Move.resolved
@@ -1,1 +1,1 @@
-Failed to resolve dependencies for package 'name': Parsing manifest for 'A': Unable to find package manifest for 'A' at "tests/test_sources/parsing_unknown_toplevel_field/../a/Move.toml": No such file or directory (os error 2)
+Failed to resolve dependencies for package 'name': Parsing manifest for 'A': Unable to find package manifest at "tests/test_sources/parsing_unknown_toplevel_field/../a": No such file or directory (os error 2)


### PR DESCRIPTION
The initial design of `DependencyGraph` only allowed for one `addr_subst` and `digest` per package in the transitive dependency graph, but in actuality there can be as many of these as there are dependency edges to that package:

- Different `addr_subst` for different packages `P`, `Q` depending on `R` allows the same address in `R` to appear as different addresses in `P` and `Q`.
- If `R` is a dependency of `P` and a dev-dependency of `Q`, then its source digest may differ between the two.

Fixed by moving the `subst` and `digest` to be edge labels in the graph, rather than node labels.

Note that this also changes the lock file format in the following ways:

- A package's dependencies are now no longer just the name of the dependency, but an inline table containing the name and optionally the digest and address substitution.
- The key within the `move` table that contains all the transitive dependencies is now called `package` rather than `dependency` (this was mainly driven by the naming within the schema, which required a name for the new, richer format for a package's dependencies.)

## Test Plan

```
move/language/tools/move-cli$ cargo nextest
move/language/tools/move-package$ cargo nextest
```

## Stack

- #741 
- #745 
- #753 
- #754 
- #759 
- #760 

See also: #765 for main.