### PR TITLE
[prover] Eliminate Boogie code involving unresolved type params

### DIFF
--- a/language/move-model/src/ty.rs
+++ b/language/move-model/src/ty.rs
@@ -224,6 +224,22 @@ impl Type {
         }
     }
 
+    pub fn contains_tparam(&self) -> bool {
+        match self {
+            Type::Primitive(_) => false,
+            Type::Tuple(v) => v.iter().any(|e| e.contains_tparam()),
+            Type::Vector(e) => e.contains_tparam(),
+            Type::Struct(_, _, insts) => insts.iter().any(|e| e.contains_tparam()),
+            Type::TypeParameter(..) => true,
+            Type::Reference(_, e) => e.contains_tparam(),
+            Type::ResourceDomain(_, _, Some(v)) => v.iter().any(|e| e.contains_tparam()),
+            Type::Fun(v, e) => v.iter().any(|e| e.contains_tparam()) || e.contains_tparam(),
+            Type::TypeDomain(t) => t.contains_tparam(),
+            Type::ResourceDomain(_, _, None) | Type::Var(..) => false,
+            Type::Error => false,
+        }
+    }
+
     /// Skip reference type.
     pub fn skip_reference(&self) -> &Type {
         if let Type::Reference(_, bt) = self {

--- a/language/move-prover/boogie-backend/src/bytecode_translator.rs
+++ b/language/move-prover/boogie-backend/src/bytecode_translator.rs
@@ -227,6 +227,9 @@ impl<'env> BoogieTranslator<'env> {
                     if !translated_types.insert(struct_name) {
                         continue;
                     }
+                    if type_inst.iter().any(|e| e.contains_tparam()) {
+                        continue;
+                    }
                     StructTranslator {
                         parent: self,
                         struct_env,
@@ -243,14 +246,26 @@ impl<'env> BoogieTranslator<'env> {
                 for (variant, ref fun_target) in self.targets.get_targets(fun_env) {
                     if variant.is_verified() {
                         verified_functions_count += 1;
-                        // Always produce a verified functions with an empty instantiation such that
-                        // there is at least one top-level entry points for a VC.
-                        FunctionTranslator {
-                            parent: self,
-                            fun_target,
-                            type_inst: &[],
+                        if !fun_target
+                            .data
+                            .local_types
+                            .iter()
+                            .any(|e| e.contains_tparam())
+                            && !fun_target
+                                .data
+                                .return_types
+                                .iter()
+                                .any(|e| e.contains_tparam())
+                        {
+                            // Always produce a verified functions with an empty instantiation such that
+                            // there is at least one top-level entry points for a VC.
+                            FunctionTranslator {
+                                parent: self,
+                                fun_target,
+                                type_inst: &[],
+                            }
+                            .translate();
                         }
-                        .translate();
 
                         // There maybe more verification targets that needs to be produced as we
                         // defer the instantiation of verified functions to this stage
@@ -266,6 +281,9 @@ impl<'env> BoogieTranslator<'env> {
                                 |(i, t)| matches!(t, Type::TypeParameter(idx) if *idx == i as u16),
                             );
                             if is_none_inst {
+                                continue;
+                            }
+                            if type_inst.iter().any(|e| e.contains_tparam()) {
                                 continue;
                             }
 
@@ -289,6 +307,9 @@ impl<'env> BoogieTranslator<'env> {
                         {
                             let fun_name = boogie_function_name(fun_env, type_inst);
                             if !translated_funs.insert(fun_name) {
+                                continue;
+                            }
+                            if type_inst.iter().any(|e| e.contains_tparam()) {
                                 continue;
                             }
                             FunctionTranslator {

--- a/language/move-prover/boogie-backend/src/lib.rs
+++ b/language/move-prover/boogie-backend/src/lib.rs
@@ -237,6 +237,7 @@ pub fn add_prelude(
             .flat_map(|(_, insts)| {
                 insts
                     .iter()
+                    .filter(|inst| !inst[0].contains_tparam())
                     .map(|inst| TypeInfo::new(env, options, &inst[0], false))
             })
             .collect::<BTreeSet<_>>()

--- a/language/move-prover/boogie-backend/src/spec_translator.rs
+++ b/language/move-prover/boogie-backend/src/spec_translator.rs
@@ -272,6 +272,9 @@ impl<'env> SpecTranslator<'env> {
             self.error(&fun.loc, "function or tuple result type not yet supported");
             return;
         }
+        if self.type_inst.iter().any(|e| e.contains_tparam()) {
+            return;
+        }
         let recursive = self
             .env
             .is_spec_fun_recursive(module_env.get_id().qualified(id));

--- a/language/move-prover/bytecode/src/mono_analysis.rs
+++ b/language/move-prover/bytecode/src/mono_analysis.rs
@@ -528,7 +528,9 @@ impl<'a> Analyzer<'a> {
         }
         ty.visit(&mut |t| match t {
             Type::Vector(et) => {
-                self.info.vec_inst.insert(et.as_ref().clone());
+                if !ty.contains_tparam() {
+                    self.info.vec_inst.insert(et.as_ref().clone());
+                }
             }
             Type::Struct(mid, sid, targs) => {
                 self.add_struct(self.env.get_module(*mid).into_struct(*sid), targs)
@@ -541,6 +543,9 @@ impl<'a> Analyzer<'a> {
     }
 
     fn add_struct(&mut self, struct_: StructEnv<'_>, targs: &[Type]) {
+        if targs.iter().any(|e| e.contains_tparam()) {
+            return;
+        }
         if struct_.is_intrinsic_of(INTRINSIC_TYPE_MAP) {
             self.info
                 .table_inst


### PR DESCRIPTION
## Motivation

When using the Prover with a different flavor of Move, unresolved type parameters cause problems. In particular, when expanding functions in the prelude, fields of a struct that are accessible when the type parameter is resolved (to the actual struct type) are inaccessible if type parameter is unresolved (represented by its index number rather than a concrete type).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes
