### PR TITLE
Add abstract gas sizing for StructTag, TypeTag, Value

### DIFF
--- a/language/move-core/types/src/account_address.rs
+++ b/language/move-core/types/src/account_address.rs
@@ -116,7 +116,7 @@ impl AccountAddress {
 
     /// TODO (ade): use macro to enfornce determinism
     pub fn abstract_size_for_gas_metering(&self) -> AbstractMemorySize {
-        AbstractMemorySize::new(std::mem::size_of::<Self>() as u64)
+        AbstractMemorySize::new(Self::LENGTH as u64)
     }
 }
 

--- a/language/move-core/types/src/account_address.rs
+++ b/language/move-core/types/src/account_address.rs
@@ -302,8 +302,8 @@ impl std::error::Error for AccountAddressParseError {}
 
 #[cfg(test)]
 mod tests {
-    use crate::gas_algebra::AbstractMemorySize;
     use super::AccountAddress;
+    use crate::gas_algebra::AbstractMemorySize;
     use hex::FromHex;
     use proptest::prelude::*;
     use std::{

--- a/language/move-core/types/src/account_address.rs
+++ b/language/move-core/types/src/account_address.rs
@@ -303,7 +303,6 @@ impl std::error::Error for AccountAddressParseError {}
 #[cfg(test)]
 mod tests {
     use crate::gas_algebra::AbstractMemorySize;
-
     use super::AccountAddress;
     use hex::FromHex;
     use proptest::prelude::*;

--- a/language/move-core/types/src/gas_algebra.rs
+++ b/language/move-core/types/src/gas_algebra.rs
@@ -77,6 +77,13 @@ pub type InternalGasPerAbstractMemoryUnit =
 
 pub type InternalGasPerArg = GasQuantity<UnitDiv<InternalGasUnit, Arg>>;
 
+/// Abstract size of Rust Box pointer
+/// This might be an over-estimation in many cases
+pub const BOX_ABSTRACT_SIZE: AbstractMemorySize = AbstractMemorySize::new(16);
+
+/// Base abstract size of Rust enum
+pub const ENUM_BASE_ABSTRACT_SIZE: AbstractMemorySize = AbstractMemorySize::new(8);
+
 /***************************************************************************************************
  * Constructors
  *

--- a/language/move-core/types/src/identifier.rs
+++ b/language/move-core/types/src/identifier.rs
@@ -27,6 +27,7 @@
 //! * specify keys for lookups in storage
 //! * do cross-module lookups while executing transactions
 
+use crate::gas_algebra::AbstractMemorySize;
 use anyhow::{bail, Result};
 #[cfg(any(test, feature = "fuzzing"))]
 use proptest::prelude::*;
@@ -218,6 +219,12 @@ impl IdentStr {
     /// Converts `self` to a byte slice.
     pub fn as_bytes(&self) -> &[u8] {
         self.0.as_bytes()
+    }
+
+    /// Returns the abstract size of the struct
+    /// TODO (ade): use macro to enfornce determinism
+    pub fn abstract_size_for_gas_metering(&self) -> AbstractMemorySize {
+        AbstractMemorySize::new((self.len()) as u64)
     }
 }
 

--- a/language/move-core/types/src/language_storage.rs
+++ b/language/move-core/types/src/language_storage.rs
@@ -4,11 +4,11 @@
 
 use crate::{
     account_address::AccountAddress,
-    gas_algebra::AbstractMemorySize,
+    gas_algebra::{AbstractMemorySize, BOX_ABSTRACT_SIZE, ENUM_BASE_ABSTRACT_SIZE},
     identifier::{IdentStr, Identifier},
     parser::{parse_struct_tag, parse_type_tag},
-    u256,
 };
+use once_cell::sync::Lazy;
 #[cfg(any(test, feature = "fuzzing"))]
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
@@ -22,6 +22,10 @@ pub const RESOURCE_TAG: u8 = 1;
 
 /// Hex address: 0x1
 pub const CORE_CODE_ADDRESS: AccountAddress = AccountAddress::ONE;
+
+/// Rough estimate of abstract size for TypeTag
+pub static TYPETAG_ENUM_ABSTRACT_SIZE: Lazy<AbstractMemorySize> =
+    Lazy::new(|| ENUM_BASE_ABSTRACT_SIZE + BOX_ABSTRACT_SIZE);
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Hash, Eq, Clone, PartialOrd, Ord)]
 pub enum TypeTag {
@@ -80,11 +84,24 @@ impl TypeTag {
         }
     }
 
-    pub fn size(&self) -> AbstractMemorySize {
-        // Enum size is size of largest variant
-        // In this case, largest it's `U256`
-        // TODO: make this derivation more robust?
-        AbstractMemorySize::new((std::mem::size_of::<u256::U256>()) as u64)
+    /// Return the abstract size we use for gas metering
+    /// This size might be imperfect but should be consistent across platforms
+    /// TODO (ade): use macro to enfornce determinism
+    pub fn abstract_size_for_gas_metering(&self) -> AbstractMemorySize {
+        *TYPETAG_ENUM_ABSTRACT_SIZE
+            + match self {
+                TypeTag::Bool
+                | TypeTag::U8
+                | TypeTag::U64
+                | TypeTag::U128
+                | TypeTag::Address
+                | TypeTag::Signer
+                | TypeTag::U16
+                | TypeTag::U32
+                | TypeTag::U256 => AbstractMemorySize::new(0),
+                TypeTag::Vector(x) => x.abstract_size_for_gas_metering(),
+                TypeTag::Struct(y) => y.abstract_size_for_gas_metering(),
+            }
     }
 }
 
@@ -160,13 +177,20 @@ impl StructTag {
         )
     }
 
-    pub fn size(&self) -> AbstractMemorySize {
+    /// Return the abstract size we use for gas metering
+    /// This size might be imperfect but should be consistent across platforms
+    /// TODO (ade): use macro to enfornce determinism
+    pub fn abstract_size_for_gas_metering(&self) -> AbstractMemorySize {
         // TODO: make this more robust as struct size changes
-        AbstractMemorySize::new(
-            (std::mem::size_of::<AccountAddress>()
-                + 2 * std::mem::size_of::<Identifier>()
-                + self.type_params.len() * std::mem::size_of::<TypeTag>()) as u64,
-        )
+        self.address.abstract_size_for_gas_metering()
+            + self.module.abstract_size_for_gas_metering()
+            + self.name.abstract_size_for_gas_metering()
+            + self
+                .type_params
+                .iter()
+                .fold(AbstractMemorySize::new(0), |accum, val| {
+                    accum + val.abstract_size_for_gas_metering()
+                })
     }
 }
 

--- a/language/move-core/types/src/unit_tests/identifier_test.rs
+++ b/language/move-core/types/src/unit_tests/identifier_test.rs
@@ -2,7 +2,10 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::identifier::{IdentStr, Identifier, ALLOWED_IDENTIFIERS, ALLOWED_NO_SELF_IDENTIFIERS};
+use crate::{
+    gas_algebra::AbstractMemorySize,
+    identifier::{IdentStr, Identifier, ALLOWED_IDENTIFIERS, ALLOWED_NO_SELF_IDENTIFIERS},
+};
 use bcs::test_helpers::assert_canonical_encode_decode;
 use once_cell::sync::Lazy;
 use proptest::prelude::*;
@@ -122,4 +125,15 @@ fn serde_serialize_no_wrapper() {
     let foobar = Identifier::new("foobar").expect("should parse correctly");
     let s = serde_json::to_string(&foobar).expect("Identifier should serialize correctly");
     assert_eq!(s, "\"foobar\"");
+}
+
+/// Ensure abstract size is properly computed
+#[test]
+fn test_abstract_size() {
+    let foobar = Identifier::new("foobar").expect("should parse correctly");
+
+    // Size should be 6 chars * 1 byte/char + = 6 bytes.
+    let expected = AbstractMemorySize::new(6);
+    let actual = foobar.abstract_size_for_gas_metering();
+    assert_eq!(expected, actual);
 }

--- a/language/move-core/types/src/unit_tests/language_storage_test.rs
+++ b/language/move-core/types/src/unit_tests/language_storage_test.rs
@@ -4,8 +4,9 @@
 
 use crate::{
     account_address::AccountAddress,
+    gas_algebra::AbstractMemorySize,
     identifier::{IdentStr, Identifier},
-    language_storage::{ModuleId, StructTag, TypeTag},
+    language_storage::{ModuleId, StructTag, TypeTag, TYPETAG_ENUM_ABSTRACT_SIZE},
 };
 use bcs::test_helpers::assert_canonical_encode_decode;
 use proptest::prelude::*;
@@ -15,6 +16,78 @@ proptest! {
     fn test_module_id_canonical_roundtrip(module_id in any::<ModuleId>()) {
         assert_canonical_encode_decode(module_id);
     }
+}
+
+#[test]
+fn test_type_tag_abstract_size() {
+    // size = TYPETAG_ENUM_ABSTRACT_SIZE + TYPETAG_ENUM_ABSTRACT_SIZE
+    let type_tag1 = TypeTag::Vector(Box::new(TypeTag::U16));
+    // size = TYPETAG_ENUM_ABSTRACT_SIZE + TYPETAG_ENUM_ABSTRACT_SIZE
+    let type_tag2 = TypeTag::Vector(Box::new(TypeTag::U256));
+    // size = TYPETAG_ENUM_ABSTRACT_SIZE + TYPETAG_ENUM_ABSTRACT_SIZE
+    let type_tag3 = TypeTag::Vector(Box::new(TypeTag::U128));
+
+    assert_eq!(
+        type_tag1.abstract_size_for_gas_metering(),
+        *TYPETAG_ENUM_ABSTRACT_SIZE + *TYPETAG_ENUM_ABSTRACT_SIZE
+    );
+    assert_eq!(
+        type_tag2.abstract_size_for_gas_metering(),
+        *TYPETAG_ENUM_ABSTRACT_SIZE + *TYPETAG_ENUM_ABSTRACT_SIZE
+    );
+    assert_eq!(
+        type_tag3.abstract_size_for_gas_metering(),
+        *TYPETAG_ENUM_ABSTRACT_SIZE + *TYPETAG_ENUM_ABSTRACT_SIZE
+    );
+
+    let struct_tag1 = StructTag {
+        // size = AccountAddress::LENGTH
+        address: AccountAddress::ONE,
+        // size = 10
+        module: Identifier::from(IdentStr::new("TestModule").unwrap()),
+        // size = 10
+        name: Identifier::from(IdentStr::new("TestStruct").unwrap()),
+        type_params: vec![
+            // size = TYPETAG_ENUM_ABSTRACT_SIZE
+            TypeTag::U8,
+            // size = TYPETAG_ENUM_ABSTRACT_SIZE
+            TypeTag::U16,
+            // size = TYPETAG_ENUM_ABSTRACT_SIZE
+            TypeTag::U32,
+            // size = TYPETAG_ENUM_ABSTRACT_SIZE
+            TypeTag::U64,
+            // size = TYPETAG_ENUM_ABSTRACT_SIZE
+            TypeTag::U128,
+            // size = TYPETAG_ENUM_ABSTRACT_SIZE
+            TypeTag::U256,
+            // size = TYPETAG_ENUM_ABSTRACT_SIZE
+            TypeTag::Bool,
+            // size = TYPETAG_ENUM_ABSTRACT_SIZE
+            TypeTag::Address,
+            // size = TYPETAG_ENUM_ABSTRACT_SIZE
+            TypeTag::Signer,
+            // size = TYPETAG_ENUM_ABSTRACT_SIZE + TYPETAG_ENUM_ABSTRACT_SIZE
+            type_tag1,
+            // size = TYPETAG_ENUM_ABSTRACT_SIZE + TYPETAG_ENUM_ABSTRACT_SIZE
+            type_tag2,
+            // size = TYPETAG_ENUM_ABSTRACT_SIZE + TYPETAG_ENUM_ABSTRACT_SIZE
+            type_tag3,
+        ],
+    };
+
+    assert_eq!(
+        struct_tag1.abstract_size_for_gas_metering(),
+        AbstractMemorySize::new(
+            u64::from(*TYPETAG_ENUM_ABSTRACT_SIZE) * 15 + 10 + 10 + (AccountAddress::LENGTH as u64)
+        )
+    );
+
+    let type_tag4 = TypeTag::Struct(Box::new(struct_tag1.clone()));
+
+    assert_eq!(
+        type_tag4.abstract_size_for_gas_metering(),
+        struct_tag1.abstract_size_for_gas_metering() + *TYPETAG_ENUM_ABSTRACT_SIZE
+    );
 }
 
 #[test]

--- a/language/move-vm/types/src/values/values_impl.rs
+++ b/language/move-vm/types/src/values/values_impl.rs
@@ -2293,7 +2293,6 @@ pub(crate) const LEGACY_REFERENCE_SIZE: AbstractMemorySize = AbstractMemorySize:
 pub(crate) const LEGACY_STRUCT_SIZE: AbstractMemorySize = AbstractMemorySize::new(2);
 
 impl Container {
-    #[cfg(test)]
     fn legacy_size(&self) -> AbstractMemorySize {
         match self {
             Self::Locals(r) | Self::Vec(r) | Self::Struct(r) => {
@@ -2328,21 +2327,18 @@ impl Container {
 }
 
 impl ContainerRef {
-    #[cfg(test)]
     fn legacy_size(&self) -> AbstractMemorySize {
         LEGACY_REFERENCE_SIZE
     }
 }
 
 impl IndexedRef {
-    #[cfg(test)]
     fn legacy_size(&self) -> AbstractMemorySize {
         LEGACY_REFERENCE_SIZE
     }
 }
 
 impl ValueImpl {
-    #[cfg(test)]
     fn legacy_size(&self) -> AbstractMemorySize {
         use ValueImpl::*;
 
@@ -2360,7 +2356,6 @@ impl ValueImpl {
 }
 
 impl Struct {
-    #[cfg(test)]
     fn legacy_size_impl(fields: &[ValueImpl]) -> AbstractMemorySize {
         fields
             .iter()
@@ -2374,14 +2369,13 @@ impl Struct {
 }
 
 impl Value {
-    #[cfg(test)]
-    pub(crate) fn legacy_size(&self) -> AbstractMemorySize {
+    pub fn legacy_size(&self) -> AbstractMemorySize {
         self.0.legacy_size()
     }
 }
 
+#[cfg(test)]
 impl ReferenceImpl {
-    #[cfg(test)]
     fn legacy_size(&self) -> AbstractMemorySize {
         match self {
             Self::ContainerRef(r) => r.legacy_size(),
@@ -2390,8 +2384,8 @@ impl ReferenceImpl {
     }
 }
 
+#[cfg(test)]
 impl Reference {
-    #[cfg(test)]
     pub(crate) fn legacy_size(&self) -> AbstractMemorySize {
         self.0.legacy_size()
     }


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Move Language.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

We need some way of deterministically sizing types for gas metering.
For now we're okay handrolling but will use macros to ensure structs are properly sized.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes
## Test Plan

Unit tests
