### PR TITLE
[move-prover] add the unroll pragma

### DIFF
--- a/language/move-model/src/model.rs
+++ b/language/move-model/src/model.rs
@@ -3151,28 +3151,17 @@ impl<'env> FunctionEnv<'env> {
         false
     }
 
-    /// Returns whether the value of a numeric pragma is explicitly set for this function.
-    pub fn is_num_pragma_set(&self, name: &str) -> bool {
-        let env = self.module_env.env;
-        env.get_num_property(&self.get_spec().properties, name)
-            .is_some()
-            || env
-                .get_num_property(&self.module_env.get_spec().properties, name)
-                .is_some()
-    }
-
-    /// Returns the value of a numeric pragma for this function. This first looks up a
-    /// pragma in this function, then the enclosing module, and finally uses the provided default.
-    /// value
-    pub fn get_num_pragma(&self, name: &str, default: impl FnOnce() -> usize) -> usize {
+    /// Returns the value of a numeric pragma for this function. This first looks up a pragma in
+    /// this function, then the enclosing module, and finally uses the provided default value.
+    pub fn get_num_pragma(&self, name: &str) -> Option<usize> {
         let env = self.module_env.env;
         if let Some(n) = env.get_num_property(&self.get_spec().properties, name) {
-            return n;
+            return Some(n);
         }
         if let Some(n) = env.get_num_property(&self.module_env.get_spec().properties, name) {
-            return n;
+            return Some(n);
         }
-        default()
+        None
     }
 
     /// Returns the value of a pragma representing an identifier for this function.

--- a/language/move-model/src/pragmas.rs
+++ b/language/move-model/src/pragmas.rs
@@ -76,6 +76,10 @@ pub const DISABLE_INVARIANTS_IN_BODY_PRAGMA: &str = "disable_invariants_in_body"
 /// to this function
 pub const DELEGATE_INVARIANTS_TO_CALLER_PRAGMA: &str = "delegate_invariants_to_caller";
 
+/// Pragma indicating that all loops within the scope of this pragma should be unrolled
+/// to a certain depth *when there are no invariants specified*
+pub const UNROLL_PRAGMA: &str = "unroll";
+
 /// # Pragmas for intrinsic table declaration
 
 /// The intrinsic type for `Map<K, V>`
@@ -197,6 +201,7 @@ pub fn is_pragma_valid_for_block(
                 | ABORTS_IF_IS_STRICT_PRAGMA
                 | ABORTS_IF_IS_PARTIAL_PRAGMA
                 | INTRINSIC_PRAGMA
+                | UNROLL_PRAGMA
         ),
         Function(..) => matches!(
             pragma,
@@ -220,6 +225,7 @@ pub fn is_pragma_valid_for_block(
                 | DELEGATE_INVARIANTS_TO_CALLER_PRAGMA
                 | BV_PARAM_PROP
                 | BV_RET_PROP
+                | UNROLL_PRAGMA
         ),
         Struct(..) => match pragma {
             INTRINSIC_PRAGMA | BV_PARAM_PROP => true,

--- a/language/move-prover/boogie-backend/src/bytecode_translator.rs
+++ b/language/move-prover/boogie-backend/src/bytecode_translator.rs
@@ -603,16 +603,15 @@ impl<'env> FunctionTranslator<'env> {
             FunctionVariant::Verification(flavor) => {
                 let timeout = fun_target
                     .func_env
-                    .get_num_pragma(TIMEOUT_PRAGMA, || options.vc_timeout);
-
+                    .get_num_pragma(TIMEOUT_PRAGMA)
+                    .unwrap_or(options.vc_timeout);
                 let mut attribs = vec![format!("{{:timeLimit {}}} ", timeout)];
 
-                if fun_target.func_env.is_num_pragma_set(SEED_PRAGMA) {
-                    let seed = fun_target
-                        .func_env
-                        .get_num_pragma(SEED_PRAGMA, || options.random_seed);
+                if let Some(seed) = fun_target.func_env.get_num_pragma(SEED_PRAGMA) {
                     attribs.push(format!("{{:random_seed {}}} ", seed));
-                };
+                } else if fun_target.func_env.is_pragma_true(SEED_PRAGMA, || false) {
+                    attribs.push(format!("{{:random_seed {}}} ", options.random_seed));
+                }
 
                 let suffix = match flavor {
                     VerificationFlavor::Regular => "$verify".to_string(),

--- a/language/move-prover/tests/sources/functional/loop_unroll.exp
+++ b/language/move-prover/tests/sources/functional/loop_unroll.exp
@@ -49,3 +49,42 @@ error: abort not covered by any of the `aborts_if` clauses
     =         i = <redacted>
     =     at tests/sources/functional/loop_unroll.move:97: t6_failure
     =         ABORTED
+
+error: abort not covered by any of the `aborts_if` clauses
+    ┌─ tests/sources/functional/loop_unroll.move:128:5
+    │
+124 │               assert!(i != 5, 0);
+    │               ------------------ abort happened here with code 0x0
+    ·
+128 │ ╭     spec t7_failure {
+129 │ │         pragma unroll = 6;
+130 │ │         // this will not hold when we increase the unroll count
+131 │ │         aborts_if false;
+132 │ │     }
+    │ ╰─────^
+    │
+    =     at tests/sources/functional/loop_unroll.move:120: t7_failure
+    =         n = <redacted>
+    =     at tests/sources/functional/loop_unroll.move:121: t7_failure
+    =         i = <redacted>
+    =     at tests/sources/functional/loop_unroll.move:122: t7_failure
+    =     at tests/sources/functional/loop_unroll.move:123: t7_failure
+    =         i = <redacted>
+    =     at tests/sources/functional/loop_unroll.move:124: t7_failure
+    =     at tests/sources/functional/loop_unroll.move:122: t7_failure
+    =     at tests/sources/functional/loop_unroll.move:123: t7_failure
+    =         i = <redacted>
+    =     at tests/sources/functional/loop_unroll.move:124: t7_failure
+    =     at tests/sources/functional/loop_unroll.move:122: t7_failure
+    =     at tests/sources/functional/loop_unroll.move:123: t7_failure
+    =         i = <redacted>
+    =     at tests/sources/functional/loop_unroll.move:124: t7_failure
+    =     at tests/sources/functional/loop_unroll.move:122: t7_failure
+    =     at tests/sources/functional/loop_unroll.move:123: t7_failure
+    =         i = <redacted>
+    =     at tests/sources/functional/loop_unroll.move:124: t7_failure
+    =     at tests/sources/functional/loop_unroll.move:122: t7_failure
+    =     at tests/sources/functional/loop_unroll.move:123: t7_failure
+    =         i = <redacted>
+    =     at tests/sources/functional/loop_unroll.move:124: t7_failure
+    =         ABORTED

--- a/language/move-prover/tests/sources/functional/loop_unroll.move
+++ b/language/move-prover/tests/sources/functional/loop_unroll.move
@@ -102,4 +102,32 @@ module 0x42::loop_unroll {
         // this will not hold when we increase the unroll count
         aborts_if false;
     }
+
+    fun t7_success(n: u64): u64 {
+        let i = 0;
+        while (i < n) {
+            i = i + 1;
+            assert!(i != 5, 0);
+        };
+        i
+    }
+    spec t7_success {
+        pragma unroll = 3;
+        // this is expected, as we only unroll the loop 3 times
+        aborts_if false;
+    }
+
+    fun t7_failure(n: u64): u64 {
+        let i = 0;
+        while (i < n) {
+            i = i + 1;
+            assert!(i != 5, 0);
+        };
+        i
+    }
+    spec t7_failure {
+        pragma unroll = 6;
+        // this will not hold when we increase the unroll count
+        aborts_if false;
+    }
 }


### PR DESCRIPTION
We now support both function-level and module-level
```
pragma unroll = <depth-limit>;
```

The effect of specifying this pragma is:
- if a loop is in the function/module and has loop invariants, this pragma has no effect. The loop will still be verified against loop invariants.
- if a loop is in the function/module and has no loop invariants, if the loop has a spec block with `invariant [unroll = K] true;`, unroll the loop `K` times.
- if a loop is in the function/module and has no loop invariants, and has no per-loop unrolling instruction, use the pramga's count to unroll the loop.

The effect of this pragma is illustrated in the `loop_unroll.move` test case.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Move Language.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

More coarse-grained (and user-friendly) loop unrolling annotation

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes

## Test Plan

CI
