### PR TITLE
[loader] Canonicalize type identity across relinked modules

### DIFF
--- a/language/move-vm/integration-tests/src/tests/loader_tests.rs
+++ b/language/move-vm/integration-tests/src/tests/loader_tests.rs
@@ -100,16 +100,9 @@ impl Adapter {
     }
 
     fn relink(self, context: AccountAddress, linkage: BTreeMap<ModuleId, ModuleId>) -> Self {
-        let config = VMConfig {
-            verifier: VerifierConfig {
-                max_dependency_depth: Some(100),
-                ..Default::default()
-            },
-            ..Default::default()
-        };
         Self {
             store: self.store.relink(context, linkage),
-            vm: Arc::new(MoveVM::new_with_config(vec![], config).unwrap()),
+            vm: self.vm,
             functions: self.functions,
         }
     }

--- a/language/move-vm/integration-tests/src/tests/loader_tests.rs
+++ b/language/move-vm/integration-tests/src/tests/loader_tests.rs
@@ -24,7 +24,7 @@ use move_vm_runtime::{config::VMConfig, move_vm::MoveVM, session::SerializedRetu
 use move_vm_test_utils::InMemoryStorage;
 use move_vm_types::{gas::UnmeteredGasMeter, loaded_data::runtime_types::Type};
 
-use std::{collections::BTreeMap, path::PathBuf, sync::Arc, thread, str::FromStr};
+use std::{collections::BTreeMap, path::PathBuf, str::FromStr, sync::Arc, thread};
 
 const DEFAULT_ACCOUNT: AccountAddress = AccountAddress::TWO;
 const UPGRADE_ACCOUNT: AccountAddress = {
@@ -182,7 +182,9 @@ impl Adapter {
 
     fn load_type(&self, type_tag: &TypeTag) -> Type {
         let session = self.vm.new_session(&self.store);
-        session.load_type(type_tag).expect("Loading type should succeed")
+        session
+            .load_type(type_tag)
+            .expect("Loading type should succeed")
     }
 
     fn call_functions(&self) {

--- a/language/move-vm/integration-tests/src/tests/relinking_tests_b_v1.move
+++ b/language/move-vm/integration-tests/src/tests/relinking_tests_b_v1.move
@@ -1,5 +1,7 @@
 /// Dependencies: [C v0+]
 module 0x2::b {
+    struct S { x: u64 }
+
     public fun b(): u64 {
         0x2::c::c() * 0x2::c::d()
     }

--- a/language/move-vm/integration-tests/src/tests/relinking_tests_c_v0.move
+++ b/language/move-vm/integration-tests/src/tests/relinking_tests_c_v0.move
@@ -1,5 +1,7 @@
 /// Dependencies: []
 module 0x2::c {
+    struct S { x: u64 }
+
     public fun c(): u64 {
         42
     }

--- a/language/move-vm/integration-tests/src/tests/relinking_tests_c_v1.move
+++ b/language/move-vm/integration-tests/src/tests/relinking_tests_c_v1.move
@@ -1,5 +1,7 @@
 /// Dependencies: []
 module 0x2::c {
+    struct S { x: u64 }
+
     public fun c(): u64 {
         43
     }

--- a/language/move-vm/runtime/src/loader.rs
+++ b/language/move-vm/runtime/src/loader.rs
@@ -68,8 +68,10 @@ where
     fn insert(&mut self, key: K, binary: V) -> PartialVMResult<&Arc<V>> {
         let idx = self.binaries.len();
         if self.id_map.insert(key, idx).is_some() {
-            return Err(PartialVMError::new(StatusCode::LINKER_ERROR)
-                .with_message("Duplicate key in loader cache".to_string()));
+            return Err(
+                PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
+                    .with_message("Duplicate key in loader cache".to_string()),
+            );
         };
 
         self.binaries.push(Arc::new(binary));


### PR DESCRIPTION
Store loaded structs in a `BinaryCache` rather than a vector so that we can look them up by their fully qualified runtime ID and name.  This enables us to canonicalize the global struct index we output for a given struct even if it appears as a definition in multiple modules which can happen due to relinking).

For now, the canonical identity of a package references its **runtime ID**, not its defining ID.  This will change in an upcoming PR.

This also simplifies struct resolution by name (which can use this cache directly rather than going via the loaded module cache, which requires access to a link context) and type loading which does not need a special code path for loading types during a module load anymore.

There is some additional complexity in the `reset` operation that must happen if a module load fails, which now needs to clean-up `(Runtime ID, Name) -> Global Index` mappings in the `structs` cache (as well as truncate the list of loaded structs).

## Test Plan

New loader test:

```
$ cargo nextest -- loader_tests::relink_type_identity
```
