### PR TITLE
[sanity fix] Declaration order of structs/constants/functions used for definition tables

### DIFF
--- a/language/extensions/async/move-async-vm/tests/sources/AccountStateMachine.exp
+++ b/language/extensions/async/move-async-vm/tests/sources/AccountStateMachine.exp
@@ -52,4 +52,4 @@ actor 0x4 handling 0x3::AccountStateMachine::verify (hash=0x3450A8717C6383FF)
 actor 0x5 handling 0x3::AccountStateMachine::verify (hash=0x3450A8717C6383FF)
   SUCCESS
 actor 0x5 handling 0x3::AccountStateMachine::verify (hash=0x3450A8717C6383FF)
-  FAIL  VMError with status ABORTED with sub status 2 at location Module ModuleId { address: 00000000000000000000000000000003, name: Identifier("AccountStateMachine") } and message 0x00000000000000000000000000000003::AccountStateMachine::verify at offset 8 at code offset 8 in function definition 16
+  FAIL  VMError with status ABORTED with sub status 2 at location Module ModuleId { address: 00000000000000000000000000000003, name: Identifier("AccountStateMachine") } and message 0x00000000000000000000000000000003::AccountStateMachine::verify at offset 8 at code offset 8 in function definition 3

--- a/language/move-compiler/src/cfgir/ast.rs
+++ b/language/move-compiler/src/cfgir/ast.rs
@@ -66,6 +66,8 @@ pub struct ModuleDefinition {
 
 #[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Constant {
+    // index in the original order as defined in the source file
+    pub index: usize,
     pub attributes: Attributes,
     pub loc: Loc,
     pub signature: BaseType,
@@ -90,6 +92,8 @@ pub type FunctionBody = Spanned<FunctionBody_>;
 
 #[derive(PartialEq, Debug, Clone)]
 pub struct Function {
+    // index in the original order as defined in the source file
+    pub index: usize,
     pub attributes: Attributes,
     pub visibility: Visibility,
     pub entry: Option<Loc>,
@@ -269,6 +273,7 @@ impl AstDebug for (ConstantName, &Constant) {
         let (
             name,
             Constant {
+                index,
                 attributes,
                 loc: _loc,
                 signature,
@@ -276,7 +281,7 @@ impl AstDebug for (ConstantName, &Constant) {
             },
         ) = self;
         attributes.ast_debug(w);
-        w.write(&format!("const {}:", name));
+        w.write(&format!("const#{index} {name}:"));
         signature.ast_debug(w);
         w.write(" = ");
         match value {
@@ -315,6 +320,7 @@ impl AstDebug for (FunctionName, &Function) {
         let (
             name,
             Function {
+                index,
                 attributes,
                 visibility,
                 entry,
@@ -331,7 +337,7 @@ impl AstDebug for (FunctionName, &Function) {
         if let FunctionBody_::Native = &body.value {
             w.write("native ");
         }
-        w.write(&format!("{}", name));
+        w.write(&format!("fun#{index} {name}"));
         signature.ast_debug(w);
         if !acquires.is_empty() {
             w.write(" acquires ");

--- a/language/move-compiler/src/cfgir/translate.rs
+++ b/language/move-compiler/src/cfgir/translate.rs
@@ -247,6 +247,7 @@ fn script(context: &mut Context, hscript: H::Script) -> G::Script {
 
 fn constant(context: &mut Context, _name: ConstantName, c: H::Constant) -> G::Constant {
     let H::Constant {
+        index,
         attributes,
         loc,
         signature,
@@ -257,6 +258,7 @@ fn constant(context: &mut Context, _name: ConstantName, c: H::Constant) -> G::Co
     let value = final_value.and_then(move_value_from_exp);
 
     G::Constant {
+        index,
         attributes,
         loc,
         signature,
@@ -384,6 +386,7 @@ pub(crate) fn move_value_from_value_(v_: Value_) -> MoveValue {
 
 fn function(context: &mut Context, _name: FunctionName, f: H::Function) -> G::Function {
     let H::Function {
+        index,
         attributes,
         visibility,
         entry,
@@ -393,6 +396,7 @@ fn function(context: &mut Context, _name: FunctionName, f: H::Function) -> G::Fu
     } = f;
     let body = function_body(context, &signature, &acquires, body);
     G::Function {
+        index,
         attributes,
         visibility,
         entry,

--- a/language/move-compiler/src/expansion/ast.rs
+++ b/language/move-compiler/src/expansion/ast.rs
@@ -154,6 +154,8 @@ pub struct StructTypeParameter {
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct StructDefinition {
+    // index in the original order as defined in the source file
+    pub index: usize,
     pub attributes: Attributes,
     pub loc: Loc,
     pub abilities: AbilitySet,
@@ -197,6 +199,8 @@ pub struct SpecId(usize);
 
 #[derive(PartialEq, Clone, Debug)]
 pub struct Function {
+    // index in the original order as defined in the source file
+    pub index: usize,
     pub attributes: Attributes,
     pub loc: Loc,
     pub visibility: Visibility,
@@ -213,6 +217,8 @@ pub struct Function {
 
 #[derive(PartialEq, Clone, Debug)]
 pub struct Constant {
+    // index in the original order as defined in the source file
+    pub index: usize,
     pub attributes: Attributes,
     pub loc: Loc,
     pub signature: Type,
@@ -1008,6 +1014,7 @@ impl AstDebug for (StructName, &StructDefinition) {
         let (
             name,
             StructDefinition {
+                index,
                 attributes,
                 loc: _loc,
                 abilities,
@@ -1022,7 +1029,7 @@ impl AstDebug for (StructName, &StructDefinition) {
             w.write("native ");
         }
 
-        w.write(&format!("struct {}", name));
+        w.write(&format!("struct#{index} {name}"));
         type_parameters.ast_debug(w);
         ability_modifiers_ast_debug(w, abilities);
         if let StructFields::Defined(fields) = fields {
@@ -1229,6 +1236,7 @@ impl AstDebug for (FunctionName, &Function) {
         let (
             name,
             Function {
+                index,
                 attributes,
                 loc: _loc,
                 visibility,
@@ -1247,7 +1255,7 @@ impl AstDebug for (FunctionName, &Function) {
         if let FunctionBody_::Native = &body.value {
             w.write("native ");
         }
-        w.write(&format!("fun {}", name));
+        w.write(&format!("fun#{index} {name}"));
         signature.ast_debug(w);
         if !acquires.is_empty() {
             w.write(" acquires ");
@@ -1290,6 +1298,7 @@ impl AstDebug for (ConstantName, &Constant) {
         let (
             name,
             Constant {
+                index,
                 attributes,
                 loc: _loc,
                 signature,
@@ -1297,7 +1306,7 @@ impl AstDebug for (ConstantName, &Constant) {
             },
         ) = self;
         attributes.ast_debug(w);
-        w.write(&format!("const {}:", name));
+        w.write(&format!("const#{index} {}:", name));
         signature.ast_debug(w);
         w.write(" = ");
         value.ast_debug(w);

--- a/language/move-compiler/src/hlir/ast.rs
+++ b/language/move-compiler/src/hlir/ast.rs
@@ -66,6 +66,8 @@ pub struct ModuleDefinition {
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct StructDefinition {
+    // index in the original order as defined in the source file
+    pub index: usize,
     pub attributes: Attributes,
     pub abilities: AbilitySet,
     pub type_parameters: Vec<StructTypeParameter>,
@@ -84,6 +86,8 @@ pub enum StructFields {
 
 #[derive(PartialEq, Debug, Clone)]
 pub struct Constant {
+    // index in the original order as defined in the source file
+    pub index: usize,
     pub attributes: Attributes,
     pub loc: Loc,
     pub signature: BaseType,
@@ -113,6 +117,8 @@ pub type FunctionBody = Spanned<FunctionBody_>;
 
 #[derive(PartialEq, Debug, Clone)]
 pub struct Function {
+    // index in the original order as defined in the source file
+    pub index: usize,
     pub attributes: Attributes,
     pub visibility: Visibility,
     pub entry: Option<Loc>,
@@ -755,6 +761,7 @@ impl AstDebug for (StructName, &StructDefinition) {
         let (
             name,
             StructDefinition {
+                index,
                 attributes,
                 abilities,
                 type_parameters,
@@ -766,7 +773,7 @@ impl AstDebug for (StructName, &StructDefinition) {
             w.write("native ");
         }
 
-        w.write(&format!("struct {}", name));
+        w.write(&format!("struct#{index} {name}"));
         type_parameters.ast_debug(w);
         ability_modifiers_ast_debug(w, abilities);
         if let StructFields::Defined(fields) = fields {
@@ -786,6 +793,7 @@ impl AstDebug for (FunctionName, &Function) {
         let (
             name,
             Function {
+                index,
                 attributes,
                 visibility,
                 entry,
@@ -802,7 +810,7 @@ impl AstDebug for (FunctionName, &Function) {
         if let FunctionBody_::Native = &body.value {
             w.write("native ");
         }
-        w.write(&format!("fun {}", name));
+        w.write(&format!("fun#{index} {name}"));
         signature.ast_debug(w);
         if !acquires.is_empty() {
             w.write(" acquires ");
@@ -869,6 +877,7 @@ impl AstDebug for (ConstantName, &Constant) {
         let (
             name,
             Constant {
+                index,
                 attributes,
                 loc: _loc,
                 signature,
@@ -876,7 +885,7 @@ impl AstDebug for (ConstantName, &Constant) {
             },
         ) = self;
         attributes.ast_debug(w);
-        w.write(&format!("const {}:", name));
+        w.write(&format!("const#{index} {name}:"));
         signature.ast_debug(w);
         w.write(" = ");
         w.block(|w| value.ast_debug(w));

--- a/language/move-compiler/src/hlir/translate.rs
+++ b/language/move-compiler/src/hlir/translate.rs
@@ -277,6 +277,7 @@ fn function(context: &mut Context, _name: FunctionName, f: T::Function) -> H::Fu
     assert!(context.has_empty_locals());
     assert!(context.tmp_counter == 0);
     let T::Function {
+        index,
         attributes,
         visibility,
         entry,
@@ -287,6 +288,7 @@ fn function(context: &mut Context, _name: FunctionName, f: T::Function) -> H::Fu
     let signature = function_signature(context, signature);
     let body = function_body(context, &signature, body);
     H::Function {
+        index,
         attributes,
         visibility,
         entry,
@@ -371,6 +373,7 @@ fn function_body_defined(
 
 fn constant(context: &mut Context, _name: ConstantName, cdef: T::Constant) -> H::Constant {
     let T::Constant {
+        index,
         attributes,
         loc,
         signature: tsignature,
@@ -390,6 +393,7 @@ fn constant(context: &mut Context, _name: ConstantName, cdef: T::Constant) -> H:
     };
     let (locals, body) = function_body_defined(context, &function_signature, eloc, tseq);
     H::Constant {
+        index,
         attributes,
         loc,
         signature,
@@ -406,11 +410,16 @@ fn struct_def(
     _name: StructName,
     sdef: N::StructDefinition,
 ) -> H::StructDefinition {
-    let attributes = sdef.attributes;
-    let abilities = sdef.abilities;
-    let type_parameters = sdef.type_parameters;
-    let fields = struct_fields(context, sdef.fields);
+    let N::StructDefinition {
+        index,
+        attributes,
+        abilities,
+        type_parameters,
+        fields,
+    } = sdef;
+    let fields = struct_fields(context, fields);
     H::StructDefinition {
+        index,
         attributes,
         abilities,
         type_parameters,

--- a/language/move-compiler/src/naming/ast.rs
+++ b/language/move-compiler/src/naming/ast.rs
@@ -68,6 +68,8 @@ pub struct ModuleDefinition {
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct StructDefinition {
+    // index in the original order as defined in the source file
+    pub index: usize,
     pub attributes: Attributes,
     pub abilities: AbilitySet,
     pub type_parameters: Vec<StructTypeParameter>,
@@ -106,6 +108,8 @@ pub type FunctionBody = Spanned<FunctionBody_>;
 
 #[derive(PartialEq, Debug, Clone)]
 pub struct Function {
+    // index in the original order as defined in the source file
+    pub index: usize,
     pub attributes: Attributes,
     pub visibility: Visibility,
     pub entry: Option<Loc>,
@@ -120,6 +124,8 @@ pub struct Function {
 
 #[derive(PartialEq, Debug, Clone)]
 pub struct Constant {
+    // index in the original order as defined in the source file
+    pub index: usize,
     pub attributes: Attributes,
     pub loc: Loc,
     pub signature: Type,
@@ -730,6 +736,7 @@ impl AstDebug for (StructName, &StructDefinition) {
         let (
             name,
             StructDefinition {
+                index,
                 attributes,
                 abilities,
                 type_parameters,
@@ -740,7 +747,7 @@ impl AstDebug for (StructName, &StructDefinition) {
         if let StructFields::Native(_) = fields {
             w.write("native ");
         }
-        w.write(&format!("struct {}", name));
+        w.write(&format!("struct#{index} {name}"));
         type_parameters.ast_debug(w);
         ability_modifiers_ast_debug(w, abilities);
         if let StructFields::Defined(fields) = fields {
@@ -761,6 +768,7 @@ impl AstDebug for (FunctionName, &Function) {
         let (
             name,
             Function {
+                index,
                 attributes,
                 visibility,
                 entry,
@@ -777,7 +785,7 @@ impl AstDebug for (FunctionName, &Function) {
         if let FunctionBody_::Native = &body.value {
             w.write("native ");
         }
-        w.write(&format!("fun {}", name));
+        w.write(&format!("fun#{index} {name}"));
         signature.ast_debug(w);
         if !acquires.is_empty() {
             w.write(" acquires ");
@@ -850,6 +858,7 @@ impl AstDebug for (ConstantName, &Constant) {
         let (
             name,
             Constant {
+                index,
                 attributes,
                 loc: _loc,
                 signature,
@@ -857,7 +866,7 @@ impl AstDebug for (ConstantName, &Constant) {
             },
         ) = self;
         attributes.ast_debug(w);
-        w.write(&format!("const {}:", name));
+        w.write(&format!("const#{index} {name}:"));
         signature.ast_debug(w);
         w.write(" = ");
         value.ast_debug(w);

--- a/language/move-compiler/src/naming/translate.rs
+++ b/language/move-compiler/src/naming/translate.rs
@@ -534,6 +534,7 @@ fn function(
     ef: E::Function,
 ) -> N::Function {
     let E::Function {
+        index,
         attributes,
         loc: _,
         visibility,
@@ -552,6 +553,7 @@ fn function(
     let acquires = function_acquires(context, acquires);
     let body = function_body(context, body);
     let mut f = N::Function {
+        index,
         attributes,
         visibility,
         entry,
@@ -713,11 +715,18 @@ fn struct_def(
     _name: StructName,
     sdef: E::StructDefinition,
 ) -> N::StructDefinition {
-    let attributes = sdef.attributes;
-    let abilities = sdef.abilities;
-    let type_parameters = struct_type_parameters(context, sdef.type_parameters);
-    let fields = struct_fields(context, sdef.fields);
+    let E::StructDefinition {
+        index,
+        attributes,
+        loc: _loc,
+        abilities,
+        type_parameters,
+        fields,
+    } = sdef;
+    let type_parameters = struct_type_parameters(context, type_parameters);
+    let fields = struct_fields(context, fields);
     N::StructDefinition {
+        index,
         attributes,
         abilities,
         type_parameters,
@@ -740,6 +749,7 @@ fn struct_fields(context: &mut Context, efields: E::StructFields) -> N::StructFi
 
 fn constant(context: &mut Context, _name: ConstantName, econstant: E::Constant) -> N::Constant {
     let E::Constant {
+        index,
         attributes,
         loc,
         signature: esignature,
@@ -755,6 +765,7 @@ fn constant(context: &mut Context, _name: ConstantName, econstant: E::Constant) 
     context.local_count = BTreeMap::new();
     context.used_locals = BTreeSet::new();
     N::Constant {
+        index,
         attributes,
         loc,
         signature,

--- a/language/move-compiler/src/to_bytecode/translate.rs
+++ b/language/move-compiler/src/to_bytecode/translate.rs
@@ -448,16 +448,12 @@ fn struct_defs(
     m: &ModuleIdent,
     structs: UniqueMap<StructName, H::StructDefinition>,
 ) -> Vec<IR::StructDefinition> {
-    let sorting: HashMap<Symbol, usize> = structs
-        .iter()
-        .map(|(_, sname, sdef)| (*sname, sdef.index))
-        .collect();
-    let mut structs_vec = structs
+    let mut structs = structs.into_iter().collect::<Vec<_>>();
+    structs.sort_by_key(|(_, s)| s.index);
+    structs
         .into_iter()
         .map(|(s, sdef)| struct_def(context, &m, s, sdef))
-        .collect::<Vec<_>>();
-    structs_vec.sort_by_key(|sdef| sorting[&sdef.value.name.0]);
-    structs_vec
+        .collect()
 }
 
 fn struct_def(
@@ -524,18 +520,14 @@ fn struct_fields(
 fn constants(
     context: &mut Context,
     m: Option<&ModuleIdent>,
-    gconstants: UniqueMap<ConstantName, G::Constant>,
+    constants: UniqueMap<ConstantName, G::Constant>,
 ) -> Vec<IR::Constant> {
-    let sorting: HashMap<Symbol, usize> = gconstants
-        .iter()
-        .map(|(_, cname, c)| (*cname, c.index))
-        .collect();
-    let mut constant_vec = gconstants
+    let mut constants = constants.into_iter().collect::<Vec<_>>();
+    constants.sort_by_key(|(_, c)| c.index);
+    constants
         .into_iter()
         .map(|(n, c)| constant(context, m, n, c))
-        .collect::<Vec<_>>();
-    constant_vec.sort_by_key(|c| sorting[&c.name.0]);
-    constant_vec
+        .collect::<Vec<_>>()
 }
 
 fn constant(
@@ -561,14 +553,12 @@ fn constant(
 fn functions(
     context: &mut Context,
     m: Option<&ModuleIdent>,
-    gfunctions: UniqueMap<FunctionName, G::Function>,
+    functions: UniqueMap<FunctionName, G::Function>,
 ) -> (CollectedInfos, Vec<(IR::FunctionName, IR::Function)>) {
-    let sorting: HashMap<Symbol, usize> = gfunctions
-        .iter()
-        .map(|(_, fname, f)| (*fname, f.index))
-        .collect();
+    let mut functions = functions.into_iter().collect::<Vec<_>>();
+    functions.sort_by_key(|(_, f)| f.index);
     let mut collected_function_infos = UniqueMap::new();
-    let mut functions_vec = gfunctions
+    let functions_vec = functions
         .into_iter()
         // TODO full prover support for vector bytecode instructions
         // TODO filter out fake natives
@@ -586,7 +576,6 @@ fn functions(
             res
         })
         .collect::<Vec<_>>();
-    functions_vec.sort_by_key(|(fname, _)| sorting[&fname.0]);
     (collected_function_infos, functions_vec)
 }
 

--- a/language/move-compiler/src/to_bytecode/translate.rs
+++ b/language/move-compiler/src/to_bytecode/translate.rs
@@ -452,7 +452,7 @@ fn struct_defs(
     structs.sort_by_key(|(_, s)| s.index);
     structs
         .into_iter()
-        .map(|(s, sdef)| struct_def(context, &m, s, sdef))
+        .map(|(s, sdef)| struct_def(context, m, s, sdef))
         .collect()
 }
 

--- a/language/move-compiler/src/typing/ast.rs
+++ b/language/move-compiler/src/typing/ast.rs
@@ -71,6 +71,8 @@ pub type FunctionBody = Spanned<FunctionBody_>;
 
 #[derive(PartialEq, Debug, Clone)]
 pub struct Function {
+    // index in the original order as defined in the source file
+    pub index: usize,
     pub attributes: Attributes,
     pub visibility: Visibility,
     pub entry: Option<Loc>,
@@ -85,6 +87,8 @@ pub struct Function {
 
 #[derive(PartialEq, Debug, Clone)]
 pub struct Constant {
+    // index in the original order as defined in the source file
+    pub index: usize,
     pub attributes: Attributes,
     pub loc: Loc,
     pub signature: Type,
@@ -340,6 +344,7 @@ impl AstDebug for (FunctionName, &Function) {
         let (
             name,
             Function {
+                index,
                 attributes,
                 visibility,
                 entry,
@@ -356,7 +361,7 @@ impl AstDebug for (FunctionName, &Function) {
         if let FunctionBody_::Native = &body.value {
             w.write("native ");
         }
-        w.write(&format!("fun {}", name));
+        w.write(&format!("fun#{index} {name}"));
         signature.ast_debug(w);
         if !acquires.is_empty() {
             w.write(" acquires ");
@@ -375,6 +380,7 @@ impl AstDebug for (ConstantName, &Constant) {
         let (
             name,
             Constant {
+                index,
                 attributes,
                 loc: _loc,
                 signature,
@@ -382,7 +388,7 @@ impl AstDebug for (ConstantName, &Constant) {
             },
         ) = self;
         attributes.ast_debug(w);
-        w.write(&format!("const {}:", name));
+        w.write(&format!("const#{index} {name}:"));
         signature.ast_debug(w);
         w.write(" = ");
         value.ast_debug(w);

--- a/language/move-compiler/src/typing/translate.rs
+++ b/language/move-compiler/src/typing/translate.rs
@@ -132,6 +132,7 @@ fn function(
 ) -> T::Function {
     let loc = name.loc();
     let N::Function {
+        index,
         attributes,
         visibility,
         entry,
@@ -165,6 +166,7 @@ fn function(
     let body = function_body(context, &acquires, n_body);
     context.current_function = None;
     T::Function {
+        index,
         attributes,
         visibility,
         entry,
@@ -229,6 +231,7 @@ fn constant(context: &mut Context, _name: ConstantName, nconstant: N::Constant) 
     context.reset_for_module_item();
 
     let N::Constant {
+        index,
         attributes,
         loc,
         signature,
@@ -263,6 +266,7 @@ fn constant(context: &mut Context, _name: ConstantName, nconstant: N::Constant) 
     check_valid_constant::exp(context, &value);
 
     T::Constant {
+        index,
         attributes,
         loc,
         signature,

--- a/language/move-compiler/transactional-tests/tests/evaluation_order/struct_arguments.exp
+++ b/language/move-compiler/transactional-tests/tests/evaluation_order/struct_arguments.exp
@@ -6,7 +6,7 @@ Error: Script execution failed with VMError: {
     sub_status: None,
     location: 0x42::M,
     indices: [],
-    offsets: [(FunctionDefinitionIndex(2), 2)],
+    offsets: [(FunctionDefinitionIndex(0), 2)],
 }
 
 task 2 'run'. lines 62-69:
@@ -15,7 +15,7 @@ Error: Script execution failed with VMError: {
     sub_status: None,
     location: 0x42::M,
     indices: [],
-    offsets: [(FunctionDefinitionIndex(3), 2)],
+    offsets: [(FunctionDefinitionIndex(1), 2)],
 }
 
 task 3 'run'. lines 71-78:
@@ -24,7 +24,7 @@ Error: Script execution failed with VMError: {
     sub_status: None,
     location: 0x42::M,
     indices: [],
-    offsets: [(FunctionDefinitionIndex(4), 2)],
+    offsets: [(FunctionDefinitionIndex(2), 2)],
 }
 
 task 4 'run'. lines 80-87:
@@ -33,7 +33,7 @@ Error: Script execution failed with VMError: {
     sub_status: None,
     location: 0x42::M,
     indices: [],
-    offsets: [(FunctionDefinitionIndex(5), 2)],
+    offsets: [(FunctionDefinitionIndex(3), 2)],
 }
 
 task 5 'run'. lines 89-96:
@@ -42,7 +42,7 @@ Error: Script execution failed with VMError: {
     sub_status: None,
     location: 0x42::M,
     indices: [],
-    offsets: [(FunctionDefinitionIndex(6), 2)],
+    offsets: [(FunctionDefinitionIndex(4), 2)],
 }
 
 task 6 'run'. lines 98-105:
@@ -51,7 +51,7 @@ Error: Script execution failed with VMError: {
     sub_status: None,
     location: 0x42::M,
     indices: [],
-    offsets: [(FunctionDefinitionIndex(7), 3)],
+    offsets: [(FunctionDefinitionIndex(5), 3)],
 }
 
 task 7 'run'. lines 107-114:
@@ -60,5 +60,5 @@ Error: Script execution failed with VMError: {
     sub_status: None,
     location: 0x42::M,
     indices: [],
-    offsets: [(FunctionDefinitionIndex(1), 5)],
+    offsets: [(FunctionDefinitionIndex(8), 5)],
 }

--- a/language/testing-infra/transactional-test-runner/tests/vm_test_harness/example.exp
+++ b/language/testing-infra/transactional-test-runner/tests/vm_test_harness/example.exp
@@ -9,7 +9,7 @@ Error: Function execution failed with VMError: {
     sub_status: Some(0),
     location: 0x42::N,
     indices: [],
-    offsets: [(FunctionDefinitionIndex(0), 1)],
+    offsets: [(FunctionDefinitionIndex(2), 1)],
 }
 
 task 7 'view'. lines 47-49:

--- a/language/tools/move-cli/tests/build_tests/disassemble_module/Move.toml
+++ b/language/tools/move-cli/tests/build_tests/disassemble_module/Move.toml
@@ -1,0 +1,3 @@
+[package]
+name = "Test"
+version = "0.0.0"

--- a/language/tools/move-cli/tests/build_tests/disassemble_module/args.exp
+++ b/language/tools/move-cli/tests/build_tests/disassemble_module/args.exp
@@ -1,0 +1,23 @@
+Command `build`:
+BUILDING Test
+Command `disassemble --package Test --name m`:
+// Move bytecode v6
+module 42.m {
+struct Zs {
+	dummy_field: bool
+}
+struct As {
+	dummy_field: bool
+}
+
+public zf(): u64 {
+B0:
+	0: LdConst[0](U64: [1, 0, 0, 0, 0, 0, 0, 0])
+	1: Ret
+}
+public af(): u64 {
+B0:
+	0: LdConst[1](U64: [0, 0, 0, 0, 0, 0, 0, 0])
+	1: Ret
+}
+}

--- a/language/tools/move-cli/tests/build_tests/disassemble_module/args.txt
+++ b/language/tools/move-cli/tests/build_tests/disassemble_module/args.txt
@@ -1,0 +1,2 @@
+build
+disassemble --package Test --name m

--- a/language/tools/move-cli/tests/build_tests/disassemble_module/sources/m.move
+++ b/language/tools/move-cli/tests/build_tests/disassemble_module/sources/m.move
@@ -1,0 +1,12 @@
+module 0x42::m {
+
+struct Zs {}
+struct As {}
+
+const Zc: u64 = 1;
+const Ac: u64 = 0;
+
+public fun zf(): u64 { Zc }
+public fun af(): u64 { Ac }
+
+}

--- a/language/tools/move-cli/tests/sandbox_tests/module_disassemble/args.exp
+++ b/language/tools/move-cli/tests/sandbox_tests/module_disassemble/args.exp
@@ -13,11 +13,6 @@ struct S {
 	i: u64
 }
 
-public bar(): u64 {
-B0:
-	0: LdU64(7)
-	1: Ret
-}
 public foo(Arg0: u64): vector<u64> {
 B0:
 	0: Call bar(): u64
@@ -27,6 +22,11 @@ B0:
 	4: Add
 	5: Call vector::singleton<u64>(u64): vector<u64>
 	6: Ret
+}
+public bar(): u64 {
+B0:
+	0: LdU64(7)
+	1: Ret
 }
 }
 Command `sandbox view storage/0x0000000000000000000000000000000c/modules/M.mv`:
@@ -40,6 +40,16 @@ use 0000000000000000000000000000000b::M as 2M;
 
 
 
+public f(): u64 {
+B0:
+	0: LdU64(7)
+	1: Ret
+}
+public g(): u64 {
+B0:
+	0: LdU64(12)
+	1: Ret
+}
 public call_f(): u64 {
 B0:
 	0: Call f(): u64
@@ -57,15 +67,5 @@ B0:
 	3: Call B::g(): u64
 	4: Add
 	5: Ret
-}
-public f(): u64 {
-B0:
-	0: LdU64(7)
-	1: Ret
-}
-public g(): u64 {
-B0:
-	0: LdU64(12)
-	1: Ret
 }
 }

--- a/language/tools/move-cli/tests/sandbox_tests/package_basics/args.exp
+++ b/language/tools/move-cli/tests/sandbox_tests/package_basics/args.exp
@@ -75,6 +75,7 @@ Command `disassemble --package MoveStdlib --name signer`:
 module 1.signer {
 
 
+native public borrow_address(s#0#0: &signer): &address
 public address_of(s#0#0: &signer): address {
 B0:
 	0: MoveLoc[0](s#0#0: &signer)
@@ -82,7 +83,6 @@ B0:
 	2: ReadRef
 	3: Ret
 }
-native public borrow_address(s#0#0: &signer): &address
 }
 Command `errmap`:
 Command `info`:

--- a/language/tools/move-cli/tests/sandbox_tests/verify_native_functions_in_multi_module_publish/args.exp
+++ b/language/tools/move-cli/tests/sandbox_tests/verify_native_functions_in_multi_module_publish/args.exp
@@ -1,8 +1,8 @@
 Command `sandbox publish --bundle --override-ordering M --override-ordering N`:
 Invalid multi-module publishing: VMError with status MISSING_DEPENDENCY at location Module ModuleId { address: 00000000000000000000000000000042, name: Identifier("M") } at index 0 for function handle
 error[E02007]: invalid 'fun' declaration
-  ┌─ ./sources/example.move:3:16
+  ┌─ ./sources/example.move:2:16
   │
-3 │     native fun create_nothing();
-  │                ^^^^^^^^^^^^^^ Missing implementation for the native function M::create_nothing
+2 │     native fun create_signer(addr: address): signer;
+  │                ^^^^^^^^^^^^^ Missing implementation for the native function M::create_signer
 

--- a/language/tools/move-cli/tests/sandbox_tests/verify_native_functions_in_publish/args.exp
+++ b/language/tools/move-cli/tests/sandbox_tests/verify_native_functions_in_publish/args.exp
@@ -1,7 +1,7 @@
 Command `sandbox publish`:
 error[E02007]: invalid 'fun' declaration
-  ┌─ ./sources/example.move:3:16
+  ┌─ ./sources/example.move:2:16
   │
-3 │     native fun create_nothing();
-  │                ^^^^^^^^^^^^^^ Missing implementation for the native function M::create_nothing
+2 │     native fun create_signer(addr: address): signer;
+  │                ^^^^^^^^^^^^^ Missing implementation for the native function M::create_signer
 


### PR DESCRIPTION
- The definition tables in the CompiledModule were populated via the alphanumeric ordering
- This might be unexpected as other constructs, namely fields, do not do this.
- This fix sorts the definitions based on the source file declaration order

## Test Plan

- new test and updated tests
