### PR TITLE
[Move-package] Enable bytecode as dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3456,6 +3456,7 @@ dependencies = [
  "log",
  "move-binary-format",
  "move-command-line-common",
+ "move-compiler",
  "move-core-types",
  "move-model",
  "move-stackless-bytecode",

--- a/language/move-compiler/src/command_line/compiler.rs
+++ b/language/move-compiler/src/command_line/compiler.rs
@@ -607,6 +607,8 @@ fn generate_interface_files_for_deps(
     let interface_files_paths =
         generate_interface_files(deps, interface_files_dir_opt, module_to_named_address, true)?;
     deps.extend(interface_files_paths);
+    // Remove bytecode files
+    deps.retain(|p| !p.path.as_str().ends_with(MOVE_COMPILED_EXTENSION));
     Ok(())
 }
 

--- a/language/move-compiler/src/interface_generator.rs
+++ b/language/move-compiler/src/interface_generator.rs
@@ -15,6 +15,8 @@ use move_binary_format::{
 use move_core_types::language_storage::ModuleId;
 use std::{collections::BTreeMap, fs};
 
+pub const NATIVE_INTERFACE: &str = "native_interface";
+
 macro_rules! push_line {
     ($s:ident, $e:expr) => {{
         $s = format!("{}{}\n", $s, $e);
@@ -88,6 +90,7 @@ pub fn write_module_to_string(
         members.push(format!("    {}", DISCLAIMER));
     }
     for fdef in externally_visible_funs {
+        members.push(format!("    #[{}]", NATIVE_INTERFACE));
         members.push(write_function_def(&mut context, fdef));
     }
     if has_externally_visible_funs {

--- a/language/move-prover/boogie-backend/Cargo.toml
+++ b/language/move-prover/boogie-backend/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2021"
 async-trait = "0.1.42"
 move-stackless-bytecode = { path = "../bytecode" }
 move-command-line-common = { path = "../../move-command-line-common" }
+move-compiler = { path = "../../move-compiler" }
 move-model = { path = "../../move-model" }
 move-binary-format = { path = "../../move-binary-format" }
 num = "0.4.0"

--- a/language/move-prover/boogie-backend/src/bytecode_translator.rs
+++ b/language/move-prover/boogie-backend/src/bytecode_translator.rs
@@ -11,8 +11,9 @@ use itertools::Itertools;
 #[allow(unused_imports)]
 use log::{debug, info, log, warn, Level};
 
+use move_compiler::interface_generator::NATIVE_INTERFACE;
 use move_model::{
-    ast::{TempIndex, TraceKind},
+    ast::{Attribute, TempIndex, TraceKind},
     code_writer::CodeWriter,
     emit, emitln,
     model::{FieldId, GlobalEnv, Loc, NodeId, QualifiedInstId, StructEnv, StructId},
@@ -1272,6 +1273,26 @@ impl<'env> FunctionTranslator<'env> {
                         // regular path
                         if !processed {
                             let targeted = self.fun_target.module_env().is_target();
+                            // If the callee has been generated from a native interface, return an error
+                            if callee_env.is_native() && targeted {
+                                for attr in callee_env.get_attributes() {
+                                    if let Attribute::Apply(_, name, _) = attr {
+                                        if self
+                                            .fun_target
+                                            .module_env()
+                                            .symbol_pool()
+                                            .string(*name)
+                                            .as_str()
+                                            == NATIVE_INTERFACE
+                                        {
+                                            let loc = self.fun_target.get_bytecode_loc(attr_id);
+                                            self.parent
+                                                .env
+                                                .error(&loc, "Unknown native function is called");
+                                        }
+                                    }
+                                }
+                            }
                             let caller_mid = self.fun_target.module_env().get_id();
                             let caller_fid = self.fun_target.get_id();
                             let fun_verified =

--- a/language/tools/move-cli/tests/build_tests/build_with_bytecode/B/Move.toml
+++ b/language/tools/move-cli/tests/build_tests/build_with_bytecode/B/Move.toml
@@ -1,0 +1,9 @@
+[package]
+name = "Bar"
+version = "0.0.0"
+
+[addresses]
+B = "0x2"
+
+[dependencies]
+Foo = { local = "../C" }

--- a/language/tools/move-cli/tests/build_tests/build_with_bytecode/B/sources/Bar.move
+++ b/language/tools/move-cli/tests/build_tests/build_with_bytecode/B/sources/Bar.move
@@ -1,0 +1,7 @@
+module B::Bar {
+    use C::Foo;
+
+    public fun foo(): u64 {
+        Foo::bar()
+    }
+}

--- a/language/tools/move-cli/tests/build_tests/build_with_bytecode/C/Move.toml
+++ b/language/tools/move-cli/tests/build_tests/build_with_bytecode/C/Move.toml
@@ -1,0 +1,6 @@
+[package]
+name = "Foo"
+version = "0.0.0"
+
+[addresses]
+C = "0x3"

--- a/language/tools/move-cli/tests/build_tests/build_with_bytecode/C/sources/Foo.move
+++ b/language/tools/move-cli/tests/build_tests/build_with_bytecode/C/sources/Foo.move
@@ -1,0 +1,5 @@
+module C::Foo {
+    public fun bar(): u64 {
+        1
+    }
+}

--- a/language/tools/move-cli/tests/build_tests/build_with_bytecode/Move.toml
+++ b/language/tools/move-cli/tests/build_tests/build_with_bytecode/Move.toml
@@ -1,0 +1,10 @@
+[package]
+name = "A"
+version = "0.0.0"
+
+[addresses]
+A = "0x2"
+
+[dependencies]
+Bar = { local = "./B" }
+Foo = { local = "./C" }

--- a/language/tools/move-cli/tests/build_tests/build_with_bytecode/args.exp
+++ b/language/tools/move-cli/tests/build_tests/build_with_bytecode/args.exp
@@ -1,0 +1,13 @@
+Command `build -v -p ./C`:
+BUILDING Foo
+External Command `mv ./C/sources/Foo.move ./C/sources/Foo.move_old`:
+External Command `rm -rf ./C/build/Foo/sources`:
+Command `build -v -p ./B`:
+INCLUDING DEPENDENCY Foo
+BUILDING Bar
+External Command `mv ./B/sources/Bar.move ./C/sources/Bar.move_old`:
+External Command `rm -rf ./B/build/Bar/sources`:
+Command `build -v`:
+INCLUDING DEPENDENCY Bar
+INCLUDING DEPENDENCY Foo
+BUILDING A

--- a/language/tools/move-cli/tests/build_tests/build_with_bytecode/args.txt
+++ b/language/tools/move-cli/tests/build_tests/build_with_bytecode/args.txt
@@ -1,0 +1,7 @@
+build -v -p ./C
+> mv ./C/sources/Foo.move ./C/sources/Foo.move_old
+> rm -rf ./C/build/Foo/sources
+build -v -p ./B
+> mv ./B/sources/Bar.move ./C/sources/Bar.move_old
+> rm -rf ./B/build/Bar/sources
+build -v

--- a/language/tools/move-cli/tests/build_tests/build_with_bytecode/sources/A.move
+++ b/language/tools/move-cli/tests/build_tests/build_with_bytecode/sources/A.move
@@ -1,0 +1,8 @@
+module A::A {
+    use B::Bar;
+    use C::Foo;
+
+    public fun foo(): u64 {
+        Bar::foo() + Foo::bar()
+    }
+}

--- a/language/tools/move-package/src/compilation/build_plan.rs
+++ b/language/tools/move-package/src/compilation/build_plan.rs
@@ -152,14 +152,23 @@ impl BuildPlan {
                     .package_table
                     .get(&package_name)
                     .unwrap();
-                let dep_source_paths = dep_package
+                let mut dep_source_paths = dep_package
                     .get_sources(&self.resolution_graph.build_options)
                     .unwrap();
+                let mut source_available = true;
+                // If source is empty, search bytecode(mv) files
+                if dep_source_paths.is_empty() {
+                    dep_source_paths = dep_package
+                        .get_bytecodes(&self.resolution_graph.build_options)
+                        .unwrap();
+                    source_available = false;
+                }
                 (
                     package_name,
                     immediate_dependencies_names.contains(&package_name),
                     dep_source_paths,
                     &dep_package.resolution_table,
+                    source_available,
                 )
             })
             .collect();

--- a/language/tools/move-package/src/compilation/compiled_package.rs
+++ b/language/tools/move-package/src/compilation/compiled_package.rs
@@ -13,6 +13,7 @@ use crate::{
 };
 use anyhow::{ensure, Result};
 use colored::Colorize;
+use itertools::{Either, Itertools};
 use move_abigen::{Abigen, AbigenOptions};
 use move_binary_format::file_format::{CompiledModule, CompiledScript};
 use move_bytecode_source_map::utils::source_map_from_file;
@@ -535,6 +536,7 @@ impl CompiledPackage {
             /* is immediate */ bool,
             /* source paths */ Vec<Symbol>,
             /* address mapping */ &ResolvedTable,
+            /* whether source is available */ bool,
         )>,
         resolution_graph: &ResolvedGraph,
         mut compiler_driver: impl FnMut(
@@ -544,16 +546,18 @@ impl CompiledPackage {
     ) -> Result<CompiledPackage> {
         let immediate_dependencies = transitive_dependencies
             .iter()
-            .filter(|(_, is_immediate, _, _)| *is_immediate)
-            .map(|(name, _, _, _)| *name)
+            .filter(|(_, is_immediate, _, _, _)| *is_immediate)
+            .map(|(name, _, _, _, _)| *name)
             .collect::<Vec<_>>();
         let transitive_dependencies = transitive_dependencies
             .into_iter()
-            .map(|(name, _is_immediate, source_paths, address_mapping)| {
-                (name, source_paths, address_mapping)
-            })
+            .map(
+                |(name, _is_immediate, source_paths, address_mapping, src_flag)| {
+                    (name, source_paths, address_mapping, src_flag)
+                },
+            )
             .collect::<Vec<_>>();
-        for (dep_package_name, _, _) in &transitive_dependencies {
+        for (dep_package_name, _, _, _) in &transitive_dependencies {
             writeln!(
                 w,
                 "{} {}",
@@ -563,7 +567,6 @@ impl CompiledPackage {
         }
         let root_package_name = resolved_package.source_package.package.name;
         writeln!(w, "{} {}", "BUILDING".bold().green(), root_package_name)?;
-
         // gather source/dep files with their address mappings
         let (sources_package_paths, deps_package_paths) = make_source_and_deps_for_compiler(
             resolution_graph,
@@ -575,11 +578,27 @@ impl CompiledPackage {
         } else {
             Flags::empty()
         };
+        // Partition deps_package according whether src is available
+        let (src_deps, bytecode_deps): (Vec<_>, Vec<_>) = deps_package_paths
+            .clone()
+            .into_iter()
+            .partition_map(|(p, b)| if b { Either::Left(p) } else { Either::Right(p) });
+        // If bytecode dependency is not empty, do not allow renaming
+        if !bytecode_deps.is_empty() {
+            if let Some(pkg_name) = resolution_graph.contains_renaming() {
+                anyhow::bail!(
+                    "Found address renaming in package '{}' when \
+                    building Move model -- this is currently not supported",
+                    pkg_name
+                )
+            }
+        }
+
         // invoke the compiler
-        let mut paths = deps_package_paths.clone();
+        let mut paths = src_deps;
         paths.push(sources_package_paths.clone());
 
-        let compiler = Compiler::from_package_paths(paths, vec![]).set_flags(flags);
+        let compiler = Compiler::from_package_paths(paths, bytecode_deps).set_flags(flags);
         let (file_map, all_compiled_units) = compiler_driver(compiler)?;
         let mut root_compiled_units = vec![];
         let mut deps_compiled_units = vec![];
@@ -607,7 +626,7 @@ impl CompiledPackage {
         {
             let model = run_model_builder_with_options(
                 vec![sources_package_paths],
-                deps_package_paths,
+                deps_package_paths.into_iter().map(|(p, _)| p).collect_vec(),
                 ModelBuilderOptions::default(),
             )?;
 
@@ -895,25 +914,29 @@ pub(crate) fn make_source_and_deps_for_compiler(
         /* name */ Symbol,
         /* source paths */ Vec<Symbol>,
         /* address mapping */ &ResolvedTable,
+        /* whether src is available */ bool,
     )>,
 ) -> Result<(
     /* sources */ PackagePaths,
-    /* deps */ Vec<PackagePaths>,
+    /* deps */ Vec<(PackagePaths, bool)>,
 )> {
     let deps_package_paths = deps
         .into_iter()
-        .map(|(name, source_paths, resolved_table)| {
+        .map(|(name, source_paths, resolved_table, src_flag)| {
             let paths = source_paths
                 .into_iter()
                 .collect::<BTreeSet<_>>()
                 .into_iter()
                 .collect::<Vec<_>>();
             let named_address_map = named_address_mapping_for_compiler(resolved_table);
-            Ok(PackagePaths {
-                name: Some(name),
-                paths,
-                named_address_map,
-            })
+            Ok((
+                PackagePaths {
+                    name: Some(name),
+                    paths,
+                    named_address_map,
+                },
+                src_flag,
+            ))
         })
         .collect::<Result<Vec<_>>>()?;
     let root_named_addrs = apply_named_address_renaming(

--- a/language/tools/move-package/src/compilation/model_builder.rs
+++ b/language/tools/move-package/src/compilation/model_builder.rs
@@ -7,6 +7,7 @@ use crate::{
     resolution::resolution_graph::ResolvedGraph, ModelConfig,
 };
 use anyhow::Result;
+use itertools::Itertools;
 use move_compiler::shared::PackagePaths;
 use move_model::{model::GlobalEnv, options::ModelBuilderOptions, run_model_builder_with_options};
 
@@ -31,14 +32,12 @@ impl ModelBuilder {
     // where we want to support building a Move model.
     pub fn build_model(&self) -> Result<GlobalEnv> {
         // Make sure no renamings have been performed
-        for (pkg_name, pkg) in self.resolution_graph.package_table.iter() {
-            if !pkg.renaming.is_empty() {
-                anyhow::bail!(
-                    "Found address renaming in package '{}' when \
+        if let Some(pkg_name) = self.resolution_graph.contains_renaming() {
+            anyhow::bail!(
+                "Found address renaming in package '{}' when \
                     building Move model -- this is currently not supported",
-                    pkg_name
-                )
-            }
+                pkg_name
+            )
         }
 
         // Targets are all files in the root package
@@ -52,13 +51,25 @@ impl ModelBuilder {
                 if nm == root_name {
                     return None;
                 }
-                let dep_source_paths = pkg
+                let mut dep_source_paths = pkg
                     .get_sources(&self.resolution_graph.build_options)
                     .unwrap();
-                Some(Ok((*nm, dep_source_paths, &pkg.resolution_table)))
+                let mut source_available = true;
+                // If source is empty, search bytecode
+                if dep_source_paths.is_empty() {
+                    dep_source_paths = pkg
+                        .get_bytecodes(&self.resolution_graph.build_options)
+                        .unwrap();
+                    source_available = false;
+                }
+                Some(Ok((
+                    *nm,
+                    dep_source_paths,
+                    &pkg.resolution_table,
+                    source_available,
+                )))
             })
             .collect::<Result<Vec<_>>>()?;
-
         let (target, deps) = make_source_and_deps_for_compiler(
             &self.resolution_graph,
             &root_package,
@@ -66,7 +77,7 @@ impl ModelBuilder {
         )?;
         let (all_targets, all_deps) = if self.model_config.all_files_as_targets {
             let mut targets = vec![target];
-            targets.extend(deps.into_iter());
+            targets.extend(deps.into_iter().map(|(p, _)| p).collect_vec());
             (targets, vec![])
         } else {
             (vec![target], deps)
@@ -74,7 +85,7 @@ impl ModelBuilder {
         let (all_targets, all_deps) = match &self.model_config.target_filter {
             Some(filter) => {
                 let mut new_targets = vec![];
-                let mut new_deps = all_deps;
+                let mut new_deps = all_deps.into_iter().map(|(p, _)| p).collect_vec();
                 for PackagePaths {
                     name,
                     paths,
@@ -100,7 +111,10 @@ impl ModelBuilder {
                 }
                 (new_targets, new_deps)
             }
-            None => (all_targets, all_deps),
+            None => (
+                all_targets,
+                all_deps.into_iter().map(|(p, _)| p).collect_vec(),
+            ),
         };
 
         run_model_builder_with_options(all_targets, all_deps, ModelBuilderOptions::default())

--- a/language/tools/move-package/src/resolution/resolution_graph.rs
+++ b/language/tools/move-package/src/resolution/resolution_graph.rs
@@ -17,7 +17,10 @@ use crate::{
 };
 use anyhow::{bail, Context, Result};
 use colored::Colorize;
-use move_command_line_common::files::{find_move_filenames, FileHash};
+use move_command_line_common::files::{
+    extension_equals, find_filenames, find_move_filenames, FileHash, MOVE_COMPILED_EXTENSION,
+};
+use move_compiler::command_line::DEFAULT_OUTPUT_DIR;
 use move_core_types::account_address::AccountAddress;
 use move_symbol_pool::Symbol;
 use petgraph::{algo, graphmap::DiGraphMap, Outgoing};
@@ -772,6 +775,15 @@ impl ResolvingPackage {
         Ok(places_to_look)
     }
 
+    fn get_build_paths(package_path: &Path) -> Result<Vec<PathBuf>> {
+        let mut places_to_look = Vec::new();
+        let path = package_path.join(Path::new(DEFAULT_OUTPUT_DIR));
+        if path.exists() {
+            places_to_look.push(path);
+        }
+        Ok(places_to_look)
+    }
+
     fn get_package_digest_for_config(
         package_path: &Path,
         config: &BuildConfig,
@@ -867,6 +879,16 @@ impl ResolvedGraph {
             })
             .collect()
     }
+
+    pub fn contains_renaming(&self) -> Option<PackageName> {
+        // Make sure no renamings have been performed
+        for (pkg_name, pkg) in self.package_table.iter() {
+            if !pkg.renaming.is_empty() {
+                return Some(*pkg_name);
+            }
+        }
+        None
+    }
 }
 
 impl ResolvedPackage {
@@ -880,6 +902,22 @@ impl ResolvedPackage {
             .into_iter()
             .map(Symbol::from)
             .collect())
+    }
+
+    pub fn get_bytecodes(&self, config: &BuildConfig) -> Result<Vec<FileName>> {
+        let mut path = ResolvingPackage::get_source_paths_for_config(&self.package_path, config)?;
+        let mut build_path = ResolvingPackage::get_build_paths(&self.package_path)?;
+        path.append(&mut build_path);
+        let places_to_look = path
+            .into_iter()
+            .map(|p| p.to_string_lossy().to_string())
+            .collect::<Vec<_>>();
+        Ok(find_filenames(&places_to_look, |path| {
+            extension_equals(path, MOVE_COMPILED_EXTENSION)
+        })?
+        .into_iter()
+        .map(Symbol::from)
+        .collect())
     }
 
     /// Returns the transitive dependencies of this package in dependency order


### PR DESCRIPTION
## Motivation

Re-enable the feature to use bytecode as dependencies when compiling Move programs.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes

## Test Plan

Add later
