### PR TITLE
Fix typo

### DIFF
--- a/language/move-bytecode-verifier/README.md
+++ b/language/move-bytecode-verifier/README.md
@@ -29,7 +29,7 @@ Resources represent the assets of the blockchain. As such, there are certain res
 
 * `CopyLoc` and `StLoc` require that the type of local is not of resource kind.
 * `WriteRef`, `Eq`, and `Neq` require that the type of the reference is not of resource kind.
-* At the end of a function (when `Ret` is reached), no local whose type is of resource kind must be empty, i.e., the value must have been moved out of the local.
+* At the end of a function (when `Ret` is reached), any local whose type is of resource kind must be empty, i.e., the value must have been moved out of the local.
 
 As mentioned above, this last rule around `Ret` implies that the resource *must* have been either:
 


### PR DESCRIPTION
"At the end of a function (when `Ret` is reached), *no local* whose type is of resource kind must be empty, i.e., the value must have been moved out of the local." I suppose that should be *any local* instead.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Move Language.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

To fix a typo in the readme.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes.

## Test Plan

No need for test.
