### PR TITLE
[natives] New function `exists_at`

### DIFF
--- a/language/move-stdlib/sources/globals.move
+++ b/language/move-stdlib/sources/globals.move
@@ -1,0 +1,6 @@
+/// Utilities for working with global memory.
+module std::globals {
+
+    /// Tests whether the resource exists in global memory.
+    public native fun exists_at<R:key>(addr: address): bool;
+}

--- a/language/move-stdlib/src/natives/globals.rs
+++ b/language/move-stdlib/src/natives/globals.rs
@@ -1,0 +1,63 @@
+// Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::natives::helpers::make_module_natives;
+use move_binary_format::errors::PartialVMResult;
+use move_core_types::{
+    gas_algebra::{InternalGas, },
+};
+use move_vm_runtime::native_functions::{NativeContext, NativeFunction};
+use move_vm_types::{
+    loaded_data::runtime_types::Type,
+    natives::function::NativeResult,
+    pop_arg,
+    values::{Value},
+};
+use std::{collections::VecDeque, sync::Arc};
+use move_core_types::account_address::AccountAddress;
+
+#[derive(Debug, Clone)]
+pub struct ExistsAtGasParameters {
+    // TODO: in fact exists (the instruction) has a more complex gas cost based on reading the
+    //   entire resource :-/ This here needs to be aligned with this.
+    pub cost: InternalGas,
+}
+
+#[inline]
+fn native_exists_at(
+    gas_params: &ExistsAtGasParameters,
+    context: &mut NativeContext,
+    mut ty_args: Vec<Type>,
+    mut args: VecDeque<Value>,
+) -> PartialVMResult<NativeResult> {
+    debug_assert!(ty_args.len() == 1);
+    debug_assert!(args.len() == 1);
+
+    let addr = pop_arg!(args, AccountAddress);
+    let arg_type = ty_args.pop().unwrap();
+
+    let res = context.resource_exists_at(&arg_type, addr).map(|b| Value::bool(b));
+    NativeResult::map_partial_vm_result_one(gas_params.cost, res)
+}
+
+pub fn make_native_exists_at(gas_params: ExistsAtGasParameters) -> NativeFunction {
+    Arc::new(
+        move |context, ty_args, args| -> PartialVMResult<NativeResult> {
+            native_exists_at(&gas_params, context, ty_args, args)
+        },
+    )
+}
+
+/***************************************************************************************************
+ * module
+ **************************************************************************************************/
+#[derive(Debug, Clone)]
+pub struct GasParameters {
+    pub exists_at: ExistsAtGasParameters,
+}
+
+pub fn make_all(gas_params: GasParameters) -> impl Iterator<Item = (String, NativeFunction)> {
+    let natives = [("to_bytes", make_native_exists_at(gas_params.exists_at))];
+    make_module_natives(natives)
+}

--- a/language/move-stdlib/src/natives/mod.rs
+++ b/language/move-stdlib/src/natives/mod.rs
@@ -14,6 +14,7 @@ pub mod unit_test;
 pub mod vector;
 
 mod helpers;
+pub mod globals;
 
 use move_core_types::account_address::AccountAddress;
 use move_vm_runtime::native_functions::{make_table_from_iter, NativeFunctionTable};
@@ -26,6 +27,7 @@ pub struct GasParameters {
     pub string: string::GasParameters,
     pub type_name: type_name::GasParameters,
     pub vector: vector::GasParameters,
+    pub globals: globals::GasParameters,
 
     #[cfg(feature = "testing")]
     pub unit_test: unit_test::GasParameters,
@@ -91,6 +93,8 @@ impl GasParameters {
                 destroy_empty: vector::DestroyEmptyGasParameters { base: 0.into() },
                 swap: vector::SwapGasParameters { base: 0.into() },
             },
+            globals: globals::GasParameters { exists_at: globals::ExistsAtGasParameters{ cost: 0.into()}},
+
             #[cfg(feature = "testing")]
             unit_test: unit_test::GasParameters {
                 create_signers_for_testing: unit_test::CreateSignersForTestingGasParameters {
@@ -122,6 +126,7 @@ pub fn all_natives(
     add_natives!("string", string::make_all(gas_params.string));
     add_natives!("type_name", type_name::make_all(gas_params.type_name));
     add_natives!("vector", vector::make_all(gas_params.vector));
+    add_natives!("globals", globals::make_all(gas_params.globals));
     #[cfg(feature = "testing")]
     {
         add_natives!("unit_test", unit_test::make_all(gas_params.unit_test));

--- a/language/move-vm/runtime/src/native_functions.rs
+++ b/language/move-vm/runtime/src/native_functions.rs
@@ -172,4 +172,10 @@ impl<'a, 'b> NativeContext<'a, 'b> {
     pub fn stack_frames(&self, count: usize) -> ExecutionState {
         self.interpreter.get_stack_frames(count)
     }
+
+    pub fn resource_exists_at(&mut self, ty: &Type, addr: AccountAddress) -> PartialVMResult<bool> {
+        // TODO: charge gas in terms of resource size? This is what we currently do for the exists
+        // instruction which is actually quite bad.
+        self.data_store.load_resource(addr, ty).and_then(|(r, _)| r.exists())
+    }
 }


### PR DESCRIPTION
This adds a new native function `globals::exists_at` which allows to check existance of a resource outside of the module which defines this resource. This functionality is needed for Move Objects to be able to build typed object references.

This is an alternative to #852. Preview state, no tests added yet, and the gas formula is incomplete.

