### PR TITLE
[move-prover] limited support for inline spec in prover

### DIFF
--- a/language/move-compiler/src/cfgir/borrows/mod.rs
+++ b/language/move-compiler/src/cfgir/borrows/mod.rs
@@ -2,18 +2,21 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-mod state;
+use std::collections::BTreeMap;
 
-use super::absint::*;
+use move_ir_types::location::*;
+use state::{Value, *};
+
 use crate::{
     diagnostics::Diagnostics,
     hlir::ast::*,
     parser::ast::{BinOp_, StructName, Var},
     shared::{unique_map::UniqueMap, CompilationEnv},
 };
-use move_ir_types::location::*;
-use state::{Value, *};
-use std::collections::BTreeMap;
+
+use super::absint::*;
+
+mod state;
 
 //**************************************************************************************************
 // Entry and trait bindings
@@ -253,7 +256,7 @@ fn exp(context: &mut Context, parent_e: &Exp) -> Values {
         }
 
         E::Unit { .. } => vec![],
-        E::Value(_) | E::Constant(_) | E::Spec(_, _) | E::UnresolvedError => svalue(),
+        E::Value(_) | E::Constant(_) | E::Spec(_, _, _) | E::UnresolvedError => svalue(),
 
         E::Cast(e, _) | E::UnaryExp(_, e) => {
             let v = exp(context, e);

--- a/language/move-compiler/src/cfgir/cfg.rs
+++ b/language/move-compiler/src/cfgir/cfg.rs
@@ -2,6 +2,13 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use std::{
+    cmp::Reverse,
+    collections::{BTreeMap, BTreeSet, BinaryHeap, VecDeque},
+};
+
+use move_ir_types::location::*;
+
 use crate::{
     cfgir::{
         ast::{BasicBlock, BasicBlocks, BlockInfo, LoopEnd, LoopInfo},
@@ -11,11 +18,6 @@ use crate::{
     diagnostics::Diagnostics,
     hlir::ast::{Command, Command_, Exp, ExpListItem, Label, UnannotatedExp_, UnitCase},
     shared::ast_debug::*,
-};
-use move_ir_types::location::*;
-use std::{
-    cmp::Reverse,
-    collections::{BTreeMap, BTreeSet, BinaryHeap, VecDeque},
 };
 
 //**************************************************************************************************
@@ -275,7 +277,7 @@ fn unreachable_loc_exp(parent_e: &Exp) -> Option<Loc> {
         E::Unit { .. }
         | E::Value(_)
         | E::Constant(_)
-        | E::Spec(_, _)
+        | E::Spec(_, _, _)
         | E::UnresolvedError
         | E::BorrowLocal(_, _)
         | E::Copy { .. }

--- a/language/move-compiler/src/cfgir/liveness/mod.rs
+++ b/language/move-compiler/src/cfgir/liveness/mod.rs
@@ -129,7 +129,7 @@ fn exp(state: &mut LivenessState, parent_e: &Exp) {
             state.0.insert(*var);
         }
 
-        E::Spec(_, _, used_locals) => used_locals.keys().for_each(|v| {
+        E::Spec(_, _, used_locals) => used_locals.values().for_each(|(_, v)| {
             state.0.insert(*v);
         }),
 
@@ -336,7 +336,7 @@ mod last_usage {
 
             E::Spec(_, _, used_locals) => {
                 // remove it from context to prevent accidental dropping in previous usages
-                used_locals.keys().for_each(|var| {
+                used_locals.values().for_each(|(_, var)| {
                     context.dropped_live.remove(var);
                 })
             }

--- a/language/move-compiler/src/cfgir/liveness/mod.rs
+++ b/language/move-compiler/src/cfgir/liveness/mod.rs
@@ -2,22 +2,25 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-mod state;
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
 
-use super::{
-    absint::*,
-    cfg::{BlockCFG, ReverseBlockCFG, CFG},
-    locals,
-};
+use move_ir_types::location::*;
+use state::*;
+
 use crate::{
     diagnostics::Diagnostics,
     hlir::ast::{self as H, *},
     parser::ast::Var,
     shared::{unique_map::UniqueMap, CompilationEnv},
 };
-use move_ir_types::location::*;
-use state::*;
-use std::collections::{BTreeMap, BTreeSet, VecDeque};
+
+use super::{
+    absint::*,
+    cfg::{BlockCFG, ReverseBlockCFG, CFG},
+    locals,
+};
+
+mod state;
 
 //**************************************************************************************************
 // Entry and trait bindings
@@ -126,7 +129,7 @@ fn exp(state: &mut LivenessState, parent_e: &Exp) {
             state.0.insert(*var);
         }
 
-        E::Spec(_, used_locals) => used_locals.keys().for_each(|v| {
+        E::Spec(_, _, used_locals) => used_locals.keys().for_each(|v| {
             state.0.insert(*v);
         }),
 
@@ -191,6 +194,8 @@ pub fn last_usage(
 }
 
 mod last_usage {
+    use std::collections::{BTreeSet, VecDeque};
+
     use crate::{
         cfgir::liveness::state::LivenessState,
         diag,
@@ -201,7 +206,6 @@ mod last_usage {
         parser::ast::{Ability_, Var},
         shared::{unique_map::*, *},
     };
-    use std::collections::{BTreeSet, VecDeque};
 
     struct Context<'a, 'b> {
         env: &'a mut CompilationEnv,
@@ -330,7 +334,7 @@ mod last_usage {
                 context.dropped_live.remove(var);
             }
 
-            E::Spec(_, used_locals) => {
+            E::Spec(_, _, used_locals) => {
                 // remove it from context to prevent accidental dropping in previous usages
                 used_locals.keys().for_each(|var| {
                     context.dropped_live.remove(var);

--- a/language/move-compiler/src/cfgir/locals/mod.rs
+++ b/language/move-compiler/src/cfgir/locals/mod.rs
@@ -2,9 +2,11 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-pub mod state;
+use std::collections::BTreeMap;
 
-use super::absint::*;
+use move_ir_types::location::*;
+use state::*;
+
 use crate::{
     diag,
     diagnostics::{Diagnostic, Diagnostics},
@@ -17,9 +19,10 @@ use crate::{
     parser::ast::{Ability_, StructName, Var},
     shared::{unique_map::UniqueMap, *},
 };
-use move_ir_types::location::*;
-use state::*;
-use std::collections::BTreeMap;
+
+use super::absint::*;
+
+pub mod state;
 
 //**************************************************************************************************
 // Entry and trait bindings
@@ -247,7 +250,7 @@ fn exp(context: &mut Context, parent_e: &Exp) {
     use UnannotatedExp_ as E;
     let eloc = &parent_e.exp.loc;
     match &parent_e.exp.value {
-        E::Unit { .. } | E::Value(_) | E::Constant(_) | E::Spec(_, _) | E::UnresolvedError => (),
+        E::Unit { .. } | E::Value(_) | E::Constant(_) | E::Spec(_, _, _) | E::UnresolvedError => (),
 
         E::BorrowLocal(_, var) | E::Copy { var, .. } => use_local(context, eloc, var),
 

--- a/language/move-compiler/src/cfgir/optimize/constant_fold.rs
+++ b/language/move-compiler/src/cfgir/optimize/constant_fold.rs
@@ -2,6 +2,10 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use std::convert::TryFrom;
+
+use move_ir_types::location::*;
+
 use crate::{
     cfgir::cfg::BlockCFG,
     hlir::ast::{
@@ -12,8 +16,6 @@ use crate::{
     parser::ast::{BinOp, BinOp_, UnaryOp, UnaryOp_, Var},
     shared::unique_map::UniqueMap,
 };
-use move_ir_types::location::*;
-use std::convert::TryFrom;
 
 /// returns true if anything changed
 pub fn optimize(
@@ -81,7 +83,7 @@ fn optimize_exp(e: &mut Exp) -> bool {
         | E::Value(_)
         | E::Constant(_)
         | E::UnresolvedError
-        | E::Spec(_, _)
+        | E::Spec(_, _, _)
         | E::BorrowLocal(_, _)
         | E::Move { .. }
         | E::Copy { .. }

--- a/language/move-compiler/src/cfgir/optimize/eliminate_locals.rs
+++ b/language/move-compiler/src/cfgir/optimize/eliminate_locals.rs
@@ -151,7 +151,9 @@ mod count {
         match &parent_e.exp.value {
             E::Unit { .. } | E::Value(_) | E::Constant(_) | E::UnresolvedError => (),
             E::Spec(_, _, used_locals) => {
-                used_locals.keys().for_each(|var| context.used(var, false));
+                used_locals
+                    .values()
+                    .for_each(|(_, var)| context.used(var, false));
             }
 
             E::BorrowLocal(_, var) => context.used(var, false),

--- a/language/move-compiler/src/compiled_unit.rs
+++ b/language/move-compiler/src/compiled_unit.rs
@@ -2,14 +2,8 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{
-    diag,
-    diagnostics::Diagnostics,
-    expansion::ast::{Attributes, ModuleIdent, ModuleIdent_, SpecId},
-    hlir::ast as H,
-    parser::ast::{FunctionName, ModuleName, Var},
-    shared::{unique_map::UniqueMap, Name, NumericalAddress},
-};
+use std::collections::BTreeMap;
+
 use move_binary_format::file_format as F;
 use move_bytecode_source_map::source_map::SourceMap;
 use move_core_types::{
@@ -18,7 +12,16 @@ use move_core_types::{
 };
 use move_ir_types::location::*;
 use move_symbol_pool::Symbol;
-use std::collections::BTreeMap;
+
+use crate::{
+    diag,
+    diagnostics::Diagnostics,
+    expansion::ast::{Attributes, ModuleIdent, ModuleIdent_, SpecId},
+    hlir::ast as H,
+    parser::ast::{FunctionName, ModuleName, Var},
+    shared::{unique_map::UniqueMap, Name, NumericalAddress},
+    typing::ast as T,
+};
 
 //**************************************************************************************************
 // Compiled Unit
@@ -33,6 +36,7 @@ pub struct VarInfo {
 #[derive(Debug, Clone)]
 pub struct SpecInfo {
     pub offset: F::CodeOffset,
+    pub origin: T::SpecIdent,
     // Free locals that are used but not declared in the block
     pub used_locals: UniqueMap<Var, VarInfo>,
 }

--- a/language/move-compiler/src/hlir/ast.rs
+++ b/language/move-compiler/src/hlir/ast.rs
@@ -335,7 +335,7 @@ pub enum UnannotatedExp_ {
 
     Unreachable,
 
-    Spec(SpecId, SpecIdent, BTreeMap<Var, SingleType>),
+    Spec(SpecId, SpecIdent, BTreeMap<Var, (SingleType, Var)>),
 
     UnresolvedError,
 }
@@ -1179,8 +1179,8 @@ impl AstDebug for UnannotatedExp_ {
                 w.write(&format!(" from {}", origin));
                 if !used_locals.is_empty() {
                     w.write(" uses [");
-                    w.comma(used_locals, |w, (n, st)| {
-                        w.annotate(|w| w.write(&format!("{}", n)), st)
+                    w.comma(used_locals, |w, (n, (st, m))| {
+                        w.annotate(|w| w.write(&format!("{} ({})", n, m)), st)
                     });
                     w.write("]");
                 }

--- a/language/move-compiler/src/hlir/ast.rs
+++ b/language/move-compiler/src/hlir/ast.rs
@@ -17,6 +17,7 @@ use crate::{
         BinOp, ConstantName, Field, FunctionName, StructName, UnaryOp, Var, ENTRY_MODIFIER,
     },
     shared::{ast_debug::*, unique_map::UniqueMap, NumericalAddress},
+    typing::ast::SpecIdent,
 };
 
 // High Level IR
@@ -334,7 +335,7 @@ pub enum UnannotatedExp_ {
 
     Unreachable,
 
-    Spec(SpecId, BTreeMap<Var, SingleType>),
+    Spec(SpecId, SpecIdent, BTreeMap<Var, SingleType>),
 
     UnresolvedError,
 }
@@ -1173,8 +1174,9 @@ impl AstDebug for UnannotatedExp_ {
                 bt.ast_debug(w);
                 w.write(")");
             }
-            E::Spec(u, used_locals) => {
+            E::Spec(u, origin, used_locals) => {
                 w.write(&format!("spec #{}", u));
+                w.write(&format!(" from {}", origin));
                 if !used_locals.is_empty() {
                     w.write(" uses [");
                     w.comma(used_locals, |w, (n, st)| {

--- a/language/move-compiler/src/hlir/translate.rs
+++ b/language/move-compiler/src/hlir/translate.rs
@@ -1366,10 +1366,10 @@ fn exp_impl(
         TE::Spec(u, origin, tused_locals) => {
             let used_locals = tused_locals
                 .into_iter()
-                .map(|(var, ty)| {
+                .map(|(orig_var, (ty, var))| {
                     let v = context.remapped_local(var);
                     let st = single_type(context, ty);
-                    (v, st)
+                    (orig_var, (st, v))
                 })
                 .collect();
             HE::Spec(

--- a/language/move-compiler/src/inlining/visitor.rs
+++ b/language/move-compiler/src/inlining/visitor.rs
@@ -185,7 +185,7 @@ impl<'l, V: Visitor> Dispatcher<'l, V> {
                 self.exp(ex.as_mut())
             }
 
-            UnannotatedExp_::Spec(_, uses) => {
+            UnannotatedExp_::Spec(_, _, uses) => {
                 let keys: Vec<_> = uses.keys().cloned().collect();
                 let mut temp = BTreeMap::new();
                 for key in keys {

--- a/language/move-compiler/src/inlining/visitor.rs
+++ b/language/move-compiler/src/inlining/visitor.rs
@@ -189,10 +189,10 @@ impl<'l, V: Visitor> Dispatcher<'l, V> {
                 let keys: Vec<_> = uses.keys().cloned().collect();
                 let mut temp = BTreeMap::new();
                 for key in keys {
-                    let (mut var, mut ty) = uses.remove_entry(&key).unwrap();
+                    let (orig_var, (mut ty, mut var)) = uses.remove_entry(&key).unwrap();
                     self.type_(&mut ty);
                     self.visitor.var_use(&mut var);
-                    temp.insert(var, ty);
+                    temp.insert(orig_var, (ty, var));
                 }
                 uses.append(&mut temp);
             }

--- a/language/move-compiler/src/typing/ast.rs
+++ b/language/move-compiler/src/typing/ast.rs
@@ -190,7 +190,7 @@ pub enum UnannotatedExp_ {
     Cast(Box<Exp>, Box<Type>),
     Annotate(Box<Exp>, Box<Type>),
 
-    Spec(SpecId, Option<SpecIdent>, BTreeMap<Var, Type>),
+    Spec(SpecId, Option<SpecIdent>, BTreeMap<Var, (Type, Var)>),
 
     UnresolvedError,
 }
@@ -639,8 +639,8 @@ impl AstDebug for UnannotatedExp_ {
                 }
                 if !used_locals.is_empty() {
                     w.write(" uses [");
-                    w.comma(used_locals, |w, (n, ty)| {
-                        w.annotate(|w| w.write(&format!("{}", n)), ty)
+                    w.comma(used_locals, |w, (n, (ty, m))| {
+                        w.annotate(|w| w.write(&format!("{} ({})", n, m)), ty)
                     });
                     w.write("]");
                 }

--- a/language/move-compiler/src/typing/expand.rs
+++ b/language/move-compiler/src/typing/expand.rs
@@ -229,7 +229,9 @@ pub fn exp(context: &mut Context, e: &mut T::Exp) {
             e.exp.value = new_exp;
         }
 
-        E::Spec(_, _, used_locals) => used_locals.values_mut().for_each(|ty| type_(context, ty)),
+        E::Spec(_, _, used_locals) => used_locals
+            .values_mut()
+            .for_each(|(ty, _)| type_(context, ty)),
 
         E::Unit { .. }
         | E::Value(_)

--- a/language/move-compiler/src/typing/expand.rs
+++ b/language/move-compiler/src/typing/expand.rs
@@ -2,7 +2,9 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use super::core::{self, Context};
+use move_core_types::u256::U256;
+use move_ir_types::location::*;
+
 use crate::{
     diag,
     expansion::ast::Value_,
@@ -10,8 +12,8 @@ use crate::{
     parser::ast::Ability_,
     typing::ast as T,
 };
-use move_core_types::u256::U256;
-use move_ir_types::location::*;
+
+use super::core::{self, Context};
 
 //**************************************************************************************************
 // Functions
@@ -227,7 +229,7 @@ pub fn exp(context: &mut Context, e: &mut T::Exp) {
             e.exp.value = new_exp;
         }
 
-        E::Spec(_, used_locals) => used_locals.values_mut().for_each(|ty| type_(context, ty)),
+        E::Spec(_, _, used_locals) => used_locals.values_mut().for_each(|ty| type_(context, ty)),
 
         E::Unit { .. }
         | E::Value(_)

--- a/language/move-compiler/src/typing/globals.rs
+++ b/language/move-compiler/src/typing/globals.rs
@@ -2,15 +2,18 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use super::core::{self, Context, Subst};
+use std::collections::BTreeMap;
+
+use move_ir_types::location::*;
+
 use crate::{
     diag,
     naming::ast::{BuiltinTypeName_, Type, TypeName_, Type_},
     parser::ast::{Ability_, StructName},
     typing::ast as T,
 };
-use move_ir_types::location::*;
-use std::collections::BTreeMap;
+
+use super::core::{self, Context, Subst};
 
 //**************************************************************************************************
 // Functions
@@ -67,7 +70,7 @@ fn exp(context: &mut Context, annotated_acquires: &BTreeMap<StructName, Loc>, e:
         | E::BorrowLocal(_, _)
         | E::Break
         | E::Continue
-        | E::Spec(_, _)
+        | E::Spec(_, _, _)
         | E::UnresolvedError => (),
 
         E::ModuleCall(call) if is_current_function(context, call) => {

--- a/language/move-compiler/src/typing/infinite_instantiations.rs
+++ b/language/move-compiler/src/typing/infinite_instantiations.rs
@@ -2,7 +2,16 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use super::core::{self, Subst, TParamSubst};
+use std::collections::BTreeMap;
+
+use petgraph::{
+    algo::{astar as petgraph_astar, tarjan_scc as petgraph_scc},
+    graphmap::DiGraphMap,
+};
+
+use move_ir_types::location::*;
+use move_symbol_pool::Symbol;
+
 use crate::{
     diagnostics::{codes::TypeSafety, Diagnostic},
     expansion::ast::ModuleIdent,
@@ -11,13 +20,8 @@ use crate::{
     shared::{unique_map::UniqueMap, CompilationEnv},
     typing::ast as T,
 };
-use move_ir_types::location::*;
-use move_symbol_pool::Symbol;
-use petgraph::{
-    algo::{astar as petgraph_astar, tarjan_scc as petgraph_scc},
-    graphmap::DiGraphMap,
-};
-use std::collections::BTreeMap;
+
+use super::core::{self, Subst, TParamSubst};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum Edge {
@@ -221,7 +225,7 @@ fn exp(context: &mut Context, e: &T::Exp) {
         | E::BorrowLocal(_, _)
         | E::Break
         | E::Continue
-        | E::Spec(_, _)
+        | E::Spec(_, _, _)
         | E::UnresolvedError => (),
 
         E::ModuleCall(call) => {

--- a/language/move-compiler/src/typing/translate.rs
+++ b/language/move-compiler/src/typing/translate.rs
@@ -1548,7 +1548,7 @@ fn exp_inner(context: &mut Context, sp!(eloc, ne_): N::Exp) -> T::Exp {
                 .into_iter()
                 .filter_map(|v| {
                     let ty = context.get_local_(&v)?;
-                    Some((v, ty))
+                    Some((v, (ty, v)))
                 })
                 .collect();
             (sp(eloc, Type_::Unit), TE::Spec(u, None, used_local_types))

--- a/language/move-compiler/src/typing/translate.rs
+++ b/language/move-compiler/src/typing/translate.rs
@@ -2,10 +2,11 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use super::{
-    core::{self, Context, Subst},
-    expand, infinite_instantiations, recursive_structs,
-};
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
+
+use move_ir_types::location::*;
+use move_symbol_pool::Symbol;
+
 use crate::{
     diag,
     diagnostics::{codes::*, Diagnostic},
@@ -16,9 +17,11 @@ use crate::{
     typing::{ast as T, core::InferAbilityContext, globals},
     FullyCompiledProgram,
 };
-use move_ir_types::location::*;
-use move_symbol_pool::Symbol;
-use std::collections::{BTreeMap, BTreeSet, VecDeque};
+
+use super::{
+    core::{self, Context, Subst},
+    expand, infinite_instantiations, recursive_structs,
+};
 
 //**************************************************************************************************
 // Entry
@@ -288,7 +291,8 @@ fn constant(context: &mut Context, _name: ConstantName, nconstant: N::Constant) 
 }
 
 mod check_valid_constant {
-    use super::subtype_no_report;
+    use move_ir_types::location::*;
+
     use crate::{
         diag,
         diagnostics::codes::DiagnosticCode,
@@ -299,7 +303,8 @@ mod check_valid_constant {
             core::{self, Context, Subst},
         },
     };
-    use move_ir_types::location::*;
+
+    use super::subtype_no_report;
 
     pub(crate) fn signature<T: ToString, F: FnOnce() -> T>(
         context: &mut Context,
@@ -402,7 +407,7 @@ mod check_valid_constant {
             //*****************************************
             // Invalid cases
             //*****************************************
-            E::Spec(_, _) => "Spec blocks are",
+            E::Spec(_, _, _) => "Spec blocks are",
             E::BorrowLocal(_, _) => REFERENCE_CASE,
             E::ModuleCall(call) => {
                 exp(context, &call.arguments);
@@ -1546,7 +1551,7 @@ fn exp_inner(context: &mut Context, sp!(eloc, ne_): N::Exp) -> T::Exp {
                     Some((v, ty))
                 })
                 .collect();
-            (sp(eloc, Type_::Unit), TE::Spec(u, used_local_types))
+            (sp(eloc, Type_::Unit), TE::Spec(u, None, used_local_types))
         }
         NE::UnresolvedError => {
             assert!(context.env.has_errors());

--- a/language/move-compiler/tests/move_check/inlining/spec_inlining.move
+++ b/language/move-compiler/tests/move_check/inlining/spec_inlining.move
@@ -1,0 +1,22 @@
+module 0x42::Test {
+    inline fun apply(v: u64, predicate: |u64| bool): bool {
+        spec {
+            assert v >= 0;
+        };
+        predicate(v)
+    }
+
+    public fun test_apply() {
+        let r1 = apply(0, |v| v >= 0);
+        spec {
+            assert r1;
+        };
+        assert!(r1, 1);
+
+        let r2 = apply(0, |v| v != 0);
+        spec {
+            assert r2;
+        };
+        assert!(r2, 2);
+    }
+}

--- a/language/move-model/src/builder/model_builder.rs
+++ b/language/move-model/src/builder/model_builder.rs
@@ -129,6 +129,7 @@ pub(crate) struct FunEntry {
     pub result_type: Type,
     pub is_pure: bool,
     pub attributes: Vec<Attribute>,
+    pub inline_specs: BTreeMap<EA::SpecId, EA::SpecBlock>,
 }
 
 #[derive(Debug, Clone)]
@@ -280,6 +281,7 @@ impl<'env> ModelBuilder<'env> {
         type_params: Vec<(Symbol, Type)>,
         params: Vec<(Symbol, Type)>,
         result_type: Type,
+        inline_specs: BTreeMap<EA::SpecId, EA::SpecBlock>,
     ) {
         let entry = FunEntry {
             loc,
@@ -293,6 +295,7 @@ impl<'env> ModelBuilder<'env> {
             params,
             result_type,
             is_pure: false,
+            inline_specs,
         };
         // Duplicate declarations have been checked by the Move compiler.
         assert!(self.fun_table.insert(name, entry).is_none());

--- a/language/move-prover/tests/sources/functional/inline_fun.exp
+++ b/language/move-prover/tests/sources/functional/inline_fun.exp
@@ -1,0 +1,6 @@
+Move prover returns: exiting with model building errors
+error: no function named `predicate` found
+   ┌─ tests/sources/functional/inline_fun.move:12:46
+   │
+12 │                 invariant forall k in 0..i: !predicate(v[k]);
+   │                                              ^^^^^^^^^^^^^^^

--- a/language/move-prover/tests/sources/functional/inline_fun.move
+++ b/language/move-prover/tests/sources/functional/inline_fun.move
@@ -5,6 +5,10 @@ module 0x42::Test {
         let i = 0;
         while ({
             spec {
+                // TODO: this will cause a no-such-function error as `predicate`
+                // is inlined away in the implementation. We are aware of this
+                // issue and is working on a fix by bridging more information
+                // from inlined functions into the spec.
                 invariant forall k in 0..i: !predicate(v[k]);
                 // TODO: complete the set of loop invariants
             };

--- a/language/move-prover/tests/sources/functional/inline_fun_simple.exp
+++ b/language/move-prover/tests/sources/functional/inline_fun_simple.exp
@@ -1,0 +1,16 @@
+Move prover returns: exiting with verification errors
+error: unknown assertion failed
+  ┌─ tests/sources/functional/inline_fun_simple.move:4:13
+  │
+4 │             assert v >= 42;
+  │             ^^^^^^^^^^^^^^^
+  │
+  =     at tests/sources/functional/inline_fun_simple.move:22: test_apply_error
+  =         v#6 = <redacted>
+  =     at tests/sources/functional/inline_fun_simple.move:4
+  =     at tests/sources/functional/inline_fun_simple.move:22: test_apply_error
+  =         r1 = <redacted>
+  =     at tests/sources/functional/inline_fun_simple.move:24: test_apply_error
+  =     at tests/sources/functional/inline_fun_simple.move:27: test_apply_error
+  =         v#9 = <redacted>
+  =     at tests/sources/functional/inline_fun_simple.move:4

--- a/language/move-prover/tests/sources/functional/inline_fun_simple.move
+++ b/language/move-prover/tests/sources/functional/inline_fun_simple.move
@@ -1,0 +1,32 @@
+module 0x42::Test {
+    inline fun apply(v: u64, predicate: |u64| bool): bool {
+        spec {
+            assert v >= 42;
+        };
+        predicate(v)
+    }
+
+    public fun test_apply_correct() {
+        let r1 = apply(42, |v| v >= 1);
+        spec {
+            assert r1;
+        };
+
+        let r2 = apply(43, |v| v <= 2);
+        spec {
+            assert !r2;
+        };
+    }
+
+    public fun test_apply_error() {
+        let r1 = apply(42, |v| v >= 1);
+        spec {
+            assert r1;
+        };
+
+        let r2 = apply(3, |v| v <= 2);
+        spec {
+            assert !r2;
+        };
+    }
+}


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Move Language.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

This PR is an aggregated results of several PRs, including:
#876, #877 and this one.

It involves three changes:

**Change 1: extending the AST representation for `UnannotatedExp_::Spec`**

This PR changes `typing::UnannotatedExp_::Spec` as following:

```diff
- Spec(SpecId, BTreeMap<Var, Type>),
+ Spec(SpecId, Option<SpecIdent>, BTreeMap<Var, (Type, Var)>),
```

Where `SpecIdent` marks the origin of the spec block (before inlining)

```rust
pub struct SpecIdent {
    pub module: Option<ModuleIdent_>,  // None means a script
    pub function: Symbol,
    pub id: SpecId,
}
```

In the new representation:
```rust
Spec(SpecId, Option<SpecIdent>, BTreeMap<Var, (Type, Var)>),
             ^^^ origin of spec
                                         ^^^ name of the original local variable used in spec
                                                     ^^^ name of the re-mapped local variable
```

This allows move-model to look-up the correct spec definition
when processing in-body spec blocks.

**Change 2: unique `SpecId` for each spec block, including inlined spec blocks**

This PR also re-assigns `SpecId` for each `UnannotatedExp_::Spec` inlined to maintain that each inline spec block has a unique ID. This is needed later in the compilation stage.

This behavior is tested with a `spec_inlining.move` test case added in the `move_check` folder. Previously, this test case hits an assertion in the compiler.

**Change 3: allows move-model to inline specs by referring to the spec origin**

This is enabled by the changes in the `UnannotatedExp_::Spec` variant. In move-model,
instead of assuming that the spec comes from the same function definition, we now
use its origin to look up the spec definition and process the inlining accordingly.

## Motivation

Preliminary support for inlined functions

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes

## Test Plan

- CI
- new test cases added
