### PR TITLE
[language] Fix the doc of CastU64

### DIFF
--- a/language/move-binary-format/src/file_format.rs
+++ b/language/move-binary-format/src/file_format.rs
@@ -1210,7 +1210,7 @@ pub enum Bytecode {
     ///
     /// Stack transition:
     ///
-    /// ```..., integer_value -> ..., u8_value```
+    /// ```..., integer_value -> ..., u64_value```
     CastU64,
     /// Convert the value at the top of the stack into u128.
     ///


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Move Language.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

The stack transition part of CastU64 is miswritten. It should be u64_value rather than u8_value.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes

## Test Plan

