### PR TITLE
[model-compiler] Enabling basic type checking of Move functions

### DIFF
--- a/language/move-model/src/ast.rs
+++ b/language/move-model/src/ast.rs
@@ -406,6 +406,18 @@ pub enum ExpData {
     Block(NodeId, Vec<LocalVarDecl>, Exp),
     /// Represents a conditional.
     IfElse(NodeId, Exp, Exp, Exp),
+
+    // ---------------------------------------------------------
+    // Subsequent expressions only appear in imperative context
+    /// Represents a sequence of effects, the last value also being the result.
+    Sequence(NodeId, Vec<Exp>),
+    /// Represents a loop, with a body expression.
+    Loop(NodeId, Exp),
+    /// Represents a loop continuation for the enclosing loop. The bool indicates whether the
+    /// loop is continued (true) or broken (false).
+    LoopCont(NodeId, bool),
+    /// Represents the return from a function
+    Return(NodeId, Exp),
 }
 
 /// An internalized expression. We do use a wrapper around the underlying internement implementation
@@ -463,6 +475,17 @@ impl ExpData {
         self.into()
     }
 
+    /// Determines whether this is an imperative expression construct
+    pub fn is_imperative_construct(&self) -> bool {
+        matches!(
+            self,
+            ExpData::Sequence(_, _)
+                | ExpData::Loop(_, _)
+                | ExpData::LoopCont(_, _)
+                | ExpData::Return(_, _)
+        )
+    }
+
     pub fn ptr_eq(e1: &Exp, e2: &Exp) -> bool {
         // For the internement based implementations, we can just test equality. Other
         // representations may need different measures.
@@ -481,7 +504,11 @@ impl ExpData {
             | Lambda(node_id, ..)
             | Quant(node_id, ..)
             | Block(node_id, ..)
-            | IfElse(node_id, ..) => *node_id,
+            | IfElse(node_id, ..)
+            | Sequence(node_id, ..)
+            | Loop(node_id, ..)
+            | LoopCont(node_id, ..)
+            | Return(node_id, ..) => *node_id,
         }
     }
 
@@ -679,8 +706,15 @@ impl ExpData {
                 t.visit_pre_post(visitor);
                 e.visit_pre_post(visitor);
             },
+            Loop(_, e) => e.visit_pre_post(visitor),
+            Return(_, e) => e.visit_pre_post(visitor),
+            Sequence(_, es) => {
+                for e in es {
+                    e.visit_pre_post(visitor)
+                }
+            },
             // Explicitly list all enum variants
-            Value(..) | LocalVar(..) | Temporary(..) | Invalid(..) => {},
+            LoopCont(..) | Value(..) | LocalVar(..) | Temporary(..) | Invalid(..) => {},
         }
         visitor(true, self);
     }
@@ -1290,6 +1324,21 @@ impl<'a> fmt::Display for ExpDisplay<'a> {
                     else_exp.display(self.env)
                 )
             },
+            Sequence(_, es) => {
+                for (i, e) in es.iter().enumerate() {
+                    if i > 0 {
+                        writeln!(f, ";")?
+                    }
+                    write!(f, "{}", e.display(self.env))?
+                }
+                Ok(())
+            },
+            Loop(_, e) => {
+                write!(f, "loop {{\n{}\n}}", e.display(self.env))
+            },
+            LoopCont(_, true) => write!(f, "continue"),
+            LoopCont(_, false) => write!(f, "break"),
+            Return(_, e) => write!(f, "return {}", e.display(self.env)),
         }
     }
 }

--- a/language/move-model/src/builder/exp_translator.rs
+++ b/language/move-model/src/builder/exp_translator.rs
@@ -52,13 +52,15 @@ pub(crate) struct ExpTranslator<'env, 'translator, 'module_translator> {
     pub type_var_counter: u16,
     /// A marker to indicate the node_counter start state.
     pub node_counter_start: usize,
-    /// The locals which have been accessed with this build. The boolean indicates whether
+    /// The locals which have been accessed with this translator. The boolean indicates whether
     /// they ore accessed in `old(..)` context.
     pub accessed_locals: BTreeSet<(Symbol, bool)>,
     /// The number of outer context scopes in  `local_table` which are accounted for in
     /// `accessed_locals`. See also documentation of function `mark_context_scopes`.
     pub outer_context_scopes: usize,
-    /// A flag to indicate whether we are translating expressions in a spec fun.
+    /// Whether we translating a regular Move function
+    pub translating_move_fun: bool,
+    /// Whether we are translating a regular Move function to interpret as spec fun.
     pub translating_fun_as_spec_fun: bool,
     /// A flag to indicate whether errors have been generated so far.
     pub errors_generated: RefCell<bool>,
@@ -91,7 +93,8 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
             node_counter_start,
             accessed_locals: BTreeSet::new(),
             outer_context_scopes: 0,
-            /// Following flags used to translate pure Move functions.
+            /// Following flags used to translate Move functions.
+            translating_move_fun: false,
             translating_fun_as_spec_fun: false,
             errors_generated: RefCell::new(false),
             called_spec_funs: BTreeSet::new(),
@@ -111,11 +114,15 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
         et
     }
 
+    pub fn translate_move_fun(&mut self) {
+        self.translating_move_fun = true;
+    }
+
     pub fn translate_fun_as_spec_fun(&mut self) {
         self.translating_fun_as_spec_fun = true;
     }
 
-    /// Extract a map from names to types from the scopes of this build.
+    /// Extract a map from names to types from the scopes of this translator.
     pub fn extract_var_map(&self) -> BTreeMap<Symbol, LocalVarEntry> {
         let mut vars: BTreeMap<Symbol, LocalVarEntry> = BTreeMap::new();
         for s in &self.local_table {
@@ -124,7 +131,7 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
         vars
     }
 
-    // Get type parameters from this build.
+    // Get type parameters from this translator.
     #[allow(unused)]
     pub fn get_type_params(&self) -> Vec<Type> {
         self.type_params
@@ -133,7 +140,7 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
             .collect_vec()
     }
 
-    // Get type parameters with names from this build.
+    // Get type parameters with names from this translator.
     pub fn get_type_params_with_name(&self) -> Vec<(Symbol, Type)> {
         self.type_params.clone()
     }
@@ -224,7 +231,7 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
             .update_node_instantiation(node_id, instantiation);
     }
 
-    /// Finalizes types in this build, producing errors if some could not be inferred
+    /// Finalizes types in this translator, producing errors if some could not be inferred
     /// and remained incomplete.
     pub fn finalize_types(&mut self) {
         for i in self.node_counter_start..self.parent.parent.env.next_free_node_number() {
@@ -261,7 +268,7 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
         ty
     }
 
-    /// Fix any free type variables remaining in this expression build to a freshly
+    /// Fix any free type variables remaining in this expression translator to a freshly
     /// generated type parameter, adding them to the passed vector.
     #[allow(unused)]
     pub fn fix_types(&mut self, generated_params: &mut Vec<Type>) {
@@ -335,7 +342,7 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
         self
     }
 
-    /// Gets the locals this build has accessed so far and which belong to the
+    /// Gets the locals this translator has accessed so far and which belong to the
     /// context, i.a. are not declared in this expression.
     #[allow(unused)]
     pub fn get_accessed_context_locals(&self) -> Vec<(Symbol, bool)> {
@@ -420,7 +427,7 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
         }
     }
 
-    /// Lookup a local in this build.
+    /// Lookup a local in this translator.
     pub fn lookup_local(&mut self, name: Symbol, in_old: bool) -> Option<&LocalVarEntry> {
         let mut depth = self.local_table.len();
         for scope in &self.local_table {
@@ -1027,7 +1034,8 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
                 match &spec_fun_entry.oper {
                     Operation::Function(module_id, spec_fun_id, None) => {
                         if !self.translating_fun_as_spec_fun {
-                            // Record the usage of spec function in specs, used later in spec build.
+                            // Record the usage of spec function in specs, used later in spec
+                            // translator.
                             self.parent
                                 .parent
                                 .add_used_spec_fun(module_id.qualified(*spec_fun_id));
@@ -1457,7 +1465,7 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
         let struct_ty = self.subs.specialize(struct_ty);
         let field_name = self.symbol_pool().make(&name.value);
         if let Type::Struct(mid, sid, targs) = &struct_ty {
-            // Lookup the StructEntry in the build. It must be defined for valid
+            // Lookup the StructEntry in the translator. It must be defined for valid
             // Type::Struct instances.
             let struct_name = self
                 .parent
@@ -1625,7 +1633,7 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
             },
             1 => {
                 let (cand, subs, instantiation) = matching.remove(0);
-                // Commit the candidate substitution to this expression build.
+                // Commit the candidate substitution to this expression translator.
                 self.subs = subs;
                 // Now translate lambda-based arguments passing expected type to aid type inference.
                 for i in 0..translated_args.len() {
@@ -1668,7 +1676,7 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
                 if let Operation::Function(module_id, spec_fun_id, None) = cand.oper {
                     if !self.translating_fun_as_spec_fun {
                         // Record the usage of spec function in specs, used later
-                        // in spec build.
+                        // in spec translator.
                         self.parent
                             .parent
                             .add_used_spec_fun(module_id.qualified(spec_fun_id));
@@ -2056,7 +2064,7 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
 
     pub fn check_type(&mut self, loc: &Loc, ty: &Type, expected: &Type, context_msg: &str) -> Type {
         // Because of Rust borrow semantics, we must temporarily detach the substitution from
-        // the build. This is because we also need to inherently borrow self via the
+        // the translator. This is because we also need to inherently borrow self via the
         // type_display_context which is passed into unification.
         let mut subs = std::mem::replace(&mut self.subs, Substitution::new());
         let result = match subs.unify(Variance::Shallow, ty, expected) {

--- a/language/move-model/src/builder/module_builder.rs
+++ b/language/move-model/src/builder/module_builder.rs
@@ -69,6 +69,8 @@ pub(crate) struct ModuleBuilder<'env, 'translator> {
     pub spec_vars: Vec<SpecVarDecl>,
     /// Translated function specifications.
     pub fun_specs: BTreeMap<Symbol, Spec>,
+    /// Translated function definitions, if we are compiling Move code
+    pub fun_defs: BTreeMap<Symbol, Exp>,
     /// Translated struct specifications.
     pub struct_specs: BTreeMap<Symbol, Spec>,
     /// Translated module spec
@@ -78,6 +80,14 @@ pub(crate) struct ModuleBuilder<'env, 'translator> {
     /// Let bindings for the current spec block, characterized by a boolean indicating whether
     /// post state is active and the node id of the original expression of the let.
     pub spec_block_lets: BTreeMap<Symbol, (bool, NodeId)>,
+}
+
+/// Represents information about a module already compiled into bytecode.
+#[derive(Debug)]
+pub(crate) struct BytecodeModule {
+    pub compiled_module: CompiledModule,
+    pub source_map: SourceMap,
+    pub function_infos: UniqueMap<PA::FunctionName, FunctionInfo>,
 }
 
 /// A value which we pass in to spec block analyzers, describing the resolved target of the spec
@@ -121,6 +131,7 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
             spec_fun_index: 0,
             spec_vars: vec![],
             fun_specs: BTreeMap::new(),
+            fun_defs: BTreeMap::new(),
             struct_specs: BTreeMap::new(),
             module_spec: Spec::default(),
             spec_block_infos: Default::default(),
@@ -149,15 +160,13 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
         &mut self,
         loc: Loc,
         module_def: EA::ModuleDefinition,
-        compiled_module: CompiledModule,
-        source_map: SourceMap,
-        function_infos: UniqueMap<PA::FunctionName, FunctionInfo>,
+        compiled_module: BytecodeModule,
     ) {
-        self.decl_ana(&module_def, &compiled_module, &source_map);
-        self.def_ana(&module_def, &function_infos);
+        self.decl_ana(&module_def, &compiled_module);
+        self.def_ana(&module_def, &compiled_module);
         self.collect_spec_block_infos(&module_def);
         let attrs = self.translate_attributes(&module_def.attributes);
-        self.populate_env_from_result(loc, attrs, compiled_module, source_map);
+        self.populate_and_finalize_env_from_compiled_module(loc, attrs, compiled_module);
     }
 }
 
@@ -165,6 +174,15 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
     /// Shortcut for accessing the symbol pool.
     pub fn symbol_pool(&self) -> &SymbolPool {
         self.parent.env.symbol_pool()
+    }
+
+    /// Shortcut to check whether we are compiling Move functions (not only specs)
+    pub fn compile_via_model(&self) -> bool {
+        self.parent
+            .env
+            .get_extension::<ModelBuilderOptions>()
+            .expect("options")
+            .compile_via_model
     }
 
     /// Qualifies the given symbol by the current module.
@@ -337,8 +355,7 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
     fn decl_ana(
         &mut self,
         module_def: &EA::ModuleDefinition,
-        compiled_module: &CompiledModule,
-        source_map: &SourceMap,
+        compiled_module_opt: &BytecodeModule,
     ) {
         for (name, struct_def) in module_def.structs.key_cloned_iter() {
             self.decl_ana_struct(&name, struct_def);
@@ -347,7 +364,7 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
             self.decl_ana_fun(&name, fun_def);
         }
         for (name, const_def) in module_def.constants.key_cloned_iter() {
-            self.decl_ana_const(&name, const_def, compiled_module, source_map);
+            self.decl_ana_const(&name, const_def, compiled_module_opt);
         }
         for spec in &module_def.specs {
             self.decl_ana_spec_block(spec);
@@ -358,9 +375,13 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
         &mut self,
         name: &PA::ConstantName,
         def: &EA::Constant,
-        compiled_module: &CompiledModule,
-        source_map: &SourceMap,
+        compiled_module: &BytecodeModule,
     ) {
+        let BytecodeModule {
+            compiled_module,
+            source_map,
+            function_infos: _,
+        } = compiled_module;
         let qsym = self.qualified_by_module_from_name(&name.0);
         let name = qsym.symbol;
         let const_name = ConstantName(self.symbol_pool().string(name).to_string().into());
@@ -652,11 +673,9 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
 /// # Definition Analysis
 
 impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
-    fn def_ana(
-        &mut self,
-        module_def: &EA::ModuleDefinition,
-        function_infos: &UniqueMap<PA::FunctionName, FunctionInfo>,
-    ) {
+    fn def_ana(&mut self, module_def: &EA::ModuleDefinition, compiled_module: &BytecodeModule) {
+        let compile_move = self.compile_via_model();
+
         // Analyze all structs.
         for (name, def) in module_def.structs.key_cloned_iter() {
             self.def_ana_struct(&name, def);
@@ -664,7 +683,7 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
 
         // Analyze all functions.
         for (idx, (name, fun_def)) in module_def.functions.key_cloned_iter().enumerate() {
-            self.def_ana_fun(&name, &fun_def.body, idx);
+            self.def_ana_fun(&name, &fun_def.body, idx, compile_move);
         }
 
         // Propagate the impurity of functions: a Move function which calls an
@@ -783,7 +802,7 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
             }
 
             let fun_name_loc = self.parent.to_loc(&name.loc());
-            let fun_spec_info = &function_infos.get(&name).unwrap().spec_info;
+            let fun_spec_info = &compiled_module.function_infos.get(&name).unwrap().spec_info;
 
             for spec_info in fun_spec_info.values() {
                 // locate the spec block
@@ -943,7 +962,14 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
 impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
     /// Definition analysis for Move functions.
     /// If the function is pure, we translate its body.
-    fn def_ana_fun(&mut self, name: &PA::FunctionName, body: &EA::FunctionBody, fun_idx: usize) {
+    /// If we are operating as a Move compiler, we also translate its body.
+    fn def_ana_fun(
+        &mut self,
+        name: &PA::FunctionName,
+        body: &EA::FunctionBody,
+        fun_idx: usize,
+        compile_move: bool,
+    ) {
         if let EA::FunctionBody_::Defined(seq) = &body.value {
             let full_name = self.qualified_by_module_from_name(&name.0);
             let entry = self
@@ -954,19 +980,29 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
             let type_params = entry.type_params.clone();
             let params = entry.params.clone();
             let result_type = entry.result_type.clone();
+
+            let body_translator = |et: &mut ExpTranslator, as_spec_fun: bool| {
+                if as_spec_fun {
+                    et.translate_fun_as_spec_fun()
+                } else {
+                    et.translate_move_fun()
+                }
+                let loc = et.to_loc(&body.loc);
+                for (n, ty) in &type_params {
+                    et.define_type_param(&loc, *n, ty.clone());
+                }
+                et.enter_scope();
+                for (idx, (n, ty)) in params.iter().enumerate() {
+                    et.define_local(&loc, *n, ty.clone(), None, Some(idx));
+                }
+                let result = et.translate_seq(&loc, seq, &result_type);
+                et.finalize_types();
+                result
+            };
+
+            // Attempt to translate as specification function
             let mut et = ExpTranslator::new(self);
-            et.translate_fun_as_spec_fun();
-            let loc = et.to_loc(&body.loc);
-            for (n, ty) in &type_params {
-                et.define_type_param(&loc, *n, ty.clone());
-            }
-            et.enter_scope();
-            for (idx, (n, ty)) in params.iter().enumerate() {
-                et.define_local(&loc, *n, ty.clone(), None, Some(idx));
-            }
-            let translated = et.translate_seq(&loc, seq, &result_type);
-            et.finalize_types();
-            // If no errors were generated, then the function is considered pure.
+            let translated = body_translator(&mut et, true);
             if !*et.errors_generated.borrow() {
                 // Rewrite all type annotations in expressions to skip references.
                 for node_id in translated.node_ids() {
@@ -981,8 +1017,18 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
                 });
                 self.spec_funs[self.spec_fun_index].body = Some(translated.into_exp());
             }
+
+            if compile_move {
+                // Also translate as regular Move function
+                let mut et = ExpTranslator::new(self);
+                let translated = body_translator(&mut et, false);
+                assert!(self
+                    .fun_defs
+                    .insert(full_name.symbol, translated.into_exp())
+                    .is_none());
+            }
         }
-        self.spec_fun_index += 1;
+        self.spec_fun_index += 1; // TODO: why is this at the end? Document or move close to use
     }
 
     /// Propagate the impurity of Move functions from callees to callers so
@@ -3200,16 +3246,21 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
     }
 }
 
-/// # Environment Population
+/// # Environment Population and finalization
 
 impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
-    fn populate_env_from_result(
+    fn populate_and_finalize_env_from_compiled_module(
         &mut self,
         loc: Loc,
         attributes: Vec<Attribute>,
-        module: CompiledModule,
-        source_map: SourceMap,
+        compiled_module: BytecodeModule,
     ) {
+        let BytecodeModule {
+            compiled_module: module,
+            source_map,
+            function_infos: _,
+        } = compiled_module;
+
         let struct_data: BTreeMap<StructId, StructData> = (0..module.struct_defs().len())
             .filter_map(|idx| {
                 let def_idx = StructDefinitionIndex(idx as u16);
@@ -3263,6 +3314,7 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
                     self.symbol_pool().make(name_str)
                 };
                 let fun_spec = self.fun_specs.remove(&name).unwrap_or_default();
+                let fun_def = self.fun_defs.remove(&name);
                 if let Some(entry) = self.parent.fun_table.get(&self.qualified_by_module(name)) {
                     let arg_names = project_1st(&entry.params);
                     let type_arg_names = project_1st(&entry.type_params);
@@ -3275,6 +3327,7 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
                         arg_names,
                         type_arg_names,
                         fun_spec,
+                        fun_def
                     )))
                 } else {
                     let funs = self.parent.fun_table.keys().map(|k| {

--- a/language/move-model/src/exp_rewriter.rs
+++ b/language/move-model/src/exp_rewriter.rs
@@ -314,6 +314,41 @@ pub trait ExpRewriterFunctions {
                     exp
                 }
             },
+            Sequence(id, es) => {
+                let (id_changed, new_id) = self.internal_rewrite_id(id);
+                let changed_vec = self.internal_rewrite_vec(es);
+                if id_changed || changed_vec.is_some() {
+                    Sequence(new_id, changed_vec.unwrap_or_else(|| es.clone())).into_exp()
+                } else {
+                    exp
+                }
+            },
+            Loop(id, body) => {
+                let (id_changed, new_id) = self.internal_rewrite_id(id);
+                let (body_changed, new_body) = self.internal_rewrite_exp(body);
+                if id_changed || body_changed {
+                    Loop(new_id, new_body).into_exp()
+                } else {
+                    exp
+                }
+            },
+            LoopCont(id, do_cont) => {
+                let (id_changed, new_id) = self.internal_rewrite_id(id);
+                if id_changed {
+                    LoopCont(new_id, *do_cont).into_exp()
+                } else {
+                    exp
+                }
+            },
+            Return(id, val) => {
+                let (id_changed, new_id) = self.internal_rewrite_id(id);
+                let (val_changed, new_val) = self.internal_rewrite_exp(val);
+                if id_changed || val_changed {
+                    Return(new_id, new_val).into_exp()
+                } else {
+                    exp
+                }
+            },
             // This can happen since we are calling the rewriter during type checking, and
             // we may have encountered an error which is represented as an Invalid expression.
             Invalid(id) => Invalid(*id).into_exp(),

--- a/language/move-model/src/model.rs
+++ b/language/move-model/src/model.rs
@@ -1184,6 +1184,7 @@ impl GlobalEnv {
         arg_names: Vec<Symbol>,
         type_arg_names: Vec<Symbol>,
         spec: Spec,
+        def: Option<Exp>,
     ) -> FunctionData {
         let handle_idx = module.function_def_at(def_idx).function;
         FunctionData {
@@ -1195,6 +1196,7 @@ impl GlobalEnv {
             arg_names,
             type_arg_names,
             spec,
+            def,
             called_funs: Default::default(),
             calling_funs: Default::default(),
             transitive_closure_of_called_funs: Default::default(),
@@ -2983,6 +2985,10 @@ pub struct FunctionData {
     /// Specification associated with this function.
     spec: Spec,
 
+    /// Optional definition associated with this function. The definition is available if
+    /// the model is build with option `ModelBuilderOptions::compile_via_model`.
+    def: Option<Exp>,
+
     /// A cache for the called functions.
     called_funs: RefCell<Option<BTreeSet<QualifiedId<FunId>>>>,
 
@@ -3008,6 +3014,7 @@ impl FunctionData {
             arg_names: vec![],
             type_arg_names: vec![],
             spec: Spec::default(),
+            def: None,
             called_funs: Default::default(),
             calling_funs: Default::default(),
             transitive_closure_of_called_funs: Default::default(),
@@ -3528,6 +3535,12 @@ impl<'env> FunctionEnv<'env> {
     /// Returns associated specification.
     pub fn get_spec(&'env self) -> &'env Spec {
         &self.data.spec
+    }
+
+    /// Returns associated definition. The definition of the function, in Exp form, is available
+    /// if the model is build with `ModelBuilderOptions::compile_via_model`
+    pub fn get_def(&self) -> &Option<Exp> {
+        &self.data.def
     }
 
     /// Returns the acquired global resource types.

--- a/language/move-model/src/options.rs
+++ b/language/move-model/src/options.rs
@@ -8,6 +8,10 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct ModelBuilderOptions {
+    /// Whether compilation of the Move code into bytecode should be handled by the new compiler
+    /// part of the model.
+    pub compile_via_model: bool,
+
     /// Ignore the "opaque" pragma on internal function (i.e., functions with no unknown callers)
     /// specs when possible. The opaque can be ignored as long as the function spec has no property
     /// marked as `[concrete]` or `[abstract]`.

--- a/language/move-model/tests/sources/compile_via_model/simple.exp
+++ b/language/move-model/tests/sources/compile_via_model/simple.exp
@@ -1,0 +1,11 @@
+error: assignment only allowed in spec var updates
+  ┌─ tests/sources/compile_via_model/simple.move:3:72
+  │
+3 │     fun showing_sequential_not_supported_yet(x: u64): u64 { let x = x; x = x + 1; x }
+  │                                                                        ^^^^^^^^^
+
+error: only binding `let p = e; ...` allowed here
+  ┌─ tests/sources/compile_via_model/simple.move:3:72
+  │
+3 │     fun showing_sequential_not_supported_yet(x: u64): u64 { let x = x; x = x + 1; x }
+  │                                                                        ^^^^^^^^^

--- a/language/move-model/tests/sources/compile_via_model/simple.move
+++ b/language/move-model/tests/sources/compile_via_model/simple.move
@@ -1,0 +1,4 @@
+module 0x1::simple {
+    fun works_fine(x: u64): u64 { x + 1 }
+    fun showing_sequential_not_supported_yet(x: u64): u64 { let x = x; x = x + 1; x }
+}

--- a/language/move-model/tests/testsuite.rs
+++ b/language/move-model/tests/testsuite.rs
@@ -9,54 +9,63 @@ use move_binary_format::{
 };
 use move_command_line_common::testing::EXP_EXT;
 use move_compiler::shared::PackagePaths;
-use move_model::{run_bytecode_model_builder, run_model_builder};
+use move_model::{
+    options::ModelBuilderOptions, run_bytecode_model_builder, run_model_builder_with_options,
+};
 use move_prover_test_utils::baseline_test::verify_or_update_baseline;
 use std::path::Path;
 
-fn test_runner(path: &Path) -> datatest_stable::Result<()> {
+fn test_runner(
+    path: &Path,
+    options: ModelBuilderOptions,
+    check_from_bytecode: bool,
+) -> datatest_stable::Result<()> {
     let targets = vec![PackagePaths {
         name: None,
         paths: vec![path.to_str().unwrap().to_string()],
         named_address_map: std::collections::BTreeMap::<String, _>::new(),
     }];
-    let env = run_model_builder(targets, vec![])?;
+    let env = run_model_builder_with_options(targets, vec![], options)?;
     let diags = if env.diag_count(Severity::Warning) > 0 {
         let mut writer = Buffer::no_color();
         env.report_diag(&mut writer, Severity::Warning);
         String::from_utf8_lossy(&writer.into_inner()).to_string()
     } else {
-        // check that translating from bytecodes also works + yields similar results
-        let modules = env.get_bytecode_modules();
-        let bytecode_env = run_bytecode_model_builder(modules)?;
-        assert_eq!(bytecode_env.get_module_count(), env.get_module_count());
-        for m in bytecode_env.get_modules() {
-            let raw_module = m.get_verified_module();
-            let other_m = env
-                .find_module_by_language_storage_id(&raw_module.self_id())
-                .expect("Module not found");
-            assert_eq!(m.get_function_count(), other_m.get_function_count());
-            // other_m can have ghost structs, so only check that we have at least as many
-            // structs as in bytecode.
-            assert!(m.get_struct_count() <= other_m.get_struct_count());
-            for (i, _) in raw_module.struct_defs().iter().enumerate() {
-                let idx = StructDefinitionIndex(i as u16);
-                let s = m.get_struct_by_def_idx(idx);
-                let other_s = other_m.get_struct_by_def_idx(idx);
-                assert_eq!(s.get_field_count(), other_s.get_field_count());
-                for f in s.get_fields() {
-                    let other_f = other_s.get_field_by_offset(f.get_offset());
-                    assert_eq!(f.get_identifier(), other_f.get_identifier());
+        if check_from_bytecode {
+            // check that translating from bytecodes also works + yields similar results
+            let modules = env.get_bytecode_modules();
+            let bytecode_env = run_bytecode_model_builder(modules)?;
+            assert_eq!(bytecode_env.get_module_count(), env.get_module_count());
+            for m in bytecode_env.get_modules() {
+                let raw_module = m.get_verified_module();
+                let other_m = env
+                    .find_module_by_language_storage_id(&raw_module.self_id())
+                    .expect("Module not found");
+                assert_eq!(m.get_function_count(), other_m.get_function_count());
+                // other_m can have ghost structs, so only check that we have at least as many
+                // structs as in bytecode.
+                assert!(m.get_struct_count() <= other_m.get_struct_count());
+                for (i, _) in raw_module.struct_defs().iter().enumerate() {
+                    let idx = StructDefinitionIndex(i as u16);
+                    let s = m.get_struct_by_def_idx(idx);
+                    let other_s = other_m.get_struct_by_def_idx(idx);
+                    assert_eq!(s.get_field_count(), other_s.get_field_count());
+                    for f in s.get_fields() {
+                        let other_f = other_s.get_field_by_offset(f.get_offset());
+                        assert_eq!(f.get_identifier(), other_f.get_identifier());
+                    }
                 }
-            }
-            for (i, _) in raw_module.function_defs().iter().enumerate() {
-                let idx = FunctionDefinitionIndex(i as u16);
-                let fun = m.get_function(m.try_get_function_id(idx).expect("Function not found"));
-                let other_fun = other_m.get_function(
-                    other_m
-                        .try_get_function_id(idx)
-                        .expect("Function not found"),
-                );
-                assert_eq!(fun.get_identifier(), other_fun.get_identifier())
+                for (i, _) in raw_module.function_defs().iter().enumerate() {
+                    let idx = FunctionDefinitionIndex(i as u16);
+                    let fun =
+                        m.get_function(m.try_get_function_id(idx).expect("Function not found"));
+                    let other_fun = other_m.get_function(
+                        other_m
+                            .try_get_function_id(idx)
+                            .expect("Function not found"),
+                    );
+                    assert_eq!(fun.get_identifier(), other_fun.get_identifier())
+                }
             }
         }
 
@@ -67,4 +76,19 @@ fn test_runner(path: &Path) -> datatest_stable::Result<()> {
     Ok(())
 }
 
-datatest_stable::harness!(test_runner, "tests/sources", r".*\.move");
+fn runner(path: &Path) -> datatest_stable::Result<()> {
+    if path.display().to_string().contains("/compile_via_model/") {
+        test_runner(
+            path,
+            ModelBuilderOptions {
+                compile_via_model: true,
+                ..Default::default()
+            },
+            false,
+        )
+    } else {
+        test_runner(path, ModelBuilderOptions::default(), true)
+    }
+}
+
+datatest_stable::harness!(runner, "tests/sources", r".*\.move");

--- a/language/move-prover/boogie-backend/src/spec_translator.rs
+++ b/language/move-prover/boogie-backend/src/spec_translator.rs
@@ -690,6 +690,10 @@ impl<'env> SpecTranslator<'env> {
                 emit!(self.writer, ")");
             },
             ExpData::Invalid(_) => panic!("unexpected error expression"),
+            ExpData::Return(..)
+            | ExpData::Sequence(..)
+            | ExpData::Loop(..)
+            | ExpData::LoopCont(..) => panic!("imperative expressions not supported"),
         }
     }
 

--- a/language/move-prover/interpreter/src/concrete/evaluator.rs
+++ b/language/move-prover/interpreter/src/concrete/evaluator.rs
@@ -215,6 +215,10 @@ impl<'env> Evaluator<'env> {
             ExpData::Invalid(_) => unreachable!(),
             // should not appear in this context
             ExpData::Lambda(..) | ExpData::Block(..) => unreachable!(),
+            ExpData::Return(..)
+            | ExpData::Sequence(..)
+            | ExpData::Loop(..)
+            | ExpData::LoopCont(..) => panic!("imperative expressions not supported"),
         };
 
         if debug_expression {

--- a/language/move-prover/tools/spec-flatten/src/ast_print.rs
+++ b/language/move-prover/tools/spec-flatten/src/ast_print.rs
@@ -346,6 +346,10 @@ impl SpecPrinter<'_> {
                     TypeValue => unreachable!("TypeValue is not currently supported"),
                 }
             },
+            ExpData::Return(..)
+            | ExpData::Sequence(..)
+            | ExpData::Loop(..)
+            | ExpData::LoopCont(..) => panic!("imperative expressions not supported"),
         }
     }
 


### PR DESCRIPTION
This is a very first step to enable the move model to process Move functions from source (and not just bytecode), and thus act as a compiler.

In this initial approach, the old Move compiler is run together with the new one. This allows us to continue to have a `CompiledModule` in the `GlobalEnv`. Untangling the model from compiled module is a larger refactoring which we can factor out in different PRs.

A new model builder option `compile_via_model` is added. If set, the body of function definitions will be piped through the model's exp builder to translate expansion AST into model AST, which is now stored in the model and accessible via `FunctionEnv::get_def()`. The model AST has been extended to handle new imperative expression constructs, but the translator has not yet been extended to support imperative constructs. Test infra has been set up as well, to be refined as we proceed.
