### PR TITLE
[Prover] Declare the memory variables for type parameters in the generated boogie file

### DIFF
--- a/language/move-prover/boogie-backend/src/bytecode_translator.rs
+++ b/language/move-prover/boogie-backend/src/bytecode_translator.rs
@@ -199,6 +199,9 @@ impl<'env> BoogieTranslator<'env> {
 
             // declare free variables to represent the type info for this type
             emitln!(writer, "var {}_info: $TypeParamInfo;", param_type);
+
+            // declare the memory variable for this type
+            emitln!(writer, "var {}_$memory: $Memory {};", suffix, param_type);
         }
         emitln!(writer);
 


### PR DESCRIPTION
A type parameter that has the key-ability can have a memory space. This PR makes Prover declare the memory variables for type parameters in the generated boogie file.

## Motivation

To declare the memory variables for type parameters

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

yes

## Test Plan

cargo test
