### PR TITLE
sui-move: [8/x][move-package/lock] DependencyGraph::immediate_dependencies

### DIFF
--- a/language/tools/move-package/src/resolution/dependency_graph.rs
+++ b/language/tools/move-package/src/resolution/dependency_graph.rs
@@ -348,6 +348,20 @@ impl DependencyGraph {
             .expect("Graph is determined to be acyclic when created")
     }
 
+    /// Return an iterator over `pkg`'s immediate dependencies in the graph.  If `mode` is
+    /// `DependencyMode::Always`, only always dependencies are included, whereas if `mode` is
+    /// `DependencyMode::DevOnly`, both always and dev-only dependecies are included.
+    pub fn immediate_dependencies(
+        &'_ self,
+        pkg: PM::PackageName,
+        mode: DependencyMode,
+    ) -> impl Iterator<Item = (PM::PackageName, &'_ Dependency, &'_ Package)> {
+        self.package_graph
+            .edges(pkg)
+            .filter(move |(_, _, dep)| dep.mode <= mode)
+            .map(|(_, dep_name, dep)| (dep_name, dep, &self.package_table[&dep_name]))
+    }
+
     /// Add the transitive dependencies and dev-dependencies from `package` to the dependency graph.
     fn extend_graph<Progress: Write>(
         &mut self,


### PR DESCRIPTION
Function to return a package's immediate dependencies in the transitive dependency graph, for use by `ResolutionGraph` when resolving renamings and in-scope addresses during resolution

## Test Plan

New tests:

```
move/language/tools/move-package$ cargo nextest
```

## Stack

- #741 
- #745 
- #753 
- #754 
- #759 
- #760 
- #854 

See also: #784 for main.