### PR TITLE
[Move-package] Restrict searching bytecode within the build folder

### DIFF
--- a/language/tools/move-package/src/compilation/build_plan.rs
+++ b/language/tools/move-package/src/compilation/build_plan.rs
@@ -158,9 +158,7 @@ impl BuildPlan {
                 let mut source_available = true;
                 // If source is empty, search bytecode(mv) files
                 if dep_source_paths.is_empty() {
-                    dep_source_paths = dep_package
-                        .get_bytecodes(&self.resolution_graph.build_options)
-                        .unwrap();
+                    dep_source_paths = dep_package.get_bytecodes().unwrap();
                     source_available = false;
                 }
                 (

--- a/language/tools/move-package/src/compilation/compiled_package.rs
+++ b/language/tools/move-package/src/compilation/compiled_package.rs
@@ -588,7 +588,7 @@ impl CompiledPackage {
             if let Some(pkg_name) = resolution_graph.contains_renaming() {
                 anyhow::bail!(
                     "Found address renaming in package '{}' when \
-                    building Move model -- this is currently not supported",
+                    building with bytecode dependencies -- this is currently not supported",
                     pkg_name
                 )
             }

--- a/language/tools/move-package/src/compilation/model_builder.rs
+++ b/language/tools/move-package/src/compilation/model_builder.rs
@@ -57,9 +57,7 @@ impl ModelBuilder {
                 let mut source_available = true;
                 // If source is empty, search bytecode
                 if dep_source_paths.is_empty() {
-                    dep_source_paths = pkg
-                        .get_bytecodes(&self.resolution_graph.build_options)
-                        .unwrap();
+                    dep_source_paths = pkg.get_bytecodes().unwrap();
                     source_available = false;
                 }
                 Some(Ok((

--- a/language/tools/move-package/src/resolution/resolution_graph.rs
+++ b/language/tools/move-package/src/resolution/resolution_graph.rs
@@ -904,10 +904,8 @@ impl ResolvedPackage {
             .collect())
     }
 
-    pub fn get_bytecodes(&self, config: &BuildConfig) -> Result<Vec<FileName>> {
-        let mut path = ResolvingPackage::get_source_paths_for_config(&self.package_path, config)?;
-        let mut build_path = ResolvingPackage::get_build_paths(&self.package_path)?;
-        path.append(&mut build_path);
+    pub fn get_bytecodes(&self) -> Result<Vec<FileName>> {
+        let path = ResolvingPackage::get_build_paths(&self.package_path)?;
         let places_to_look = path
             .into_iter()
             .map(|p| p.to_string_lossy().to_string())


### PR DESCRIPTION
## Motivation

This PR 1) restrict searching bytecode within the `build` folder; and 2) fix an error message. 

