### PR TITLE
add VMRuntimeLimitsConfig and vector len limit

### DIFF
--- a/language/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/signature_tests.rs
+++ b/language/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/signature_tests.rs
@@ -7,7 +7,8 @@ use move_binary_format::file_format::{
     Bytecode::*, CompiledModule, SignatureToken::*, Visibility::Public, *,
 };
 use move_bytecode_verifier::{
-    verify_module, verify_module_with_config, SignatureChecker, VerifierConfig,
+    verifier::MAX_CONSTANT_VECTOR_LEN, verify_module, verify_module_with_config, SignatureChecker,
+    VerifierConfig,
 };
 use move_core_types::{
     account_address::AccountAddress, identifier::Identifier, vm_status::StatusCode,
@@ -228,6 +229,7 @@ fn big_signature_test() {
             max_struct_definitions: Some(200),
             max_fields_in_struct: Some(30),
             max_function_definitions: Some(1000),
+            max_constant_vector_len: MAX_CONSTANT_VECTOR_LEN,
         },
         &module,
     )

--- a/language/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/vec_pack_tests.rs
+++ b/language/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/vec_pack_tests.rs
@@ -5,7 +5,7 @@ use move_binary_format::file_format::{
     empty_module, Bytecode, CodeUnit, FunctionDefinition, FunctionHandle, FunctionHandleIndex,
     IdentifierIndex, ModuleHandleIndex, Signature, SignatureIndex, SignatureToken, Visibility,
 };
-use move_bytecode_verifier::VerifierConfig;
+use move_bytecode_verifier::{verifier::MAX_CONSTANT_VECTOR_LEN, VerifierConfig};
 use move_core_types::{identifier::Identifier, vm_status::StatusCode};
 
 fn vec_sig(len: usize) -> SignatureToken {
@@ -72,6 +72,7 @@ fn test_vec_pack() {
             max_struct_definitions: Some(200),
             max_fields_in_struct: Some(30),
             max_function_definitions: Some(1000),
+            max_constant_vector_len: MAX_CONSTANT_VECTOR_LEN,
         },
         &m,
     )

--- a/language/move-bytecode-verifier/src/verifier.rs
+++ b/language/move-bytecode-verifier/src/verifier.rs
@@ -18,6 +18,8 @@ use move_binary_format::{
 };
 use move_core_types::{state::VMState, vm_status::StatusCode};
 
+pub const MAX_CONSTANT_VECTOR_LEN: u64 = 1024 * 1024;
+
 #[derive(Debug, Clone)]
 pub struct VerifierConfig {
     pub max_loop_depth: Option<usize>,
@@ -31,6 +33,7 @@ pub struct VerifierConfig {
     pub max_struct_definitions: Option<usize>,
     pub max_fields_in_struct: Option<usize>,
     pub max_function_definitions: Option<usize>,
+    pub max_constant_vector_len: u64,
 }
 
 /// Helper for a "canonical" verification of a module.
@@ -139,6 +142,8 @@ impl Default for VerifierConfig {
             max_fields_in_struct: None,
             // Max count of functions in a module
             max_function_definitions: None,
+            // Max len of vector constant
+            max_constant_vector_len: MAX_CONSTANT_VECTOR_LEN,
         }
     }
 }

--- a/language/move-core/types/src/vm_status.rs
+++ b/language/move-core/types/src/vm_status.rs
@@ -608,6 +608,7 @@ pub enum StatusCode {
     MAX_FUNCTION_DEFINITIONS_REACHED = 1119,
     MAX_STRUCT_DEFINITIONS_REACHED = 1120,
     MAX_FIELD_DEFINITIONS_REACHED = 1121,
+    TOO_MANY_VECTOR_ELEMENTS = 1122,
 
     // These are errors that the VM might raise if a violation of internal
     // invariants takes place.

--- a/language/move-stdlib/src/natives/vector.rs
+++ b/language/move-stdlib/src/natives/vector.rs
@@ -132,7 +132,11 @@ pub fn native_push_back(
 
     NativeResult::map_partial_vm_result_empty(
         native_gas_total_cost!(context, gas_left),
-        r.push_back(e, &ty_args[0]),
+        r.push_back(
+            e,
+            &ty_args[0],
+            context.runtime_limits_config().vector_len_max,
+        ),
     )
 }
 

--- a/language/move-stdlib/tests/move_unit_test.rs
+++ b/language/move-stdlib/tests/move_unit_test.rs
@@ -32,7 +32,7 @@ fn run_tests_for_pkg(path_to_pkg: impl Into<String>, include_nursery_natives: bo
             install_dir: Some(tempdir().unwrap().path().to_path_buf()),
             ..Default::default()
         },
-        UnitTestingConfig::default_with_bound(Some(100_000)),
+        UnitTestingConfig::default_with_bound(Some(1_000_000_000)),
         natives,
         None,
         /* compute_coverage */ false,

--- a/language/move-stdlib/tests/vector_tests.move
+++ b/language/move-stdlib/tests/vector_tests.move
@@ -539,4 +539,31 @@ module std::vector_tests {
         let v = vector[7];
         V::insert(&mut v, 6, 2);
     }
+
+    #[test]
+    fun size_limit_ok() {
+        let v = V::empty();
+        let i = 0;
+        // Limit is currently 1024 * 1024
+        let max_len = 1024 * 1024;
+
+        while (i < max_len) {
+            V::push_back(&mut v, i);
+            i = i + 1;
+        };
+    }
+
+    #[test]
+    #[expected_failure(vector_error, minor_status = 4, location = Self)]
+    fun size_limit_fail() {
+        let v = V::empty();
+        let i = 0;
+        // Limit is currently 1024 * 1024
+        let max_len = 1024 * 1024 + 1;
+
+        while (i < max_len) {
+            V::push_back(&mut v, i);
+            i = i + 1;
+        };
+    }
 }

--- a/language/move-vm/runtime/src/config.rs
+++ b/language/move-vm/runtime/src/config.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use move_binary_format::file_format_common::VERSION_MAX;
-use move_bytecode_verifier::VerifierConfig;
+use move_bytecode_verifier::{verifier::MAX_CONSTANT_VECTOR_LEN, VerifierConfig};
 
 /// Dynamic config options for the Move VM.
 pub struct VMConfig {
@@ -33,7 +33,7 @@ pub struct VMRuntimeLimitsConfig {
 impl Default for VMRuntimeLimitsConfig {
     fn default() -> Self {
         Self {
-            vector_len_max: 1024 * 1024,
+            vector_len_max: MAX_CONSTANT_VECTOR_LEN,
         }
     }
 }

--- a/language/move-vm/runtime/src/config.rs
+++ b/language/move-vm/runtime/src/config.rs
@@ -11,6 +11,7 @@ pub struct VMConfig {
     // When this flag is set to true, MoveVM will perform type check at every instruction
     // execution to ensure that type safety cannot be violated at runtime.
     pub paranoid_type_checks: bool,
+    pub runtime_limits_config: VMRuntimeLimitsConfig,
 }
 
 impl Default for VMConfig {
@@ -19,6 +20,20 @@ impl Default for VMConfig {
             verifier: VerifierConfig::default(),
             max_binary_format_version: VERSION_MAX,
             paranoid_type_checks: false,
+            runtime_limits_config: VMRuntimeLimitsConfig::default(),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct VMRuntimeLimitsConfig {
+    /// Maximum number of items that can be pushed into a vec
+    pub vector_len_max: u64,
+}
+impl Default for VMRuntimeLimitsConfig {
+    fn default() -> Self {
+        Self {
+            vector_len_max: 1024 * 1024,
         }
     }
 }

--- a/language/move-vm/runtime/src/native_functions.rs
+++ b/language/move-vm/runtime/src/native_functions.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    interpreter::Interpreter, loader::Resolver, native_extensions::NativeContextExtensions,
+    interpreter::Interpreter, loader::Resolver, native_extensions::NativeContextExtensions, config::VMRuntimeLimitsConfig,
 };
 use move_binary_format::errors::{ExecutionState, PartialVMError, PartialVMResult};
 use move_core_types::{
@@ -113,6 +113,11 @@ impl<'a, 'b> NativeContext<'a, 'b> {
             extensions,
             gas_budget,
         }
+    }
+
+    /// Limits imposed at runtime
+    pub fn runtime_limits_config(&self) -> &VMRuntimeLimitsConfig {
+        self.interpreter.runtime_limits_config()
     }
 }
 

--- a/language/move-vm/runtime/src/native_functions.rs
+++ b/language/move-vm/runtime/src/native_functions.rs
@@ -3,7 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    interpreter::Interpreter, loader::Resolver, native_extensions::NativeContextExtensions, config::VMRuntimeLimitsConfig,
+    config::VMRuntimeLimitsConfig, interpreter::Interpreter, loader::Resolver,
+    native_extensions::NativeContextExtensions,
 };
 use move_binary_format::errors::{ExecutionState, PartialVMError, PartialVMResult};
 use move_core_types::{


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Move Language.
The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Add `VMRuntimeLimitsConfig` which exposes `vector_len_max` and allows for bounding vec len at runtime. 
Add verifier check to ensure constant vector sizes limit.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes
## Test Plan

push_back tests of limit at and above
