### PR TITLE
[compiler] Enforce a canonical order for module handles

### DIFF
--- a/language/move-compiler/src/to_bytecode/canonicalize_handles.rs
+++ b/language/move-compiler/src/to_bytecode/canonicalize_handles.rs
@@ -1,0 +1,172 @@
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::HashMap;
+
+use move_binary_format::{
+    access::{ModuleAccess, ScriptAccess},
+    file_format::{CompiledScript, ModuleHandleIndex, TableIndex},
+    internals::ModuleIndex,
+    CompiledModule,
+};
+use move_core_types::account_address::AccountAddress;
+use move_symbol_pool::Symbol;
+
+/// Pass to order handles in compiled modules and scripts stably and canonically.  Performs the
+/// following canonicalizations:
+///
+/// - Module Handles are sorted so the self-module comes first, followed by modules with named
+///   addresses in lexical order (by address name and module name), followed by unnamed addresses in
+///   their original order.
+
+/// Key for ordering module handles, distinguishing the module's self handle, handles with names,
+/// and handles without names.
+#[derive(Eq, PartialEq, Ord, PartialOrd)]
+enum ModuleKey<'a> {
+    SelfModule,
+    Named { address: Symbol, module: &'a str },
+    Unnamed,
+}
+
+/// Forward the index at `$ix`, of type `$Ix` to its new location according to the `$perm`utation
+/// array.
+macro_rules! permute {
+    ($Ix:ty, $ix:expr, $perm:expr) => {
+        $ix = <$Ix>::new($perm[$ix.into_index()])
+    };
+}
+
+/// Apply canonicalization to a compiled module.
+pub fn in_module(
+    module: &mut CompiledModule,
+    address_names: &HashMap<(AccountAddress, &str), Symbol>,
+) {
+    let modules = permutation(&module.module_handles, |handle| {
+        // Order the self module first
+        if handle == module.self_handle() {
+            return ModuleKey::SelfModule;
+        }
+
+        let address = module.address_identifier_at(handle.address);
+        let name = module.identifier_at(handle.name);
+
+        // Preserve order between modules without a named address, pushing them to the end of the
+        // pool.
+        let Some(address_name) = address_names.get(&(*address, name.as_str())) else {
+            return ModuleKey::Unnamed;
+        };
+
+        // Layout remaining modules in lexicographical order of named address and module name.
+        ModuleKey::Named { address: *address_name, module: name.as_str() }
+    });
+
+    permute!(ModuleHandleIndex, module.self_module_handle_idx, modules);
+    for fun in &mut module.function_handles {
+        permute!(ModuleHandleIndex, fun.module, modules);
+    }
+    for struct_ in &mut module.struct_handles {
+        permute!(ModuleHandleIndex, struct_.module, modules);
+    }
+    apply_permutation(&mut module.module_handles, modules);
+}
+
+/// Apply canonicalization to a compiled script.
+pub fn in_script(
+    script: &mut CompiledScript,
+    address_names: &HashMap<(AccountAddress, &str), Symbol>,
+) {
+    let modules = permutation(&script.module_handles, |handle| {
+        let address = script.address_identifier_at(handle.address);
+        let name = script.identifier_at(handle.name);
+
+        // Preserve order between modules without a named address, pushing them to the end of the
+        // pool.
+        let Some(address_name) = address_names.get(&(*address, name.as_str())) else {
+            return ModuleKey::Unnamed;
+        };
+
+        // Layout remaining modules in lexicographical order of named address and module name.
+        ModuleKey::Named { address: *address_name, module: name.as_str() }
+    });
+
+    for fun in &mut script.function_handles {
+        permute!(ModuleHandleIndex, fun.module, modules);
+    }
+    for struct_ in &mut script.struct_handles {
+        permute!(ModuleHandleIndex, struct_.module, modules);
+    }
+    apply_permutation(&mut script.module_handles, modules);
+}
+
+/// Calculates the permutation of indices in `pool` that sorts it according to the key function
+/// `key`:  The resulting `permutation` array is such that, new `pool'` defined by:
+///
+///     pool'[permutation[i]] = pool[i]
+///
+/// is sorted according to `key`.
+fn permutation<T, K: Ord>(pool: &Vec<T>, key: impl Fn(&T) -> K) -> Vec<TableIndex> {
+    let mut inverse: Vec<_> = (0..pool.len() as TableIndex).collect();
+    inverse.sort_by_key(move |ix| key(&pool[*ix as usize]));
+
+    let mut permutation = vec![0 as TableIndex; pool.len()];
+    for (ix, jx) in inverse.into_iter().enumerate() {
+        permutation[jx as usize] = ix as TableIndex;
+    }
+
+    permutation
+}
+
+/// Re-order `pool` according to the `permutation` array.  `permutation[i]` is the new location of
+/// `pool[i].
+fn apply_permutation<T>(pool: &mut Vec<T>, mut permutation: Vec<TableIndex>) {
+    assert_eq!(pool.len(), permutation.len());
+
+    // At every iteration we confirm that one more value is in its final position in the pool,
+    // either because we discover it is already in the correct place, or we move it to its correct
+    // place.
+    for ix in 0..pool.len() {
+        loop {
+            let jx = permutation[ix] as usize;
+            if ix == jx {
+                break;
+            }
+            pool.swap(ix, jx);
+            permutation.swap(ix, jx);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn permutation_reverse() {
+        let mut orig = vec![0i32, 1, 2, 3];
+
+        let perm = permutation(&orig, |i| -i);
+        assert_eq!(perm, vec![3, 2, 1, 0]);
+
+        apply_permutation(&mut orig, perm);
+        assert_eq!(orig, vec![3, 2, 1, 0]);
+    }
+
+    #[test]
+    fn permutation_stability() {
+        let orig = vec![5, 3, 6, 2, 1, 4];
+
+        // Generating the permutation
+        let perm = permutation(&orig, |i| i % 2 == 1);
+        assert_eq!(perm, vec![3, 4, 0, 1, 5, 2]);
+
+        // Applying the permutation
+        let mut sort = orig.clone();
+        apply_permutation(&mut sort, perm.clone());
+        assert_eq!(sort, vec![6, 2, 4, 5, 3, 1]);
+
+        // Confirm the definition of the permutation array
+        for (ix, i) in orig.iter().enumerate() {
+            assert_eq!(sort[perm[ix] as usize], *i, "{ix}: {i}");
+        }
+    }
+}

--- a/language/move-compiler/src/to_bytecode/canonicalize_handles.rs
+++ b/language/move-compiler/src/to_bytecode/canonicalize_handles.rs
@@ -5,7 +5,10 @@ use std::collections::HashMap;
 
 use move_binary_format::{
     access::{ModuleAccess, ScriptAccess},
-    file_format::{CompiledScript, ModuleHandleIndex, TableIndex},
+    file_format::{
+        CompiledScript, ModuleHandleIndex, Signature, SignatureToken, StructDefinition,
+        StructDefinitionIndex, StructFieldInformation, StructHandleIndex, TableIndex,
+    },
     internals::ModuleIndex,
     CompiledModule,
 };
@@ -28,6 +31,17 @@ enum ModuleKey<'a> {
     Unnamed,
 }
 
+/// Key for ordering function and struct handles, distinguishing handles for definitions in
+/// the module and handles for externally defined functions and structs.
+#[derive(Eq, PartialEq, Ord, PartialOrd)]
+enum ReferenceKey<'a> {
+    Internal(TableIndex),
+    External {
+        module: ModuleHandleIndex,
+        name: &'a str,
+    },
+}
+
 /// Forward the index at `$ix`, of type `$Ix` to its new location according to the `$perm`utation
 /// array.
 macro_rules! permute {
@@ -41,33 +55,82 @@ pub fn in_module(
     module: &mut CompiledModule,
     address_names: &HashMap<(AccountAddress, &str), Symbol>,
 ) {
-    let modules = permutation(&module.module_handles, |handle| {
+    // 1 (a). Choose ordering for module handles
+    let modules = permutation(&module.module_handles, |_ix, handle| {
         // Order the self module first
         if handle == module.self_handle() {
             return ModuleKey::SelfModule;
         }
 
         let address = module.address_identifier_at(handle.address);
-        let name = module.identifier_at(handle.name);
+        let module = module.identifier_at(handle.name).as_str();
 
         // Preserve order between modules without a named address, pushing them to the end of the
         // pool.
-        let Some(address_name) = address_names.get(&(*address, name.as_str())) else {
+        let Some(address_name) = address_names.get(&(*address, module)) else {
             return ModuleKey::Unnamed;
         };
 
         // Layout remaining modules in lexicographical order of named address and module name.
-        ModuleKey::Named { address: *address_name, module: name.as_str() }
+        ModuleKey::Named {
+            address: *address_name,
+            module,
+        }
     });
 
+    // 1 (b). Update references to module handles
     permute!(ModuleHandleIndex, module.self_module_handle_idx, modules);
+
     for fun in &mut module.function_handles {
         permute!(ModuleHandleIndex, fun.module, modules);
     }
+
     for struct_ in &mut module.struct_handles {
         permute!(ModuleHandleIndex, struct_.module, modules);
     }
+
+    // 1 (c). Update ordering for module handles -- this needs to happen before other handles are
+    //        replaced so that they can continue referencing modules in their own comparators.
     apply_permutation(&mut module.module_handles, modules);
+
+    // 2 (a). Choose ordering for struct handles
+    let struct_defs = struct_definition_order(&module.struct_defs);
+    let structs = permutation(&module.struct_handles, |ix, handle| {
+        if handle.module == module.self_handle_idx() {
+            // Order structs from this module first, and in definition order
+            let Some(def_position) = struct_defs.get(&StructHandleIndex(ix)) else {
+                panic!("ICE struct handle from module without definition: {handle:?}");
+            };
+            ReferenceKey::Internal(def_position.0)
+        } else {
+            // Order the remaining handles afterwards, in lexicographical order of module, then
+            // struct name.
+            let name = module.identifier_at(handle.name).as_str();
+            ReferenceKey::External {
+                module: handle.module,
+                name,
+            }
+        }
+    });
+
+    // 2 (b). Update references to struct handles
+    for def in &mut module.struct_defs {
+        permute!(StructHandleIndex, def.struct_handle, structs);
+        if let StructFieldInformation::Declared(fields) = &mut def.field_information {
+            for field in fields {
+                permute_signature_token(&mut field.signature.0, &structs);
+            }
+        };
+    }
+
+    for Signature(tokens) in &mut module.signatures {
+        for token in tokens {
+            permute_signature_token(token, &structs);
+        }
+    }
+
+    // 2 (c). Update ordering for struct handles.
+    apply_permutation(&mut module.struct_handles, structs);
 }
 
 /// Apply canonicalization to a compiled script.
@@ -75,7 +138,8 @@ pub fn in_script(
     script: &mut CompiledScript,
     address_names: &HashMap<(AccountAddress, &str), Symbol>,
 ) {
-    let modules = permutation(&script.module_handles, |handle| {
+    // 1 (a). Choose ordering for module handles
+    let modules = permutation(&script.module_handles, |_ix, handle| {
         let address = script.address_identifier_at(handle.address);
         let name = script.identifier_at(handle.name);
 
@@ -86,16 +150,90 @@ pub fn in_script(
         };
 
         // Layout remaining modules in lexicographical order of named address and module name.
-        ModuleKey::Named { address: *address_name, module: name.as_str() }
+        ModuleKey::Named {
+            address: *address_name,
+            module: name.as_str(),
+        }
     });
 
+    // 1 (b). Update references to module handles
     for fun in &mut script.function_handles {
         permute!(ModuleHandleIndex, fun.module, modules);
     }
+
     for struct_ in &mut script.struct_handles {
         permute!(ModuleHandleIndex, struct_.module, modules);
     }
+
+    // 1 (c). Update ordering for module handles -- this needs to happen before other handles are
+    //        replaced so that they can continue referencing modules in their own comparators.
     apply_permutation(&mut script.module_handles, modules);
+
+    // 2 (a). Choose ordering for struct handles
+    let structs = permutation(&script.struct_handles, |_ix, handle| {
+        let name = script.identifier_at(handle.name).as_str();
+        ReferenceKey::External {
+            module: handle.module,
+            name,
+        }
+    });
+
+    // 2 (b). Update references to struct handles
+    for Signature(tokens) in &mut script.signatures {
+        for token in tokens {
+            permute_signature_token(token, &structs);
+        }
+    }
+
+    // 2 (b). Update ordering for struct handles
+    apply_permutation(&mut script.struct_handles, structs);
+}
+
+/// Reverses mapping from `StructDefinition(Index)` to `StructHandle`, so that handles for structs
+/// defined in a module can be arranged in definition order.
+fn struct_definition_order(
+    defs: &[StructDefinition],
+) -> HashMap<StructHandleIndex, StructDefinitionIndex> {
+    defs.iter()
+        .enumerate()
+        .map(|(ix, def)| {
+            (
+                StructHandleIndex(def.struct_handle.0),
+                StructDefinitionIndex(ix as TableIndex),
+            )
+        })
+        .collect()
+}
+
+/// Update references to `StructHandle`s within signatures according to the permutation defined by
+/// `structs`.
+fn permute_signature_token(token: &mut SignatureToken, structs: &[TableIndex]) {
+    use SignatureToken as T;
+    match token {
+        T::Bool
+        | T::U8
+        | T::U16
+        | T::U32
+        | T::U64
+        | T::U128
+        | T::U256
+        | T::Address
+        | T::Signer
+        | T::TypeParameter(_) => (),
+
+        T::Vector(token) | T::Reference(token) | T::MutableReference(token) => {
+            permute_signature_token(token, structs)
+        }
+
+        T::Struct(handle) => permute!(StructHandleIndex, *handle, structs),
+
+        T::StructInstantiation(handle, tokens) => {
+            permute!(StructHandleIndex, *handle, structs);
+            for token in tokens {
+                permute_signature_token(token, structs)
+            }
+        }
+    }
 }
 
 /// Calculates the permutation of indices in `pool` that sorts it according to the key function
@@ -104,9 +242,9 @@ pub fn in_script(
 ///     pool'[permutation[i]] = pool[i]
 ///
 /// is sorted according to `key`.
-fn permutation<T, K: Ord>(pool: &Vec<T>, key: impl Fn(&T) -> K) -> Vec<TableIndex> {
+fn permutation<T, K: Ord>(pool: &Vec<T>, key: impl Fn(TableIndex, &T) -> K) -> Vec<TableIndex> {
     let mut inverse: Vec<_> = (0..pool.len() as TableIndex).collect();
-    inverse.sort_by_key(move |ix| key(&pool[*ix as usize]));
+    inverse.sort_by_key(move |ix| key(*ix, &pool[*ix as usize]));
 
     let mut permutation = vec![0 as TableIndex; pool.len()];
     for (ix, jx) in inverse.into_iter().enumerate() {
@@ -144,7 +282,7 @@ mod tests {
     fn permutation_reverse() {
         let mut orig = vec![0i32, 1, 2, 3];
 
-        let perm = permutation(&orig, |i| -i);
+        let perm = permutation(&orig, |_, i| -i);
         assert_eq!(perm, vec![3, 2, 1, 0]);
 
         apply_permutation(&mut orig, perm);
@@ -156,7 +294,7 @@ mod tests {
         let orig = vec![5, 3, 6, 2, 1, 4];
 
         // Generating the permutation
-        let perm = permutation(&orig, |i| i % 2 == 1);
+        let perm = permutation(&orig, |_, i| i % 2 == 1);
         assert_eq!(perm, vec![3, 4, 0, 1, 5, 2]);
 
         // Applying the permutation

--- a/language/move-compiler/src/to_bytecode/canonicalize_handles.rs
+++ b/language/move-compiler/src/to_bytecode/canonicalize_handles.rs
@@ -313,7 +313,7 @@ fn permute_code(code: &mut CodeUnit, functions: &[TableIndex]) {
 /// Calculates the permutation of indices in `pool` that sorts it according to the key function
 /// `key`:  The resulting `permutation` array is such that, new `pool'` defined by:
 ///
-///     pool'[permutation[i]] = pool[i]
+///   pool'[permutation[i]] = pool[i]
 ///
 /// is sorted according to `key`.
 fn permutation<T, K: Ord>(pool: &Vec<T>, key: impl Fn(TableIndex, &T) -> K) -> Vec<TableIndex> {

--- a/language/move-compiler/src/to_bytecode/canonicalize_handles.rs
+++ b/language/move-compiler/src/to_bytecode/canonicalize_handles.rs
@@ -22,6 +22,10 @@ use move_symbol_pool::Symbol;
 /// - Module Handles are sorted so the self-module comes first, followed by modules with named
 ///   addresses in lexical order (by address name and module name), followed by unnamed addresses in
 ///   their original order.
+///
+/// - Struct and Function Handles are sorted so that definitions in the module come first, in
+///   definition order, and remaining handles follow, in lexicographical order by fully-qualified
+///   name.
 
 /// Key for ordering module handles, distinguishing the module's self handle, handles with names,
 /// and handles without names.

--- a/language/move-compiler/src/to_bytecode/canonicalize_handles.rs
+++ b/language/move-compiler/src/to_bytecode/canonicalize_handles.rs
@@ -20,6 +20,8 @@ use move_symbol_pool::Symbol;
 /// Pass to order handles in compiled modules and scripts stably and canonically.  Performs the
 /// following canonicalizations:
 ///
+/// - Identifiers are sorted in lexicographic order.
+///
 /// - Module Handles are sorted so the self-module comes first, followed by modules with named
 ///   addresses in lexical order (by address name and module name), followed by unnamed addresses in
 ///   their original order.
@@ -27,6 +29,9 @@ use move_symbol_pool::Symbol;
 /// - Struct and Function Handles are sorted so that definitions in the module come first, in
 ///   definition order, and remaining handles follow, in lexicographical order by fully-qualified
 ///   name.
+///
+/// - Friend Declarations are sorted in lexical order (by address name and module name), followed by
+///   unnamed addresses in their original order.
 
 /// Key for ordering module handles, distinguishing the module's self handle, handles with names,
 /// and handles without names.

--- a/language/move-compiler/src/to_bytecode/mod.rs
+++ b/language/move-compiler/src/to_bytecode/mod.rs
@@ -2,6 +2,7 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+mod canonicalize_handles;
 #[macro_use]
 mod context;
 mod optimize;

--- a/language/move-compiler/src/to_bytecode/translate.rs
+++ b/language/move-compiler/src/to_bytecode/translate.rs
@@ -325,7 +325,7 @@ fn script(
     }))
 }
 
-/// Generate a mapping from numerical address and module name to named address, for module's whose
+/// Generate a mapping from numerical address and module name to named address, for modules whose
 /// identities contained a named address.
 fn address_names<'a>(
     dependencies: impl Iterator<Item = &'a ModuleIdent>,

--- a/language/move-compiler/src/to_bytecode/translate.rs
+++ b/language/move-compiler/src/to_bytecode/translate.rs
@@ -2,7 +2,7 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use super::{context::*, optimize};
+use super::{canonicalize_handles, context::*, optimize};
 use crate::{
     cfgir::{ast as G, translate::move_value_from_value_},
     compiled_unit::*,
@@ -19,8 +19,8 @@ use crate::{
         fake_natives,
     },
     parser::ast::{
-        Ability, Ability_, BinOp, BinOp_, ConstantName, Field, FunctionName, StructName, UnaryOp,
-        UnaryOp_,
+        Ability, Ability_, BinOp, BinOp_, ConstantName, Field, FunctionName, ModuleName,
+        StructName, UnaryOp, UnaryOp_,
     },
     shared::{unique_map::UniqueMap, *},
     FullyCompiledProgram,
@@ -233,17 +233,18 @@ fn module(
         synthetics: vec![],
     };
     let deps: Vec<&F::CompiledModule> = vec![];
-    let (module, source_map) = match move_ir_to_bytecode::compiler::compile_module(ir_module, deps)
-    {
-        Ok(res) => res,
-        Err(e) => {
-            compilation_env.add_diag(diag!(
-                Bug::BytecodeGeneration,
-                (ident_loc, format!("IR ERROR: {}", e))
-            ));
-            return None;
-        }
-    };
+    let (mut module, source_map) =
+        match move_ir_to_bytecode::compiler::compile_module(ir_module, deps) {
+            Ok(res) => res,
+            Err(e) => {
+                compilation_env.add_diag(diag!(
+                    Bug::BytecodeGeneration,
+                    (ident_loc, format!("IR ERROR: {}", e))
+                ));
+                return None;
+            }
+        };
+    canonicalize_handles::in_module(&mut module, &address_names(dependency_orderings.keys()));
     let function_infos = module_function_infos(&module, &source_map, &collected_function_infos);
     let module = NamedCompiledModule {
         package_name: mdef.package_name,
@@ -298,17 +299,18 @@ fn script(
         main,
     };
     let deps: Vec<&F::CompiledModule> = vec![];
-    let (script, source_map) = match move_ir_to_bytecode::compiler::compile_script(ir_script, deps)
-    {
-        Ok(res) => res,
-        Err(e) => {
-            compilation_env.add_diag(diag!(
-                Bug::BytecodeGeneration,
-                (loc, format!("IR ERROR: {}", e))
-            ));
-            return None;
-        }
-    };
+    let (mut script, source_map) =
+        match move_ir_to_bytecode::compiler::compile_script(ir_script, deps) {
+            Ok(res) => res,
+            Err(e) => {
+                compilation_env.add_diag(diag!(
+                    Bug::BytecodeGeneration,
+                    (loc, format!("IR ERROR: {}", e))
+                ));
+                return None;
+            }
+        };
+    canonicalize_handles::in_script(&mut script, &address_names(dependency_orderings.keys()));
     let function_info = script_function_info(&source_map, info);
     let script = NamedCompiledScript {
         package_name,
@@ -321,6 +323,24 @@ fn script(
         named_script: script,
         function_info,
     }))
+}
+
+/// Generate a mapping from numerical address and module name to named address, for module's whose
+/// identities contained a named address.
+fn address_names<'a>(
+    dependencies: impl Iterator<Item = &'a ModuleIdent>,
+) -> HashMap<(MoveAddress, &'a str), Symbol> {
+    dependencies
+        .filter_map(|sp!(_, mident)| {
+            let ModuleIdent_ { address, module } = mident;
+            let ModuleName(sp!(_, module)) = module;
+            if let Address::Numerical(Some(sp!(_, named)), sp!(_, numeric)) = address {
+                Some(((numeric.into_inner(), module.as_str()), *named))
+            } else {
+                None
+            }
+        })
+        .collect()
 }
 
 fn module_function_infos(

--- a/language/tools/move-cli/src/base/disassemble.rs
+++ b/language/tools/move-cli/src/base/disassemble.rs
@@ -3,7 +3,7 @@
 
 use super::reroot_path;
 use clap::*;
-use move_compiler::compiled_unit::{CompiledUnit, NamedCompiledModule, CompiledUnitEnum};
+use move_compiler::compiled_unit::{CompiledUnit, CompiledUnitEnum, NamedCompiledModule};
 use move_disassembler::disassembler::Disassembler;
 use move_package::{compilation::compiled_package::CompiledUnitWithSource, BuildConfig};
 use std::path::PathBuf;

--- a/language/tools/move-cli/src/base/disassemble.rs
+++ b/language/tools/move-cli/src/base/disassemble.rs
@@ -3,7 +3,7 @@
 
 use super::reroot_path;
 use clap::*;
-use move_compiler::compiled_unit::{CompiledUnit, NamedCompiledModule};
+use move_compiler::compiled_unit::{CompiledUnit, NamedCompiledModule, CompiledUnitEnum};
 use move_disassembler::disassembler::Disassembler;
 use move_package::{compilation::compiled_package::CompiledUnitWithSource, BuildConfig};
 use std::path::PathBuf;
@@ -21,6 +21,9 @@ pub struct Disassemble {
     /// The name of the module or script in the package to disassemble
     #[clap(long = "name")]
     pub module_or_script_name: String,
+    /// Also print the raw disassembly using Rust's Debug output, at the end.
+    #[clap(long = "Xdebug")]
+    pub debug: bool,
 }
 
 impl Disassemble {
@@ -30,6 +33,7 @@ impl Disassemble {
             interactive,
             package_name,
             module_or_script_name,
+            debug,
         } = self;
         // Make sure the package is built
         let package = config.compile_package(&rerooted_path, &mut Vec::new())?;
@@ -48,8 +52,7 @@ impl Disassemble {
             ),
             Some(unit) => {
                 // Once we find the compiled bytecode we're interested in, startup the bytecode
-                // viewer, or run the disassembler depending on if we need to run interactively
-                // or not.
+                // viewer, run the disassembler, or display the debug output, depending on args.
                 if interactive {
                     match unit {
                         CompiledUnitWithSource {
@@ -67,6 +70,12 @@ impl Disassemble {
                     }
                 } else {
                     println!("{}", Disassembler::from_unit(&unit.unit).disassemble()?);
+                    if debug {
+                        match &unit.unit {
+                            CompiledUnitEnum::Module(module) => println!("\n{:#?}", module.module),
+                            CompiledUnitEnum::Script(script) => println!("\n{:#?}", script.script),
+                        }
+                    }
                 }
             }
         }

--- a/language/tools/move-cli/tests/build_tests/canonicalize_module/Move.toml
+++ b/language/tools/move-cli/tests/build_tests/canonicalize_module/Move.toml
@@ -1,0 +1,9 @@
+[package]
+name = "Test"
+version = "0.0.0"
+
+[addresses]
+foo = "0x1"
+bar = "0x2"
+baz = "0x3"
+qux = "0x4"

--- a/language/tools/move-cli/tests/build_tests/canonicalize_module/args.exp
+++ b/language/tools/move-cli/tests/build_tests/canonicalize_module/args.exp
@@ -1,4 +1,4 @@
-Command `disassemble --package Test --name c`:
+Command `disassemble --Xdebug --package Test --name c`:
 // Move bytecode v6
 module 2.c {
 use 00000000000000000000000000000002::b;
@@ -20,4 +20,136 @@ B0:
 	6: Add
 	7: Ret
 }
+}
+
+CompiledModule {
+    version: 6,
+    self_module_handle_idx: ModuleHandleIndex(0),
+    module_handles: [
+        ModuleHandle {
+            address: AddressIdentifierIndex(0),
+            name: IdentifierIndex(0),
+        },
+        ModuleHandle {
+            address: AddressIdentifierIndex(0),
+            name: IdentifierIndex(2),
+        },
+        ModuleHandle {
+            address: AddressIdentifierIndex(2),
+            name: IdentifierIndex(3),
+        },
+        ModuleHandle {
+            address: AddressIdentifierIndex(1),
+            name: IdentifierIndex(1),
+        },
+        ModuleHandle {
+            address: AddressIdentifierIndex(3),
+            name: IdentifierIndex(4),
+        },
+    ],
+    struct_handles: [],
+    function_handles: [
+        FunctionHandle {
+            module: ModuleHandleIndex(0),
+            name: IdentifierIndex(5),
+            parameters: SignatureIndex(0),
+            return_: SignatureIndex(1),
+            type_parameters: [],
+        },
+        FunctionHandle {
+            module: ModuleHandleIndex(1),
+            name: IdentifierIndex(5),
+            parameters: SignatureIndex(0),
+            return_: SignatureIndex(1),
+            type_parameters: [],
+        },
+        FunctionHandle {
+            module: ModuleHandleIndex(2),
+            name: IdentifierIndex(5),
+            parameters: SignatureIndex(0),
+            return_: SignatureIndex(1),
+            type_parameters: [],
+        },
+        FunctionHandle {
+            module: ModuleHandleIndex(3),
+            name: IdentifierIndex(5),
+            parameters: SignatureIndex(0),
+            return_: SignatureIndex(1),
+            type_parameters: [],
+        },
+        FunctionHandle {
+            module: ModuleHandleIndex(4),
+            name: IdentifierIndex(5),
+            parameters: SignatureIndex(0),
+            return_: SignatureIndex(1),
+            type_parameters: [],
+        },
+    ],
+    field_handles: [],
+    friend_decls: [],
+    struct_def_instantiations: [],
+    function_instantiations: [],
+    field_instantiations: [],
+    signatures: [
+        Signature(
+            [],
+        ),
+        Signature(
+            [
+                U64,
+            ],
+        ),
+    ],
+    identifiers: [
+        Identifier(
+            "c",
+        ),
+        Identifier(
+            "a",
+        ),
+        Identifier(
+            "b",
+        ),
+        Identifier(
+            "d",
+        ),
+        Identifier(
+            "e",
+        ),
+        Identifier(
+            "f",
+        ),
+    ],
+    address_identifiers: [
+        00000000000000000000000000000002,
+        00000000000000000000000000000001,
+        00000000000000000000000000000003,
+        00000000000000000000000000000004,
+    ],
+    constant_pool: [],
+    metadata: [],
+    struct_defs: [],
+    function_defs: [
+        FunctionDefinition {
+            function: FunctionHandleIndex(0),
+            visibility: Public,
+            is_entry: false,
+            acquires_global_resources: [],
+            code: Some(
+                CodeUnit {
+                    locals: SignatureIndex(0),
+                    code: [
+                        Call(3),
+                        Call(1),
+                        Add,
+                        Call(2),
+                        Add,
+                        Call(4),
+                        Add,
+                        Ret,
+                    ],
+                },
+            ),
+        },
+    ],
 }

--- a/language/tools/move-cli/tests/build_tests/canonicalize_module/args.exp
+++ b/language/tools/move-cli/tests/build_tests/canonicalize_module/args.exp
@@ -1,0 +1,23 @@
+Command `disassemble --package Test --name c`:
+// Move bytecode v6
+module 2.c {
+use 00000000000000000000000000000002::b;
+use 00000000000000000000000000000003::d;
+use 00000000000000000000000000000001::a;
+use 00000000000000000000000000000004::e;
+
+
+
+
+public f(): u64 {
+B0:
+	0: Call a::f(): u64
+	1: Call b::f(): u64
+	2: Add
+	3: Call d::f(): u64
+	4: Add
+	5: Call e::f(): u64
+	6: Add
+	7: Ret
+}
+}

--- a/language/tools/move-cli/tests/build_tests/canonicalize_module/args.exp
+++ b/language/tools/move-cli/tests/build_tests/canonicalize_module/args.exp
@@ -7,18 +7,30 @@ use 00000000000000000000000000000001::a;
 use 00000000000000000000000000000004::e;
 
 
+struct B {
+	x: u64
+}
+struct A {
+	b: vector<B>
+}
 
-
-public f(): u64 {
+public g(): u64 {
 B0:
 	0: Call a::f(): u64
 	1: Call b::f(): u64
 	2: Add
-	3: Call d::f(): u64
-	4: Add
-	5: Call e::f(): u64
-	6: Add
-	7: Ret
+	3: Call e::b(): B
+	4: Call e::g(B): u64
+	5: Add
+	6: Ret
+}
+public f(): u64 {
+B0:
+	0: Call d::f(): u64
+	1: Call e::a(): A
+	2: Call e::f(A): u64
+	3: Add
+	4: Ret
 }
 }
 
@@ -47,40 +59,93 @@ CompiledModule {
             name: IdentifierIndex(4),
         },
     ],
-    struct_handles: [],
+    struct_handles: [
+        StructHandle {
+            module: ModuleHandleIndex(0),
+            name: IdentifierIndex(5),
+            abilities: [],
+            type_parameters: [],
+        },
+        StructHandle {
+            module: ModuleHandleIndex(0),
+            name: IdentifierIndex(6),
+            abilities: [],
+            type_parameters: [],
+        },
+        StructHandle {
+            module: ModuleHandleIndex(4),
+            name: IdentifierIndex(6),
+            abilities: [Drop, ],
+            type_parameters: [],
+        },
+        StructHandle {
+            module: ModuleHandleIndex(4),
+            name: IdentifierIndex(5),
+            abilities: [Drop, ],
+            type_parameters: [],
+        },
+    ],
     function_handles: [
         FunctionHandle {
             module: ModuleHandleIndex(0),
-            name: IdentifierIndex(5),
+            name: IdentifierIndex(7),
+            parameters: SignatureIndex(0),
+            return_: SignatureIndex(1),
+            type_parameters: [],
+        },
+        FunctionHandle {
+            module: ModuleHandleIndex(0),
+            name: IdentifierIndex(8),
             parameters: SignatureIndex(0),
             return_: SignatureIndex(1),
             type_parameters: [],
         },
         FunctionHandle {
             module: ModuleHandleIndex(1),
-            name: IdentifierIndex(5),
+            name: IdentifierIndex(8),
             parameters: SignatureIndex(0),
             return_: SignatureIndex(1),
             type_parameters: [],
         },
         FunctionHandle {
             module: ModuleHandleIndex(2),
-            name: IdentifierIndex(5),
+            name: IdentifierIndex(8),
             parameters: SignatureIndex(0),
             return_: SignatureIndex(1),
             type_parameters: [],
         },
         FunctionHandle {
             module: ModuleHandleIndex(3),
-            name: IdentifierIndex(5),
+            name: IdentifierIndex(8),
             parameters: SignatureIndex(0),
             return_: SignatureIndex(1),
             type_parameters: [],
         },
         FunctionHandle {
             module: ModuleHandleIndex(4),
-            name: IdentifierIndex(5),
+            name: IdentifierIndex(1),
             parameters: SignatureIndex(0),
+            return_: SignatureIndex(3),
+            type_parameters: [],
+        },
+        FunctionHandle {
+            module: ModuleHandleIndex(4),
+            name: IdentifierIndex(2),
+            parameters: SignatureIndex(0),
+            return_: SignatureIndex(2),
+            type_parameters: [],
+        },
+        FunctionHandle {
+            module: ModuleHandleIndex(4),
+            name: IdentifierIndex(8),
+            parameters: SignatureIndex(3),
+            return_: SignatureIndex(1),
+            type_parameters: [],
+        },
+        FunctionHandle {
+            module: ModuleHandleIndex(4),
+            name: IdentifierIndex(7),
+            parameters: SignatureIndex(2),
             return_: SignatureIndex(1),
             type_parameters: [],
         },
@@ -97,6 +162,16 @@ CompiledModule {
         Signature(
             [
                 U64,
+            ],
+        ),
+        Signature(
+            [
+                Struct(StructHandleIndex(3)),
+            ],
+        ),
+        Signature(
+            [
+                Struct(StructHandleIndex(2)),
             ],
         ),
     ],
@@ -117,7 +192,19 @@ CompiledModule {
             "e",
         ),
         Identifier(
+            "B",
+        ),
+        Identifier(
+            "A",
+        ),
+        Identifier(
+            "g",
+        ),
+        Identifier(
             "f",
+        ),
+        Identifier(
+            "x",
         ),
     ],
     address_identifiers: [
@@ -128,7 +215,34 @@ CompiledModule {
     ],
     constant_pool: [],
     metadata: [],
-    struct_defs: [],
+    struct_defs: [
+        StructDefinition {
+            struct_handle: StructHandleIndex(0),
+            field_information: Declared(
+                [
+                    FieldDefinition {
+                        name: IdentifierIndex(9),
+                        signature: TypeSignature(
+                            U64,
+                        ),
+                    },
+                ],
+            ),
+        },
+        StructDefinition {
+            struct_handle: StructHandleIndex(1),
+            field_information: Declared(
+                [
+                    FieldDefinition {
+                        name: IdentifierIndex(2),
+                        signature: TypeSignature(
+                            Vector(Struct(StructHandleIndex(0))),
+                        ),
+                    },
+                ],
+            ),
+        },
+    ],
     function_defs: [
         FunctionDefinition {
             function: FunctionHandleIndex(0),
@@ -139,12 +253,29 @@ CompiledModule {
                 CodeUnit {
                     locals: SignatureIndex(0),
                     code: [
-                        Call(3),
-                        Call(1),
-                        Add,
+                        Call(4),
                         Call(2),
                         Add,
-                        Call(4),
+                        Call(6),
+                        Call(8),
+                        Add,
+                        Ret,
+                    ],
+                },
+            ),
+        },
+        FunctionDefinition {
+            function: FunctionHandleIndex(1),
+            visibility: Public,
+            is_entry: false,
+            acquires_global_resources: [],
+            code: Some(
+                CodeUnit {
+                    locals: SignatureIndex(0),
+                    code: [
+                        Call(3),
+                        Call(5),
+                        Call(7),
                         Add,
                         Ret,
                     ],

--- a/language/tools/move-cli/tests/build_tests/canonicalize_module/args.exp
+++ b/language/tools/move-cli/tests/build_tests/canonicalize_module/args.exp
@@ -40,47 +40,47 @@ CompiledModule {
     module_handles: [
         ModuleHandle {
             address: AddressIdentifierIndex(0),
-            name: IdentifierIndex(0),
+            name: IdentifierIndex(4),
         },
         ModuleHandle {
             address: AddressIdentifierIndex(0),
-            name: IdentifierIndex(2),
-        },
-        ModuleHandle {
-            address: AddressIdentifierIndex(2),
             name: IdentifierIndex(3),
         },
         ModuleHandle {
+            address: AddressIdentifierIndex(2),
+            name: IdentifierIndex(5),
+        },
+        ModuleHandle {
             address: AddressIdentifierIndex(1),
-            name: IdentifierIndex(1),
+            name: IdentifierIndex(2),
         },
         ModuleHandle {
             address: AddressIdentifierIndex(3),
-            name: IdentifierIndex(4),
+            name: IdentifierIndex(6),
         },
     ],
     struct_handles: [
         StructHandle {
             module: ModuleHandleIndex(0),
-            name: IdentifierIndex(5),
+            name: IdentifierIndex(1),
             abilities: [],
             type_parameters: [],
         },
         StructHandle {
             module: ModuleHandleIndex(0),
-            name: IdentifierIndex(6),
+            name: IdentifierIndex(0),
             abilities: [],
             type_parameters: [],
         },
         StructHandle {
             module: ModuleHandleIndex(4),
-            name: IdentifierIndex(6),
+            name: IdentifierIndex(0),
             abilities: [Drop, ],
             type_parameters: [],
         },
         StructHandle {
             module: ModuleHandleIndex(4),
-            name: IdentifierIndex(5),
+            name: IdentifierIndex(1),
             abilities: [Drop, ],
             type_parameters: [],
         },
@@ -88,63 +88,63 @@ CompiledModule {
     function_handles: [
         FunctionHandle {
             module: ModuleHandleIndex(0),
-            name: IdentifierIndex(7),
+            name: IdentifierIndex(8),
             parameters: SignatureIndex(0),
             return_: SignatureIndex(1),
             type_parameters: [],
         },
         FunctionHandle {
             module: ModuleHandleIndex(0),
-            name: IdentifierIndex(8),
+            name: IdentifierIndex(7),
             parameters: SignatureIndex(0),
             return_: SignatureIndex(1),
             type_parameters: [],
         },
         FunctionHandle {
             module: ModuleHandleIndex(1),
-            name: IdentifierIndex(8),
+            name: IdentifierIndex(7),
             parameters: SignatureIndex(0),
             return_: SignatureIndex(1),
             type_parameters: [],
         },
         FunctionHandle {
             module: ModuleHandleIndex(2),
-            name: IdentifierIndex(8),
+            name: IdentifierIndex(7),
             parameters: SignatureIndex(0),
             return_: SignatureIndex(1),
             type_parameters: [],
         },
         FunctionHandle {
             module: ModuleHandleIndex(3),
-            name: IdentifierIndex(8),
+            name: IdentifierIndex(7),
             parameters: SignatureIndex(0),
             return_: SignatureIndex(1),
-            type_parameters: [],
-        },
-        FunctionHandle {
-            module: ModuleHandleIndex(4),
-            name: IdentifierIndex(1),
-            parameters: SignatureIndex(0),
-            return_: SignatureIndex(3),
             type_parameters: [],
         },
         FunctionHandle {
             module: ModuleHandleIndex(4),
             name: IdentifierIndex(2),
             parameters: SignatureIndex(0),
+            return_: SignatureIndex(3),
+            type_parameters: [],
+        },
+        FunctionHandle {
+            module: ModuleHandleIndex(4),
+            name: IdentifierIndex(3),
+            parameters: SignatureIndex(0),
             return_: SignatureIndex(2),
             type_parameters: [],
         },
         FunctionHandle {
             module: ModuleHandleIndex(4),
-            name: IdentifierIndex(8),
+            name: IdentifierIndex(7),
             parameters: SignatureIndex(3),
             return_: SignatureIndex(1),
             type_parameters: [],
         },
         FunctionHandle {
             module: ModuleHandleIndex(4),
-            name: IdentifierIndex(7),
+            name: IdentifierIndex(8),
             parameters: SignatureIndex(2),
             return_: SignatureIndex(1),
             type_parameters: [],
@@ -177,7 +177,10 @@ CompiledModule {
     ],
     identifiers: [
         Identifier(
-            "c",
+            "A",
+        ),
+        Identifier(
+            "B",
         ),
         Identifier(
             "a",
@@ -186,22 +189,19 @@ CompiledModule {
             "b",
         ),
         Identifier(
+            "c",
+        ),
+        Identifier(
             "d",
         ),
         Identifier(
             "e",
         ),
         Identifier(
-            "B",
-        ),
-        Identifier(
-            "A",
+            "f",
         ),
         Identifier(
             "g",
-        ),
-        Identifier(
-            "f",
         ),
         Identifier(
             "x",
@@ -234,7 +234,7 @@ CompiledModule {
             field_information: Declared(
                 [
                     FieldDefinition {
-                        name: IdentifierIndex(2),
+                        name: IdentifierIndex(3),
                         signature: TypeSignature(
                             Vector(Struct(StructHandleIndex(0))),
                         ),

--- a/language/tools/move-cli/tests/build_tests/canonicalize_module/args.txt
+++ b/language/tools/move-cli/tests/build_tests/canonicalize_module/args.txt
@@ -1,1 +1,1 @@
-disassemble --package Test --name c
+disassemble --Xdebug --package Test --name c

--- a/language/tools/move-cli/tests/build_tests/canonicalize_module/args.txt
+++ b/language/tools/move-cli/tests/build_tests/canonicalize_module/args.txt
@@ -1,0 +1,1 @@
+disassemble --package Test --name c

--- a/language/tools/move-cli/tests/build_tests/canonicalize_module/sources/m.move
+++ b/language/tools/move-cli/tests/build_tests/canonicalize_module/sources/m.move
@@ -11,11 +11,18 @@ module bar::b {
 }
 
 module bar::c {
-    public fun f(): u64 {
+    struct B { x: u64 }
+    struct A { b: vector<B> }
+
+    public fun g(): u64 {
         foo::a::f() +
         bar::b::f() +
+        qux::e::g(qux::e::b())
+    }
+
+    public fun f(): u64 {
         baz::d::f() +
-        qux::e::f()
+        qux::e::f(qux::e::a())
     }
 }
 
@@ -26,7 +33,22 @@ module baz::d {
 }
 
 module qux::e {
-    public fun f(): u64 {
-        46
+    struct B has drop { x: u64 }
+    struct A has drop { x: u64 }
+
+    public fun a(): A {
+        A { x: 46 }
+    }
+
+    public fun b(): B {
+        B { x: 47 }
+    }
+
+    public fun f(a: A): u64 {
+        a.x
+    }
+
+    public fun g(b: B): u64 {
+        b.x
     }
 }

--- a/language/tools/move-cli/tests/build_tests/canonicalize_module/sources/m.move
+++ b/language/tools/move-cli/tests/build_tests/canonicalize_module/sources/m.move
@@ -1,0 +1,32 @@
+module foo::a {
+    public fun f(): u64 {
+        42
+    }
+}
+
+module bar::b {
+    public fun f(): u64 {
+        43
+    }
+}
+
+module bar::c {
+    public fun f(): u64 {
+        foo::a::f() +
+        bar::b::f() +
+        baz::d::f() +
+        qux::e::f()
+    }
+}
+
+module baz::d {
+    public fun f(): u64 {
+        45
+    }
+}
+
+module qux::e {
+    public fun f(): u64 {
+        46
+    }
+}

--- a/language/tools/move-cli/tests/build_tests/canonicalize_script/Move.toml
+++ b/language/tools/move-cli/tests/build_tests/canonicalize_script/Move.toml
@@ -1,0 +1,9 @@
+[package]
+name = "Test"
+version = "0.0.0"
+
+[addresses]
+foo = "0x1"
+bar = "0x2"
+baz = "0x3"
+qux = "0x4"

--- a/language/tools/move-cli/tests/build_tests/canonicalize_script/args.exp
+++ b/language/tools/move-cli/tests/build_tests/canonicalize_script/args.exp
@@ -10,24 +10,34 @@ use 00000000000000000000000000000004::d;
 
 
 main() {
+L0:	a#1#0: A
+L1:	b#1#0: B
 B0:
-	0: Call a::f(): u64
-	1: Call b::f(): u64
-	2: Add
-	3: Call c::f(): u64
-	4: Add
-	5: Call d::f(): u64
+	0: Call d::a(): A
+	1: StLoc[0](a#1#0: A)
+	2: Call d::b(): B
+	3: StLoc[1](b#1#0: B)
+	4: Call a::f(): u64
+	5: Call b::f(): u64
 	6: Add
-	7: LdU64(174)
-	8: Eq
-	9: BrFalse(11)
+	7: Call c::f(): u64
+	8: Add
+	9: MoveLoc[1](b#1#0: B)
+	10: Call d::g(B): u64
+	11: Add
+	12: MoveLoc[0](a#1#0: A)
+	13: Call d::f(A): u64
+	14: Add
+	15: LdU64(220)
+	16: Eq
+	17: BrFalse(19)
 B1:
-	10: Branch(13)
+	18: Branch(21)
 B2:
-	11: LdU64(0)
-	12: Abort
+	19: LdU64(0)
+	20: Abort
 B3:
-	13: Ret
+	21: Ret
 }
 }
 
@@ -51,34 +61,68 @@ CompiledScript {
             name: IdentifierIndex(3),
         },
     ],
-    struct_handles: [],
+    struct_handles: [
+        StructHandle {
+            module: ModuleHandleIndex(3),
+            name: IdentifierIndex(4),
+            abilities: [Drop, ],
+            type_parameters: [],
+        },
+        StructHandle {
+            module: ModuleHandleIndex(3),
+            name: IdentifierIndex(5),
+            abilities: [Drop, ],
+            type_parameters: [],
+        },
+    ],
     function_handles: [
         FunctionHandle {
             module: ModuleHandleIndex(0),
-            name: IdentifierIndex(4),
+            name: IdentifierIndex(6),
             parameters: SignatureIndex(0),
-            return_: SignatureIndex(1),
+            return_: SignatureIndex(4),
             type_parameters: [],
         },
         FunctionHandle {
             module: ModuleHandleIndex(1),
-            name: IdentifierIndex(4),
+            name: IdentifierIndex(6),
             parameters: SignatureIndex(0),
-            return_: SignatureIndex(1),
+            return_: SignatureIndex(4),
             type_parameters: [],
         },
         FunctionHandle {
             module: ModuleHandleIndex(2),
-            name: IdentifierIndex(4),
+            name: IdentifierIndex(6),
             parameters: SignatureIndex(0),
-            return_: SignatureIndex(1),
+            return_: SignatureIndex(4),
             type_parameters: [],
         },
         FunctionHandle {
             module: ModuleHandleIndex(3),
-            name: IdentifierIndex(4),
+            name: IdentifierIndex(0),
             parameters: SignatureIndex(0),
-            return_: SignatureIndex(1),
+            return_: SignatureIndex(2),
+            type_parameters: [],
+        },
+        FunctionHandle {
+            module: ModuleHandleIndex(3),
+            name: IdentifierIndex(1),
+            parameters: SignatureIndex(0),
+            return_: SignatureIndex(3),
+            type_parameters: [],
+        },
+        FunctionHandle {
+            module: ModuleHandleIndex(3),
+            name: IdentifierIndex(6),
+            parameters: SignatureIndex(2),
+            return_: SignatureIndex(4),
+            type_parameters: [],
+        },
+        FunctionHandle {
+            module: ModuleHandleIndex(3),
+            name: IdentifierIndex(7),
+            parameters: SignatureIndex(3),
+            return_: SignatureIndex(4),
             type_parameters: [],
         },
     ],
@@ -86,6 +130,22 @@ CompiledScript {
     signatures: [
         Signature(
             [],
+        ),
+        Signature(
+            [
+                Struct(StructHandleIndex(0)),
+                Struct(StructHandleIndex(1)),
+            ],
+        ),
+        Signature(
+            [
+                Struct(StructHandleIndex(0)),
+            ],
+        ),
+        Signature(
+            [
+                Struct(StructHandleIndex(1)),
+            ],
         ),
         Signature(
             [
@@ -107,7 +167,16 @@ CompiledScript {
             "d",
         ),
         Identifier(
+            "A",
+        ),
+        Identifier(
+            "B",
+        ),
+        Identifier(
             "f",
+        ),
+        Identifier(
+            "g",
         ),
     ],
     address_identifiers: [
@@ -119,19 +188,27 @@ CompiledScript {
     constant_pool: [],
     metadata: [],
     code: CodeUnit {
-        locals: SignatureIndex(0),
+        locals: SignatureIndex(1),
         code: [
+            Call(3),
+            StLoc(0),
+            Call(4),
+            StLoc(1),
             Call(2),
             Call(0),
             Add,
             Call(1),
             Add,
-            Call(3),
+            MoveLoc(1),
+            Call(6),
             Add,
-            LdU64(174),
+            MoveLoc(0),
+            Call(5),
+            Add,
+            LdU64(220),
             Eq,
-            BrFalse(11),
-            Branch(13),
+            BrFalse(19),
+            Branch(21),
             LdU64(0),
             Abort,
             Ret,

--- a/language/tools/move-cli/tests/build_tests/canonicalize_script/args.exp
+++ b/language/tools/move-cli/tests/build_tests/canonicalize_script/args.exp
@@ -1,4 +1,4 @@
-Command `disassemble --name main`:
+Command `disassemble --Xdebug --name main`:
 // Move bytecode v6
 script {
 use 00000000000000000000000000000002::b;
@@ -29,4 +29,114 @@ B2:
 B3:
 	13: Ret
 }
+}
+
+CompiledScript {
+    version: 6,
+    module_handles: [
+        ModuleHandle {
+            address: AddressIdentifierIndex(1),
+            name: IdentifierIndex(1),
+        },
+        ModuleHandle {
+            address: AddressIdentifierIndex(2),
+            name: IdentifierIndex(2),
+        },
+        ModuleHandle {
+            address: AddressIdentifierIndex(0),
+            name: IdentifierIndex(0),
+        },
+        ModuleHandle {
+            address: AddressIdentifierIndex(3),
+            name: IdentifierIndex(3),
+        },
+    ],
+    struct_handles: [],
+    function_handles: [
+        FunctionHandle {
+            module: ModuleHandleIndex(0),
+            name: IdentifierIndex(4),
+            parameters: SignatureIndex(0),
+            return_: SignatureIndex(1),
+            type_parameters: [],
+        },
+        FunctionHandle {
+            module: ModuleHandleIndex(1),
+            name: IdentifierIndex(4),
+            parameters: SignatureIndex(0),
+            return_: SignatureIndex(1),
+            type_parameters: [],
+        },
+        FunctionHandle {
+            module: ModuleHandleIndex(2),
+            name: IdentifierIndex(4),
+            parameters: SignatureIndex(0),
+            return_: SignatureIndex(1),
+            type_parameters: [],
+        },
+        FunctionHandle {
+            module: ModuleHandleIndex(3),
+            name: IdentifierIndex(4),
+            parameters: SignatureIndex(0),
+            return_: SignatureIndex(1),
+            type_parameters: [],
+        },
+    ],
+    function_instantiations: [],
+    signatures: [
+        Signature(
+            [],
+        ),
+        Signature(
+            [
+                U64,
+            ],
+        ),
+    ],
+    identifiers: [
+        Identifier(
+            "a",
+        ),
+        Identifier(
+            "b",
+        ),
+        Identifier(
+            "c",
+        ),
+        Identifier(
+            "d",
+        ),
+        Identifier(
+            "f",
+        ),
+    ],
+    address_identifiers: [
+        00000000000000000000000000000001,
+        00000000000000000000000000000002,
+        00000000000000000000000000000003,
+        00000000000000000000000000000004,
+    ],
+    constant_pool: [],
+    metadata: [],
+    code: CodeUnit {
+        locals: SignatureIndex(0),
+        code: [
+            Call(2),
+            Call(0),
+            Add,
+            Call(1),
+            Add,
+            Call(3),
+            Add,
+            LdU64(174),
+            Eq,
+            BrFalse(11),
+            Branch(13),
+            LdU64(0),
+            Abort,
+            Ret,
+        ],
+    },
+    type_parameters: [],
+    parameters: SignatureIndex(0),
 }

--- a/language/tools/move-cli/tests/build_tests/canonicalize_script/args.exp
+++ b/language/tools/move-cli/tests/build_tests/canonicalize_script/args.exp
@@ -46,31 +46,31 @@ CompiledScript {
     module_handles: [
         ModuleHandle {
             address: AddressIdentifierIndex(1),
-            name: IdentifierIndex(1),
+            name: IdentifierIndex(3),
         },
         ModuleHandle {
             address: AddressIdentifierIndex(2),
-            name: IdentifierIndex(2),
+            name: IdentifierIndex(4),
         },
         ModuleHandle {
             address: AddressIdentifierIndex(0),
-            name: IdentifierIndex(0),
+            name: IdentifierIndex(2),
         },
         ModuleHandle {
             address: AddressIdentifierIndex(3),
-            name: IdentifierIndex(3),
+            name: IdentifierIndex(5),
         },
     ],
     struct_handles: [
         StructHandle {
             module: ModuleHandleIndex(3),
-            name: IdentifierIndex(4),
+            name: IdentifierIndex(0),
             abilities: [Drop, ],
             type_parameters: [],
         },
         StructHandle {
             module: ModuleHandleIndex(3),
-            name: IdentifierIndex(5),
+            name: IdentifierIndex(1),
             abilities: [Drop, ],
             type_parameters: [],
         },
@@ -99,14 +99,14 @@ CompiledScript {
         },
         FunctionHandle {
             module: ModuleHandleIndex(3),
-            name: IdentifierIndex(0),
+            name: IdentifierIndex(2),
             parameters: SignatureIndex(0),
             return_: SignatureIndex(2),
             type_parameters: [],
         },
         FunctionHandle {
             module: ModuleHandleIndex(3),
-            name: IdentifierIndex(1),
+            name: IdentifierIndex(3),
             parameters: SignatureIndex(0),
             return_: SignatureIndex(3),
             type_parameters: [],
@@ -155,6 +155,12 @@ CompiledScript {
     ],
     identifiers: [
         Identifier(
+            "A",
+        ),
+        Identifier(
+            "B",
+        ),
+        Identifier(
             "a",
         ),
         Identifier(
@@ -165,12 +171,6 @@ CompiledScript {
         ),
         Identifier(
             "d",
-        ),
-        Identifier(
-            "A",
-        ),
-        Identifier(
-            "B",
         ),
         Identifier(
             "f",

--- a/language/tools/move-cli/tests/build_tests/canonicalize_script/args.exp
+++ b/language/tools/move-cli/tests/build_tests/canonicalize_script/args.exp
@@ -1,0 +1,32 @@
+Command `disassemble --name main`:
+// Move bytecode v6
+script {
+use 00000000000000000000000000000002::b;
+use 00000000000000000000000000000003::c;
+use 00000000000000000000000000000001::a;
+use 00000000000000000000000000000004::d;
+
+
+
+
+main() {
+B0:
+	0: Call a::f(): u64
+	1: Call b::f(): u64
+	2: Add
+	3: Call c::f(): u64
+	4: Add
+	5: Call d::f(): u64
+	6: Add
+	7: LdU64(174)
+	8: Eq
+	9: BrFalse(11)
+B1:
+	10: Branch(13)
+B2:
+	11: LdU64(0)
+	12: Abort
+B3:
+	13: Ret
+}
+}

--- a/language/tools/move-cli/tests/build_tests/canonicalize_script/args.txt
+++ b/language/tools/move-cli/tests/build_tests/canonicalize_script/args.txt
@@ -1,0 +1,1 @@
+disassemble --name main

--- a/language/tools/move-cli/tests/build_tests/canonicalize_script/args.txt
+++ b/language/tools/move-cli/tests/build_tests/canonicalize_script/args.txt
@@ -1,1 +1,1 @@
-disassemble --name main
+disassemble --Xdebug --name main

--- a/language/tools/move-cli/tests/build_tests/canonicalize_script/sources/m.move
+++ b/language/tools/move-cli/tests/build_tests/canonicalize_script/sources/m.move
@@ -12,12 +12,16 @@ module bar::b {
 
 script {
     fun main() {
+        let a = qux::d::a();
+        let b = qux::d::b();
+
         assert!(
             foo::a::f() +
             bar::b::f() +
             baz::c::f() +
-            qux::d::f() ==
-            42 + 43 + 44 + 45,
+            qux::d::g(b) +
+            qux::d::f(a) ==
+            42 + 43 + 44 + 45 + 46,
             0,
         );
     }
@@ -30,7 +34,22 @@ module baz::c {
 }
 
 module qux::d {
-    public fun f(): u64 {
-        45
+    struct B has drop { x: u64 }
+    struct A has drop { x: u64 }
+
+    public fun a(): A {
+        A { x: 45 }
+    }
+
+    public fun b(): B {
+        B { x: 46 }
+    }
+
+    public fun f(a: A): u64 {
+        a.x
+    }
+
+    public fun g(b: B): u64 {
+        b.x
     }
 }

--- a/language/tools/move-cli/tests/build_tests/canonicalize_script/sources/m.move
+++ b/language/tools/move-cli/tests/build_tests/canonicalize_script/sources/m.move
@@ -1,0 +1,36 @@
+module foo::a {
+    public fun f(): u64 {
+        42
+    }
+}
+
+module bar::b {
+    public fun f(): u64 {
+        43
+    }
+}
+
+script {
+    fun main() {
+        assert!(
+            foo::a::f() +
+            bar::b::f() +
+            baz::c::f() +
+            qux::d::f() ==
+            42 + 43 + 44 + 45,
+            0,
+        );
+    }
+}
+
+module baz::c {
+    public fun f(): u64 {
+        44
+    }
+}
+
+module qux::d {
+    public fun f(): u64 {
+        45
+    }
+}


### PR DESCRIPTION
Add a pass to the compiler, immediately after conversion from IR to bytecode, to re-order module handles to guarantee a stable ordering.

## Test Plan

New tests for canonical order:

```
$ cargo nextest -- canonicalize_
```