### PR TITLE
[gas] fix NativeContext::exists_at & introduce new gas parameter to fix buggy gas formula in the table extension

### DIFF
--- a/language/extensions/move-table-extension/src/lib.rs
+++ b/language/extensions/move-table-extension/src/lib.rs
@@ -309,17 +309,18 @@ pub fn table_natives(table_addr: AccountAddress, gas_params: GasParameters) -> N
 
 #[derive(Debug, Clone)]
 pub struct CommonGasParameters {
-    pub load_base: InternalGas,
+    pub load_base_legacy: InternalGas,
+    pub load_base_new: InternalGas,
     pub load_per_byte: InternalGasPerByte,
     pub load_failure: InternalGas,
 }
 
 impl CommonGasParameters {
     fn calculate_load_cost(&self, loaded: Option<Option<NumBytes>>) -> InternalGas {
-        self.load_base
+        self.load_base_legacy
             + match loaded {
-                Some(Some(num_bytes)) => self.load_per_byte * num_bytes,
-                Some(None) => self.load_failure,
+                Some(Some(num_bytes)) => self.load_base_new + self.load_per_byte * num_bytes,
+                Some(None) => self.load_base_new + self.load_failure,
                 None => 0.into(),
             }
     }
@@ -644,7 +645,8 @@ impl GasParameters {
     pub fn zeros() -> Self {
         Self {
             common: CommonGasParameters {
-                load_base: 0.into(),
+                load_base_legacy: 0.into(),
+                load_base_new: 0.into(),
                 load_per_byte: 0.into(),
                 load_failure: 0.into(),
             },

--- a/language/move-vm/runtime/src/native_functions.rs
+++ b/language/move-vm/runtime/src/native_functions.rs
@@ -128,7 +128,7 @@ impl<'a, 'b> NativeContext<'a, 'b> {
         &mut self,
         address: AccountAddress,
         type_: &Type,
-    ) -> VMResult<(bool, Option<NumBytes>)> {
+    ) -> VMResult<(bool, Option<Option<NumBytes>>)> {
         let (value, num_bytes) = self
             .data_store
             .load_resource(address, type_)
@@ -136,7 +136,7 @@ impl<'a, 'b> NativeContext<'a, 'b> {
         let exists = value
             .exists()
             .map_err(|err| err.finish(Location::Undefined))?;
-        Ok((exists, num_bytes.flatten()))
+        Ok((exists, num_bytes))
     }
 
     pub fn save_event(


### PR DESCRIPTION
This fixes two issues:
1. `NativeContext::exists_at` should not have flattened the nested options. 
2. The table extension does not waive the base fee even when the resource being loaded is already in the cache.