### PR TITLE
[gas] add Clone bounds to iterators

### DIFF
--- a/language/move-vm/runtime/src/interpreter.rs
+++ b/language/move-vm/runtime/src/interpreter.rs
@@ -142,11 +142,12 @@ impl Interpreter {
                     let non_ref_vals = current_frame
                         .locals
                         .drop_all_values()
-                        .map(|(_idx, val)| val);
+                        .map(|(_idx, val)| val)
+                        .collect::<Vec<_>>();
 
                     // TODO: Check if the error location is set correctly.
                     gas_meter
-                        .charge_drop_frame(non_ref_vals.into_iter())
+                        .charge_drop_frame(non_ref_vals.iter())
                         .map_err(|e| self.set_location(e))?;
 
                     if let Some(frame) = self.call_stack.pop() {
@@ -917,7 +918,7 @@ impl Stack {
         Ok(args)
     }
 
-    fn last_n(&self, n: usize) -> PartialVMResult<impl ExactSizeIterator<Item = &Value>> {
+    fn last_n(&self, n: usize) -> PartialVMResult<impl ExactSizeIterator<Item = &Value> + Clone> {
         if self.value.len() < n {
             return Err(PartialVMError::new(StatusCode::EMPTY_VALUE_STACK)
                 .with_message("Failed to get last n arguments on the argument stack".to_string()));

--- a/language/move-vm/runtime/src/interpreter.rs
+++ b/language/move-vm/runtime/src/interpreter.rs
@@ -526,6 +526,7 @@ impl Interpreter {
 
     /// Loads a resource from the data store and return the number of bytes read from the storage.
     fn load_resource<'b>(
+        loader: &Loader,
         gas_meter: &mut impl GasMeter,
         data_store: &'b mut impl DataStore,
         addr: AccountAddress,
@@ -547,7 +548,7 @@ impl Interpreter {
                         }
                         None => None,
                     };
-                    gas_meter.charge_load_resource(opt)?;
+                    gas_meter.charge_load_resource(addr, TypeWithLoader { ty, loader }, opt)?;
                 }
                 Ok(gv)
             }
@@ -572,7 +573,7 @@ impl Interpreter {
         addr: AccountAddress,
         ty: &Type,
     ) -> PartialVMResult<()> {
-        let res = Self::load_resource(gas_meter, data_store, addr, ty)?.borrow_global();
+        let res = Self::load_resource(loader, gas_meter, data_store, addr, ty)?.borrow_global();
         gas_meter.charge_borrow_global(
             is_mut,
             is_generic,
@@ -593,7 +594,7 @@ impl Interpreter {
         addr: AccountAddress,
         ty: &Type,
     ) -> PartialVMResult<()> {
-        let gv = Self::load_resource(gas_meter, data_store, addr, ty)?;
+        let gv = Self::load_resource(loader, gas_meter, data_store, addr, ty)?;
         let exists = gv.exists()?;
         gas_meter.charge_exists(is_generic, TypeWithLoader { ty, loader }, exists)?;
         self.operand_stack.push(Value::bool(exists))?;
@@ -610,21 +611,22 @@ impl Interpreter {
         addr: AccountAddress,
         ty: &Type,
     ) -> PartialVMResult<()> {
-        let resource = match Self::load_resource(gas_meter, data_store, addr, ty)?.move_from() {
-            Ok(resource) => {
-                gas_meter.charge_move_from(
-                    is_generic,
-                    TypeWithLoader { ty, loader },
-                    Some(&resource),
-                )?;
-                resource
-            }
-            Err(err) => {
-                let val: Option<&Value> = None;
-                gas_meter.charge_move_from(is_generic, TypeWithLoader { ty, loader }, val)?;
-                return Err(err);
-            }
-        };
+        let resource =
+            match Self::load_resource(loader, gas_meter, data_store, addr, ty)?.move_from() {
+                Ok(resource) => {
+                    gas_meter.charge_move_from(
+                        is_generic,
+                        TypeWithLoader { ty, loader },
+                        Some(&resource),
+                    )?;
+                    resource
+                }
+                Err(err) => {
+                    let val: Option<&Value> = None;
+                    gas_meter.charge_move_from(is_generic, TypeWithLoader { ty, loader }, val)?;
+                    return Err(err);
+                }
+            };
         self.operand_stack.push(resource)?;
         Ok(())
     }
@@ -640,7 +642,7 @@ impl Interpreter {
         ty: &Type,
         resource: Value,
     ) -> PartialVMResult<()> {
-        let gv = Self::load_resource(gas_meter, data_store, addr, ty)?;
+        let gv = Self::load_resource(loader, gas_meter, data_store, addr, ty)?;
         // NOTE(Gas): To maintain backward compatibility, we need to charge gas after attempting
         //            the move_to operation.
         match gv.move_to(resource) {

--- a/language/move-vm/runtime/src/interpreter.rs
+++ b/language/move-vm/runtime/src/interpreter.rs
@@ -1717,21 +1717,25 @@ impl Frame {
                         return Ok(ExitCode::Return);
                     }
                     Bytecode::BrTrue(offset) => {
-                        gas_meter.charge_simple_instr(S::BrTrue)?;
                         if interpreter.operand_stack.pop_as::<bool>()? {
+                            gas_meter.charge_br_true(Some(*offset))?;
                             self.pc = *offset;
                             break;
+                        } else {
+                            gas_meter.charge_br_true(None)?;
                         }
                     }
                     Bytecode::BrFalse(offset) => {
-                        gas_meter.charge_simple_instr(S::BrFalse)?;
                         if !interpreter.operand_stack.pop_as::<bool>()? {
+                            gas_meter.charge_br_false(Some(*offset))?;
                             self.pc = *offset;
                             break;
+                        } else {
+                            gas_meter.charge_br_false(None)?;
                         }
                     }
                     Bytecode::Branch(offset) => {
-                        gas_meter.charge_simple_instr(S::Branch)?;
+                        gas_meter.charge_branch(*offset)?;
                         self.pc = *offset;
                         break;
                     }

--- a/language/move-vm/test-utils/src/gas_schedule.rs
+++ b/language/move-vm/test-utils/src/gas_schedule.rs
@@ -17,6 +17,7 @@ use move_binary_format::{
     file_format_common::{instruction_key, Opcodes},
 };
 use move_core_types::{
+    account_address::AccountAddress,
     gas_algebra::{
         AbstractMemorySize, GasQuantity, InternalGas, InternalGasPerAbstractMemoryUnit,
         InternalGasUnit, NumArgs, NumBytes, ToUnit, ToUnitFractional,
@@ -409,6 +410,8 @@ impl<'b> GasMeter for GasStatus<'b> {
 
     fn charge_load_resource(
         &mut self,
+        _addr: AccountAddress,
+        _ty: impl TypeView,
         _loaded: Option<(NumBytes, impl ValueView)>,
     ) -> PartialVMResult<()> {
         Ok(())

--- a/language/move-vm/test-utils/src/gas_schedule.rs
+++ b/language/move-vm/test-utils/src/gas_schedule.rs
@@ -10,7 +10,7 @@
 use move_binary_format::{
     errors::{PartialVMError, PartialVMResult},
     file_format::{
-        Bytecode, ConstantPoolIndex, FieldHandleIndex, FieldInstantiationIndex,
+        Bytecode, CodeOffset, ConstantPoolIndex, FieldHandleIndex, FieldInstantiationIndex,
         FunctionHandleIndex, FunctionInstantiationIndex, SignatureIndex,
         StructDefInstantiationIndex, StructDefinitionIndex,
     },
@@ -207,10 +207,6 @@ fn get_simple_instruction_opcode(instr: SimpleInstruction) -> Opcodes {
         Nop => NOP,
         Ret => RET,
 
-        BrTrue => BR_TRUE,
-        BrFalse => BR_FALSE,
-        Branch => BRANCH,
-
         LdU8 => LD_U8,
         LdU64 => LD_U64,
         LdU128 => LD_U128,
@@ -268,6 +264,18 @@ impl<'b> GasMeter for GasStatus<'b> {
     /// Charge an instruction and fail if not enough gas units are left.
     fn charge_simple_instr(&mut self, instr: SimpleInstruction) -> PartialVMResult<()> {
         self.charge_instr(get_simple_instruction_opcode(instr))
+    }
+
+    fn charge_br_false(&mut self, _target_offset: Option<CodeOffset>) -> PartialVMResult<()> {
+        self.charge_instr(Opcodes::BR_FALSE)
+    }
+
+    fn charge_br_true(&mut self, _target_offset: Option<CodeOffset>) -> PartialVMResult<()> {
+        self.charge_instr(Opcodes::BR_TRUE)
+    }
+
+    fn charge_branch(&mut self, _target_offset: CodeOffset) -> PartialVMResult<()> {
+        self.charge_instr(Opcodes::BRANCH)
     }
 
     fn charge_pop(&mut self, _popped_val: impl ValueView) -> PartialVMResult<()> {

--- a/language/move-vm/test-utils/src/gas_schedule.rs
+++ b/language/move-vm/test-utils/src/gas_schedule.rs
@@ -200,63 +200,6 @@ impl<'a> GasStatus<'a> {
     }
 }
 
-fn get_simple_instruction_opcode(instr: SimpleInstruction) -> Opcodes {
-    use Opcodes::*;
-    use SimpleInstruction::*;
-
-    match instr {
-        Nop => NOP,
-        Ret => RET,
-
-        LdU8 => LD_U8,
-        LdU64 => LD_U64,
-        LdU128 => LD_U128,
-        LdTrue => LD_TRUE,
-        LdFalse => LD_FALSE,
-
-        FreezeRef => FREEZE_REF,
-        MutBorrowLoc => MUT_BORROW_LOC,
-        ImmBorrowLoc => IMM_BORROW_LOC,
-        ImmBorrowField => IMM_BORROW_FIELD,
-        MutBorrowField => MUT_BORROW_FIELD,
-        ImmBorrowFieldGeneric => IMM_BORROW_FIELD_GENERIC,
-        MutBorrowFieldGeneric => MUT_BORROW_FIELD_GENERIC,
-
-        CastU8 => CAST_U8,
-        CastU64 => CAST_U64,
-        CastU128 => CAST_U128,
-
-        Add => ADD,
-        Sub => SUB,
-        Mul => MUL,
-        Mod => MOD,
-        Div => DIV,
-
-        BitOr => BIT_OR,
-        BitAnd => BIT_AND,
-        Xor => XOR,
-        Shl => SHL,
-        Shr => SHR,
-
-        Or => OR,
-        And => AND,
-        Not => NOT,
-
-        Lt => LT,
-        Gt => GT,
-        Le => LE,
-        Ge => GE,
-
-        Abort => ABORT,
-        LdU16 => LD_U16,
-        LdU32 => LD_U32,
-        LdU256 => LD_U256,
-        CastU16 => CAST_U16,
-        CastU32 => CAST_U32,
-        CastU256 => CAST_U256,
-    }
-}
-
 impl<'b> GasMeter for GasStatus<'b> {
     fn balance_internal(&self) -> InternalGas {
         self.gas_left
@@ -264,7 +207,7 @@ impl<'b> GasMeter for GasStatus<'b> {
 
     /// Charge an instruction and fail if not enough gas units are left.
     fn charge_simple_instr(&mut self, instr: SimpleInstruction) -> PartialVMResult<()> {
-        self.charge_instr(get_simple_instruction_opcode(instr))
+        self.charge_instr(instr.to_opcode())
     }
 
     fn charge_br_false(&mut self, _target_offset: Option<CodeOffset>) -> PartialVMResult<()> {

--- a/language/move-vm/types/src/gas.rs
+++ b/language/move-vm/types/src/gas.rs
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::views::{TypeView, ValueView};
-use move_binary_format::{errors::PartialVMResult, file_format::CodeOffset};
+use move_binary_format::{
+    errors::PartialVMResult, file_format::CodeOffset, file_format_common::Opcodes,
+};
 use move_core_types::{
     account_address::AccountAddress,
     gas_algebra::{InternalGas, NumArgs, NumBytes},
@@ -62,6 +64,65 @@ pub enum SimpleInstruction {
     CastU16,
     CastU32,
     CastU256,
+}
+
+impl SimpleInstruction {
+    pub fn to_opcode(&self) -> Opcodes {
+        use Opcodes::*;
+        use SimpleInstruction::*;
+
+        match self {
+            Nop => NOP,
+            Ret => RET,
+
+            LdU8 => LD_U8,
+            LdU64 => LD_U64,
+            LdU128 => LD_U128,
+            LdTrue => LD_TRUE,
+            LdFalse => LD_FALSE,
+
+            FreezeRef => FREEZE_REF,
+            MutBorrowLoc => MUT_BORROW_LOC,
+            ImmBorrowLoc => IMM_BORROW_LOC,
+            ImmBorrowField => IMM_BORROW_FIELD,
+            MutBorrowField => MUT_BORROW_FIELD,
+            ImmBorrowFieldGeneric => IMM_BORROW_FIELD_GENERIC,
+            MutBorrowFieldGeneric => MUT_BORROW_FIELD_GENERIC,
+
+            CastU8 => CAST_U8,
+            CastU64 => CAST_U64,
+            CastU128 => CAST_U128,
+
+            Add => ADD,
+            Sub => SUB,
+            Mul => MUL,
+            Mod => MOD,
+            Div => DIV,
+
+            BitOr => BIT_OR,
+            BitAnd => BIT_AND,
+            Xor => XOR,
+            Shl => SHL,
+            Shr => SHR,
+
+            Or => OR,
+            And => AND,
+            Not => NOT,
+
+            Lt => LT,
+            Gt => GT,
+            Le => LE,
+            Ge => GE,
+
+            Abort => ABORT,
+            LdU16 => LD_U16,
+            LdU32 => LD_U32,
+            LdU256 => LD_U256,
+            CastU16 => CAST_U16,
+            CastU32 => CAST_U32,
+            CastU256 => CAST_U256,
+        }
+    }
 }
 
 /// Trait that defines a generic gas meter interface, allowing clients of the Move VM to implement

--- a/language/move-vm/types/src/gas.rs
+++ b/language/move-vm/types/src/gas.rs
@@ -81,7 +81,7 @@ pub trait GasMeter {
         &mut self,
         module_id: &ModuleId,
         func_name: &str,
-        args: impl ExactSizeIterator<Item = impl ValueView>,
+        args: impl ExactSizeIterator<Item = impl ValueView> + Clone,
         num_locals: NumArgs,
     ) -> PartialVMResult<()>;
 
@@ -89,8 +89,8 @@ pub trait GasMeter {
         &mut self,
         module_id: &ModuleId,
         func_name: &str,
-        ty_args: impl ExactSizeIterator<Item = impl TypeView>,
-        args: impl ExactSizeIterator<Item = impl ValueView>,
+        ty_args: impl ExactSizeIterator<Item = impl TypeView> + Clone,
+        args: impl ExactSizeIterator<Item = impl ValueView> + Clone,
         num_locals: NumArgs,
     ) -> PartialVMResult<()>;
 
@@ -108,13 +108,13 @@ pub trait GasMeter {
     fn charge_pack(
         &mut self,
         is_generic: bool,
-        args: impl ExactSizeIterator<Item = impl ValueView>,
+        args: impl ExactSizeIterator<Item = impl ValueView> + Clone,
     ) -> PartialVMResult<()>;
 
     fn charge_unpack(
         &mut self,
         is_generic: bool,
-        args: impl ExactSizeIterator<Item = impl ValueView>,
+        args: impl ExactSizeIterator<Item = impl ValueView> + Clone,
     ) -> PartialVMResult<()>;
 
     fn charge_read_ref(&mut self, val: impl ValueView) -> PartialVMResult<()>;
@@ -163,7 +163,7 @@ pub trait GasMeter {
     fn charge_vec_pack<'a>(
         &mut self,
         ty: impl TypeView + 'a,
-        args: impl ExactSizeIterator<Item = impl ValueView>,
+        args: impl ExactSizeIterator<Item = impl ValueView> + Clone,
     ) -> PartialVMResult<()>;
 
     fn charge_vec_len(&mut self, ty: impl TypeView) -> PartialVMResult<()>;
@@ -192,7 +192,7 @@ pub trait GasMeter {
         &mut self,
         ty: impl TypeView,
         expect_num_elements: NumArgs,
-        elems: impl ExactSizeIterator<Item = impl ValueView>,
+        elems: impl ExactSizeIterator<Item = impl ValueView> + Clone,
     ) -> PartialVMResult<()>;
 
     // TODO(Gas): Expose the two elements
@@ -219,18 +219,18 @@ pub trait GasMeter {
     fn charge_native_function(
         &mut self,
         amount: InternalGas,
-        ret_vals: Option<impl ExactSizeIterator<Item = impl ValueView>>,
+        ret_vals: Option<impl ExactSizeIterator<Item = impl ValueView> + Clone>,
     ) -> PartialVMResult<()>;
 
     fn charge_native_function_before_execution(
         &mut self,
-        ty_args: impl ExactSizeIterator<Item = impl TypeView>,
-        args: impl ExactSizeIterator<Item = impl ValueView>,
+        ty_args: impl ExactSizeIterator<Item = impl TypeView> + Clone,
+        args: impl ExactSizeIterator<Item = impl ValueView> + Clone,
     ) -> PartialVMResult<()>;
 
     fn charge_drop_frame(
         &mut self,
-        locals: impl Iterator<Item = impl ValueView>,
+        locals: impl Iterator<Item = impl ValueView> + Clone,
     ) -> PartialVMResult<()>;
 }
 

--- a/language/move-vm/types/src/gas.rs
+++ b/language/move-vm/types/src/gas.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::views::{TypeView, ValueView};
-use move_binary_format::errors::PartialVMResult;
+use move_binary_format::{errors::PartialVMResult, file_format::CodeOffset};
 use move_core_types::{
     gas_algebra::{InternalGas, NumArgs, NumBytes},
     language_storage::ModuleId,
@@ -13,10 +13,6 @@ use move_core_types::{
 pub enum SimpleInstruction {
     Nop,
     Ret,
-
-    BrTrue,
-    BrFalse,
-    Branch,
 
     LdU8,
     LdU64,
@@ -74,6 +70,12 @@ pub trait GasMeter {
 
     /// Charge an instruction and fail if not enough gas units are left.
     fn charge_simple_instr(&mut self, instr: SimpleInstruction) -> PartialVMResult<()>;
+
+    fn charge_br_true(&mut self, target_offset: Option<CodeOffset>) -> PartialVMResult<()>;
+
+    fn charge_br_false(&mut self, target_offset: Option<CodeOffset>) -> PartialVMResult<()>;
+
+    fn charge_branch(&mut self, target_offset: CodeOffset) -> PartialVMResult<()>;
 
     fn charge_pop(&mut self, popped_val: impl ValueView) -> PartialVMResult<()>;
 
@@ -244,6 +246,18 @@ impl GasMeter for UnmeteredGasMeter {
     }
 
     fn charge_simple_instr(&mut self, _instr: SimpleInstruction) -> PartialVMResult<()> {
+        Ok(())
+    }
+
+    fn charge_br_false(&mut self, _target_offset: Option<CodeOffset>) -> PartialVMResult<()> {
+        Ok(())
+    }
+
+    fn charge_br_true(&mut self, _target_offset: Option<CodeOffset>) -> PartialVMResult<()> {
+        Ok(())
+    }
+
+    fn charge_branch(&mut self, _target_offset: CodeOffset) -> PartialVMResult<()> {
         Ok(())
     }
 

--- a/language/move-vm/types/src/gas.rs
+++ b/language/move-vm/types/src/gas.rs
@@ -4,6 +4,7 @@
 use crate::views::{TypeView, ValueView};
 use move_binary_format::{errors::PartialVMResult, file_format::CodeOffset};
 use move_core_types::{
+    account_address::AccountAddress,
     gas_algebra::{InternalGas, NumArgs, NumBytes},
     language_storage::ModuleId,
 };
@@ -209,6 +210,8 @@ pub trait GasMeter {
     /// session -- identical transactions can have different gas costs. Use at your own risk.
     fn charge_load_resource(
         &mut self,
+        addr: AccountAddress,
+        ty: impl TypeView,
         loaded: Option<(NumBytes, impl ValueView)>,
     ) -> PartialVMResult<()>;
 
@@ -435,6 +438,8 @@ impl GasMeter for UnmeteredGasMeter {
 
     fn charge_load_resource(
         &mut self,
+        _addr: AccountAddress,
+        _ty: impl TypeView,
         _loaded: Option<(NumBytes, impl ValueView)>,
     ) -> PartialVMResult<()> {
         Ok(())

--- a/language/move-vm/types/src/values/values_impl.rs
+++ b/language/move-vm/types/src/values/values_impl.rs
@@ -3418,14 +3418,14 @@ impl ValueView for SignerRef {
 
 impl Struct {
     #[allow(clippy::needless_lifetimes)]
-    pub fn field_views<'a>(&'a self) -> impl ExactSizeIterator<Item = impl ValueView + 'a> {
+    pub fn field_views<'a>(&'a self) -> impl ExactSizeIterator<Item = impl ValueView + 'a> + Clone {
         self.fields.iter()
     }
 }
 
 impl Vector {
     #[allow(clippy::needless_lifetimes)]
-    pub fn elem_views<'a>(&'a self) -> impl ExactSizeIterator<Item = impl ValueView + 'a> {
+    pub fn elem_views<'a>(&'a self) -> impl ExactSizeIterator<Item = impl ValueView + 'a> + Clone {
         struct ElemView<'b> {
             container: &'b Container,
             idx: usize,


### PR DESCRIPTION
This PR makes a few minor improvements to the gas metering system to support more complex use cases such as control flow reconstruction or gas profiling.
- It adds a helper function `SimpleInstruction::to_opcode`
- `load_resource` now passes address & type to the client
- The branch instruction callbacks now pass the target offset to the client
- The iterator arguments in the `GasMeter` callbacks now have the `Clone` bound, allowing clients to go over the items multiple times

The changes have been split into individual commits to make them easy to review.