### PR TITLE
Update BasicCoin.move to fix constant warning in compilation

### DIFF
--- a/language/documentation/tutorial/step_5/BasicCoin/sources/BasicCoin.move
+++ b/language/documentation/tutorial/step_5/BasicCoin/sources/BasicCoin.move
@@ -91,7 +91,7 @@ module NamedAddr::BasicCoin {
     }
 
     #[test(account = @0x1)]
-    #[expected_failure(abort_code = 2)] // Can specify an abort code
+    #[expected_failure(abort_code = EALREADY_HAS_BALANCE)] // Can specify an abort code
     fun publish_balance_already_exists(account: signer) {
         publish_balance(&account);
         publish_balance(&account);


### PR DESCRIPTION
Fix constant warning in compilation:

INCLUDING DEPENDENCY MoveStdlib
BUILDING BasicCoin
warning[W10007]: potential issue with attribute value
   ┌─ ./sources/BasicCoin.move:94:24
   │
94 │     #[expected_failure(abort_code = 2)] // Can specify an abort code
   │                        ^^^^^^^^^^   - Replace value with constant from expected module or add `location=...` attribute.
   │                        │             
   │                        WARNING: passes for an abort from any module.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Move Language.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Fix warnings in compilation time.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

YES

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

TESTED