### PR TITLE
[bytecode verifier] Relax metering during tests

### DIFF
--- a/language/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/binary_samples.rs
+++ b/language/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/binary_samples.rs
@@ -6,15 +6,14 @@
 //! Right now the serve to calibrate the metering working as expected. Those tests represent
 //! cases which we want to continue to succeed.
 
-use crate::unit_tests::production_config;
 use move_binary_format::{errors::VMResult, CompiledModule};
-use move_bytecode_verifier::verifier;
+use move_bytecode_verifier::{verifier, VerifierConfig};
 
 #[allow(unused)]
 fn run_binary_test(name: &str, bytes: &str) -> VMResult<()> {
     let bytes = hex::decode(bytes).expect("invalid hex string");
     let m = CompiledModule::deserialize(&bytes).expect("invalid module");
-    verifier::verify_module_with_config_for_test(name, &production_config(), &m)
+    verifier::verify_module_with_config_for_test(name, &VerifierConfig::production(), &m)
 }
 
 #[cfg(feature = "address32")]

--- a/language/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/large_type_test.rs
+++ b/language/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/large_type_test.rs
@@ -1,12 +1,12 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::unit_tests::production_config;
 use move_binary_format::file_format::{
     empty_module, Bytecode, CodeUnit, FunctionDefinition, FunctionHandle, FunctionHandleIndex,
     IdentifierIndex, ModuleHandleIndex, Signature, SignatureIndex, SignatureToken,
     Visibility::Public,
 };
+use move_bytecode_verifier::VerifierConfig;
 use move_core_types::{identifier::Identifier, vm_status::StatusCode};
 
 const NUM_LOCALS: u8 = 64;
@@ -145,7 +145,7 @@ fn test_large_types() {
 
     let result = move_bytecode_verifier::verify_module_with_config_for_test(
         "test_large_types",
-        &production_config(),
+        &VerifierConfig::production(),
         &m,
     );
     assert_eq!(

--- a/language/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/locals.rs
+++ b/language/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/locals.rs
@@ -1,12 +1,12 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::unit_tests::production_config;
 use move_binary_format::file_format::{
     empty_module, Bytecode, CodeUnit, FunctionDefinition, FunctionHandle, FunctionHandleIndex,
     IdentifierIndex, ModuleHandleIndex, Signature, SignatureIndex, SignatureToken,
     Visibility::Public,
 };
+use move_bytecode_verifier::VerifierConfig;
 use move_core_types::{identifier::Identifier, vm_status::StatusCode};
 
 #[test]
@@ -110,7 +110,7 @@ fn test_locals() {
 
     let result = move_bytecode_verifier::verify_module_with_config_for_test(
         "test_locals",
-        &production_config(),
+        &VerifierConfig::production(),
         &m,
     );
     assert_eq!(

--- a/language/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/many_back_edges.rs
+++ b/language/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/many_back_edges.rs
@@ -1,12 +1,12 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::unit_tests::production_config;
 use move_binary_format::file_format::{
     empty_module, Bytecode, CodeUnit, FunctionDefinition, FunctionHandle, FunctionHandleIndex,
     IdentifierIndex, ModuleHandleIndex, Signature, SignatureIndex, SignatureToken,
     Visibility::Public,
 };
+use move_bytecode_verifier::VerifierConfig;
 use move_core_types::{identifier::Identifier, vm_status::StatusCode};
 
 const MAX_BASIC_BLOCKS: u16 = 1024;
@@ -86,7 +86,7 @@ fn many_backedges() {
 
     let result = move_bytecode_verifier::verify_module_with_config_for_test(
         "many_backedges",
-        &production_config(),
+        &VerifierConfig::production(),
         &m,
     );
     assert_eq!(

--- a/language/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/mod.rs
+++ b/language/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/mod.rs
@@ -2,8 +2,6 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use move_bytecode_verifier::VerifierConfig;
-
 pub mod ability_field_requirements_tests;
 pub mod binary_samples;
 pub mod bounds_tests;
@@ -25,29 +23,3 @@ pub mod reference_safety_tests;
 pub mod signature_tests;
 pub mod struct_defs_tests;
 pub mod vec_pack_tests;
-
-/// Configuration used in production.
-pub(crate) fn production_config() -> VerifierConfig {
-    VerifierConfig {
-        max_loop_depth: Some(5),
-        max_generic_instantiation_length: Some(32),
-        max_function_parameters: Some(128),
-        max_basic_blocks: Some(1024),
-        max_basic_blocks_in_script: Some(1024),
-        max_value_stack_size: 1024,
-        max_type_nodes: Some(256),
-        max_push_size: Some(10000),
-        max_dependency_depth: Some(100),
-        max_struct_definitions: Some(200),
-        max_fields_in_struct: Some(30),
-        max_function_definitions: Some(1000),
-
-        // Do not use back edge constraints as they are superseded by metering
-        max_back_edges_per_function: None,
-        max_back_edges_per_module: None,
-
-        // Same as the default.
-        max_per_fun_meter_units: Some(1000 * 8000),
-        max_per_mod_meter_units: Some(1000 * 8000),
-    }
-}

--- a/language/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/reference_safety_tests.rs
+++ b/language/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/reference_safety_tests.rs
@@ -2,12 +2,12 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::unit_tests::production_config;
 use move_binary_format::file_format::{
     empty_module, Bytecode, CodeUnit, FunctionDefinition, FunctionHandle, FunctionHandleIndex,
     IdentifierIndex, ModuleHandleIndex, Signature, SignatureIndex, SignatureToken,
     Visibility::Public,
 };
+use move_bytecode_verifier::VerifierConfig;
 use move_core_types::{identifier::Identifier, vm_status::StatusCode};
 
 #[test]
@@ -123,7 +123,7 @@ fn test_bicliques() {
 
     let result = move_bytecode_verifier::verify_module_with_config_for_test(
         "test_bicliques",
-        &production_config(),
+        &VerifierConfig::production(),
         &m,
     );
     assert_eq!(
@@ -242,7 +242,7 @@ fn test_merge_state_large_graph() {
 
     let res = move_bytecode_verifier::verify_module_with_config_for_test(
         "test_merge_state_large_graph",
-        &production_config(),
+        &VerifierConfig::production(),
         &m,
     );
     assert_eq!(
@@ -330,7 +330,7 @@ fn test_merge_state() {
 
     let res = move_bytecode_verifier::verify_module_with_config_for_test(
         "test_merge_state",
-        &production_config(),
+        &VerifierConfig::production(),
         &m,
     );
     assert_eq!(
@@ -412,7 +412,7 @@ fn test_copyloc_pop() {
 
     let result = move_bytecode_verifier::verify_module_with_config_for_test(
         "test_copyloc_pop",
-        &production_config(),
+        &VerifierConfig::production(),
         &m,
     );
     assert_eq!(

--- a/language/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/signature_tests.rs
+++ b/language/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/signature_tests.rs
@@ -2,12 +2,13 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::unit_tests::production_config;
 use invalid_mutations::signature::{FieldRefMutation, SignatureRefMutation};
 use move_binary_format::file_format::{
     Bytecode::*, CompiledModule, SignatureToken::*, Visibility::Public, *,
 };
-use move_bytecode_verifier::{verify_module, verify_module_with_config_for_test, SignatureChecker};
+use move_bytecode_verifier::{
+    verify_module, verify_module_with_config_for_test, SignatureChecker, VerifierConfig,
+};
 use move_core_types::{
     account_address::AccountAddress, identifier::Identifier, vm_status::StatusCode,
 };
@@ -213,8 +214,11 @@ fn big_signature_test() {
     module.serialize(&mut mvbytes).unwrap();
     let module = CompiledModule::deserialize(&mvbytes).unwrap();
 
-    let res =
-        verify_module_with_config_for_test("big_signature_test", &production_config(), &module)
-            .unwrap_err();
+    let res = verify_module_with_config_for_test(
+        "big_signature_test",
+        &VerifierConfig::production(),
+        &module,
+    )
+    .unwrap_err();
     assert_eq!(res.major_status(), StatusCode::TOO_MANY_TYPE_NODES);
 }

--- a/language/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/vec_pack_tests.rs
+++ b/language/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/vec_pack_tests.rs
@@ -1,11 +1,11 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::unit_tests::production_config;
 use move_binary_format::file_format::{
     empty_module, Bytecode, CodeUnit, FunctionDefinition, FunctionHandle, FunctionHandleIndex,
     IdentifierIndex, ModuleHandleIndex, Signature, SignatureIndex, SignatureToken, Visibility,
 };
+use move_bytecode_verifier::VerifierConfig;
 use move_core_types::{identifier::Identifier, vm_status::StatusCode};
 
 fn vec_sig(len: usize) -> SignatureToken {
@@ -61,7 +61,7 @@ fn test_vec_pack() {
 
     let res = move_bytecode_verifier::verify_module_with_config_for_test(
         "test_vec_pack",
-        &production_config(),
+        &VerifierConfig::production(),
         &m,
     )
     .unwrap_err();

--- a/language/move-bytecode-verifier/src/verifier.rs
+++ b/language/move-bytecode-verifier/src/verifier.rs
@@ -184,10 +184,11 @@ impl Default for VerifierConfig {
             max_back_edges_per_function: None,
             max_back_edges_per_module: None,
             max_basic_blocks_in_script: None,
-            /// General metering for the verifier. This defaults to a bound which should align
-            /// with production, so all existing test cases apply it.
-            max_per_fun_meter_units: Some(1000 * 8000),
-            max_per_mod_meter_units: Some(1000 * 8000),
+            // General metering for the verifier.
+            // max_per_fun_meter_units: Some(1000 * 8000),
+            // max_per_mod_meter_units: Some(1000 * 8000),
+            max_per_fun_meter_units: None,
+            max_per_mod_meter_units: None,
         }
     }
 }
@@ -199,6 +200,32 @@ impl VerifierConfig {
             max_per_fun_meter_units: None,
             max_per_mod_meter_units: None,
             ..VerifierConfig::default()
+        }
+    }
+
+    /// An approximation of what config is used in production.
+    pub fn production() -> Self {
+        Self {
+            max_loop_depth: Some(5),
+            max_generic_instantiation_length: Some(32),
+            max_function_parameters: Some(128),
+            max_basic_blocks: Some(1024),
+            max_basic_blocks_in_script: Some(1024),
+            max_value_stack_size: 1024,
+            max_type_nodes: Some(256),
+            max_push_size: Some(10000),
+            max_dependency_depth: Some(100),
+            max_struct_definitions: Some(200),
+            max_fields_in_struct: Some(30),
+            max_function_definitions: Some(1000),
+
+            // Do not use back edge constraints as they are superseded by metering
+            max_back_edges_per_function: None,
+            max_back_edges_per_module: None,
+
+            // Same as the default.
+            max_per_fun_meter_units: Some(1000 * 8000),
+            max_per_mod_meter_units: Some(1000 * 8000),
         }
     }
 }

--- a/language/move-vm/runtime/src/config.rs
+++ b/language/move-vm/runtime/src/config.rs
@@ -22,3 +22,12 @@ impl Default for VMConfig {
         }
     }
 }
+
+impl VMConfig {
+    pub fn production() -> Self {
+        Self {
+            verifier: VerifierConfig::production(),
+            ..Self::default()
+        }
+    }
+}

--- a/language/testing-infra/transactional-test-runner/src/vm_test_harness.rs
+++ b/language/testing-infra/transactional-test-runner/src/vm_test_harness.rs
@@ -148,7 +148,7 @@ impl<'a> MoveTestAdapter<'a> for SimpleVMTestAdapter<'a> {
                     }
                     Ok(())
                 },
-                VMConfig::default(),
+                VMConfig::production(),
             )
             .unwrap();
         let mut addr_to_name_mapping = BTreeMap::new();
@@ -196,7 +196,7 @@ impl<'a> MoveTestAdapter<'a> for SimpleVMTestAdapter<'a> {
                     compat,
                 )
             },
-            VMConfig::default(),
+            VMConfig::production(),
         ) {
             Ok(()) => Ok((None, module)),
             Err(e) => Err(anyhow!(
@@ -428,7 +428,7 @@ impl From<AdapterExecuteArgs> for VMConfig {
     fn from(arg: AdapterExecuteArgs) -> VMConfig {
         VMConfig {
             paranoid_type_checks: arg.check_runtime_types,
-            ..Default::default()
+            ..Self::production()
         }
     }
 }


### PR DESCRIPTION
This aligns the default of the metering config to be unbounded, like with other constraints. Addresses https://github.com/aptos-labs/aptos-core/issues/7040