### PR TITLE
Revert event limit status code

### DIFF
--- a/language/move-core/types/src/vm_status.rs
+++ b/language/move-core/types/src/vm_status.rs
@@ -680,7 +680,10 @@ pub enum StatusCode {
     MEMORY_LIMIT_EXCEEDED = 4028,
     VM_MAX_TYPE_NODES_REACHED = 4029,
     EVENT_COUNT_LIMIT_EXCEEDED = 4030,
-
+    EVENT_SIZE_LIMIT_EXCEEDED = 4031,
+    CREATED_OBJECT_COUNT_LIMIT_EXCEEDED = 4032,
+    DELETED_OBJECT_COUNT_LIMIT_EXCEEDED = 4033,
+    MUTATED_OBJECT_COUNT_LIMIT_EXCEEDED = 4034,
     // A reserved status to represent an unknown vm status.
     // this is std::u64::MAX, but we can't pattern match on that, so put the hardcoded value in
     UNKNOWN_STATUS = 18446744073709551615,

--- a/language/move-core/types/src/vm_status.rs
+++ b/language/move-core/types/src/vm_status.rs
@@ -679,11 +679,6 @@ pub enum StatusCode {
     STORAGE_WRITE_LIMIT_REACHED = 4027,
     MEMORY_LIMIT_EXCEEDED = 4028,
     VM_MAX_TYPE_NODES_REACHED = 4029,
-    EVENT_COUNT_LIMIT_EXCEEDED = 4030,
-    EVENT_SIZE_LIMIT_EXCEEDED = 4031,
-    CREATED_OBJECT_COUNT_LIMIT_EXCEEDED = 4032,
-    DELETED_OBJECT_COUNT_LIMIT_EXCEEDED = 4033,
-    MUTATED_OBJECT_COUNT_LIMIT_EXCEEDED = 4034,
 
     // A reserved status to represent an unknown vm status.
     // this is std::u64::MAX, but we can't pattern match on that, so put the hardcoded value in

--- a/language/move-core/types/src/vm_status.rs
+++ b/language/move-core/types/src/vm_status.rs
@@ -684,6 +684,7 @@ pub enum StatusCode {
     CREATED_OBJECT_COUNT_LIMIT_EXCEEDED = 4032,
     DELETED_OBJECT_COUNT_LIMIT_EXCEEDED = 4033,
     MUTATED_OBJECT_COUNT_LIMIT_EXCEEDED = 4034,
+
     // A reserved status to represent an unknown vm status.
     // this is std::u64::MAX, but we can't pattern match on that, so put the hardcoded value in
     UNKNOWN_STATUS = 18446744073709551615,

--- a/language/move-core/types/src/vm_status.rs
+++ b/language/move-core/types/src/vm_status.rs
@@ -679,6 +679,7 @@ pub enum StatusCode {
     STORAGE_WRITE_LIMIT_REACHED = 4027,
     MEMORY_LIMIT_EXCEEDED = 4028,
     VM_MAX_TYPE_NODES_REACHED = 4029,
+    EVENT_COUNT_LIMIT_EXCEEDED = 4030,
 
     // A reserved status to represent an unknown vm status.
     // this is std::u64::MAX, but we can't pattern match on that, so put the hardcoded value in


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Move Language.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

We will use the `MEMORY_LIMIT_EXCEEDED` status code and define our own sub_status as needed. This prevents incompat with main branch
### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes
## Test Plan

N/A
