### PR TITLE
[tools] Add `try_exists` that surfaces other files issues if the file exists but has an error

### DIFF
--- a/language/tools/move-cli/src/sandbox/commands/run.rs
+++ b/language/tools/move-cli/src/sandbox/commands/run.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 use anyhow::{anyhow, bail, Result};
 use move_binary_format::file_format::CompiledModule;
-use move_command_line_common::env::get_bytecode_version_from_env;
+use move_command_line_common::{env::get_bytecode_version_from_env, files::try_exists};
 use move_core_types::{
     account_address::AccountAddress,
     errmap::ErrorMapping,
@@ -40,7 +40,7 @@ pub fn run(
     dry_run: bool,
     verbose: bool,
 ) -> Result<()> {
-    if !script_path.exists() {
+    if !try_exists(script_path)? {
         bail!("Script file {:?} does not exist", script_path)
     };
     let bytecode_version = get_bytecode_version_from_env();

--- a/language/tools/move-package/src/compilation/compiled_package.rs
+++ b/language/tools/move-package/src/compilation/compiled_package.rs
@@ -20,7 +20,7 @@ use move_bytecode_utils::Modules;
 use move_command_line_common::{
     env::get_bytecode_version_from_env,
     files::{
-        extension_equals, find_filenames, MOVE_COMPILED_EXTENSION, MOVE_EXTENSION,
+        extension_equals, find_filenames, try_exists, MOVE_COMPILED_EXTENSION, MOVE_EXTENSION,
         SOURCE_MAP_EXTENSION,
     },
 };
@@ -124,7 +124,7 @@ impl CompilationCachingStatus {
 
 impl OnDiskCompiledPackage {
     pub fn from_path(p: &Path) -> Result<Self> {
-        let (buf, build_path) = if p.exists() && extension_equals(p, "yaml") {
+        let (buf, build_path) = if try_exists(p)? && extension_equals(p, "yaml") {
             (std::fs::read(p)?, p.parent().unwrap().parent().unwrap())
         } else {
             (
@@ -304,11 +304,11 @@ impl OnDiskCompiledPackage {
         };
         let mut compiled_unit_paths = vec![];
         let module_path = package_dir.join(CompiledPackageLayout::CompiledModules.path());
-        if module_path.exists() {
+        if try_exists(&module_path)? {
             compiled_unit_paths.push(module_path);
         }
         let script_path = package_dir.join(CompiledPackageLayout::CompiledScripts.path());
-        if script_path.exists() {
+        if try_exists(&script_path)? {
             compiled_unit_paths.push(script_path);
         }
         find_filenames(&compiled_unit_paths, |path| {


### PR DESCRIPTION


`std::path::exists` collapses all errors to `false` however if we want to be able to return more fine-grained issues back we need to surface these errors as well.

This adds a `try_exist` function that only returns false if the file actually doesn't exist. Otherwise if there's a different error this will return an `Err` result.


