### PR TITLE
[move-compiler] add a space in spec ast debug dump

### DIFF
--- a/language/move-compiler/src/expansion/ast.rs
+++ b/language/move-compiler/src/expansion/ast.rs
@@ -2,6 +2,15 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use std::{
+    collections::{BTreeMap, BTreeSet, VecDeque},
+    fmt,
+    hash::Hash,
+};
+
+use move_ir_types::location::*;
+use move_symbol_pool::Symbol;
+
 use crate::{
     parser::ast::{
         self as P, Ability, Ability_, BinOp, ConstantName, Field, FunctionName, ModuleName,
@@ -11,13 +20,6 @@ use crate::{
         ast_debug::*, known_attributes::KnownAttribute, unique_map::UniqueMap,
         unique_set::UniqueSet, *,
     },
-};
-use move_ir_types::location::*;
-use move_symbol_pool::Symbol;
-use std::{
-    collections::{BTreeMap, BTreeSet, VecDeque},
-    fmt,
-    hash::Hash,
 };
 
 //**************************************************************************************************
@@ -1640,7 +1642,7 @@ impl AstDebug for Exp_ {
             E::Spec(u, unbound_names) => {
                 w.write(&format!("spec #{}", u));
                 if !unbound_names.is_empty() {
-                    w.write("uses [");
+                    w.write(" uses [");
                     w.comma(unbound_names, |w, n| w.write(&format!("{}", n)));
                     w.write("]");
                 }

--- a/language/move-compiler/src/hlir/ast.rs
+++ b/language/move-compiler/src/hlir/ast.rs
@@ -2,6 +2,11 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
+
+use move_ir_types::location::*;
+use move_symbol_pool::Symbol;
+
 use crate::{
     expansion::ast::{
         ability_modifiers_ast_debug, AbilitySet, Attributes, Friend, ModuleIdent, SpecId,
@@ -13,9 +18,6 @@ use crate::{
     },
     shared::{ast_debug::*, unique_map::UniqueMap, NumericalAddress},
 };
-use move_ir_types::location::*;
-use move_symbol_pool::Symbol;
-use std::collections::{BTreeMap, BTreeSet, VecDeque};
 
 // High Level IR
 
@@ -1174,7 +1176,7 @@ impl AstDebug for UnannotatedExp_ {
             E::Spec(u, used_locals) => {
                 w.write(&format!("spec #{}", u));
                 if !used_locals.is_empty() {
-                    w.write("uses [");
+                    w.write(" uses [");
                     w.comma(used_locals, |w, (n, st)| {
                         w.annotate(|w| w.write(&format!("{}", n)), st)
                     });

--- a/language/move-compiler/src/naming/ast.rs
+++ b/language/move-compiler/src/naming/ast.rs
@@ -2,6 +2,16 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use std::{
+    collections::{BTreeMap, BTreeSet, VecDeque},
+    fmt,
+};
+
+use once_cell::sync::Lazy;
+
+use move_ir_types::location::*;
+use move_symbol_pool::Symbol;
+
 use crate::{
     expansion::ast::{
         ability_constraints_ast_debug, ability_modifiers_ast_debug, AbilitySet, Attributes, Fields,
@@ -11,13 +21,6 @@ use crate::{
         BinOp, ConstantName, Field, FunctionName, StructName, UnaryOp, Var, ENTRY_MODIFIER,
     },
     shared::{ast_debug::*, unique_map::UniqueMap, *},
-};
-use move_ir_types::location::*;
-use move_symbol_pool::Symbol;
-use once_cell::sync::Lazy;
-use std::{
-    collections::{BTreeMap, BTreeSet, VecDeque},
-    fmt,
 };
 
 //**************************************************************************************************
@@ -1172,7 +1175,7 @@ impl AstDebug for Exp_ {
             E::Spec(u, used_locals) => {
                 w.write(&format!("spec #{}", u));
                 if !used_locals.is_empty() {
-                    w.write("uses [");
+                    w.write(" uses [");
                     w.comma(used_locals, |w, n| w.write(&format!("{}", n)));
                     w.write("]");
                 }

--- a/language/move-compiler/src/typing/ast.rs
+++ b/language/move-compiler/src/typing/ast.rs
@@ -2,6 +2,14 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use std::{
+    collections::{BTreeMap, VecDeque},
+    fmt,
+};
+
+use move_ir_types::location::*;
+use move_symbol_pool::Symbol;
+
 use crate::{
     expansion::ast::{Attributes, Fields, Friend, ModuleIdent, SpecId, Value, Visibility},
     naming::ast::{FunctionSignature, StructDefinition, Type, TypeName_, Type_},
@@ -9,12 +17,6 @@ use crate::{
         BinOp, ConstantName, Field, FunctionName, StructName, UnaryOp, Var, ENTRY_MODIFIER,
     },
     shared::{ast_debug::*, unique_map::UniqueMap},
-};
-use move_ir_types::location::*;
-use move_symbol_pool::Symbol;
-use std::{
-    collections::{BTreeMap, VecDeque},
-    fmt,
 };
 
 //**************************************************************************************************
@@ -608,7 +610,7 @@ impl AstDebug for UnannotatedExp_ {
             E::Spec(u, used_locals) => {
                 w.write(&format!("spec #{}", u));
                 if !used_locals.is_empty() {
-                    w.write("uses [");
+                    w.write(" uses [");
                     w.comma(used_locals, |w, (n, ty)| {
                         w.annotate(|w| w.write(&format!("{}", n)), ty)
                     });


### PR DESCRIPTION
Effect of this commit:

```diff
- spec #0uses <local variables>
+ spec #0 uses <local variables>
```

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Move Language.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

A small nicety on the way of spec inlining

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes

## Test Plan

CI
