### PR TITLE
Add graphviz to dev_setup.sh

### DIFF
--- a/scripts/dev_setup.sh
+++ b/scripts/dev_setup.sh
@@ -30,7 +30,7 @@ function usage {
   echo "-b batch mode, no user interactions and minimal output"
   echo "-p update ${HOME}/.profile"
   echo "-t install build tools"
-  echo "-y installs or updates Move prover tools: z3, cvc5, dotnet, boogie"
+  echo "-y installs or updates Move prover tools: z3, cvc5, dotnet, boogie, graphviz"
   echo "-d installs the solidity compiler"
   echo "-g installs Git (required by the Move CLI)"
   echo "-v verbose mode"
@@ -413,6 +413,7 @@ Move prover tools (since -y was provided):
   * cvc5
   * dotnet
   * boogie
+  * graphviz
 EOF
   fi
 
@@ -639,6 +640,7 @@ if [[ "$INSTALL_PROVER" == "true" ]]; then
   install_cvc5
   install_dotnet
   install_boogie
+  install_pkg graphviz "$PACKAGE_MANAGER"
 fi
 
 if [[ "$INSTALL_SOLIDITY" == "true" ]]; then


### PR DESCRIPTION
Updated dev_setup.sh to install graphviz upon the `-y` option

## Motivation

To install `graphviz` together with other Prover depenedency

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

yes

## Test Plan

`./dev_setup -y`