### PR TITLE
[vm errors] Propagate status message to adapters

### DIFF
--- a/language/move-binary-format/src/errors.rs
+++ b/language/move-binary-format/src/errors.rs
@@ -61,6 +61,7 @@ impl VMError {
             major_status,
             sub_status,
             location,
+            message,
             mut offsets,
             ..
         } = *self.0;
@@ -82,7 +83,7 @@ impl VMError {
                     "Expected a code and module/script location with ABORTED, but got {:?} and {}",
                     sub_status, location
                 );
-                VMStatus::Error(StatusCode::ABORTED)
+                VMStatus::Error(StatusCode::ABORTED, message)
             }
 
             (major_status, sub_status, location)
@@ -92,7 +93,7 @@ impl VMError {
                     Location::Script => vm_status::AbortLocation::Script,
                     Location::Module(id) => vm_status::AbortLocation::Module(id.clone()),
                     Location::Undefined => {
-                        return VMStatus::Error(major_status);
+                        return VMStatus::Error(major_status, message);
                     }
                 };
                 // Errors for OUT_OF_GAS do not always have index set: if it does not, it should already return above.
@@ -109,7 +110,7 @@ impl VMError {
                 );
                 let (function, code_offset) = match offsets.pop() {
                     None => {
-                        return VMStatus::Error(major_status);
+                        return VMStatus::Error(major_status, message);
                     }
                     Some((fdef_idx, code_offset)) => (fdef_idx.0, code_offset),
                 };
@@ -121,7 +122,7 @@ impl VMError {
                 }
             }
 
-            (major_status, _, _) => VMStatus::Error(major_status),
+            (major_status, _, _) => VMStatus::Error(major_status, message),
         }
     }
 

--- a/language/move-binary-format/src/errors.rs
+++ b/language/move-binary-format/src/errors.rs
@@ -119,6 +119,7 @@ impl VMError {
                     location: abort_location,
                     function,
                     code_offset,
+                    message,
                 }
             }
 

--- a/language/move-core/types/src/unit_tests/vm_status_test.rs
+++ b/language/move-core/types/src/unit_tests/vm_status_test.rs
@@ -6,7 +6,7 @@ use crate::vm_status::{StatusCode, VMStatus};
 
 #[test]
 fn test_stats_code() {
-    let vm_status = VMStatus::Error(StatusCode::OUT_OF_GAS);
+    let vm_status = VMStatus::Error(StatusCode::OUT_OF_GAS, None);
     let code = vm_status.status_code();
     assert_eq!(code, StatusCode::OUT_OF_GAS);
 }

--- a/language/move-core/types/src/vm_status.rs
+++ b/language/move-core/types/src/vm_status.rs
@@ -69,6 +69,7 @@ pub enum VMStatus {
         location: AbortLocation,
         function: u16,
         code_offset: u16,
+        message: Option<String>,
     },
 }
 
@@ -138,7 +139,7 @@ impl VMStatus {
     /// Returns the message associated with the `VMStatus`, if any.
     pub fn message(&self) -> Option<&String> {
         match self {
-            Self::Error(_, msg) => msg.as_ref(),
+            Self::Error(_, message) | Self::ExecutionFailure { message, .. } => message.as_ref(),
             _ => None,
         }
     }
@@ -187,6 +188,7 @@ impl VMStatus {
                 location,
                 function,
                 code_offset,
+                ..
             } => Ok(KeptVMStatus::ExecutionFailure {
                 location,
                 function,
@@ -289,12 +291,14 @@ impl fmt::Debug for VMStatus {
                 location,
                 function,
                 code_offset,
+                message,
             } => f
                 .debug_struct("EXECUTION_FAILURE")
                 .field("status_code", status_code)
                 .field("location", location)
                 .field("function_definition", function)
                 .field("code_offset", code_offset)
+                .field("message", message)
                 .finish(),
         }
     }

--- a/language/tools/move-cli/src/sandbox/utils/mod.rs
+++ b/language/tools/move-cli/src/sandbox/utils/mod.rs
@@ -494,6 +494,7 @@ pub(crate) fn explain_execution_error(
             location,
             function,
             code_offset,
+            ..
         } => {
             let status_explanation = match status_code {
                 RESOURCE_ALREADY_EXISTS => "a RESOURCE_ALREADY_EXISTS error (i.e., \

--- a/language/tools/move-cli/src/sandbox/utils/mod.rs
+++ b/language/tools/move-cli/src/sandbox/utils/mod.rs
@@ -335,13 +335,13 @@ pub(crate) fn explain_publish_error(
     let module_id = module.self_id();
     let error_clone = error.clone();
     match error.into_vm_status() {
-        VMStatus::Error(DUPLICATE_MODULE_NAME) => {
+        VMStatus::Error(DUPLICATE_MODULE_NAME, _) => {
             println!(
                 "Module {} exists already. Re-run without --no-republish to publish anyway.",
                 module_id
             );
         }
-        VMStatus::Error(BACKWARD_INCOMPATIBLE_MODULE_UPDATE) => {
+        VMStatus::Error(BACKWARD_INCOMPATIBLE_MODULE_UPDATE, _) => {
             println!("Breaking change detected--publishing aborted. Re-run with --ignore-breaking-changes to publish anyway.");
 
             let old_module = state.get_module_by_id(&module_id)?.unwrap();
@@ -364,7 +364,7 @@ pub(crate) fn explain_publish_error(
                 println!("Linking API for structs/functions of module {} has changed. Need to redeploy all dependent modules.", module_id)
             }
         }
-        VMStatus::Error(CYCLIC_MODULE_DEPENDENCY) => {
+        VMStatus::Error(CYCLIC_MODULE_DEPENDENCY, _) => {
             println!(
                 "Publishing module {} introduces cyclic dependencies.",
                 module_id
@@ -411,7 +411,7 @@ pub(crate) fn explain_publish_error(
             }
             println!("Re-run with --ignore-breaking-changes to publish anyway.")
         }
-        VMStatus::Error(MISSING_DEPENDENCY) => {
+        VMStatus::Error(MISSING_DEPENDENCY, _) => {
             let err_indices = error_clone.indices();
             let mut diags = Diagnostics::new();
             for (ind_kind, table_ind) in err_indices {
@@ -441,7 +441,7 @@ pub(crate) fn explain_publish_error(
             }
             report_diagnostics(&files, diags)
         }
-        VMStatus::Error(status_code) => {
+        VMStatus::Error(status_code, _) => {
             println!("Publishing failed with unexpected error {:?}", status_code)
         }
         VMStatus::Executed | VMStatus::MoveAbort(..) | VMStatus::ExecutionFailure { .. } => {
@@ -532,14 +532,16 @@ pub(crate) fn explain_execution_error(
                 status_explanation, location_explanation, code_offset
             )
         }
-        VMStatus::Error(NUMBER_OF_TYPE_ARGUMENTS_MISMATCH) => println!(
+        VMStatus::Error(NUMBER_OF_TYPE_ARGUMENTS_MISMATCH, _) => println!(
             "Execution failed with incorrect number of type arguments: script expected {:?}, but \
              found {:?}",
             script_type_parameters.len(),
             vm_type_args.len()
         ),
-        VMStatus::Error(TYPE_MISMATCH) => explain_type_error(script_parameters, signers, txn_args),
-        VMStatus::Error(LINKER_ERROR) => {
+        VMStatus::Error(TYPE_MISMATCH, _) => {
+            explain_type_error(script_parameters, signers, txn_args)
+        }
+        VMStatus::Error(LINKER_ERROR, _) => {
             // TODO: is this the only reason we can see LINKER_ERROR?
             // Can we also see it if someone manually deletes modules in storage?
             println!(
@@ -548,7 +550,7 @@ pub(crate) fn explain_execution_error(
                  0x1::M)"
             );
         }
-        VMStatus::Error(status_code) => {
+        VMStatus::Error(status_code, _) => {
             println!("Execution failed with unexpected error {:?}", status_code)
         }
         VMStatus::Executed => unreachable!(),


### PR DESCRIPTION
This makes the internal status message of VM errors available in `VMStatus` and accessible by adapters. The purpose is to allow adapters to show more detail of errors like they appear e.g. during bytecode verification. These errors happen more often in practice as anticipated, mainly because uses operate with different versions of networks and tools, e.g. deploying code to some chain where it is not deserializable, or using wrong dependencies on disk which do not match those on the network. Currently, the errors produced by the system are as unspecific as 'LINKER_ERROR'.
