### PR TITLE
[move-unit-test] Support CSV output from `--statistics`

### DIFF
--- a/language/move-vm/test-utils/src/gas_schedule.rs
+++ b/language/move-vm/test-utils/src/gas_schedule.rs
@@ -827,10 +827,12 @@ pub fn bytecode_instruction_costs() -> Vec<(Bytecode, GasCost)> {
     ]
 }
 
-pub static INITIAL_COST_SCHEDULE: Lazy<CostTable> = Lazy::new(|| {
+pub fn initial_cost_schedule() -> CostTable {
     let mut instrs = bytecode_instruction_costs();
     // Note that the DiemVM is expecting the table sorted by instruction order.
     instrs.sort_by_key(|cost| instruction_key(&cost.0));
 
     new_from_instructions(instrs)
-});
+}
+
+pub static INITIAL_COST_SCHEDULE: Lazy<CostTable> = Lazy::new(initial_cost_schedule);

--- a/language/tools/move-cli/src/base/test.rs
+++ b/language/tools/move-cli/src/base/test.rs
@@ -55,9 +55,9 @@ pub struct Test {
         long = "threads"
     )]
     pub num_threads: usize,
-    /// Report test statistics at the end of testing
+    /// Report test statistics at the end of testing. CSV report generated if 'csv' passed
     #[clap(name = "report_statistics", short = 's', long = "statistics")]
-    pub report_statistics: bool,
+    pub report_statistics: Option<Option<String>>,
     /// Show the storage state at the end of execution of a failing test
     #[clap(name = "global_state_on_error", short = 'g', long = "state_on_error")]
     pub report_storage_on_error: bool,

--- a/language/tools/move-unit-test/src/lib.rs
+++ b/language/tools/move-unit-test/src/lib.rs
@@ -65,9 +65,9 @@ pub struct UnitTestingConfig {
     )]
     pub dep_files: Vec<String>,
 
-    /// Report test statistics at the end of testing
+    /// Report test statistics at the end of testing. CSV report generated if 'csv' passed
     #[clap(name = "report_statistics", short = 's', long = "statistics")]
-    pub report_statistics: bool,
+    pub report_statistics: Option<Option<String>>,
 
     /// Show the storage state at the end of execution of a failing test
     #[clap(name = "global_state_on_error", short = 'g', long = "state_on_error")]
@@ -137,7 +137,7 @@ impl UnitTestingConfig {
             gas_limit: bound.or(Some(DEFAULT_EXECUTION_BOUND)),
             filter: None,
             num_threads: 8,
-            report_statistics: false,
+            report_statistics: None,
             report_storage_on_error: false,
             report_stacktrace_on_abort: false,
             ignore_compile_warnings: false,
@@ -262,8 +262,8 @@ impl UnitTestingConfig {
         }
 
         let test_results = test_runner.run(&shared_writer).unwrap();
-        if self.report_statistics {
-            test_results.report_statistics(&shared_writer)?;
+        if let Some(report_type) = &self.report_statistics {
+            test_results.report_statistics(&shared_writer, report_type)?;
         }
 
         if self.report_writeset {


### PR DESCRIPTION
Adds a flag argument to `--statistics` that will allow you to specify if you want the statistics reported in CSV format. 

`Option<Option<String>>` was chosen to support previous usage of `--statistics` as a flag. So `move test --statistics` behaves just as it did before this PR, and `move test --statistics csv` will dump the test statistics in CSV format.

