### PR TITLE
[move-compiler]Support utf8 language in comments 

### DIFF
--- a/language/move-command-line-common/src/character_sets.rs
+++ b/language/move-command-line-common/src/character_sets.rs
@@ -107,7 +107,7 @@ mod tests {
     }
 
     #[test]
-    fn test_is_printable_utf8_chars() {
+    fn test_is_permitted_utf8_chars() {
         let good_chars = "hello 世界\r\n";
         good_chars
             .chars()
@@ -115,7 +115,7 @@ mod tests {
     }
 
     #[test]
-    fn test_not_printable_utf8_chars() {
+    fn test_forbidden_utf8_chars() {
         let bad_chars = "\u{8}";
         println!("{}", bad_chars);
         bad_chars

--- a/language/move-command-line-common/src/character_sets.rs
+++ b/language/move-command-line-common/src/character_sets.rs
@@ -60,6 +60,16 @@ pub fn is_permitted_chars(chars: &[u8], idx: usize) -> bool {
     is_permitted_newline_crlf_chars(c1, c2)
 }
 
+/// Determine if the characters is permitted utf8  characters.
+///
+/// A permitted characters is either a permitted printable character, or a permitted
+/// newlines. Any other characters are disallowed from appearing in the file.
+pub fn is_permitted_utf8_chars(c: char) -> bool {
+    let is_control = c.is_ascii_control();
+    let is_allowed = c == '\n' || c == '\r' || c == '\t';
+    !is_control || is_allowed
+}
+
 #[cfg(test)]
 mod tests {
     #[test]
@@ -94,5 +104,22 @@ mod tests {
         for idx in 0..bad_chars.len() {
             assert!(!super::is_permitted_chars(&bad_chars, idx));
         }
+    }
+
+    #[test]
+    fn test_is_printable_utf8_chars() {
+        let good_chars = "hello 世界\r\n";
+        good_chars
+            .chars()
+            .for_each(|c| assert_eq!(true, super::is_permitted_utf8_chars(c)));
+    }
+
+    #[test]
+    fn test_not_printable_utf8_chars() {
+        let bad_chars = "\u{8}";
+        println!("{}", bad_chars);
+        bad_chars
+            .chars()
+            .for_each(|c| assert_eq!(false, super::is_permitted_utf8_chars(c)));
     }
 }

--- a/language/move-compiler/src/parser/comments.rs
+++ b/language/move-compiler/src/parser/comments.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{diag, diagnostics::Diagnostics};
-use move_command_line_common::{character_sets::is_printable_utf8_chars, files::FileHash};
+use move_command_line_common::{character_sets::is_permitted_utf8_chars, files::FileHash};
 use move_ir_types::location::*;
 use std::collections::BTreeMap;
 

--- a/language/move-compiler/src/parser/comments.rs
+++ b/language/move-compiler/src/parser/comments.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{diag, diagnostics::Diagnostics};
-use move_command_line_common::{character_sets::is_permitted_chars, files::FileHash};
+use move_command_line_common::{character_sets::is_printable_utf8_chars, files::FileHash};
 use move_ir_types::location::*;
 use std::collections::BTreeMap;
 
@@ -18,13 +18,13 @@ pub fn verify_string(file_hash: FileHash, string: &str) -> Result<(), Diagnostic
     match string
         .chars()
         .enumerate()
-        .find(|(idx, _)| !is_permitted_chars(string.as_bytes(), *idx))
+        .find(|(_, c)| !is_permitted_utf8_chars(*c))
     {
         None => Ok(()),
         Some((idx, chr)) => {
             let loc = Loc::new(file_hash, idx as u32, idx as u32);
             let msg = format!(
-                "Invalid character '{}' found when reading file. Only ASCII printable characters, \
+                "Invalid character '{}' found when reading file. Only printable characters, \
                  tabs (\\t), lf (\\n) and crlf (\\r\\n) are permitted.",
                 chr
             );


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Move Language.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

In code writing, there is no way to use other languages as comments. So I hope to support other languages


So, I changed the character control for comments to allow readable characters and newline tabs as well as carriage return line feeds
### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

yes

## Test Plan
Unit Test

## Issue
#1038 