### PR TITLE
[cherry-pick][move-prover] better support for custom natives

### DIFF
--- a/language/move-prover/boogie-backend/src/lib.rs
+++ b/language/move-prover/boogie-backend/src/lib.rs
@@ -245,7 +245,9 @@ pub fn add_prelude(
             .sorted()
             .collect_vec()
     };
-    let filter_native_with_one_inst = |module: &str| {
+    // make sure that all natives have only one type instantiations
+    // because of this assertion, this function returns a `Vec<TypeInfo>`
+    let filter_native_ensure_one_inst = |module: &str| {
         filter_native(module)
             .into_iter()
             .map(|mut insts| {
@@ -255,6 +257,8 @@ pub fn add_prelude(
             .sorted()
             .collect_vec()
     };
+    // make sure that all natives have exactly the same number of type instantiations,
+    // this function returns a `Vec<Vec<TypeInfo>>`
     let filter_native_check_consistency = |module: &str| {
         let filtered = filter_native(module);
         let size = match filtered.first() {
@@ -265,9 +269,9 @@ pub fn add_prelude(
         filtered
     };
 
-    let bcs_instances = filter_native_with_one_inst(BCS_MODULE);
+    let bcs_instances = filter_native_ensure_one_inst(BCS_MODULE);
     context.insert("bcs_instances", &bcs_instances);
-    let event_instances = filter_native_with_one_inst(EVENT_MODULE);
+    let event_instances = filter_native_ensure_one_inst(EVENT_MODULE);
     context.insert("event_instances", &event_instances);
 
     // TODO: we have defined {{std}} for adaptable resolution of stdlib addresses but
@@ -288,7 +292,7 @@ pub fn add_prelude(
             custom_native_options.module_instance_names
         {
             if expect_single_type_inst {
-                context.insert(instance_name, &filter_native_with_one_inst(&module_name));
+                context.insert(instance_name, &filter_native_ensure_one_inst(&module_name));
             } else {
                 context.insert(
                     instance_name,

--- a/language/move-prover/boogie-backend/src/options.rs
+++ b/language/move-prover/boogie-backend/src/options.rs
@@ -46,9 +46,9 @@ impl VectorTheory {
 pub struct CustomNativeOptions {
     /// Bytes of the custom template.
     pub template_bytes: Vec<u8>,
-    /// List of (module name, module instance key) tuples, used to generate instantiated
-    /// versions of generic native functions.
-    pub module_instance_names: Vec<(String, String)>,
+    /// List of (module name, module instance key, single_type_info) tuples,
+    /// used to generate instantiated versions of generic native functions.
+    pub module_instance_names: Vec<(String, String, bool)>,
 }
 
 /// Contains information about a native method implementing mutable borrow semantics for a given

--- a/language/move-prover/boogie-backend/src/options.rs
+++ b/language/move-prover/boogie-backend/src/options.rs
@@ -46,7 +46,7 @@ impl VectorTheory {
 pub struct CustomNativeOptions {
     /// Bytes of the custom template.
     pub template_bytes: Vec<u8>,
-    /// List of (module name, module instance key, single_type_info) tuples,
+    /// List of (module name, module instance key, single_type_expected) tuples,
     /// used to generate instantiated versions of generic native functions.
     pub module_instance_names: Vec<(String, String, bool)>,
 }

--- a/language/move-prover/bytecode/src/clean_and_optimize.rs
+++ b/language/move-prover/bytecode/src/clean_and_optimize.rs
@@ -117,7 +117,8 @@ impl<'a> TransferFunctions for Optimizer<'a> {
                         // Exploit knowledge about builtin functions
                         !(callee_env.is_well_known(VECTOR_BORROW_MUT)
                             || callee_env.is_well_known(EVENT_EMIT_EVENT)
-                            || callee_env.is_intrinsic_of(INTRINSIC_FUN_MAP_BORROW_MUT))
+                            || callee_env.is_intrinsic_of(INTRINSIC_FUN_MAP_BORROW_MUT)
+                            || is_custom_borrow(callee_env, &self.options.borrow_natives))
                     } else {
                         true
                     };
@@ -135,6 +136,16 @@ impl<'a> TransferFunctions for Optimizer<'a> {
             }
         }
     }
+}
+
+/// Check if fun_env matches one of the functions implementing custom mutable borrow semantics.
+fn is_custom_borrow(fun_env: &FunctionEnv, borrow_natives: &Vec<String>) -> bool {
+    for name in borrow_natives {
+        if &fun_env.get_full_name_str() == name {
+            return true;
+        }
+    }
+    false
 }
 
 impl<'a> DataflowAnalysis for Optimizer<'a> {}


### PR DESCRIPTION
This is to cherry-pick #909 which was landed on main. This is to provide a consistent view on custom borrow natives throughout the bytecode transformation workflow.