### PR TITLE
[session] Accept MoveResolver by value

### DIFF
--- a/language/extensions/async/move-async-vm/src/async_vm.rs
+++ b/language/extensions/async/move-async-vm/src/async_vm.rs
@@ -222,7 +222,7 @@ impl<'r, 'l, S: MoveResolver> AsyncSession<'r, 'l, S> {
                     mutable_reference_outputs: _,
                     mut return_values,
                 },
-                (mut change_set, events, mut native_extensions),
+                (mut change_set, events, _, mut native_extensions),
             )) => {
                 if return_values.len() != 1 {
                     Err(async_extension_error(format!(
@@ -315,7 +315,7 @@ impl<'r, 'l, S: MoveResolver> AsyncSession<'r, 'l, S> {
                     mut mutable_reference_outputs,
                     return_values: _,
                 },
-                (mut change_set, events, mut native_extensions),
+                (mut change_set, events, _, mut native_extensions),
             )) => {
                 if mutable_reference_outputs.len() > 1 {
                     Err(async_extension_error(format!(

--- a/language/extensions/async/move-async-vm/src/async_vm.rs
+++ b/language/extensions/async/move-async-vm/src/async_vm.rs
@@ -211,7 +211,7 @@ impl<'r, 'l, S: MoveResolver> AsyncSession<'r, 'l, S> {
                 Vec::<Vec<u8>>::new(),
                 gas_status,
             )
-            .and_then(|ret| Ok((ret, self.vm_session.finish_with_extensions()?)));
+            .and_then(|ret| Ok((ret, self.vm_session.finish_with_extensions().0?)));
         let gas_used = gas_before.checked_sub(gas_status.remaining_gas()).unwrap();
 
         // Process the result, moving the return value of the initializer function into the
@@ -222,7 +222,7 @@ impl<'r, 'l, S: MoveResolver> AsyncSession<'r, 'l, S> {
                     mutable_reference_outputs: _,
                     mut return_values,
                 },
-                (mut change_set, events, _, mut native_extensions),
+                (mut change_set, events, mut native_extensions),
             )) => {
                 if return_values.len() != 1 {
                     Err(async_extension_error(format!(
@@ -303,7 +303,7 @@ impl<'r, 'l, S: MoveResolver> AsyncSession<'r, 'l, S> {
         let result = self
             .vm_session
             .execute_function_bypass_visibility(module_id, handler_id, vec![], args, gas_status)
-            .and_then(|ret| Ok((ret, self.vm_session.finish_with_extensions()?)));
+            .and_then(|ret| Ok((ret, self.vm_session.finish_with_extensions().0?)));
 
         let gas_used = gas_before.checked_sub(gas_status.remaining_gas()).unwrap();
 
@@ -315,7 +315,7 @@ impl<'r, 'l, S: MoveResolver> AsyncSession<'r, 'l, S> {
                     mut mutable_reference_outputs,
                     return_values: _,
                 },
-                (mut change_set, events, _, mut native_extensions),
+                (mut change_set, events, mut native_extensions),
             )) => {
                 if mutable_reference_outputs.len() > 1 {
                     Err(async_extension_error(format!(

--- a/language/extensions/async/move-async-vm/src/async_vm.rs
+++ b/language/extensions/async/move-async-vm/src/async_vm.rs
@@ -83,7 +83,7 @@ impl AsyncVM {
         &'l self,
         for_actor: AccountAddress,
         virtual_time: u128,
-        move_resolver: &'r mut S,
+        move_resolver: S,
     ) -> AsyncSession<'r, 'l, S> {
         self.new_session_with_extensions(
             for_actor,
@@ -98,7 +98,7 @@ impl AsyncVM {
         &'l self,
         for_actor: AccountAddress,
         virtual_time: u128,
-        move_resolver: &'r mut S,
+        move_resolver: S,
         ext: NativeContextExtensions<'r>,
     ) -> AsyncSession<'r, 'l, S> {
         let extensions = make_extensions(ext, for_actor, virtual_time, true);

--- a/language/extensions/async/move-async-vm/tests/testsuite.rs
+++ b/language/extensions/async/move-async-vm/tests/testsuite.rs
@@ -84,8 +84,8 @@ impl Harness {
         let mut gas = GasStatus::new_unmetered();
         let mut tick = 0;
         // Publish modules.
-        let mut proxy = HarnessProxy { harness: self };
-        let mut session = self.vm.new_session(test_account(), 0, &mut proxy);
+        let proxy = HarnessProxy { harness: self };
+        let mut session = self.vm.new_session(test_account(), 0, &proxy);
         let mut done = BTreeSet::new();
         for id in self.module_cache.keys() {
             self.publish_module(&mut session, id, &mut gas, &mut done)?;
@@ -99,8 +99,8 @@ impl Harness {
                 actor.short_str_lossless()
             ));
             {
-                let mut proxy = HarnessProxy { harness: self };
-                let session = self.vm.new_session(addr, 0, &mut proxy);
+                let proxy = HarnessProxy { harness: self };
+                let session = self.vm.new_session(addr, 0, &proxy);
                 let result = session.new_actor(&actor, addr, &mut gas);
                 self.handle_result(&mut mailbox, result);
             };
@@ -130,8 +130,8 @@ impl Harness {
                 ))
             }
             // Handling
-            let mut proxy = HarnessProxy { harness: self };
-            let session = self.vm.new_session(actor, tick, &mut proxy);
+            let proxy = HarnessProxy { harness: self };
+            let session = self.vm.new_session(actor, tick, &proxy);
             tick += 1000_1000; // micros
             let result = session.handle_message(actor, message_hash, args, &mut gas);
             self.handle_result(&mut mailbox, result);
@@ -141,7 +141,7 @@ impl Harness {
 
     fn publish_module(
         &self,
-        session: &mut AsyncSession<HarnessProxy>,
+        session: &mut AsyncSession<&HarnessProxy>,
         id: &IdentStr,
         gas: &mut GasStatus,
         done: &mut BTreeSet<Identifier>,

--- a/language/move-core/types/src/resolver.rs
+++ b/language/move-core/types/src/resolver.rs
@@ -113,3 +113,23 @@ impl<T: ModuleResolver + ?Sized> ModuleResolver for &T {
         (**self).get_module(module_id)
     }
 }
+
+impl<T: LinkageResolver + ?Sized> LinkageResolver for &T {
+    type Error = T::Error;
+
+    fn link_context(&self) -> AccountAddress {
+        (**self).link_context()
+    }
+
+    fn relocate(&self, module_id: &ModuleId) -> Result<ModuleId, Self::Error> {
+        (**self).relocate(module_id)
+    }
+
+    fn defining_module(
+        &self,
+        module_id: &ModuleId,
+        struct_: &IdentStr,
+    ) -> Result<ModuleId, Self::Error> {
+        (**self).defining_module(module_id, struct_)
+    }
+}

--- a/language/move-vm/integration-tests/src/tests/bad_storage_tests.rs
+++ b/language/move-vm/integration-tests/src/tests/bad_storage_tests.rs
@@ -102,7 +102,7 @@ fn test_malformed_resource() {
     )
     .map(|_| ())
     .unwrap();
-    let (changeset, _) = sess.finish().unwrap();
+    let (changeset, _, _) = sess.finish().unwrap();
     storage.apply(changeset).unwrap();
 
     // Execut the second script and make sure it succeeds. This script simply checks

--- a/language/move-vm/integration-tests/src/tests/bad_storage_tests.rs
+++ b/language/move-vm/integration-tests/src/tests/bad_storage_tests.rs
@@ -102,7 +102,7 @@ fn test_malformed_resource() {
     )
     .map(|_| ())
     .unwrap();
-    let (changeset, _, _) = sess.finish().unwrap();
+    let (changeset, _) = sess.finish().0.unwrap();
     storage.apply(changeset).unwrap();
 
     // Execut the second script and make sure it succeeds. This script simply checks

--- a/language/move-vm/integration-tests/src/tests/exec_func_effects_tests.rs
+++ b/language/move-vm/integration-tests/src/tests/exec_func_effects_tests.rs
@@ -103,7 +103,7 @@ fn run(
             &mut UnmeteredGasMeter,
         )
         .and_then(|ret_values| {
-            let (change_set, events, _) = session.finish()?;
+            let (change_set, events) = session.finish().0?;
             Ok((change_set, events, ret_values))
         })
 }

--- a/language/move-vm/integration-tests/src/tests/exec_func_effects_tests.rs
+++ b/language/move-vm/integration-tests/src/tests/exec_func_effects_tests.rs
@@ -103,7 +103,7 @@ fn run(
             &mut UnmeteredGasMeter,
         )
         .and_then(|ret_values| {
-            let (change_set, events) = session.finish()?;
+            let (change_set, events, _) = session.finish()?;
             Ok((change_set, events, ret_values))
         })
 }

--- a/language/move-vm/integration-tests/src/tests/instantiation_tests.rs
+++ b/language/move-vm/integration-tests/src/tests/instantiation_tests.rs
@@ -192,7 +192,7 @@ fn test_runner(
     test_name: &str,
     entry_spec: fn(
         AccountAddress,
-        &mut Session<InMemoryStorage>,
+        &mut Session<&'_ InMemoryStorage>,
     ) -> (ModuleId, Identifier, Vec<TypeTag>),
     check_result: fn(u128, u128) -> bool,
 ) {
@@ -377,7 +377,7 @@ fn test_instantiation_deep_rec_gen_call() {
 //
 // Notice: this is not a particularly easy function to use. See example below on how to use it.
 fn make_module(
-    session: &mut Session<InMemoryStorage>,
+    session: &mut Session<&'_ InMemoryStorage>,
     addr: AccountAddress,
     func_type_params_count: usize,
     locals_sig: Option<Signature>,
@@ -597,7 +597,7 @@ fn run_with_module(
     gas: &mut GasStatus,
     entry_spec: fn(
         AccountAddress,
-        &mut Session<InMemoryStorage>,
+        &mut Session<&'_ InMemoryStorage>,
     ) -> (ModuleId, Identifier, Vec<TypeTag>),
 ) -> (VMResult<SerializedReturnValues>, u128) {
     let addr = AccountAddress::from_hex_literal("0xcafe").unwrap();
@@ -626,7 +626,7 @@ fn run_with_module(
 // Call a simple load u8 and pop loop
 fn load_pop(
     addr: AccountAddress,
-    session: &mut Session<InMemoryStorage>,
+    session: &mut Session<&'_ InMemoryStorage>,
 ) -> (ModuleId, Identifier, Vec<TypeTag>) {
     //
     // Module definition and publishing
@@ -667,7 +667,7 @@ fn get_load_pop() -> Vec<Bytecode> {
 // Call a vector<T> pack empty and pop with full instantiation
 fn vec_pack_instantiated(
     addr: AccountAddress,
-    session: &mut Session<InMemoryStorage>,
+    session: &mut Session<&'_ InMemoryStorage>,
 ) -> (ModuleId, Identifier, Vec<TypeTag>) {
     //
     // Module definition and publishing
@@ -703,7 +703,7 @@ fn vec_pack_instantiated(
 // Call a vector<T> pack empty and pop with simple generic instantiation
 fn vec_pack_gen_simple(
     addr: AccountAddress,
-    session: &mut Session<InMemoryStorage>,
+    session: &mut Session<&'_ InMemoryStorage>,
 ) -> (ModuleId, Identifier, Vec<TypeTag>) {
     //
     // Module definition and publishing
@@ -739,28 +739,28 @@ fn vec_pack_gen_simple(
 // Call a vector<T> pack empty and pop with deep generic instantiation
 fn vec_pack_gen_deep(
     addr: AccountAddress,
-    session: &mut Session<InMemoryStorage>,
+    session: &mut Session<&'_ InMemoryStorage>,
 ) -> (ModuleId, Identifier, Vec<TypeTag>) {
     vec_pack_gen_deep_it(addr, session, 1)
 }
 
 fn vec_pack_gen_deep_50(
     addr: AccountAddress,
-    session: &mut Session<InMemoryStorage>,
+    session: &mut Session<&'_ InMemoryStorage>,
 ) -> (ModuleId, Identifier, Vec<TypeTag>) {
     vec_pack_gen_deep_it(addr, session, 50)
 }
 
 fn vec_pack_gen_deep_500(
     addr: AccountAddress,
-    session: &mut Session<InMemoryStorage>,
+    session: &mut Session<&'_ InMemoryStorage>,
 ) -> (ModuleId, Identifier, Vec<TypeTag>) {
     vec_pack_gen_deep_it(addr, session, 500)
 }
 
 fn vec_pack_gen_deep_it(
     addr: AccountAddress,
-    session: &mut Session<InMemoryStorage>,
+    session: &mut Session<&'_ InMemoryStorage>,
     snippet_rep: usize,
 ) -> (ModuleId, Identifier, Vec<TypeTag>) {
     const STRUCT_TY_PARAMS: usize = 3;
@@ -824,7 +824,7 @@ fn get_vec_pack(idx: u16) -> Vec<Bytecode> {
 // Call `Exists` on an instantiated generic and pop
 fn instantiated_gen_exists(
     addr: AccountAddress,
-    session: &mut Session<InMemoryStorage>,
+    session: &mut Session<&'_ InMemoryStorage>,
 ) -> (ModuleId, Identifier, Vec<TypeTag>) {
     //
     // Module definition and publishing
@@ -860,7 +860,7 @@ fn instantiated_gen_exists(
 // Call `Exists` on a simple generic and pop
 fn simple_gen_exists(
     addr: AccountAddress,
-    session: &mut Session<InMemoryStorage>,
+    session: &mut Session<&'_ InMemoryStorage>,
 ) -> (ModuleId, Identifier, Vec<TypeTag>) {
     //
     // Module definition and publishing
@@ -899,28 +899,28 @@ fn simple_gen_exists(
 // Call `Exists` on a deep generic and pop
 fn deep_gen_exists(
     addr: AccountAddress,
-    session: &mut Session<InMemoryStorage>,
+    session: &mut Session<&'_ InMemoryStorage>,
 ) -> (ModuleId, Identifier, Vec<TypeTag>) {
     deep_gen_exists_it(addr, session, 1)
 }
 
 fn deep_gen_exists_50(
     addr: AccountAddress,
-    session: &mut Session<InMemoryStorage>,
+    session: &mut Session<&'_ InMemoryStorage>,
 ) -> (ModuleId, Identifier, Vec<TypeTag>) {
     deep_gen_exists_it(addr, session, 50)
 }
 
 fn deep_gen_exists_500(
     addr: AccountAddress,
-    session: &mut Session<InMemoryStorage>,
+    session: &mut Session<&'_ InMemoryStorage>,
 ) -> (ModuleId, Identifier, Vec<TypeTag>) {
     deep_gen_exists_it(addr, session, 500)
 }
 
 fn deep_gen_exists_it(
     addr: AccountAddress,
-    session: &mut Session<InMemoryStorage>,
+    session: &mut Session<&'_ InMemoryStorage>,
     snippet_rep: usize,
 ) -> (ModuleId, Identifier, Vec<TypeTag>) {
     const STRUCT_TY_PARAMS: usize = 3;
@@ -988,7 +988,7 @@ fn get_generic_exists() -> Vec<Bytecode> {
 // Call an instantiated generic function
 fn instantiated_gen_call(
     addr: AccountAddress,
-    session: &mut Session<InMemoryStorage>,
+    session: &mut Session<&'_ InMemoryStorage>,
 ) -> (ModuleId, Identifier, Vec<TypeTag>) {
     //
     // Module definition and publishing
@@ -1024,7 +1024,7 @@ fn instantiated_gen_call(
 // Call simple generic function
 fn simple_gen_call(
     addr: AccountAddress,
-    session: &mut Session<InMemoryStorage>,
+    session: &mut Session<&'_ InMemoryStorage>,
 ) -> (ModuleId, Identifier, Vec<TypeTag>) {
     //
     // Module definition and publishing
@@ -1060,28 +1060,28 @@ fn simple_gen_call(
 // Call deep instantiation generic function
 fn deep_gen_call(
     addr: AccountAddress,
-    session: &mut Session<InMemoryStorage>,
+    session: &mut Session<&'_ InMemoryStorage>,
 ) -> (ModuleId, Identifier, Vec<TypeTag>) {
     deep_gen_call_it(addr, session, 1)
 }
 
 fn deep_gen_call_50(
     addr: AccountAddress,
-    session: &mut Session<InMemoryStorage>,
+    session: &mut Session<&'_ InMemoryStorage>,
 ) -> (ModuleId, Identifier, Vec<TypeTag>) {
     deep_gen_call_it(addr, session, 50)
 }
 
 fn deep_gen_call_500(
     addr: AccountAddress,
-    session: &mut Session<InMemoryStorage>,
+    session: &mut Session<&'_ InMemoryStorage>,
 ) -> (ModuleId, Identifier, Vec<TypeTag>) {
     deep_gen_call_it(addr, session, 500)
 }
 
 fn deep_gen_call_it(
     addr: AccountAddress,
-    session: &mut Session<InMemoryStorage>,
+    session: &mut Session<&'_ InMemoryStorage>,
     snippet_rep: usize,
 ) -> (ModuleId, Identifier, Vec<TypeTag>) {
     const STRUCT_TY_PARAMS: usize = 3;
@@ -1145,7 +1145,7 @@ fn get_generic_call_loop() -> Vec<Bytecode> {
 // Call an instantiated generic function
 fn instantiated_rec_gen_call(
     addr: AccountAddress,
-    session: &mut Session<InMemoryStorage>,
+    session: &mut Session<&'_ InMemoryStorage>,
 ) -> (ModuleId, Identifier, Vec<TypeTag>) {
     //
     // Module definition and publishing
@@ -1181,7 +1181,7 @@ fn instantiated_rec_gen_call(
 // Call simple generic function
 fn simple_rec_gen_call(
     addr: AccountAddress,
-    session: &mut Session<InMemoryStorage>,
+    session: &mut Session<&'_ InMemoryStorage>,
 ) -> (ModuleId, Identifier, Vec<TypeTag>) {
     //
     // Module definition and publishing
@@ -1217,7 +1217,7 @@ fn simple_rec_gen_call(
 // Call deep instantiation generic function
 fn deep_rec_gen_call(
     addr: AccountAddress,
-    session: &mut Session<InMemoryStorage>,
+    session: &mut Session<&'_ InMemoryStorage>,
 ) -> (ModuleId, Identifier, Vec<TypeTag>) {
     const STRUCT_TY_PARAMS: usize = 3;
     const STRUCT_TY_ARGS_DEPTH: usize = 2;

--- a/language/move-vm/integration-tests/src/tests/loader_tests.rs
+++ b/language/move-vm/integration-tests/src/tests/loader_tests.rs
@@ -133,7 +133,7 @@ impl Adapter {
                 .publish_module(binary, DEFAULT_ACCOUNT, &mut UnmeteredGasMeter)
                 .unwrap_or_else(|e| panic!("failure publishing module: {e:?}\n{:#?}", module));
         }
-        let (changeset, _, _) = session.finish().expect("failure getting write set");
+        let (changeset, _) = session.finish().0.expect("failure getting write set");
         self.store
             .apply(changeset)
             .expect("failure applying write set");
@@ -170,7 +170,7 @@ impl Adapter {
             .publish_module_bundle(binaries, DEFAULT_ACCOUNT, &mut UnmeteredGasMeter)
             .unwrap_or_else(|e| panic!("failure publishing module bundle: {e:?}"));
 
-        let (changeset, _, _) = session.finish().expect("failure getting write set");
+        let (changeset, _) = session.finish().0.expect("failure getting write set");
         self.store
             .apply(changeset)
             .expect("failure applying write set");

--- a/language/move-vm/integration-tests/src/tests/loader_tests.rs
+++ b/language/move-vm/integration-tests/src/tests/loader_tests.rs
@@ -133,7 +133,7 @@ impl Adapter {
                 .publish_module(binary, DEFAULT_ACCOUNT, &mut UnmeteredGasMeter)
                 .unwrap_or_else(|e| panic!("failure publishing module: {e:?}\n{:#?}", module));
         }
-        let (changeset, _) = session.finish().expect("failure getting write set");
+        let (changeset, _, _) = session.finish().expect("failure getting write set");
         self.store
             .apply(changeset)
             .expect("failure applying write set");
@@ -170,7 +170,7 @@ impl Adapter {
             .publish_module_bundle(binaries, DEFAULT_ACCOUNT, &mut UnmeteredGasMeter)
             .unwrap_or_else(|e| panic!("failure publishing module bundle: {e:?}"));
 
-        let (changeset, _) = session.finish().expect("failure getting write set");
+        let (changeset, _, _) = session.finish().expect("failure getting write set");
         self.store
             .apply(changeset)
             .expect("failure applying write set");

--- a/language/move-vm/integration-tests/src/tests/mutated_accounts_tests.rs
+++ b/language/move-vm/integration-tests/src/tests/mutated_accounts_tests.rs
@@ -87,7 +87,7 @@ fn mutated_accounts() {
     .unwrap();
     assert_eq!(sess.num_mutated_accounts(&TEST_ADDR), 2);
 
-    let (changes, _, _) = sess.finish().unwrap();
+    let (changes, _) = sess.finish().0.unwrap();
     storage.apply(changes).unwrap();
 
     let mut sess = vm.new_session(&storage);

--- a/language/move-vm/integration-tests/src/tests/mutated_accounts_tests.rs
+++ b/language/move-vm/integration-tests/src/tests/mutated_accounts_tests.rs
@@ -87,7 +87,7 @@ fn mutated_accounts() {
     .unwrap();
     assert_eq!(sess.num_mutated_accounts(&TEST_ADDR), 2);
 
-    let (changes, _) = sess.finish().unwrap();
+    let (changes, _, _) = sess.finish().unwrap();
     storage.apply(changes).unwrap();
 
     let mut sess = vm.new_session(&storage);

--- a/language/move-vm/runtime/src/data_cache.rs
+++ b/language/move-vm/runtime/src/data_cache.rs
@@ -149,6 +149,10 @@ impl<'l, S: MoveResolver> TransactionDataCache<'l, S> {
     pub(crate) fn get_remote_resolver(&self) -> &S {
         &self.remote
     }
+
+    pub(crate) fn get_remote_resolver_mut(&mut self) -> &mut S {
+        &mut self.remote
+    }
 }
 
 // `DataStore` implementation for the `TransactionDataCache`

--- a/language/move-vm/runtime/src/data_cache.rs
+++ b/language/move-vm/runtime/src/data_cache.rs
@@ -49,17 +49,17 @@ impl AccountDataCache {
 /// The Move VM takes a `DataStore` in input and this is the default and correct implementation
 /// for a data store related to a transaction. Clients should create an instance of this type
 /// and pass it to the Move VM.
-pub(crate) struct TransactionDataCache<'r, 'l, S> {
-    remote: &'r S,
+pub(crate) struct TransactionDataCache<'l, S> {
+    remote: S,
     loader: &'l Loader,
     account_map: BTreeMap<AccountAddress, AccountDataCache>,
     event_data: Vec<(Vec<u8>, u64, Type, MoveTypeLayout, Value)>,
 }
 
-impl<'r, 'l, S: MoveResolver> TransactionDataCache<'r, 'l, S> {
+impl<'l, S: MoveResolver> TransactionDataCache<'l, S> {
     /// Create a `TransactionDataCache` with a `RemoteCache` that provides access to data
     /// not updated in the transaction.
-    pub(crate) fn new(remote: &'r S, loader: &'l Loader) -> Self {
+    pub(crate) fn new(remote: S, loader: &'l Loader) -> Self {
         TransactionDataCache {
             remote,
             loader,
@@ -157,7 +157,7 @@ impl<'r, 'l, S: MoveResolver> TransactionDataCache<'r, 'l, S> {
 }
 
 // `DataStore` implementation for the `TransactionDataCache`
-impl<'r, 'l, S: MoveResolver> DataStore for TransactionDataCache<'r, 'l, S> {
+impl<'l, S: MoveResolver> DataStore for TransactionDataCache<'l, S> {
     // Retrieve data from the local cache or loads it from the remote cache into the local cache.
     // All operations on the global data are based on this API and they all load the data
     // into the cache.

--- a/language/move-vm/runtime/src/data_cache.rs
+++ b/language/move-vm/runtime/src/data_cache.rs
@@ -72,7 +72,7 @@ impl<'l, S: MoveResolver> TransactionDataCache<'l, S> {
     /// published modules.
     ///
     /// Gives all proper guarantees on lifetime of global data as well.
-    pub(crate) fn into_effects(self) -> PartialVMResult<(ChangeSet, Vec<Event>)> {
+    pub(crate) fn into_effects(self) -> PartialVMResult<(ChangeSet, Vec<Event>, S)> {
         let mut change_set = ChangeSet::new();
         for (addr, account_data_cache) in self.account_map.into_iter() {
             let mut modules = BTreeMap::new();
@@ -129,7 +129,7 @@ impl<'l, S: MoveResolver> TransactionDataCache<'l, S> {
             events.push((guid, seq_num, ty_tag, blob))
         }
 
-        Ok((change_set, events))
+        Ok((change_set, events, self.remote))
     }
 
     pub(crate) fn num_mutated_accounts(&self, sender: &AccountAddress) -> u64 {

--- a/language/move-vm/runtime/src/move_vm.rs
+++ b/language/move-vm/runtime/src/move_vm.rs
@@ -52,24 +52,24 @@ impl MoveVM {
     ///     cases where this may not be necessary, with the most notable one being the common module
     ///     publishing flow: you can keep using the same Move VM if you publish some modules in a Session
     ///     and apply the effects to the storage when the Session ends.
-    pub fn new_session<'r, S: MoveResolver>(&self, remote: &'r S) -> Session<'r, '_, S> {
+    pub fn new_session<'r, S: MoveResolver>(&self, remote: S) -> Session<'r, '_, S> {
         self.runtime.new_session(remote)
     }
 
     /// Create a new session, as in `new_session`, but provide native context extensions.
     pub fn new_session_with_extensions<'r, S: MoveResolver>(
         &self,
-        remote: &'r S,
+        remote: S,
         extensions: NativeContextExtensions<'r>,
     ) -> Session<'r, '_, S> {
         self.runtime.new_session_with_extensions(remote, extensions)
     }
 
     /// Load a module into VM's code cache
-    pub fn load_module<'r, S: MoveResolver>(
+    pub fn load_module<S: MoveResolver>(
         &self,
         module_id: &ModuleId,
-        remote: &'r S,
+        remote: S,
     ) -> VMResult<Arc<CompiledModule>> {
         self.runtime
             .loader()

--- a/language/move-vm/runtime/src/runtime.rs
+++ b/language/move-vm/runtime/src/runtime.rs
@@ -50,13 +50,13 @@ impl VMRuntime {
         })
     }
 
-    pub fn new_session<'r, S: MoveResolver>(&self, remote: &'r S) -> Session<'r, '_, S> {
+    pub fn new_session<'r, S: MoveResolver>(&self, remote: S) -> Session<'r, '_, S> {
         self.new_session_with_extensions(remote, NativeContextExtensions::default())
     }
 
     pub fn new_session_with_extensions<'r, S: MoveResolver>(
         &self,
-        remote: &'r S,
+        remote: S,
         native_extensions: NativeContextExtensions<'r>,
     ) -> Session<'r, '_, S> {
         Session {

--- a/language/move-vm/runtime/src/session.rs
+++ b/language/move-vm/runtime/src/session.rs
@@ -195,25 +195,29 @@ impl<'r, 'l, S: MoveResolver> Session<'r, 'l, S> {
     /// This function should always succeed with no user errors returned, barring invariant violations.
     ///
     /// This MUST NOT be called if there is a previous invocation that failed with an invariant violation.
-    pub fn finish(self) -> VMResult<(ChangeSet, Vec<Event>, S)> {
-        self.data_cache
-            .into_effects()
-            .map_err(|e| e.finish(Location::Undefined))
+    pub fn finish(self) -> (VMResult<(ChangeSet, Vec<Event>)>, S) {
+        let (res, remote) = self.data_cache.into_effects();
+        (res.map_err(|e| e.finish(Location::Undefined)), remote)
     }
 
     /// Same like `finish`, but also extracts the native context extensions from the session.
     pub fn finish_with_extensions(
         self,
-    ) -> VMResult<(ChangeSet, Vec<Event>, S, NativeContextExtensions<'r>)> {
+    ) -> (
+        VMResult<(ChangeSet, Vec<Event>, NativeContextExtensions<'r>)>,
+        S,
+    ) {
         let Session {
             data_cache,
             native_extensions,
             ..
         } = self;
-        let (change_set, events, remote) = data_cache
-            .into_effects()
-            .map_err(|e| e.finish(Location::Undefined))?;
-        Ok((change_set, events, remote, native_extensions))
+        let (res, remote) = data_cache.into_effects();
+        (
+            res.map(|(change_set, events)| (change_set, events, native_extensions))
+                .map_err(|e| e.finish(Location::Undefined)),
+            remote,
+        )
     }
 
     /// Load a script and all of its types into cache

--- a/language/move-vm/runtime/src/session.rs
+++ b/language/move-vm/runtime/src/session.rs
@@ -286,6 +286,11 @@ impl<'r, 'l, S: MoveResolver> Session<'r, 'l, S> {
             .map_err(|e| e.finish(Location::Undefined))
     }
 
+    /// Gets the remote resolver used by the data store
+    pub fn get_resolver(&self) -> &S {
+        self.data_cache.get_remote_resolver()
+    }
+
     /// Gets the underlying data store
     pub fn get_data_store(&mut self) -> &mut dyn DataStore {
         &mut self.data_cache

--- a/language/move-vm/runtime/src/session.rs
+++ b/language/move-vm/runtime/src/session.rs
@@ -27,7 +27,7 @@ use std::{borrow::Borrow, sync::Arc};
 
 pub struct Session<'r, 'l, S> {
     pub(crate) runtime: &'l VMRuntime,
-    pub(crate) data_cache: TransactionDataCache<'r, 'l, S>,
+    pub(crate) data_cache: TransactionDataCache<'l, S>,
     pub(crate) native_extensions: NativeContextExtensions<'r>,
 }
 

--- a/language/move-vm/runtime/src/session.rs
+++ b/language/move-vm/runtime/src/session.rs
@@ -195,7 +195,7 @@ impl<'r, 'l, S: MoveResolver> Session<'r, 'l, S> {
     /// This function should always succeed with no user errors returned, barring invariant violations.
     ///
     /// This MUST NOT be called if there is a previous invocation that failed with an invariant violation.
-    pub fn finish(self) -> VMResult<(ChangeSet, Vec<Event>)> {
+    pub fn finish(self) -> VMResult<(ChangeSet, Vec<Event>, S)> {
         self.data_cache
             .into_effects()
             .map_err(|e| e.finish(Location::Undefined))
@@ -204,16 +204,16 @@ impl<'r, 'l, S: MoveResolver> Session<'r, 'l, S> {
     /// Same like `finish`, but also extracts the native context extensions from the session.
     pub fn finish_with_extensions(
         self,
-    ) -> VMResult<(ChangeSet, Vec<Event>, NativeContextExtensions<'r>)> {
+    ) -> VMResult<(ChangeSet, Vec<Event>, S, NativeContextExtensions<'r>)> {
         let Session {
             data_cache,
             native_extensions,
             ..
         } = self;
-        let (change_set, events) = data_cache
+        let (change_set, events, remote) = data_cache
             .into_effects()
             .map_err(|e| e.finish(Location::Undefined))?;
-        Ok((change_set, events, native_extensions))
+        Ok((change_set, events, remote, native_extensions))
     }
 
     /// Load a script and all of its types into cache

--- a/language/move-vm/runtime/src/session.rs
+++ b/language/move-vm/runtime/src/session.rs
@@ -291,6 +291,10 @@ impl<'r, 'l, S: MoveResolver> Session<'r, 'l, S> {
         self.data_cache.get_remote_resolver()
     }
 
+    pub fn get_resolver_mut(&mut self) -> &mut S {
+        self.data_cache.get_remote_resolver_mut()
+    }
+
     /// Gets the underlying data store
     pub fn get_data_store(&mut self) -> &mut dyn DataStore {
         &mut self.data_cache

--- a/language/testing-infra/transactional-test-runner/src/vm_test_harness.rs
+++ b/language/testing-infra/transactional-test-runner/src/vm_test_harness.rs
@@ -338,7 +338,7 @@ impl<'a> SimpleVMTestAdapter<'a> {
 
         // save changeset
         // TODO support events
-        let (changeset, _events, _store) = session.finish()?;
+        let (changeset, _events) = session.finish().0?;
         self.storage.apply(changeset).unwrap();
         Ok(res)
     }

--- a/language/testing-infra/transactional-test-runner/src/vm_test_harness.rs
+++ b/language/testing-infra/transactional-test-runner/src/vm_test_harness.rs
@@ -338,7 +338,7 @@ impl<'a> SimpleVMTestAdapter<'a> {
 
         // save changeset
         // TODO support events
-        let (changeset, _events) = session.finish()?;
+        let (changeset, _events, _store) = session.finish()?;
         self.storage.apply(changeset).unwrap();
         Ok(res)
     }

--- a/language/testing-infra/transactional-test-runner/src/vm_test_harness.rs
+++ b/language/testing-infra/transactional-test-runner/src/vm_test_harness.rs
@@ -310,7 +310,7 @@ impl<'a> SimpleVMTestAdapter<'a> {
     fn perform_session_action<Ret>(
         &mut self,
         gas_budget: Option<u64>,
-        f: impl FnOnce(&mut Session<InMemoryStorage>, &mut GasStatus) -> VMResult<Ret>,
+        f: impl FnOnce(&mut Session<&InMemoryStorage>, &mut GasStatus) -> VMResult<Ret>,
         vm_config: VMConfig,
     ) -> VMResult<Ret> {
         // start session

--- a/language/tools/move-cli/src/sandbox/commands/publish.rs
+++ b/language/tools/move-cli/src/sandbox/commands/publish.rs
@@ -148,7 +148,7 @@ pub fn publish(
         }
 
         if !has_error {
-            let (changeset, events, _) = session.finish().map_err(|e| e.into_vm_status())?;
+            let (changeset, events) = session.finish().0.map_err(|e| e.into_vm_status())?;
             assert!(events.is_empty());
             if verbose {
                 explain_publish_changeset(&changeset);

--- a/language/tools/move-cli/src/sandbox/commands/publish.rs
+++ b/language/tools/move-cli/src/sandbox/commands/publish.rs
@@ -148,7 +148,7 @@ pub fn publish(
         }
 
         if !has_error {
-            let (changeset, events) = session.finish().map_err(|e| e.into_vm_status())?;
+            let (changeset, events, _) = session.finish().map_err(|e| e.into_vm_status())?;
             assert!(events.is_empty());
             if verbose {
                 explain_publish_changeset(&changeset);

--- a/language/tools/move-cli/src/sandbox/commands/run.rs
+++ b/language/tools/move-cli/src/sandbox/commands/run.rs
@@ -123,7 +123,7 @@ move run` must be applied to a module inside `storage/`",
             txn_args,
         )
     } else {
-        let (changeset, events) = session.finish().map_err(|e| e.into_vm_status())?;
+        let (changeset, events, _) = session.finish().map_err(|e| e.into_vm_status())?;
         if verbose {
             explain_execution_effects(&changeset, &events, state)?
         }

--- a/language/tools/move-cli/src/sandbox/commands/run.rs
+++ b/language/tools/move-cli/src/sandbox/commands/run.rs
@@ -123,7 +123,7 @@ move run` must be applied to a module inside `storage/`",
             txn_args,
         )
     } else {
-        let (changeset, events, _) = session.finish().map_err(|e| e.into_vm_status())?;
+        let (changeset, events) = session.finish().0.map_err(|e| e.into_vm_status())?;
         if verbose {
             explain_execution_effects(&changeset, &events, state)?
         }

--- a/language/tools/move-unit-test/src/test_runner.rs
+++ b/language/tools/move-unit-test/src/test_runner.rs
@@ -310,7 +310,7 @@ impl SharedTestingConfig {
                 .into(),
         );
         match session.finish_with_extensions() {
-            Ok((cs, _, extensions)) => (Ok(cs), Ok(extensions), return_result, test_run_info),
+            Ok((cs, _, _, extensions)) => (Ok(cs), Ok(extensions), return_result, test_run_info),
             Err(err) => (Err(err.clone()), Err(err), return_result, test_run_info),
         }
     }

--- a/language/tools/move-unit-test/src/test_runner.rs
+++ b/language/tools/move-unit-test/src/test_runner.rs
@@ -309,8 +309,8 @@ impl SharedTestingConfig {
                 .unwrap()
                 .into(),
         );
-        match session.finish_with_extensions() {
-            Ok((cs, _, _, extensions)) => (Ok(cs), Ok(extensions), return_result, test_run_info),
+        match session.finish_with_extensions().0 {
+            Ok((cs, _, extensions)) => (Ok(cs), Ok(extensions), return_result, test_run_info),
             Err(err) => (Err(err.clone()), Err(err), return_result, test_run_info),
         }
     }


### PR DESCRIPTION
Rather than accepting `MoveResolver` by reference accept it by value, but provide generic implementations for references of types that implement the traits.  Also expose a reference to it on `Session` and return it by value on `finish`.

This allows for the creation of resolvers that hold state that is scoped to the session, internally to themselves, rather than relying on that state's lifetime being maintained externally.

## Test Plan

```
$ cargo nextest
```