### PR TITLE
[session] Expose struct loading

### DIFF
--- a/language/move-bytecode-verifier/src/absint.rs
+++ b/language/move-bytecode-verifier/src/absint.rs
@@ -111,6 +111,7 @@ pub trait AbstractInterpreter: TransferFunctions {
                                     .is_back_edge(block_id, *successor_block_id)
                                 {
                                     next_block_candidate = Some(*successor_block_id);
+                                    break;
                                 }
                             }
                         }

--- a/language/move-vm/runtime/src/session.rs
+++ b/language/move-vm/runtime/src/session.rs
@@ -278,6 +278,13 @@ impl<'r, 'l, S: MoveResolver> Session<'r, 'l, S> {
             .get_fully_annotated_type_layout(type_tag, &self.data_cache)
     }
 
+    pub fn type_to_type_layout(&self, ty: &Type) -> VMResult<MoveTypeLayout> {
+        self.runtime
+            .loader()
+            .type_to_type_layout(ty)
+            .map_err(|e| e.finish(Location::Undefined))
+    }
+
     pub fn get_type_tag(&self, ty: &Type) -> VMResult<TypeTag> {
         self.runtime
             .loader()

--- a/language/move-vm/runtime/src/session.rs
+++ b/language/move-vm/runtime/src/session.rs
@@ -249,6 +249,19 @@ impl<'r, 'l, S: MoveResolver> Session<'r, 'l, S> {
         Ok(instantiation)
     }
 
+    /// Load a struct by its name to get the global index that it is referenced by within the
+    /// loader, and the loaded struct information.  This operation also ensures the defining module
+    /// is loaded from the data store and will fail if the type does not exist in that module.
+    pub fn load_struct(
+        &self,
+        module_id: &ModuleId,
+        struct_name: &IdentStr,
+    ) -> VMResult<(CachedStructIndex, Arc<StructType>)> {
+        self.runtime
+            .loader()
+            .load_struct_by_name(struct_name, module_id, &self.data_cache)
+    }
+
     pub fn load_type(&self, type_tag: &TypeTag) -> VMResult<Type> {
         self.runtime.loader().load_type(type_tag, &self.data_cache)
     }


### PR DESCRIPTION
## Motivation

This operation loads the struct type information.  It differs from `load_type` which, when loading a generic struct type, will also instantiate type parameters.  Having this separate entry into the loader allows us to implement type loading support in the presence of package upgrades from the adapter layer.

## Test Plan

```
$ env SOLC=... cargo nextest --no-fail-fast
```
