### PR TITLE
[move-compiler] Fixed abstract interpreter bug with continue statement

### DIFF
--- a/language/move-compiler/src/cfgir/absint.rs
+++ b/language/move-compiler/src/cfgir/absint.rs
@@ -120,13 +120,14 @@ pub trait AbstractInterpreter: TransferFunctions {
                                 // the same post
                             }
                             JoinResult::Changed => {
+                                // Pre has changed, the post condition is now unknown for the block
+                                next_block_invariant.post = BlockPostcondition::Unprocessed;
                                 // If the cur->successor is a back edge, jump back to the beginning
                                 // of the loop, instead of the normal next block
                                 if cfg.is_back_edge(block_label, *next_block_id) {
                                     next_block_candidate = Some(*next_block_id);
+                                    break;
                                 }
-                                // Pre has changed, the post condition is now unknown for the block
-                                next_block_invariant.post = BlockPostcondition::Unprocessed
                             }
                         }
                     }


### PR DESCRIPTION
continue in while loop causes an unexpected error.

Cherry-pick: MystenLabs/sui#13349
Bugfix: move-language#1068

