### PR TITLE
[lock] BuildConfig::install_dir configures temporary lock file directory

### DIFF
--- a/language/tools/move-package/src/lib.rs
+++ b/language/tools/move-package/src/lib.rs
@@ -231,9 +231,10 @@ impl BuildConfig {
 
         let mut dependency_cache = DependencyCache::new(self.skip_fetch_latest_git_deps);
         let dependency_graph =
-            DependencyGraph::new(&manifest, path, &mut dependency_cache, writer)?;
+            DependencyGraph::new(&manifest, path.clone(), &mut dependency_cache, writer)?;
 
-        let lock = dependency_graph.write_to_lock()?;
+        let install_dir = self.install_dir.as_ref().unwrap_or(&path).to_owned();
+        let lock = dependency_graph.write_to_lock(install_dir)?;
         if let Some(lock_path) = &self.lock_file {
             lock.commit(lock_path)?;
         }

--- a/language/tools/move-package/src/resolution/dependency_graph.rs
+++ b/language/tools/move-package/src/resolution/dependency_graph.rs
@@ -327,8 +327,8 @@ impl DependencyGraph {
     ///
     /// This operation fails, writing nothing, if the graph contains a cycle, and can fail with an
     /// undefined output if it cannot be represented in a TOML file.
-    pub fn write_to_lock(&self) -> Result<LockFile> {
-        let lock = LockFile::new(&self.root_path)?;
+    pub fn write_to_lock(&self, install_dir: PathBuf) -> Result<LockFile> {
+        let lock = LockFile::new(install_dir)?;
         let mut writer = BufWriter::new(&*lock);
 
         self.write_dependencies_to_lock(self.root_package, &mut writer)?;

--- a/language/tools/move-package/tests/test_dependency_graph.rs
+++ b/language/tools/move-package/tests/test_dependency_graph.rs
@@ -78,7 +78,9 @@ fn lock_file_roundtrip() {
     )
     .expect("Reading DependencyGraph");
 
-    let lock = graph.write_to_lock().expect("Writing DependencyGraph");
+    let lock = graph
+        .write_to_lock(tmp.path().to_path_buf())
+        .expect("Writing DependencyGraph");
 
     lock.commit(&commit).expect("Committing lock file");
 
@@ -97,7 +99,7 @@ fn lock_file_missing_dependency() {
     let pkg = one_dep_test_package();
 
     let commit = tmp.path().join("Move.lock");
-    let lock = LockFile::new(&pkg).expect("Creating new lock file");
+    let lock = LockFile::new(pkg.clone()).expect("Creating new lock file");
 
     // Write a reference to a dependency that there isn't package information for.
     writeln!(&*lock, r#"dependencies = [{{ name = "OtherDep" }}]"#).unwrap();

--- a/language/tools/move-package/tests/test_lock_file.rs
+++ b/language/tools/move-package/tests/test_lock_file.rs
@@ -16,7 +16,7 @@ fn commit() {
     let lock_path = pkg.path().join("Move.lock");
 
     {
-        let mut lock = LockFile::new(pkg.path()).unwrap();
+        let mut lock = LockFile::new(pkg.path().to_path_buf()).unwrap();
         writeln!(lock, "# Write and commit").unwrap();
         lock.commit(&lock_path).unwrap();
     }
@@ -44,7 +44,7 @@ fn discard() {
     let pkg = create_test_package().unwrap();
 
     {
-        let mut lock = LockFile::new(pkg.path()).unwrap();
+        let mut lock = LockFile::new(pkg.path().to_path_buf()).unwrap();
         writeln!(lock, "# Write but don't commit").unwrap();
     }
 


### PR DESCRIPTION
Previously, temporary lock files were always stored in a sub-directory of the package root because `LockFile` assumed that the `build` directory was always there, while the lock file itself could be committed elsewhere.

But the location of `/build/` is controlled by
`BuildConfig::install_dir` so we should heed that as well when finding where to store the temporary lock file.

## Test Plan

Existing tests:

```
cargo nextest
```