### PR TITLE
[move-prover] table intrinsic: bug fix and new intrinsic function

### DIFF
--- a/language/move-model/src/pragmas.rs
+++ b/language/move-model/src/pragmas.rs
@@ -87,6 +87,10 @@ pub const INTRINSIC_TYPE_MAP: &str = "map";
 /// `[move] fun map_new<K, V>(): Map<K, V>`
 pub const INTRINSIC_FUN_MAP_NEW: &str = "map_new";
 
+/// Create a new table with an empty content (the spec version)
+/// `[spec] fun map_new<K, V>(): Map<K, V>`
+pub const INTRINSIC_FUN_MAP_SPEC_NEW: &str = "map_spec_new";
+
 /// Get the value associated with key `k`.
 /// The behavior is undefined if `k` does not exist in the map
 /// `[spec] fun map_get<K, V>(m: Map<K, V>, k: K): V`
@@ -158,6 +162,7 @@ pub static INTRINSIC_TYPE_MAP_ASSOC_FUNCTIONS: Lazy<BTreeMap<&'static str, bool>
     Lazy::new(|| {
         BTreeMap::from([
             (INTRINSIC_FUN_MAP_NEW, true),
+            (INTRINSIC_FUN_MAP_SPEC_NEW, false),
             (INTRINSIC_FUN_MAP_SPEC_GET, false),
             (INTRINSIC_FUN_MAP_SPEC_SET, false),
             (INTRINSIC_FUN_MAP_SPEC_DEL, false),

--- a/language/move-prover/boogie-backend/src/lib.rs
+++ b/language/move-prover/boogie-backend/src/lib.rs
@@ -24,7 +24,7 @@ use move_model::{
         INTRINSIC_FUN_MAP_HAS_KEY, INTRINSIC_FUN_MAP_IS_EMPTY, INTRINSIC_FUN_MAP_LEN,
         INTRINSIC_FUN_MAP_NEW, INTRINSIC_FUN_MAP_SPEC_DEL, INTRINSIC_FUN_MAP_SPEC_GET,
         INTRINSIC_FUN_MAP_SPEC_HAS_KEY, INTRINSIC_FUN_MAP_SPEC_IS_EMPTY,
-        INTRINSIC_FUN_MAP_SPEC_LEN, INTRINSIC_FUN_MAP_SPEC_SET,
+        INTRINSIC_FUN_MAP_SPEC_LEN, INTRINSIC_FUN_MAP_SPEC_NEW, INTRINSIC_FUN_MAP_SPEC_SET,
     },
     ty::{PrimitiveType, Type},
 };
@@ -88,6 +88,7 @@ struct MapImpl {
     fun_borrow: String,
     fun_borrow_mut: String,
     // spec functions
+    fun_spec_new: String,
     fun_spec_get: String,
     fun_spec_set: String,
     fun_spec_del: String,
@@ -346,6 +347,9 @@ impl MapImpl {
             ),
             fun_borrow_mut: Self::triple_opt_to_name(
                 decl.get_fun_triple(env, INTRINSIC_FUN_MAP_BORROW_MUT),
+            ),
+            fun_spec_new: Self::triple_opt_to_name(
+                decl.get_fun_triple(env, INTRINSIC_FUN_MAP_SPEC_NEW),
             ),
             fun_spec_get: Self::triple_opt_to_name(
                 decl.get_fun_triple(env, INTRINSIC_FUN_MAP_SPEC_GET),

--- a/language/move-prover/boogie-backend/src/prelude/native.bpl
+++ b/language/move-prover/boogie-backend/src/prelude/native.bpl
@@ -269,12 +269,9 @@ function $IsEqual'{{Type}}{{S}}'(t1: {{Self}}, t2: {{Self}}): bool {
 {%- else -%}
 function $IsEqual'{{Type}}{{S}}'(t1: {{Self}}, t2: {{Self}}): bool {
     LenTable(t1) == LenTable(t2) &&
-    (forall k: int :: (
-        ContainsTable(t1, k) ==> (
-            ContainsTable(t2, k) && GetTable(t1, k) == GetTable(t2, k)
-        ) &&
-        ContainsTable(t2, k) ==> ContainsTable(t1, k)
-    ))
+    (forall k: int :: ContainsTable(t1, k) <==> ContainsTable(t2, k)) &&
+    (forall k: int :: ContainsTable(t1, k) ==> GetTable(t1, k) == GetTable(t2, k)) &&
+    (forall k: int :: ContainsTable(t2, k) ==> GetTable(t1, k) == GetTable(t2, k))
 }
 {%- endif %}
 
@@ -425,10 +422,11 @@ function {:inline} {{impl.fun_spec_has_key}}{{S}}(t: ({{Self}}), k: {{K}}): bool
 
 {%- if impl.fun_spec_set != "" %}
 function {:inline} {{impl.fun_spec_set}}{{S}}(t: {{Self}}, k: {{K}}, v: {{V}}): {{Self}} {
-    if (ContainsTable(t, {{ENC}}(k))) then
-        UpdateTable(t, {{ENC}}(k), v)
+    (var enc_k := {{ENC}}(k);
+    if (ContainsTable(t, enc_k)) then
+        UpdateTable(t, enc_k, v)
     else
-        AddTable(t, {{ENC}}(k), v)
+        AddTable(t, enc_k, v))
 }
 {%- endif %}
 
@@ -444,6 +442,11 @@ function {:inline} {{impl.fun_spec_get}}{{S}}(t: {{Self}}, k: {{K}}): {{V}} {
 }
 {%- endif %}
 
+{%- if impl.fun_spec_new != "" %}
+function {:inline} {{impl.fun_spec_new}}{{S}}(): {{Self}} {
+    EmptyTable()
+}
+{%- endif %}
 
 {% endmacro table_module %}
 

--- a/language/move-prover/boogie-backend/src/prelude/table-array-theory.bpl
+++ b/language/move-prover/boogie-backend/src/prelude/table-array-theory.bpl
@@ -39,7 +39,7 @@ function {:inline} ContainsTable<K,V>(t: Table K V, k: K): bool {
 }
 
 function {:inline} UpdateTable<K,V>(t: Table K V, k: K, v: V): Table K V {
-    Table(v#Table(t)[k := v], e#Table(t)[k := true], l#Table(t))
+    Table(v#Table(t)[k := v], e#Table(t), l#Table(t))
 }
 
 function {:inline} AddTable<K,V>(t: Table K V, k: K, v: V): Table K V {

--- a/language/move-prover/tests/sources/functional/loops_with_memory_ops.exp
+++ b/language/move-prover/tests/sources/functional/loops_with_memory_ops.exp
@@ -44,11 +44,11 @@ error: unknown assertion failed
    =     at tests/sources/functional/loops_with_memory_ops.move:74: nested_loop2
    =     at tests/sources/functional/loops_with_memory_ops.move:80: nested_loop2
    =     at tests/sources/functional/loops_with_memory_ops.move:81: nested_loop2
-   =         b = <redacted>
-   =         b = <redacted>
-   =         a = <redacted>
    =     at <internal>:1
    =     at tests/sources/functional/loops_with_memory_ops.move:81: nested_loop2
+   =         b = <redacted>
+   =         a = <redacted>
+   =         a = <redacted>
    =     at tests/sources/functional/loops_with_memory_ops.move:85: nested_loop2
    =         i = <redacted>
    =     at tests/sources/functional/loops_with_memory_ops.move:86: nested_loop2
@@ -99,10 +99,8 @@ error: induction case of the loop invariant does not hold
    =     at tests/sources/functional/loops_with_memory_ops.move:74: nested_loop2
    =     at tests/sources/functional/loops_with_memory_ops.move:80: nested_loop2
    =     at tests/sources/functional/loops_with_memory_ops.move:81: nested_loop2
-   =     at <internal>:1
-   =     at tests/sources/functional/loops_with_memory_ops.move:81: nested_loop2
-   =     at <internal>:1
-   =     at tests/sources/functional/loops_with_memory_ops.move:81: nested_loop2
+   =         b = <redacted>
+   =         b = <redacted>
    =         a = <redacted>
    =         a = <redacted>
    =     at tests/sources/functional/loops_with_memory_ops.move:85: nested_loop2

--- a/language/move-prover/tests/sources/functional/verify_custom_table.exp
+++ b/language/move-prover/tests/sources/functional/verify_custom_table.exp
@@ -1,43 +1,88 @@
 Move prover returns: exiting with verification errors
 error: post-condition does not hold
-    ┌─ tests/sources/functional/verify_custom_table.move:202:9
+    ┌─ tests/sources/functional/verify_custom_table.move:249:9
     │
-202 │         ensures spec_get(result.t, k1) == 23;
+249 │         ensures spec_get(result.t, k1) == 23;
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/verify_custom_table.move:198: add_R_fail (spec)
-    =     at tests/sources/functional/verify_custom_table.move:199: add_R_fail (spec)
-    =     at tests/sources/functional/verify_custom_table.move:195: add_R_fail
-    =     at tests/sources/functional/verify_custom_table.move:176: make_R
+    =     at tests/sources/functional/verify_custom_table.move:245: add_R_fail (spec)
+    =     at tests/sources/functional/verify_custom_table.move:246: add_R_fail (spec)
+    =     at tests/sources/functional/verify_custom_table.move:242: add_R_fail
+    =     at tests/sources/functional/verify_custom_table.move:223: make_R
     =         t = <redacted>
-    =     at tests/sources/functional/verify_custom_table.move:177: make_R
+    =     at tests/sources/functional/verify_custom_table.move:224: make_R
     =         t = <redacted>
-    =     at tests/sources/functional/verify_custom_table.move:178: make_R
+    =     at tests/sources/functional/verify_custom_table.move:225: make_R
     =         t = <redacted>
-    =     at tests/sources/functional/verify_custom_table.move:179: make_R
+    =     at tests/sources/functional/verify_custom_table.move:226: make_R
     =         result = <redacted>
-    =     at tests/sources/functional/verify_custom_table.move:180: make_R
+    =     at tests/sources/functional/verify_custom_table.move:227: make_R
     =         result = <redacted>
-    =     at tests/sources/functional/verify_custom_table.move:196: add_R_fail
-    =     at tests/sources/functional/verify_custom_table.move:200: add_R_fail (spec)
-    =     at tests/sources/functional/verify_custom_table.move:201: add_R_fail (spec)
-    =     at tests/sources/functional/verify_custom_table.move:202: add_R_fail (spec)
+    =     at tests/sources/functional/verify_custom_table.move:243: add_R_fail
+    =     at tests/sources/functional/verify_custom_table.move:247: add_R_fail (spec)
+    =     at tests/sources/functional/verify_custom_table.move:248: add_R_fail (spec)
+    =     at tests/sources/functional/verify_custom_table.move:249: add_R_fail (spec)
 
 error: post-condition does not hold
-   ┌─ tests/sources/functional/verify_custom_table.move:72:9
+   ┌─ tests/sources/functional/verify_custom_table.move:74:9
    │
-72 │         ensures spec_get(result, 1) == 1;
+74 │         ensures spec_get(result, 1) == 1;
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    │
-   =     at tests/sources/functional/verify_custom_table.move:65: add_fail
-   =         t = <redacted>
-   =     at tests/sources/functional/verify_custom_table.move:66: add_fail
-   =         t = <redacted>
    =     at tests/sources/functional/verify_custom_table.move:67: add_fail
    =         t = <redacted>
    =     at tests/sources/functional/verify_custom_table.move:68: add_fail
    =         t = <redacted>
    =     at tests/sources/functional/verify_custom_table.move:69: add_fail
-   =         result = <redacted>
+   =         t = <redacted>
    =     at tests/sources/functional/verify_custom_table.move:70: add_fail
-   =     at tests/sources/functional/verify_custom_table.move:72: add_fail (spec)
+   =         t = <redacted>
+   =     at tests/sources/functional/verify_custom_table.move:71: add_fail
+   =         result = <redacted>
+   =     at tests/sources/functional/verify_custom_table.move:72: add_fail
+   =     at tests/sources/functional/verify_custom_table.move:74: add_fail (spec)
+
+error: post-condition does not hold
+    ┌─ tests/sources/functional/verify_custom_table.move:199:9
+    │
+199 │         ensures result == spec_new();
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    =     at tests/sources/functional/verify_custom_table.move:194: create_and_insert_fail1
+    =         t = <redacted>
+    =     at tests/sources/functional/verify_custom_table.move:195: create_and_insert_fail1
+    =         t = <redacted>
+    =     at tests/sources/functional/verify_custom_table.move:196: create_and_insert_fail1
+    =         result = <redacted>
+    =     at tests/sources/functional/verify_custom_table.move:197: create_and_insert_fail1
+    =     at tests/sources/functional/verify_custom_table.move:199: create_and_insert_fail1 (spec)
+
+error: post-condition does not hold
+    ┌─ tests/sources/functional/verify_custom_table.move:208:9
+    │
+208 │         ensures result == spec_set(spec_new(), 1, 2);
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    =     at tests/sources/functional/verify_custom_table.move:203: create_and_insert_fail2
+    =         t = <redacted>
+    =     at tests/sources/functional/verify_custom_table.move:204: create_and_insert_fail2
+    =         t = <redacted>
+    =     at tests/sources/functional/verify_custom_table.move:205: create_and_insert_fail2
+    =         result = <redacted>
+    =     at tests/sources/functional/verify_custom_table.move:206: create_and_insert_fail2
+    =     at tests/sources/functional/verify_custom_table.move:208: create_and_insert_fail2 (spec)
+
+error: post-condition does not hold
+    ┌─ tests/sources/functional/verify_custom_table.move:190:9
+    │
+190 │         ensures result == spec_set(spec_new(), 1, 2);
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    =     at tests/sources/functional/verify_custom_table.move:182: create_and_insert_fail_due_to_typed_key_encoding
+    =         t = <redacted>
+    =     at tests/sources/functional/verify_custom_table.move:183: create_and_insert_fail_due_to_typed_key_encoding
+    =         t = <redacted>
+    =     at tests/sources/functional/verify_custom_table.move:184: create_and_insert_fail_due_to_typed_key_encoding
+    =         result = <redacted>
+    =     at tests/sources/functional/verify_custom_table.move:185: create_and_insert_fail_due_to_typed_key_encoding
+    =     at tests/sources/functional/verify_custom_table.move:190: create_and_insert_fail_due_to_typed_key_encoding (spec)

--- a/language/move-stdlib/docs/fixed_point32.md
+++ b/language/move-stdlib/docs/fixed_point32.md
@@ -729,11 +729,8 @@ Rounds up the given FixedPoint32 to the next largest integer.
 <summary>Specification</summary>
 
 
-TODO: worked in the past but started to time out since last z3 update
 
-
-<pre><code><b>pragma</b> verify = <b>false</b>;
-<b>pragma</b> opaque;
+<pre><code><b>pragma</b> opaque;
 <b>aborts_if</b> <b>false</b>;
 <b>ensures</b> result == <a href="fixed_point32.md#0x1_fixed_point32_spec_ceil">spec_ceil</a>(num);
 </code></pre>

--- a/language/move-stdlib/sources/fixed_point32.move
+++ b/language/move-stdlib/sources/fixed_point32.move
@@ -244,8 +244,6 @@ module std::fixed_point32 {
         (val >> 32 as u64)
     }
     spec ceil {
-        /// TODO: worked in the past but started to time out since last z3 update
-        pragma verify = false;
         pragma opaque;
         aborts_if false;
         ensures result == spec_ceil(num);


### PR DESCRIPTION
This commit addresses two issues:

1. Added a new intrinsic spec function `spec_map_new` to allow the following native spec function to be emulated: `spec native fun spec_new<K, V>(): Table<K, V>;` This funciton will return an empty table on the spec side.

2. While testing the newly added intrinsic funciton, several issues are discovered.

   - One issue fixed in this commit is the equality encoding of the `table` intrinsic, evident by the fact that the newly added test `create_and_insert_fail2` will pass the verification which it really should not.

     The table equality check is now formulated in a manner symmetric to both tables (the previous formulate seems to be biased to one table, although I don't claim that I fully understand the difference).

  - Another issue not fixed in this commit is shown in the newly added test case `create_and_insert_fail_due_to_typed_key_encoding`.

    The root cause is that for tables, the key encoding is type-dependent. Hence, an encoding of `u8` and `u258` of the same numeric key is different. I.e., there is no correlation between `EncodeKey'u8'(1)` and `EncodeKey'u258'(1)` although both take the signature of `EncodeKey'<type>'(int): int`.

    Nevertheless, this subtle discrepancy is captured in the test case and hopefully can be solved later.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Move Language.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

feature addition and bug fix

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes

## Test Plan

- CI
- new test cases
