### PR TITLE
 [printing] fix bug in StructTag::struct_to_canonical_string

### DIFF
--- a/language/move-core/types/src/language_storage.rs
+++ b/language/move-core/types/src/language_storage.rs
@@ -152,8 +152,9 @@ impl StructTag {
 
     /// Return a canonical string representation of the struct.
     /// Struct types are represented as fully qualified type names; e.g.
-    /// `00000000000000000000000000000001::string::String` or
-    /// `0000000000000000000000000000000a::module_name1::type_name1<0000000000000000000000000000000a::module_name2::type_name2<u64>>`
+    /// `00000000000000000000000000000001::string::String`,
+    /// `0000000000000000000000000000000a::module_name1::type_name1<0000000000000000000000000000000a::module_name2::type_name2<u64>>`,
+    /// or `0000000000000000000000000000000a::module_name2::type_name2<bool,u64,u128>.
     /// Addresses are hex-encoded lowercase values of length ADDRESS_LENGTH (16, 20, or 32 depending on the Move platform)
     /// Note: this function is guaranteed to be stable, and this is suitable for use inside
     /// Move native functions or the VM. By contrast, the `Display` implementation is subject
@@ -164,6 +165,7 @@ impl StructTag {
             generics.push('<');
             generics.push_str(&first_ty.to_canonical_string());
             for ty in self.type_params.iter().skip(1) {
+                generics.push(',');
                 generics.push_str(&ty.to_canonical_string())
             }
             generics.push('>');

--- a/language/move-stdlib/tests/type_name_tests.move
+++ b/language/move-stdlib/tests/type_name_tests.move
@@ -9,6 +9,8 @@ module 0xA::type_name_tests {
 
     struct TestGenerics<phantom T> { }
 
+    struct TestMultiGenerics<phantom T1, phantom T2, phantom T3> { }
+
     #[test]
     fun test_ground_types() {
         assert!(into_string(get<u8>()) == string(b"u8"), 0);
@@ -34,5 +36,12 @@ module 0xA::type_name_tests {
         assert!(into_string(get<TestGenerics<std::string::String>>()) == string(b"0000000000000000000000000000000a::type_name_tests::TestGenerics<00000000000000000000000000000001::string::String>"), 0);
         assert!(into_string(get<vector<TestGenerics<u64>>>()) == string(b"vector<0000000000000000000000000000000a::type_name_tests::TestGenerics<u64>>"), 0);
         assert!(into_string(get<std::option::Option<TestGenerics<u8>>>()) == string(b"00000000000000000000000000000001::option::Option<0000000000000000000000000000000a::type_name_tests::TestGenerics<u8>>"), 0);
+    }
+
+    // Note: these tests assume a 16 byte address length, and will fail on platforms where addresses are 20 or 32 bytes
+    #[test]
+    fun test_multi_generics() {
+        assert!(into_string(get<TestMultiGenerics<bool, u64, u128>>()) == string(b"0000000000000000000000000000000a::type_name_tests::TestMultiGenerics<bool,u64,u128>"), 0);
+        assert!(into_string(get<TestMultiGenerics<bool, vector<u64>, TestGenerics<u128>>>()) == string(b"0000000000000000000000000000000a::type_name_tests::TestMultiGenerics<bool,vector<u64>,0000000000000000000000000000000a::type_name_tests::TestGenerics<u128>>"), 0);
     }
 }


### PR DESCRIPTION
Previously, a type instantiation w/ >1 type parameters was printed without a separator (e.g., `S<u64bool>` instead of `S<u64,bool>`for `S<T1,T2>` instantiated with `u64` and `bool`). This PR adds a comma separator and a test.