### PR TITLE
[verifier] fix unchecked overflow in stack usage verifier

### DIFF
--- a/language/move-bytecode-verifier/src/stack_usage_verifier.rs
+++ b/language/move-bytecode-verifier/src/stack_usage_verifier.rs
@@ -59,7 +59,12 @@ impl<'a> StackUsageVerifier<'a> {
             let (num_pops, num_pushes) = self.instruction_effect(&code[i as usize])?;
             if let Some(new_pushes) = u64::checked_add(overall_push, num_pushes) {
                 overall_push = new_pushes
-            };
+            } else {
+                if config.max_push_size.is_some() {
+                    return Err(PartialVMError::new(StatusCode::VALUE_STACK_PUSH_OVERFLOW)
+                        .at_code_offset(self.current_function(), block_start));
+                }
+            }
 
             // Check that the accumulated pushes does not exceed a pre-defined max size
             if let Some(max_push_size) = config.max_push_size {


### PR DESCRIPTION
## Motivation

When verifying stack usage for basic blocks, if the `overall_push` overflows, and `max_push_size` is set in the verifier configuration, this should result in a `VALUE_STACK_PUSH_OVERFLOW` error. But the verifier will let it pass currently. (This condition is satisfiable when usize is 64bit, but not when usize is 32bit).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes.

## Test Plan

All bytecode-verifier-tests passed.