### PR TITLE
[loader] "defining module" support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3704,6 +3704,7 @@ name = "move-vm-integration-tests"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "fail",
  "memory-stats",
  "move-binary-format",
  "move-bytecode-verifier",

--- a/language/move-core/types/src/resolver.rs
+++ b/language/move-core/types/src/resolver.rs
@@ -4,6 +4,7 @@
 
 use crate::{
     account_address::AccountAddress,
+    identifier::IdentStr,
     language_storage::{ModuleId, StructTag},
 };
 use std::fmt::Debug;
@@ -26,6 +27,16 @@ pub trait LinkageResolver {
 
     /// Translate the runtime `module_id` to the on-chain `ModuleId` that it should be loaded from.
     fn relocate(&self, module_id: &ModuleId) -> Result<ModuleId, Self::Error> {
+        Ok(module_id.clone())
+    }
+
+    /// Translate the runtime fully-qualified struct name to the on-chain `ModuleId` that originally
+    /// defined that type.
+    fn defining_module(
+        &self,
+        module_id: &ModuleId,
+        _struct: &IdentStr,
+    ) -> Result<ModuleId, Self::Error> {
         Ok(module_id.clone())
     }
 }

--- a/language/move-vm/integration-tests/Cargo.toml
+++ b/language/move-vm/integration-tests/Cargo.toml
@@ -13,6 +13,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.52"
+fail = { version = "0.4.0", features = ['failpoints'] }
 tempfile = "3.2.0"
 memory-stats = "1.0.0"
 

--- a/language/move-vm/integration-tests/src/tests/loader_tests.rs
+++ b/language/move-vm/integration-tests/src/tests/loader_tests.rs
@@ -726,7 +726,10 @@ fn relink_defining_module_cleanup() {
     adapter.publish_modules(b1_modules);
 
     // This call should fail to load the module and rollback cleanly
-    adapter.call_function_with_error(&b0, ident_str!("b"))
+    adapter.call_function_with_error(&b0, ident_str!("b"));
+
+    // Restore old behavior of failpoint
+    fail::cfg("verifier-failpoint-4", "off").unwrap();
 }
 
 #[test]

--- a/language/move-vm/integration-tests/src/tests/relinking_tests_c_v2.move
+++ b/language/move-vm/integration-tests/src/tests/relinking_tests_c_v2.move
@@ -2,12 +2,13 @@
 module 0x2::c {
     struct S { x: u64 }
     struct R { x: u64, y: u64 }
+    struct Q { x: u64, y: u64, z: u64 }
 
     public fun c(): u64 {
-        43
+        45
     }
 
     public fun d(): u64 {
-        44
+        46
     }
 }

--- a/language/move-vm/runtime/src/data_cache.rs
+++ b/language/move-vm/runtime/src/data_cache.rs
@@ -9,7 +9,7 @@ use move_core_types::{
     account_address::AccountAddress,
     effects::{AccountChangeSet, ChangeSet, Event, Op},
     gas_algebra::NumBytes,
-    identifier::Identifier,
+    identifier::{IdentStr, Identifier},
     language_storage::{ModuleId, TypeTag},
     resolver::MoveResolver,
     value::MoveTypeLayout,
@@ -235,6 +235,20 @@ impl<'r, 'l, S: MoveResolver> DataStore for TransactionDataCache<'r, 'l, S> {
             PartialVMError::new(StatusCode::LINKER_ERROR)
                 .with_message(format!("Error relocating {module_id}: {err:?}"))
         })
+    }
+
+    fn defining_module(
+        &self,
+        module_id: &ModuleId,
+        struct_: &IdentStr,
+    ) -> PartialVMResult<ModuleId> {
+        self.remote
+            .defining_module(module_id, struct_)
+            .map_err(|err| {
+                PartialVMError::new(StatusCode::LINKER_ERROR).with_message(format!(
+                    "Error finding defining module for {module_id}::{struct_}: {err:?}"
+                ))
+            })
     }
 
     fn load_module(&self, module_id: &ModuleId) -> VMResult<Vec<u8>> {

--- a/language/move-vm/types/src/data_store.rs
+++ b/language/move-vm/types/src/data_store.rs
@@ -8,8 +8,8 @@ use crate::{
 };
 use move_binary_format::errors::{PartialVMResult, VMResult};
 use move_core_types::{
-    account_address::AccountAddress, gas_algebra::NumBytes, language_storage::ModuleId,
-    value::MoveTypeLayout,
+    account_address::AccountAddress, gas_algebra::NumBytes, identifier::IdentStr,
+    language_storage::ModuleId, value::MoveTypeLayout,
 };
 
 /// Provide an implementation for bytecodes related to data with a given data store.
@@ -39,6 +39,14 @@ pub trait DataStore {
 
     /// Translate the runtime `module_id` to the on-chain `ModuleId` that it should be loaded from.
     fn relocate(&self, module_id: &ModuleId) -> PartialVMResult<ModuleId>;
+
+    /// Translate the runtime fully-qualified struct name to the on-chain `ModuleId` that originally
+    /// defined that type.
+    fn defining_module(
+        &self,
+        module_id: &ModuleId,
+        struct_: &IdentStr,
+    ) -> PartialVMResult<ModuleId>;
 
     /// Get the serialized format of a `CompiledModule` given a `ModuleId`.
     fn load_module(&self, module_id: &ModuleId) -> VMResult<Vec<u8>>;

--- a/language/move-vm/types/src/loaded_data/runtime_types.rs
+++ b/language/move-vm/types/src/loaded_data/runtime_types.rs
@@ -20,7 +20,8 @@ pub struct StructType {
     pub abilities: AbilitySet,
     pub type_parameters: Vec<StructTypeParameter>,
     pub name: Identifier,
-    pub module: ModuleId,
+    pub defining_id: ModuleId,
+    pub runtime_id: ModuleId,
     pub struct_def: StructDefinitionIndex,
 }
 


### PR DESCRIPTION
Add a new API to `LinkageResolver` to translate the fully-qualified name of a struct (including its runtime ID) to the defining ID (the ID of the package in storage that first defined the struct).

Use this API to store the defining ID as well as the runtime ID in the loaded `StructType`. (Note: This results in a situation where you can load a type from a type tag, get the type tag for that type and have that operation not be the identity, because it has translated the struct's runtime package ID to its defining package ID).

## Test Plan

New loader unit tests:

```
$ cargo nextest -- loader_tests::relink_defining_module
```
