### PR TITLE
[chore] implement GetModule for all ModuleResolvers

### DIFF
--- a/language/tools/move-cli/src/sandbox/utils/on_disk_state_view.rs
+++ b/language/tools/move-cli/src/sandbox/utils/on_disk_state_view.rs
@@ -419,21 +419,6 @@ impl ResourceResolver for OnDiskStateView {
     }
 }
 
-impl GetModule for &OnDiskStateView {
-    type Error = anyhow::Error;
-    type Item = CompiledModule;
-
-    fn get_module_by_id(&self, id: &ModuleId) -> Result<Option<CompiledModule>, Self::Error> {
-        if let Some(bytes) = self.get_module_bytes(id)? {
-            let module = CompiledModule::deserialize(&bytes)
-                .map_err(|e| anyhow!("Failure deserializing module {:?}: {:?}", id, e))?;
-            Ok(Some(module))
-        } else {
-            Ok(None)
-        }
-    }
-}
-
 impl Default for OnDiskStateView {
     fn default() -> Self {
         OnDiskStateView::create(Path::new(DEFAULT_BUILD_DIR), Path::new(DEFAULT_STORAGE_DIR))


### PR DESCRIPTION
This allows us to use GetModule with less boilerplate in some other places where it's needed--needed to unblock some testing in the `sui` repo.