### PR TITLE
[session] Accept Type Parameters by Type, not Tag

### DIFF
--- a/language/move-binary-format/src/file_format.rs
+++ b/language/move-binary-format/src/file_format.rs
@@ -1757,11 +1757,6 @@ impl Bytecode {
             "Program counter out of bounds"
         );
 
-        // Return early to prevent overflow if pc is hiting the end of max number of instructions allowed (u16::MAX).
-        if pc > u16::max_value() - 2 {
-            return vec![];
-        }
-
         let bytecode = &code[pc as usize];
         let mut v = vec![];
 

--- a/language/move-vm/integration-tests/src/tests/function_arg_tests.rs
+++ b/language/move-vm/integration-tests/src/tests/function_arg_tests.rs
@@ -21,7 +21,7 @@ const TEST_ADDR: AccountAddress = AccountAddress::new([42; AccountAddress::LENGT
 fn run(
     ty_params: &[&str],
     params: &[&str],
-    ty_args: Vec<TypeTag>,
+    ty_arg_tags: Vec<TypeTag>,
     args: Vec<MoveValue>,
 ) -> VMResult<()> {
     let ty_params = ty_params
@@ -61,6 +61,11 @@ fn run(
     let mut sess = vm.new_session(&storage);
 
     let fun_name = Identifier::new("foo").unwrap();
+
+    let ty_args: Vec<_> = ty_arg_tags
+        .into_iter()
+        .map(|tag| sess.load_type(&tag))
+        .collect::<VMResult<_>>()?;
 
     let args: Vec<_> = args
         .into_iter()

--- a/language/move-vm/integration-tests/src/tests/return_value_tests.rs
+++ b/language/move-vm/integration-tests/src/tests/return_value_tests.rs
@@ -20,7 +20,7 @@ fn run(
     structs: &[&str],
     fun_sig: &str,
     fun_body: &str,
-    ty_args: Vec<TypeTag>,
+    ty_arg_tags: Vec<TypeTag>,
     args: Vec<MoveValue>,
 ) -> VMResult<Vec<Vec<u8>>> {
     let structs = structs.to_vec().join("\n");
@@ -51,6 +51,11 @@ fn run(
     let mut sess = vm.new_session(&storage);
 
     let fun_name = Identifier::new("foo").unwrap();
+
+    let ty_args: Vec<_> = ty_arg_tags
+        .into_iter()
+        .map(|tag| sess.load_type(&tag))
+        .collect::<VMResult<_>>()?;
 
     let args: Vec<_> = args
         .into_iter()

--- a/language/move-vm/runtime/src/loader.rs
+++ b/language/move-vm/runtime/src/loader.rs
@@ -563,7 +563,7 @@ impl Loader {
     pub(crate) fn load_script(
         &self,
         script_blob: &[u8],
-        ty_args: &[TypeTag],
+        ty_args: &[Type],
         data_store: &impl DataStore,
     ) -> VMResult<(Arc<Function>, LoadedFunctionInstantiation)> {
         // retrieve or load the script
@@ -590,14 +590,9 @@ impl Loader {
         };
 
         // verify type arguments
-        let mut type_arguments = vec![];
-        for ty in ty_args {
-            type_arguments.push(self.load_type(ty, data_store)?);
-        }
-        self.verify_ty_args(main.type_parameters(), &type_arguments)
+        self.verify_ty_args(main.type_parameters(), ty_args)
             .map_err(|e| e.finish(Location::Script))?;
         let instantiation = LoadedFunctionInstantiation {
-            type_arguments,
             parameters,
             return_,
         };
@@ -670,7 +665,7 @@ impl Loader {
         &self,
         runtime_id: &ModuleId,
         function_name: &IdentStr,
-        ty_args: &[TypeTag],
+        ty_args: &[Type],
         data_store: &impl DataStore,
     ) -> VMResult<(
         Arc<CompiledModule>,
@@ -705,15 +700,10 @@ impl Loader {
             .map_err(|err| err.finish(Location::Undefined))?;
 
         // verify type arguments
-        let type_arguments = ty_args
-            .iter()
-            .map(|ty| self.load_type(ty, data_store))
-            .collect::<VMResult<Vec<_>>>()?;
-        self.verify_ty_args(func.type_parameters(), &type_arguments)
+        self.verify_ty_args(func.type_parameters(), ty_args)
             .map_err(|e| e.finish(Location::Module(runtime_id.clone())))?;
 
         let inst = LoadedFunctionInstantiation {
-            type_arguments,
             parameters,
             return_,
         };

--- a/language/move-vm/runtime/src/runtime.rs
+++ b/language/move-vm/runtime/src/runtime.rs
@@ -21,7 +21,7 @@ use move_bytecode_verifier::script_signature;
 use move_core_types::{
     account_address::AccountAddress,
     identifier::{IdentStr, Identifier},
-    language_storage::{ModuleId, TypeTag},
+    language_storage::ModuleId,
     resolver::MoveResolver,
     value::MoveTypeLayout,
     vm_status::StatusCode,
@@ -365,7 +365,7 @@ impl VMRuntime {
         &self,
         module: &ModuleId,
         function_name: &IdentStr,
-        ty_args: Vec<TypeTag>,
+        type_arguments: Vec<Type>,
         serialized_args: Vec<impl Borrow<[u8]>>,
         data_store: &mut impl DataStore,
         gas_meter: &mut impl GasMeter,
@@ -399,13 +399,12 @@ impl VMRuntime {
             _,
             func,
             LoadedFunctionInstantiation {
-                type_arguments,
                 parameters,
                 return_,
             },
         ) = self
             .loader
-            .load_function(module, function_name, &ty_args, data_store)?;
+            .load_function(module, function_name, &type_arguments, data_store)?;
 
         script_signature::verify_module_function_signature_by_name(
             compiled.as_ref(),
@@ -430,7 +429,7 @@ impl VMRuntime {
     pub(crate) fn execute_script(
         &self,
         script: impl Borrow<[u8]>,
-        ty_args: Vec<TypeTag>,
+        type_arguments: Vec<Type>,
         serialized_args: Vec<impl Borrow<[u8]>>,
         data_store: &mut impl DataStore,
         gas_meter: &mut impl GasMeter,
@@ -440,13 +439,12 @@ impl VMRuntime {
         let (
             func,
             LoadedFunctionInstantiation {
-                type_arguments,
                 parameters,
                 return_,
             },
         ) = self
             .loader
-            .load_script(script.borrow(), &ty_args, data_store)?;
+            .load_script(script.borrow(), &type_arguments, data_store)?;
         // execute the function
         self.execute_function_impl(
             func,

--- a/language/move-vm/runtime/src/session.rs
+++ b/language/move-vm/runtime/src/session.rs
@@ -72,7 +72,7 @@ impl<'r, 'l, S: MoveResolver> Session<'r, 'l, S> {
         &mut self,
         module: &ModuleId,
         function_name: &IdentStr,
-        ty_args: Vec<TypeTag>,
+        ty_args: Vec<Type>,
         args: Vec<impl Borrow<[u8]>>,
         gas_meter: &mut impl GasMeter,
     ) -> VMResult<SerializedReturnValues> {
@@ -94,7 +94,7 @@ impl<'r, 'l, S: MoveResolver> Session<'r, 'l, S> {
         &mut self,
         module: &ModuleId,
         function_name: &IdentStr,
-        ty_args: Vec<TypeTag>,
+        ty_args: Vec<Type>,
         args: Vec<impl Borrow<[u8]>>,
         gas_meter: &mut impl GasMeter,
     ) -> VMResult<SerializedReturnValues> {
@@ -130,7 +130,7 @@ impl<'r, 'l, S: MoveResolver> Session<'r, 'l, S> {
     pub fn execute_script(
         &mut self,
         script: impl Borrow<[u8]>,
-        ty_args: Vec<TypeTag>,
+        ty_args: Vec<Type>,
         args: Vec<impl Borrow<[u8]>>,
         gas_meter: &mut impl GasMeter,
     ) -> VMResult<SerializedReturnValues> {
@@ -224,12 +224,12 @@ impl<'r, 'l, S: MoveResolver> Session<'r, 'l, S> {
     pub fn load_script(
         &self,
         script: impl Borrow<[u8]>,
-        ty_args: Vec<TypeTag>,
+        ty_args: &[Type],
     ) -> VMResult<LoadedFunctionInstantiation> {
         let (_, instantiation) =
             self.runtime
                 .loader()
-                .load_script(script.borrow(), &ty_args, &self.data_cache)?;
+                .load_script(script.borrow(), ty_args, &self.data_cache)?;
         Ok(instantiation)
     }
 
@@ -238,7 +238,7 @@ impl<'r, 'l, S: MoveResolver> Session<'r, 'l, S> {
         &self,
         module_id: &ModuleId,
         function_name: &IdentStr,
-        type_arguments: &[TypeTag],
+        type_arguments: &[Type],
     ) -> VMResult<LoadedFunctionInstantiation> {
         let (_, _, _, instantiation) = self.runtime.loader().load_function(
             module_id,
@@ -307,7 +307,6 @@ impl<'r, 'l, S: MoveResolver> Session<'r, 'l, S> {
 }
 
 pub struct LoadedFunctionInstantiation {
-    pub type_arguments: Vec<Type>,
     pub parameters: Vec<Type>,
     pub return_: Vec<Type>,
 }

--- a/language/move-vm/runtime/src/unit_tests/vm_arguments_tests.rs
+++ b/language/move-vm/runtime/src/unit_tests/vm_arguments_tests.rs
@@ -285,12 +285,18 @@ fn combine_signers_and_args(
 fn call_script_with_args_ty_args_signers(
     script: Vec<u8>,
     non_signer_args: Vec<Vec<u8>>,
-    ty_args: Vec<TypeTag>,
+    ty_arg_tags: Vec<TypeTag>,
     signers: Vec<AccountAddress>,
 ) -> VMResult<()> {
     let move_vm = MoveVM::new(vec![]).unwrap();
     let remote_view = RemoteStore::new();
     let mut session = move_vm.new_session(&remote_view);
+
+    let ty_args = ty_arg_tags
+        .into_iter()
+        .map(|tag| session.load_type(&tag))
+        .collect::<VMResult<_>>()?;
+
     session
         .execute_script(
             script,
@@ -309,7 +315,7 @@ fn call_script_function_with_args_ty_args_signers(
     module: CompiledModule,
     function_name: Identifier,
     non_signer_args: Vec<Vec<u8>>,
-    ty_args: Vec<TypeTag>,
+    ty_arg_tags: Vec<TypeTag>,
     signers: Vec<AccountAddress>,
 ) -> VMResult<()> {
     let move_vm = MoveVM::new(vec![]).unwrap();
@@ -317,6 +323,12 @@ fn call_script_function_with_args_ty_args_signers(
     let id = module.self_id();
     remote_view.add_module(module);
     let mut session = move_vm.new_session(&remote_view);
+
+    let ty_args = ty_arg_tags
+        .into_iter()
+        .map(|tag| session.load_type(&tag))
+        .collect::<VMResult<_>>()?;
+
     session.execute_function_bypass_visibility(
         &id,
         function_name.as_ident_str(),

--- a/language/testing-infra/test-generation/src/lib.rs
+++ b/language/testing-infra/test-generation/src/lib.rs
@@ -124,7 +124,7 @@ fn run_vm(module: CompiledModule) -> Result<(), VMStatus> {
 fn execute_function_in_module(
     module: CompiledModule,
     idx: FunctionDefinitionIndex,
-    ty_args: Vec<TypeTag>,
+    ty_arg_tags: Vec<TypeTag>,
     args: Vec<Vec<u8>>,
     storage: &impl MoveResolver,
 ) -> Result<(), VMStatus> {
@@ -149,6 +149,11 @@ fn execute_function_in_module(
             .unwrap();
         let delta_storage = DeltaStorage::new(storage, &changeset);
         let mut sess = vm.new_session(&delta_storage);
+
+        let ty_args = ty_arg_tags
+            .into_iter()
+            .map(|tag| sess.load_type(&tag))
+            .collect::<Result<Vec<_>, _>>()?;
 
         sess.execute_function_bypass_visibility(
             &module_id,

--- a/language/testing-infra/transactional-test-runner/src/vm_test_harness.rs
+++ b/language/testing-infra/transactional-test-runner/src/vm_test_harness.rs
@@ -188,7 +188,7 @@ impl<'a> MoveTestAdapter<'a> for SimpleVMTestAdapter<'a> {
     fn execute_script(
         &mut self,
         script: CompiledScript,
-        type_args: Vec<TypeTag>,
+        type_arg_tags: Vec<TypeTag>,
         signers: Vec<ParsedAddress>,
         txn_args: Vec<MoveValue>,
         gas_budget: Option<u64>,
@@ -216,6 +216,11 @@ impl<'a> MoveTestAdapter<'a> for SimpleVMTestAdapter<'a> {
             .perform_session_action(
                 gas_budget,
                 |session, gas_status| {
+                    let type_args: Vec<_> = type_arg_tags
+                        .into_iter()
+                        .map(|tag| session.load_type(&tag))
+                        .collect::<VMResult<_>>()?;
+
                     session.execute_script(script_bytes, type_args, args, gas_status)
                 },
                 VMConfig::from(extra_args),
@@ -233,7 +238,7 @@ impl<'a> MoveTestAdapter<'a> for SimpleVMTestAdapter<'a> {
         &mut self,
         module: &ModuleId,
         function: &IdentStr,
-        type_args: Vec<TypeTag>,
+        type_arg_tags: Vec<TypeTag>,
         signers: Vec<ParsedAddress>,
         txn_args: Vec<MoveValue>,
         gas_budget: Option<u64>,
@@ -258,6 +263,11 @@ impl<'a> MoveTestAdapter<'a> for SimpleVMTestAdapter<'a> {
             .perform_session_action(
                 gas_budget,
                 |session, gas_status| {
+                    let type_args: Vec<_> = type_arg_tags
+                        .into_iter()
+                        .map(|tag| session.load_type(&tag))
+                        .collect::<VMResult<_>>()?;
+
                     session.execute_function_bypass_visibility(
                         module, function, type_args, args, gas_status,
                     )

--- a/language/tools/move-cli/src/sandbox/commands/run.rs
+++ b/language/tools/move-cli/src/sandbox/commands/run.rs
@@ -35,7 +35,7 @@ pub fn run(
     script_name_opt: &Option<String>,
     signers: &[String],
     txn_args: &[TransactionArgument],
-    vm_type_args: Vec<TypeTag>,
+    vm_type_tags: Vec<TypeTag>,
     gas_budget: Option<u64>,
     dry_run: bool,
     verbose: bool,
@@ -80,6 +80,12 @@ move run` must be applied to a module inside `storage/`",
 
     let script_type_parameters = vec![];
     let script_parameters = vec![];
+
+    let script_type_arguments = vm_type_tags
+        .iter()
+        .map(|tag| session.load_type(tag))
+        .collect::<Result<Vec<_>, _>>()?;
+
     // TODO rethink move-cli arguments for executing functions
     let vm_args = signer_addresses
         .iter()
@@ -98,14 +104,14 @@ move run` must be applied to a module inside `storage/`",
             session.execute_entry_function(
                 &module.self_id(),
                 IdentStr::new(script_name)?,
-                vm_type_args.clone(),
+                script_type_arguments,
                 vm_args,
                 &mut gas_status,
             )
         }
         None => session.execute_script(
             bytecode.to_vec(),
-            vm_type_args.clone(),
+            script_type_arguments,
             vm_args,
             &mut gas_status,
         ),
@@ -118,7 +124,7 @@ move run` must be applied to a module inside `storage/`",
             state,
             &script_type_parameters,
             &script_parameters,
-            &vm_type_args,
+            &vm_type_tags,
             &signer_addresses,
             txn_args,
         )


### PR DESCRIPTION
## Motivation

Session and the runtime now expects type parameters to be loaded outside function execution, so no longer accepts them as `TypeTag`s but as `Type`s.

This helps us integrate generics into package upgrades by allowing a type parameter to be loaded into a `Type` in its own link context.

## Test Plan

```
$ env SOLC_EXE=... cargo nextest --no-fail-fast
```