### PR TITLE
[move-binary-format] Support changing of signatures for private entry functions

### DIFF
--- a/language/move-binary-format/src/compatibility.rs
+++ b/language/move-binary-format/src/compatibility.rs
@@ -14,19 +14,23 @@ use move_core_types::vm_status::StatusCode;
 
 /// The result of a linking and layout compatibility check. Here is what the different combinations. NOTE that if `check_struct_layout` is false, type safety over a series of upgrades cannot be guaranteed.
 /// mean:
-/// `{ check_struct_and_pub_function_linking: true, check_struct_layout: true, check_friend_linking: true }`: fully backward compatible
-/// `{ check_struct_and_pub_function_linking: true, check_struct_layout: true, check_friend_linking: false }`: Backward compatible, exclude the friend module declare and friend functions
-/// `{ check_struct_and_pub_function_linking: false, check_struct_layout: true, check_friend_linking: false }`: Dependent modules that reference functions or types in this module may not link. However, fixing, recompiling, and redeploying all dependent modules will work--no data migration needed.
-/// `{ check_struct_and_pub_function_linking: true, check_struct_layout: false, check_friend_linking: true }`: Attempting to read structs published by this module will now fail at runtime. However, dependent modules will continue to link. Requires data migration, but no changes to dependent modules.
-/// `{ check_struct_and_pub_function_linking: false, check_struct_layout: false, check_friend_linking: false }`: Everything is broken. Need both a data migration and changes to dependent modules.
+/// `{ check_struct_and_pub_function_linking: true, check_struct_layout: true, check_friend_linking: true, check_private_entry_linking: true }`: fully backward compatible
+/// `{ check_struct_and_pub_function_linking: true, check_struct_layout: true, check_friend_linking: true, check_private_entry_linking: false }`: Backwards compatible, private entry function signatures can change
+/// `{ check_struct_and_pub_function_linking: true, check_struct_layout: true, check_friend_linking: false, check_private_entry_linking: true }`: Backward compatible, exclude the friend module declare and friend functions
+/// `{ check_struct_and_pub_function_linking: true, check_struct_layout: true, check_friend_linking: false, check_private_entry_linking: false }`: Backward compatible, exclude the friend module declarations, friend functions, and private and friend entry function
+/// `{ check_struct_and_pub_function_linking: false, check_struct_layout: true, check_friend_linking: false, check_private_entry_linking: _ }`: Dependent modules that reference functions or types in this module may not link. However, fixing, recompiling, and redeploying all dependent modules will work--no data migration needed.
+/// `{ check_struct_and_pub_function_linking: true, check_struct_layout: false, check_friend_linking: true, check_private_entry_linking: _ }`: Attempting to read structs published by this module will now fail at runtime. However, dependent modules will continue to link. Requires data migration, but no changes to dependent modules.
+/// `{ check_struct_and_pub_function_linking: false, check_struct_layout: false, check_friend_linking: false, check_private_entry_linking: _ }`: Everything is broken. Need both a data migration and changes to dependent modules.
 #[derive(PartialEq, Eq, Debug, Clone, Copy)]
 pub struct Compatibility {
     /// if false, do not ensure the dependent modules that reference public functions or structs in this module can link
-    check_struct_and_pub_function_linking: bool,
+    pub check_struct_and_pub_function_linking: bool,
     /// if false, do not ensure the struct layout capability
-    check_struct_layout: bool,
-    /// if false, treat `friend` as `private` when `check_struct_and_function_linking`.
-    check_friend_linking: bool,
+    pub check_struct_layout: bool,
+    /// if false, treat `friend` as `private` when `check_struct_and_pub_function_linking`.
+    pub check_friend_linking: bool,
+    /// if false, treat `entry` as `private` when `check_struct_and_pub_function_linking`.
+    pub check_private_entry_linking: bool,
 }
 
 impl Default for Compatibility {
@@ -35,6 +39,7 @@ impl Default for Compatibility {
             check_struct_and_pub_function_linking: true,
             check_struct_layout: true,
             check_friend_linking: true,
+            check_private_entry_linking: true,
         }
     }
 }
@@ -49,50 +54,35 @@ impl Compatibility {
             check_struct_and_pub_function_linking: false,
             check_struct_layout: false,
             check_friend_linking: false,
-        }
-    }
-
-    pub fn new(
-        check_struct_and_pub_function_linking: bool,
-        check_struct_layout: bool,
-        check_friend_linking: bool,
-    ) -> Self {
-        Self {
-            check_struct_and_pub_function_linking,
-            check_struct_layout,
-            check_friend_linking,
+            check_private_entry_linking: false,
         }
     }
 
     pub fn need_check_compat(&self) -> bool {
-        self.check_struct_and_pub_function_linking
-            || self.check_friend_linking
-            || self.check_struct_layout
+        self != &Self::no_check()
     }
 
     /// Check compatibility for `new_module` relative to old module `old_module`.
     pub fn check(&self, old_module: &Module, new_module: &Module) -> PartialVMResult<()> {
-        let mut struct_and_pub_function_linking = true;
+        let mut struct_and_function_linking = true;
         let mut struct_layout = true;
         let mut friend_linking = true;
+        let mut entry_linking = true;
 
         // module's name and address are unchanged
         if old_module.address != new_module.address || old_module.name != new_module.name {
-            struct_and_pub_function_linking = false;
+            struct_and_function_linking = false;
         }
 
         // old module's structs are a subset of the new module's structs
         for (name, old_struct) in &old_module.structs {
-            let new_struct = match new_module.structs.get(name) {
-                Some(new_struct) => new_struct,
-                None => {
-                    // Struct not present in new . Existing modules that depend on this struct will fail to link with the new version of the module.
-                    // Also, struct layout cannot be guaranteed transitively, because after
-                    // removing the struct, it could be re-added later with a different layout.
-                    struct_and_pub_function_linking = false;
-                    struct_layout = false;
-                    break;
-                }
+            let Some(new_struct) = new_module.structs.get(name) else {
+                // Struct not present in new . Existing modules that depend on this struct will fail to link with the new version of the module.
+                // Also, struct layout cannot be guaranteed transitively, because after
+                // removing the struct, it could be re-added later with a different layout.
+                struct_and_function_linking = false;
+                struct_layout = false;
+                break;
             };
 
             if !struct_abilities_compatibile(old_struct.abilities, new_struct.abilities)
@@ -101,7 +91,7 @@ impl Compatibility {
                     &new_struct.type_parameters,
                 )
             {
-                struct_and_pub_function_linking = false;
+                struct_and_function_linking = false;
             }
             if new_struct.fields != old_struct.fields {
                 // Fields changed. Code in this module will fail at runtime if it tries to
@@ -128,53 +118,56 @@ impl Compatibility {
         // we can remove/change a friend function if the function is not used by any module in the
         // friend list. But for simplicity, we decided to go to the more restrictive form now and
         // we may revisit this in the future.
-        for (name, old_func) in &old_module.exposed_functions {
-            let new_func = match new_module.exposed_functions.get(name) {
-                Some(new_func) => new_func,
-                None => {
-                    if matches!(old_func.visibility, Visibility::Friend) {
-                        friend_linking = false;
-                    } else {
-                        struct_and_pub_function_linking = false;
-                    }
-                    continue;
+        for (name, old_func) in &old_module.functions {
+            let Some(new_func) = new_module.functions.get(name) else {
+                if old_func.visibility == Visibility::Friend {
+                    friend_linking = false;
+                } else if old_func.visibility != Visibility::Private {
+                    struct_and_function_linking = false;
+                } else if old_func.is_entry && self.check_private_entry_linking {
+                    // This must be a private entry function. So set the link breakage if we're
+                    // checking for that.
+                    entry_linking = false;
                 }
+                continue;
             };
-            let is_vis_compatible = match (old_func.visibility, new_func.visibility) {
-                // public must remain public
-                (Visibility::Public, Visibility::Public) => true,
-                (Visibility::Public, _) => false,
-                // friend can become public or remain friend
-                (Visibility::Friend, Visibility::Public)
-                | (Visibility::Friend, Visibility::Friend) => true,
-                (Visibility::Friend, _) => false,
-                // private can become public or friend, or stay private
-                (Visibility::Private, _) => true,
-            };
-            let is_entry_compatible = if old_module.file_format_version < VERSION_5
+
+            // Check visibility compatibility
+            match (old_func.visibility, new_func.visibility) {
+                (Visibility::Public, Visibility::Private | Visibility::Friend) => {
+                    struct_and_function_linking = false
+                }
+                (Visibility::Friend, Visibility::Private) => friend_linking = false,
+                _ => (),
+            }
+
+            // Check entry compatibility
+            if old_module.file_format_version < VERSION_5
                 && new_module.file_format_version < VERSION_5
+                && old_func.visibility != Visibility::Private
+                && old_func.is_entry != new_func.is_entry
             {
-                // if it was public(script), it must remain public(script)
-                // if it was not public(script), it _cannot_ become public(script)
-                old_func.is_entry == new_func.is_entry
-            } else {
-                // If it was an entry function, it must remain one.
-                // If it was not an entry function, it is allowed to become one.
-                !old_func.is_entry || new_func.is_entry
-            };
-            if !is_vis_compatible
-                || !is_entry_compatible
-                || old_func.parameters != new_func.parameters
+                entry_linking = false
+            } else if old_func.is_entry && !new_func.is_entry {
+                entry_linking = false;
+            }
+
+            // Check signature compatibility
+            if old_func.parameters != new_func.parameters
                 || old_func.return_ != new_func.return_
                 || !fun_type_parameters_compatibile(
                     &old_func.type_parameters,
                     &new_func.type_parameters,
                 )
             {
-                if matches!(old_func.visibility, Visibility::Friend) {
-                    friend_linking = false;
-                } else {
-                    struct_and_pub_function_linking = false;
+                match old_func.visibility {
+                    Visibility::Friend => friend_linking = false,
+                    Visibility::Public => struct_and_function_linking = false,
+                    Visibility::Private => (),
+                }
+
+                if old_func.is_entry {
+                    entry_linking = false;
                 }
             }
         }
@@ -190,7 +183,7 @@ impl Compatibility {
             friend_linking = false;
         }
 
-        if self.check_struct_and_pub_function_linking && !struct_and_pub_function_linking {
+        if self.check_struct_and_pub_function_linking && !struct_and_function_linking {
             return Err(PartialVMError::new(
                 StatusCode::BACKWARD_INCOMPATIBLE_MODULE_UPDATE,
             ));
@@ -201,6 +194,11 @@ impl Compatibility {
             ));
         }
         if self.check_friend_linking && !friend_linking {
+            return Err(PartialVMError::new(
+                StatusCode::BACKWARD_INCOMPATIBLE_MODULE_UPDATE,
+            ));
+        }
+        if self.check_private_entry_linking && !entry_linking {
             return Err(PartialVMError::new(
                 StatusCode::BACKWARD_INCOMPATIBLE_MODULE_UPDATE,
             ));
@@ -298,8 +296,7 @@ impl InclusionCheck {
         // of the tables are the exact same.
         if (self == &Self::Equal)
             && (old_module.structs.len() != new_module.structs.len()
-                || old_module.exposed_functions.len() != new_module.exposed_functions.len()
-                || old_module.private_functions.len() != new_module.private_functions.len()
+                || old_module.functions.len() != new_module.functions.len()
                 || old_module.friends.len() != new_module.friends.len()
                 || old_module.constants.len() != new_module.constants.len())
         {
@@ -317,15 +314,11 @@ impl InclusionCheck {
         }
 
         // Function checks
-        for (name, old_func) in old_module
-            .exposed_functions
-            .iter()
-            .chain(old_module.private_functions.iter())
-        {
+        for (name, old_func) in &old_module.functions {
             match new_module
-                .exposed_functions
+                .functions
                 .get(name)
-                .or_else(|| new_module.private_functions.get(name))
+                .or_else(|| new_module.functions.get(name))
             {
                 Some(new_func) if old_func == new_func => (),
                 _ => {

--- a/language/move-binary-format/src/normalized.rs
+++ b/language/move-binary-format/src/normalized.rs
@@ -225,8 +225,7 @@ pub struct Module {
     pub dependencies: Vec<ModuleId>,
     pub friends: Vec<ModuleId>,
     pub structs: BTreeMap<Identifier, Struct>,
-    pub exposed_functions: BTreeMap<Identifier, Function>,
-    pub private_functions: BTreeMap<Identifier, Function>,
+    pub functions: BTreeMap<Identifier, Function>,
     pub constants: Vec<Constant>,
 }
 
@@ -243,32 +242,18 @@ impl Module {
             .iter()
             .map(|constant| Constant::new(m, constant))
             .collect();
-        let (exposed_functions, private_functions): (Vec<_>, Vec<_>) =
-            m.function_defs().iter().partition(|func_def| {
-                let is_vis_exposed = match func_def.visibility {
-                    Visibility::Public | Visibility::Friend => true,
-                    Visibility::Private => false,
-                };
-                let is_entry_exposed = func_def.is_entry;
-                is_vis_exposed || is_entry_exposed
-            });
-        let exposed_functions = exposed_functions
-            .into_iter()
+        let functions = m
+            .function_defs()
+            .iter()
             .map(|func_def| Function::new(m, func_def))
             .collect();
-        let private_functions = private_functions
-            .into_iter()
-            .map(|func_def| Function::new(m, func_def))
-            .collect();
-
         Self {
             file_format_version: m.version(),
             address: *m.address(),
             name: m.name().to_owned(),
             friends,
             structs,
-            exposed_functions,
-            private_functions,
+            functions,
             dependencies,
             constants,
         }

--- a/language/tools/move-cli/src/sandbox/utils/mod.rs
+++ b/language/tools/move-cli/src/sandbox/utils/mod.rs
@@ -345,16 +345,26 @@ pub(crate) fn explain_publish_error(
             let old_api = normalized::Module::new(&old_module);
             let new_api = normalized::Module::new(module);
 
-            if Compatibility::new(false, true, false)
-                .check(&old_api, &new_api)
-                .is_err()
+            if (Compatibility {
+                check_struct_and_pub_function_linking: false,
+                check_struct_layout: true,
+                check_friend_linking: false,
+                check_private_entry_linking: true,
+            })
+            .check(&old_api, &new_api)
+            .is_err()
             {
                 // TODO: we could choose to make this more precise by walking the global state and looking for published
                 // structs of this type. but probably a bad idea
                 println!("Layout API for structs of module {} has changed. Need to do a data migration of published structs", module_id)
-            } else if Compatibility::new(true, false, false)
-                .check(&old_api, &new_api)
-                .is_err()
+            } else if (Compatibility {
+                check_struct_and_pub_function_linking: true,
+                check_struct_layout: false,
+                check_friend_linking: false,
+                check_private_entry_linking: true,
+            })
+            .check(&old_api, &new_api)
+            .is_err()
             {
                 // TODO: this will report false positives if we *are* simultaneously redeploying all dependent modules.
                 // but this is not easy to check without walking the global state and looking for everything


### PR DESCRIPTION
Adds a new flag `check_private_entry_linking` that when true checks the private entry function signatures cannot change. E.g.,

If we had

```
entry fun fn() { }
```

and

```
entry fun fn(_x: u64) { }
```

These would be compatible if `check_private_entry_linking` was set to `false` but ruled incompatible if `check_private_entry_linking` was set to `true`.

