### PR TITLE
No semicolon on line 230

### DIFF
--- a/language/documentation/book/src/abilities.md
+++ b/language/documentation/book/src/abilities.md
@@ -227,8 +227,8 @@ fun valid(account: &signer) acquires MyResource {
         move_to(account, MyResource<u64> { f: 0 })
     };
     // Valid, 'MyResource<u64>' has 'key'
-    let r = borrow_global_mut<MyResource<u64>>(addr)
-    r.f = r.f + 1;
+    let r = borrow_global_mut<MyResource<u64>>(addr);
+    r.f = r.f + 1
 }
 
 fun invalid(account: &signer) {


### PR DESCRIPTION
Line 230 gives a compiler error because there was not semicolon

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Move Language.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

(Write your answer here.)

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)
