### PR TITLE
[Move-prover][Bitwise] Add support for vector::insert & bug fix for handling the let expression in the spec

### DIFF
--- a/language/move-prover/bytecode/src/number_operation_analysis.rs
+++ b/language/move-prover/bytecode/src/number_operation_analysis.rs
@@ -147,6 +147,7 @@ fn vector_funs_name_propogate_to_srcs(callee_name: &str) -> bool {
         || callee_name == "index_of"
         || callee_name == "append"
         || callee_name == "push_back"
+        || callee_name == "insert"
 }
 
 fn table_funs_name_propogate_to_srcs(callee_name: &str) -> bool {
@@ -239,6 +240,18 @@ impl<'a> NumberOperationAnalysis<'a> {
                         arg_oper.push(global_state.get_node_num_oper(arg.node_id()));
                     }
                     match oper {
+                        move_model::ast::Operation::Identical => {
+                            let num_oper_0 = global_state.get_node_num_oper(args[0].node_id());
+                            let num_oper_1 = global_state.get_node_num_oper(args[1].node_id());
+                            if !num_oper_0.conflict(&num_oper_1) {
+                                let merged = num_oper_0.merge(&num_oper_1);
+                                global_state.update_node_oper(*id, merged, true);
+                                for arg in args {
+                                    global_state.update_node_oper(arg.node_id(), merged, true);
+                                    update_temporary(arg, &merged, global_state, state);
+                                }
+                            }
+                        }
                         // Update node for index
                         move_model::ast::Operation::Index => {
                             global_state.update_node_oper(*id, arg_oper[0], true);

--- a/language/move-prover/tests/sources/functional/bitwise_features.move
+++ b/language/move-prover/tests/sources/functional/bitwise_features.move
@@ -32,7 +32,8 @@ module TestFeatures {
         let byte_index = feature / 8;
         let bit_mask = 1 << ((feature % 8) as u8);
         while (vector::length(features) <= byte_index) {
-            vector::push_back(features, 0)
+            let len = vector::length(features);
+            vector::insert(features, 0, len)
         };
         let entry = vector::borrow_mut(features, byte_index);
         if (include)
@@ -89,6 +90,16 @@ module TestFeatures {
 
     spec change_feature_flags {
         aborts_if signer::address_of(framework) != @std;
+    }
+
+    fun enable_feature_flags(feature: u64) acquires Features {
+        let features = &mut borrow_global_mut<Features>(@std).features;
+        set(features, feature, true);
+    }
+
+    spec enable_feature_flags {
+        let post features = borrow_global<Features>(@std).features;
+        ensures spec_contains(features, feature);
     }
 
 }


### PR DESCRIPTION
## Motivation

This PR 1) adds supports for handling vector::insert function for bitwise operations; 2) fix a bug when handling `let` expression in the spec for `bv` types. 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes

## Test Plan

`bitwise_features.move` is modified to test the change. 
