### PR TITLE
Revert "Rollforward "[vm errors] Propagate status message to adapters""

### DIFF
--- a/language/move-binary-format/src/errors.rs
+++ b/language/move-binary-format/src/errors.rs
@@ -61,7 +61,6 @@ impl VMError {
             major_status,
             sub_status,
             location,
-            message,
             mut offsets,
             ..
         } = *self.0;
@@ -83,7 +82,7 @@ impl VMError {
                     "Expected a code and module/script location with ABORTED, but got {:?} and {}",
                     sub_status, location
                 );
-                VMStatus::Error(StatusCode::ABORTED, message)
+                VMStatus::Error(StatusCode::ABORTED)
             }
 
             (major_status, sub_status, location)
@@ -93,7 +92,7 @@ impl VMError {
                     Location::Script => vm_status::AbortLocation::Script,
                     Location::Module(id) => vm_status::AbortLocation::Module(id.clone()),
                     Location::Undefined => {
-                        return VMStatus::Error(major_status, message);
+                        return VMStatus::Error(major_status);
                     }
                 };
                 // Errors for OUT_OF_GAS do not always have index set: if it does not, it should already return above.
@@ -110,7 +109,7 @@ impl VMError {
                 );
                 let (function, code_offset) = match offsets.pop() {
                     None => {
-                        return VMStatus::Error(major_status, message);
+                        return VMStatus::Error(major_status);
                     }
                     Some((fdef_idx, code_offset)) => (fdef_idx.0, code_offset),
                 };
@@ -119,11 +118,10 @@ impl VMError {
                     location: abort_location,
                     function,
                     code_offset,
-                    message,
                 }
             }
 
-            (major_status, _, _) => VMStatus::Error(major_status, message),
+            (major_status, _, _) => VMStatus::Error(major_status),
         }
     }
 

--- a/language/move-core/types/src/unit_tests/vm_status_test.rs
+++ b/language/move-core/types/src/unit_tests/vm_status_test.rs
@@ -6,7 +6,7 @@ use crate::vm_status::{StatusCode, VMStatus};
 
 #[test]
 fn test_stats_code() {
-    let vm_status = VMStatus::Error(StatusCode::OUT_OF_GAS, None);
+    let vm_status = VMStatus::Error(StatusCode::OUT_OF_GAS);
     let code = vm_status.status_code();
     assert_eq!(code, StatusCode::OUT_OF_GAS);
 }

--- a/language/tools/move-cli/src/sandbox/utils/mod.rs
+++ b/language/tools/move-cli/src/sandbox/utils/mod.rs
@@ -335,13 +335,13 @@ pub(crate) fn explain_publish_error(
     let module_id = module.self_id();
     let error_clone = error.clone();
     match error.into_vm_status() {
-        VMStatus::Error(DUPLICATE_MODULE_NAME, _) => {
+        VMStatus::Error(DUPLICATE_MODULE_NAME) => {
             println!(
                 "Module {} exists already. Re-run without --no-republish to publish anyway.",
                 module_id
             );
         }
-        VMStatus::Error(BACKWARD_INCOMPATIBLE_MODULE_UPDATE, _) => {
+        VMStatus::Error(BACKWARD_INCOMPATIBLE_MODULE_UPDATE) => {
             println!("Breaking change detected--publishing aborted. Re-run with --ignore-breaking-changes to publish anyway.");
 
             let old_module = state.get_module_by_id(&module_id)?.unwrap();
@@ -364,7 +364,7 @@ pub(crate) fn explain_publish_error(
                 println!("Linking API for structs/functions of module {} has changed. Need to redeploy all dependent modules.", module_id)
             }
         }
-        VMStatus::Error(CYCLIC_MODULE_DEPENDENCY, _) => {
+        VMStatus::Error(CYCLIC_MODULE_DEPENDENCY) => {
             println!(
                 "Publishing module {} introduces cyclic dependencies.",
                 module_id
@@ -411,7 +411,7 @@ pub(crate) fn explain_publish_error(
             }
             println!("Re-run with --ignore-breaking-changes to publish anyway.")
         }
-        VMStatus::Error(MISSING_DEPENDENCY, _) => {
+        VMStatus::Error(MISSING_DEPENDENCY) => {
             let err_indices = error_clone.indices();
             let mut diags = Diagnostics::new();
             for (ind_kind, table_ind) in err_indices {
@@ -441,7 +441,7 @@ pub(crate) fn explain_publish_error(
             }
             report_diagnostics(&files, diags)
         }
-        VMStatus::Error(status_code, _) => {
+        VMStatus::Error(status_code) => {
             println!("Publishing failed with unexpected error {:?}", status_code)
         }
         VMStatus::Executed | VMStatus::MoveAbort(..) | VMStatus::ExecutionFailure { .. } => {
@@ -494,7 +494,6 @@ pub(crate) fn explain_execution_error(
             location,
             function,
             code_offset,
-            ..
         } => {
             let status_explanation = match status_code {
                 RESOURCE_ALREADY_EXISTS => "a RESOURCE_ALREADY_EXISTS error (i.e., \
@@ -533,16 +532,14 @@ pub(crate) fn explain_execution_error(
                 status_explanation, location_explanation, code_offset
             )
         }
-        VMStatus::Error(NUMBER_OF_TYPE_ARGUMENTS_MISMATCH, _) => println!(
+        VMStatus::Error(NUMBER_OF_TYPE_ARGUMENTS_MISMATCH) => println!(
             "Execution failed with incorrect number of type arguments: script expected {:?}, but \
              found {:?}",
             script_type_parameters.len(),
             vm_type_args.len()
         ),
-        VMStatus::Error(TYPE_MISMATCH, _) => {
-            explain_type_error(script_parameters, signers, txn_args)
-        }
-        VMStatus::Error(LINKER_ERROR, _) => {
+        VMStatus::Error(TYPE_MISMATCH) => explain_type_error(script_parameters, signers, txn_args),
+        VMStatus::Error(LINKER_ERROR) => {
             // TODO: is this the only reason we can see LINKER_ERROR?
             // Can we also see it if someone manually deletes modules in storage?
             println!(
@@ -551,7 +548,7 @@ pub(crate) fn explain_execution_error(
                  0x1::M)"
             );
         }
-        VMStatus::Error(status_code, _) => {
+        VMStatus::Error(status_code) => {
             println!("Execution failed with unexpected error {:?}", status_code)
         }
         VMStatus::Executed => unreachable!(),


### PR DESCRIPTION
Reverts move-language/move#949

Let's wait until we cleanly make it through the branch cut before adding in new features :pray: 