### PR TITLE
WIP: re-add sizing for StructTag and Value

### DIFF
--- a/language/move-vm/types/src/values/values_impl.rs
+++ b/language/move-vm/types/src/values/values_impl.rs
@@ -2293,7 +2293,6 @@ pub(crate) const LEGACY_REFERENCE_SIZE: AbstractMemorySize = AbstractMemorySize:
 pub(crate) const LEGACY_STRUCT_SIZE: AbstractMemorySize = AbstractMemorySize::new(2);
 
 impl Container {
-    #[cfg(test)]
     fn legacy_size(&self) -> AbstractMemorySize {
         match self {
             Self::Locals(r) | Self::Vec(r) | Self::Struct(r) => {
@@ -2328,21 +2327,18 @@ impl Container {
 }
 
 impl ContainerRef {
-    #[cfg(test)]
     fn legacy_size(&self) -> AbstractMemorySize {
         LEGACY_REFERENCE_SIZE
     }
 }
 
 impl IndexedRef {
-    #[cfg(test)]
     fn legacy_size(&self) -> AbstractMemorySize {
         LEGACY_REFERENCE_SIZE
     }
 }
 
 impl ValueImpl {
-    #[cfg(test)]
     fn legacy_size(&self) -> AbstractMemorySize {
         use ValueImpl::*;
 
@@ -2360,7 +2356,6 @@ impl ValueImpl {
 }
 
 impl Struct {
-    #[cfg(test)]
     fn legacy_size_impl(fields: &[ValueImpl]) -> AbstractMemorySize {
         fields
             .iter()
@@ -2374,14 +2369,13 @@ impl Struct {
 }
 
 impl Value {
-    #[cfg(test)]
-    pub(crate) fn legacy_size(&self) -> AbstractMemorySize {
+    pub fn legacy_size(&self) -> AbstractMemorySize {
         self.0.legacy_size()
     }
 }
 
+#[cfg(test)]
 impl ReferenceImpl {
-    #[cfg(test)]
     fn legacy_size(&self) -> AbstractMemorySize {
         match self {
             Self::ContainerRef(r) => r.legacy_size(),
@@ -2390,8 +2384,8 @@ impl ReferenceImpl {
     }
 }
 
+#[cfg(test)]
 impl Reference {
-    #[cfg(test)]
     pub(crate) fn legacy_size(&self) -> AbstractMemorySize {
         self.0.legacy_size()
     }


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Move Language.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Need deterministic sizing logic for setting event size limits.
Most of the logic here was pre-existing but moved into test before.
Pending items are:
1. Avoiding hand-rolliing struct sizes
2. Decide how we want to size Boxed structures
### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes.
## Test Plan

TBD