### PR TITLE
remove unused trait MoveResource

### DIFF
--- a/language/move-core/types/src/move_resource.rs
+++ b/language/move-core/types/src/move_resource.rs
@@ -35,9 +35,3 @@ pub trait MoveStructType {
         }
     }
 }
-
-pub trait MoveResource: MoveStructType + DeserializeOwned {
-    fn resource_path() -> Vec<u8> {
-        Self::struct_tag().access_vector()
-    }
-}


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Move Language.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->
see RELEASE.md line 352 "* Refactored the `MoveResource` trait to add a separate `MoveStructType` trait". It seems that aptos-core not use it (aptos_api_types::MoveResource is a struct). sui and starcoin also not use it.
## Motivation

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

(Write your answer here.)

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)
